### PR TITLE
[OpenStack] Use new hash format in instance names

### DIFF
--- a/cloudmock/openstack/mockcompute/servers.go
+++ b/cloudmock/openstack/mockcompute/servers.go
@@ -153,7 +153,7 @@ func (m *MockClient) listServers(w http.ResponseWriter, vals url.Values) {
 	serverName := strings.Trim(vals.Get("name"), "^$")
 	matched := make([]servers.Server, 0)
 	for _, server := range m.servers {
-		if server.Name == serverName {
+		if strings.HasPrefix(server.Name, serverName) {
 			matched = append(matched, server)
 		}
 	}

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -150,7 +150,7 @@ func (b *ServerGroupModelBuilder) buildInstances(c *fi.ModelBuilderContext, sg *
 		metaWithName[openstack.TagKopsName] = fi.StringValue(instanceName)
 		instanceTask := &openstacktasks.Instance{
 			Name:             instanceName,
-			NamePrefix:       s(groupName),
+			GroupName:        s(groupName),
 			Region:           fi.String(b.Cluster.Spec.Subnets[0].Region),
 			Flavor:           fi.String(ig.Spec.MachineType),
 			Image:            fi.String(ig.Spec.Image),

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -4,6 +4,7 @@ AvailabilityZone: zone-1
 Flavor: blc.2-4
 FloatingIP: null
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image-node
 Lifecycle: null
@@ -21,7 +22,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups:
   - additional-sg

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -9,6 +9,7 @@ Image: image-node
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -20,6 +21,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups:
   - additional-sg

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -4,6 +4,7 @@ AvailabilityZone: zone-1
 Flavor: blc.2-4
 FloatingIP: null
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image-node
 Lifecycle: null
@@ -22,7 +23,6 @@ Metadata:
   kops.k8s.io_instancegroup: node
   some___:x: label
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -9,6 +9,7 @@ Image: image-node
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -21,6 +22,7 @@ Metadata:
   kops.k8s.io_instancegroup: node
   some___:x: label
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -4,6 +4,7 @@ AvailabilityZone: zone-1
 Flavor: blc.2-4
 FloatingIP: null
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image-node
 Lifecycle: null
@@ -22,7 +23,6 @@ Metadata:
   kops.k8s.io_instancegroup: node
   some___:x: label
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -9,6 +9,7 @@ Image: image-node
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -21,6 +22,7 @@ Metadata:
   kops.k8s.io_instancegroup: node
   some___:x: label
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -59,6 +59,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master
+  KopsName: master-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -71,6 +72,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
+NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -135,6 +137,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master
+  KopsName: master-2-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -147,6 +150,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-2-cluster
+NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -211,6 +215,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master
+  KopsName: master-3-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -223,6 +228,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-3-cluster
+NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -287,6 +293,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -298,6 +305,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -356,6 +364,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-2-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -367,6 +376,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-2-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -425,6 +435,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-3-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -436,6 +447,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-3-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -54,6 +54,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-1-cluster
 ForAPIServer: false
+GroupName: master
 ID: null
 Image: image
 Lifecycle: null
@@ -72,7 +73,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
-NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -132,6 +132,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-2-cluster
 ForAPIServer: false
+GroupName: master
 ID: null
 Image: image
 Lifecycle: null
@@ -150,7 +151,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-2-cluster
-NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -210,6 +210,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-3-cluster
 ForAPIServer: false
+GroupName: master
 ID: null
 Image: image
 Lifecycle: null
@@ -228,7 +229,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-3-cluster
-NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -288,6 +288,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-1-cluster
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image
 Lifecycle: null
@@ -305,7 +306,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -359,6 +359,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-2-cluster
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image
 Lifecycle: null
@@ -376,7 +377,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-2-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -430,6 +430,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-3-cluster
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image
 Lifecycle: null
@@ -447,7 +448,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-3-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -60,6 +60,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master-a
+  KopsName: master-a-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -72,6 +73,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
 Name: master-a-1-cluster
+NamePrefix: master-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -124,6 +126,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master-b
+  KopsName: master-b-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -136,6 +139,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
 Name: master-b-1-cluster
+NamePrefix: master-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -188,6 +192,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master-c
+  KopsName: master-c-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -200,6 +205,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
 Name: master-c-1-cluster
+NamePrefix: master-c
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -258,6 +264,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node-a
+  KopsName: node-a-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -269,6 +276,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
 Name: node-a-1-cluster
+NamePrefix: node-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -327,6 +335,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node-b
+  KopsName: node-b-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -338,6 +347,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
 Name: node-b-1-cluster
+NamePrefix: node-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -396,6 +406,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node-c
+  KopsName: node-c-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -407,6 +418,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c
 Name: node-c-1-cluster
+NamePrefix: node-c
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -55,6 +55,7 @@ AvailabilityZone: zone-1
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: master-a
 ID: null
 Image: image
 Lifecycle: null
@@ -73,7 +74,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
 Name: master-a-1-cluster
-NamePrefix: master-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -121,6 +121,7 @@ AvailabilityZone: zone-2
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: master-b
 ID: null
 Image: image
 Lifecycle: null
@@ -139,7 +140,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
 Name: master-b-1-cluster
-NamePrefix: master-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -187,6 +187,7 @@ AvailabilityZone: zone-3
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: master-c
 ID: null
 Image: image
 Lifecycle: null
@@ -205,7 +206,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
 Name: master-c-1-cluster
-NamePrefix: master-c
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -259,6 +259,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-a-1-cluster
 ForAPIServer: false
+GroupName: node-a
 ID: null
 Image: image
 Lifecycle: null
@@ -276,7 +277,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
 Name: node-a-1-cluster
-NamePrefix: node-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -330,6 +330,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-b-1-cluster
 ForAPIServer: false
+GroupName: node-b
 ID: null
 Image: image
 Lifecycle: null
@@ -347,7 +348,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
 Name: node-b-1-cluster
-NamePrefix: node-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -401,6 +401,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-c-1-cluster
 ForAPIServer: false
+GroupName: node-c
 ID: null
 Image: image
 Lifecycle: null
@@ -418,7 +419,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c
 Name: node-c-1-cluster
-NamePrefix: node-c
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -62,6 +62,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-a-1-cluster
 ForAPIServer: false
+GroupName: master-a
 ID: null
 Image: image
 Lifecycle: null
@@ -80,7 +81,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
 Name: master-a-1-cluster
-NamePrefix: master-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -140,6 +140,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-b-1-cluster
 ForAPIServer: false
+GroupName: master-b
 ID: null
 Image: image
 Lifecycle: null
@@ -158,7 +159,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
 Name: master-b-1-cluster
-NamePrefix: master-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -218,6 +218,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-c-1-cluster
 ForAPIServer: false
+GroupName: master-c
 ID: null
 Image: image
 Lifecycle: null
@@ -236,7 +237,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
 Name: master-c-1-cluster
-NamePrefix: master-c
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -296,6 +296,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-a-1-cluster
 ForAPIServer: false
+GroupName: node-a
 ID: null
 Image: image
 Lifecycle: null
@@ -313,7 +314,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
 Name: node-a-1-cluster
-NamePrefix: node-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -367,6 +367,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-b-1-cluster
 ForAPIServer: false
+GroupName: node-b
 ID: null
 Image: image
 Lifecycle: null
@@ -384,7 +385,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
 Name: node-b-1-cluster
-NamePrefix: node-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -438,6 +438,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-c-1-cluster
 ForAPIServer: false
+GroupName: node-c
 ID: null
 Image: image
 Lifecycle: null
@@ -455,7 +456,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c
 Name: node-c-1-cluster
-NamePrefix: node-c
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -67,6 +67,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master-a
+  KopsName: master-a-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -79,6 +80,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
 Name: master-a-1-cluster
+NamePrefix: master-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -143,6 +145,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master-b
+  KopsName: master-b-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -155,6 +158,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
 Name: master-b-1-cluster
+NamePrefix: master-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -219,6 +223,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master-c
+  KopsName: master-c-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -231,6 +236,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
 Name: master-c-1-cluster
+NamePrefix: master-c
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -295,6 +301,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node-a
+  KopsName: node-a-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -306,6 +313,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
 Name: node-a-1-cluster
+NamePrefix: node-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -364,6 +372,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node-b
+  KopsName: node-b-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -375,6 +384,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
 Name: node-b-1-cluster
+NamePrefix: node-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -433,6 +443,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node-c
+  KopsName: node-c-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -444,6 +455,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c
 Name: node-c-1-cluster
+NamePrefix: node-c
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -14,6 +14,7 @@ AvailabilityZone: zone-1
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: master-a
 ID: null
 Image: image
 Lifecycle: null
@@ -32,7 +33,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
 Name: master-a-1-cluster
-NamePrefix: master-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -86,6 +86,7 @@ AvailabilityZone: zone-2
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: master-b
 ID: null
 Image: image
 Lifecycle: null
@@ -104,7 +105,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
 Name: master-b-1-cluster
-NamePrefix: master-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -158,6 +158,7 @@ AvailabilityZone: zone-3
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: master-c
 ID: null
 Image: image
 Lifecycle: null
@@ -176,7 +177,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
 Name: master-c-1-cluster
-NamePrefix: master-c
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -230,6 +230,7 @@ AvailabilityZone: zone-1
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: node-a
 ID: null
 Image: image
 Lifecycle: null
@@ -247,7 +248,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
 Name: node-a-1-cluster
-NamePrefix: node-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -295,6 +295,7 @@ AvailabilityZone: zone-2
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: node-b
 ID: null
 Image: image
 Lifecycle: null
@@ -312,7 +313,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
 Name: node-b-1-cluster
-NamePrefix: node-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -360,6 +360,7 @@ AvailabilityZone: zone-3
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: node-c
 ID: null
 Image: image
 Lifecycle: null
@@ -377,7 +378,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c
 Name: node-c-1-cluster
-NamePrefix: node-c
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -19,6 +19,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master-a
+  KopsName: master-a-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -31,6 +32,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
 Name: master-a-1-cluster
+NamePrefix: master-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -89,6 +91,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master-b
+  KopsName: master-b-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -101,6 +104,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
 Name: master-b-1-cluster
+NamePrefix: master-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -159,6 +163,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master-c
+  KopsName: master-c-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -171,6 +176,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
 Name: master-c-1-cluster
+NamePrefix: master-c
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -229,6 +235,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node-a
+  KopsName: node-a-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -240,6 +247,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
 Name: node-a-1-cluster
+NamePrefix: node-a
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -292,6 +300,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node-b
+  KopsName: node-b-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -303,6 +312,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
 Name: node-b-1-cluster
+NamePrefix: node-b
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -355,6 +365,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node-c
+  KopsName: node-c-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -366,6 +377,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c
 Name: node-c-1-cluster
+NamePrefix: node-c
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -8,6 +8,7 @@ AvailabilityZone: zone-1
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: bastion
 ID: null
 Image: image
 Lifecycle: null
@@ -24,7 +25,6 @@ Metadata:
   k8s.io_role_bastion: "1"
   kops.k8s.io_instancegroup: bastion
 Name: bastion-1-cluster
-NamePrefix: bastion
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -72,6 +72,7 @@ AvailabilityZone: zone-1
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: master
 ID: null
 Image: image
 Lifecycle: null
@@ -90,7 +91,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
-NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -144,6 +144,7 @@ AvailabilityZone: zone-1
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image
 Lifecycle: null
@@ -161,7 +162,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -13,6 +13,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: bastion
+  KopsName: bastion-1-cluster
   KopsNetwork: cluster
   KopsRole: Bastion
   cluster_generation: "0"
@@ -23,6 +24,7 @@ Metadata:
   k8s.io_role_bastion: "1"
   kops.k8s.io_instancegroup: bastion
 Name: bastion-1-cluster
+NamePrefix: bastion
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -75,6 +77,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master
+  KopsName: master-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -87,6 +90,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
+NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -145,6 +149,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -156,6 +161,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -33,6 +33,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: bastion
+  KopsName: bastion-1-cluster
   KopsNetwork: cluster
   KopsRole: Bastion
   cluster_generation: "0"
@@ -43,6 +44,7 @@ Metadata:
   k8s.io_role_bastion: "1"
   kops.k8s.io_instancegroup: bastion
 Name: bastion-1-cluster
+NamePrefix: bastion
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -101,6 +103,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master
+  KopsName: master-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -113,6 +116,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
+NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -171,6 +175,7 @@ Image: image
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -182,6 +187,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -28,6 +28,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-bastion-1-cluster
 ForAPIServer: false
+GroupName: bastion
 ID: null
 Image: image
 Lifecycle: null
@@ -44,7 +45,6 @@ Metadata:
   k8s.io_role_bastion: "1"
   kops.k8s.io_instancegroup: bastion
 Name: bastion-1-cluster
-NamePrefix: bastion
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -98,6 +98,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-1-cluster
 ForAPIServer: false
+GroupName: master
 ID: null
 Image: image
 Lifecycle: null
@@ -116,7 +117,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
-NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -170,6 +170,7 @@ AvailabilityZone: zone-1
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image
 Lifecycle: null
@@ -187,7 +188,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -11,6 +11,7 @@ Image: image-master
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master
+  KopsName: master-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -23,6 +24,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
+NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -81,6 +83,7 @@ Image: image-node
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -92,6 +95,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -6,6 +6,7 @@ AvailabilityZone: zone-1
 Flavor: blc.1-2
 FloatingIP: null
 ForAPIServer: false
+GroupName: master
 ID: null
 Image: image-master
 Lifecycle: null
@@ -24,7 +25,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
-NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -78,6 +78,7 @@ AvailabilityZone: zone-1
 Flavor: blc.2-4
 FloatingIP: null
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image-node
 Lifecycle: null
@@ -95,7 +96,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -31,6 +31,7 @@ Image: image-master
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: master
+  KopsName: master-1-cluster
   KopsNetwork: cluster
   KopsRole: Master
   KubernetesCluster: cluster
@@ -43,6 +44,7 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
+NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -107,6 +109,7 @@ Image: image-node
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -118,6 +121,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -26,6 +26,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-master-1-cluster
 ForAPIServer: false
+GroupName: master
 ID: null
 Image: image-master
 Lifecycle: null
@@ -44,7 +45,6 @@ Metadata:
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
 Name: master-1-cluster
-NamePrefix: master
 Port:
   AdditionalSecurityGroups: null
   ID: null
@@ -104,6 +104,7 @@ FloatingIP:
   Lifecycle: Sync
   Name: fip-node-1-cluster
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image-node
 Lifecycle: null
@@ -121,7 +122,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups: null
   ID: null

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -4,6 +4,7 @@ AvailabilityZone: subnet
 Flavor: blc.2-4
 FloatingIP: null
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image-node
 Lifecycle: null
@@ -21,7 +22,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups:
   - additional-sg

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -9,6 +9,7 @@ Image: image-node
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -20,6 +21,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups:
   - additional-sg

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -4,6 +4,7 @@ AvailabilityZone: zone-a
 Flavor: blc.2-4
 FloatingIP: null
 ForAPIServer: false
+GroupName: node
 ID: null
 Image: image-node
 Lifecycle: null
@@ -21,7 +22,6 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
-NamePrefix: node
 Port:
   AdditionalSecurityGroups:
   - additional-sg

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -9,6 +9,7 @@ Image: image-node
 Lifecycle: null
 Metadata:
   KopsInstanceGroup: node
+  KopsName: node-1-cluster
   KopsNetwork: cluster
   KopsRole: Node
   KubernetesCluster: cluster
@@ -20,6 +21,7 @@ Metadata:
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
 Name: node-1-cluster
+NamePrefix: node
 Port:
   AdditionalSecurityGroups:
   - additional-sg

--- a/pkg/resources/openstack/floatingip.go
+++ b/pkg/resources/openstack/floatingip.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstack
 
 import (
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	l3floatingip "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"k8s.io/kops/pkg/resources"
 	"k8s.io/kops/upup/pkg/fi"
@@ -55,14 +56,14 @@ func (os *clusterDiscoveryOS) listL3FloatingIPs(routerID string) ([]*resources.R
 	return resourceTrackers, nil
 }
 
-func (os *clusterDiscoveryOS) listFloatingIPs(instanceID string) ([]*resources.Resource, error) {
+func (os *clusterDiscoveryOS) listFloatingIPs(instance servers.Server) ([]*resources.Resource, error) {
 	var resourceTrackers []*resources.Resource
-	instance, err := os.osCloud.GetInstance(instanceID)
-	if err != nil {
-		return resourceTrackers, err
+	name := instance.Name
+	if val, ok := instance.Metadata[openstack.TagKopsName]; ok {
+		name = val
 	}
 	floatingIPs, err := os.osCloud.ListL3FloatingIPs(l3floatingip.ListOpts{
-		Description: "fip-" + instance.Name,
+		Description: "fip-" + name,
 	})
 	if err != nil {
 		return resourceTrackers, err

--- a/pkg/resources/openstack/floatingip.go
+++ b/pkg/resources/openstack/floatingip.go
@@ -59,6 +59,7 @@ func (os *clusterDiscoveryOS) listL3FloatingIPs(routerID string) ([]*resources.R
 func (os *clusterDiscoveryOS) listFloatingIPs(instance servers.Server) ([]*resources.Resource, error) {
 	var resourceTrackers []*resources.Resource
 	name := instance.Name
+	// this is needed for backwards compatbility issues with new and old instance name format
 	if val, ok := instance.Metadata[openstack.TagKopsName]; ok {
 		name = val
 	}

--- a/pkg/resources/openstack/floatingip.go
+++ b/pkg/resources/openstack/floatingip.go
@@ -58,8 +58,9 @@ func (os *clusterDiscoveryOS) listL3FloatingIPs(routerID string) ([]*resources.R
 
 func (os *clusterDiscoveryOS) listFloatingIPs(instance servers.Server) ([]*resources.Resource, error) {
 	var resourceTrackers []*resources.Resource
+	// we can find real instance name from instance name in old format
+	// however, in new format the real name can be found in metadata
 	name := instance.Name
-	// this is needed for backwards compatbility issues with new and old instance name format
 	if val, ok := instance.Metadata[openstack.TagKopsName]; ok {
 		name = val
 	}

--- a/pkg/resources/openstack/instances.go
+++ b/pkg/resources/openstack/instances.go
@@ -38,7 +38,7 @@ func (os *clusterDiscoveryOS) ListInstances() ([]*resources.Resource, error) {
 		val, ok := instance.Metadata["k8s"]
 		if ok && val == os.clusterName {
 			// Clean up any bound floating IP's
-			floatingIPs, err := os.listFloatingIPs(instance.ID)
+			floatingIPs, err := os.listFloatingIPs(instance)
 			if err != nil {
 				return resourceTrackers, err
 			}

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -65,6 +65,7 @@ const (
 	TagClusterName           = "KubernetesCluster"
 	TagRoleMaster            = "master"
 	TagKopsNetwork           = "KopsNetwork"
+	TagKopsName              = "KopsName"
 	ResourceTypePort         = "ports"
 	ResourceTypeNetwork      = "networks"
 	ResourceTypeSubnet       = "subnets"

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -19,6 +19,7 @@ package openstacktasks
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	l3floatingip "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
@@ -36,6 +37,7 @@ import (
 type Instance struct {
 	ID               *string
 	Name             *string
+	NamePrefix       *string
 	Port             *Port
 	Region           *string
 	Flavor           *string
@@ -118,31 +120,51 @@ func (e *Instance) Find(c *fi.Context) (*Instance, error) {
 	cloud := c.Cloud.(openstack.OpenstackCloud)
 	computeClient := cloud.ComputeClient()
 	serverPage, err := servers.List(computeClient, servers.ListOpts{
-		Name: fmt.Sprintf("^%s$", fi.StringValue(e.Name)),
+		Name: fmt.Sprintf("^%s", fi.StringValue(e.NamePrefix)),
 	}).AllPages()
 	if err != nil {
-		return nil, fmt.Errorf("error finding server with name %s: %v", fi.StringValue(e.Name), err)
+		return nil, fmt.Errorf("error listing servers: %v", err)
 	}
 	serverList, err := servers.ExtractServers(serverPage)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting server page: %v", err)
 	}
-	if len(serverList) == 0 {
+
+	var filteredList []servers.Server
+	for _, server := range serverList {
+		val, ok := server.Metadata["k8s"]
+		if !ok || val != fi.StringValue(e.ServerGroup.ClusterName) {
+			continue
+		}
+		metadataName := ""
+		val, ok = server.Metadata[openstack.TagKopsName]
+		if ok {
+			metadataName = val
+		}
+		// name or metadata tag should match to instance name
+		// this is needed for backwards compatibility
+		if server.Name == fi.StringValue(e.Name) || metadataName == fi.StringValue(e.Name) {
+			filteredList = append(filteredList, server)
+		}
+	}
+
+	if filteredList == nil {
 		return nil, nil
 	}
-	if len(serverList) > 1 {
+	if len(filteredList) > 1 {
 		return nil, fmt.Errorf("Multiple servers found with name %s", fi.StringValue(e.Name))
 	}
 
-	server := serverList[0]
+	server := filteredList[0]
 	actual := &Instance{
 		ID:               fi.String(server.ID),
-		Name:             fi.String(server.Name),
+		Name:             e.Name,
 		SSHKey:           fi.String(server.KeyName),
 		Lifecycle:        e.Lifecycle,
 		Metadata:         server.Metadata,
 		Role:             fi.String(server.Metadata["KopsRole"]),
 		AvailabilityZone: e.AvailabilityZone,
+		NamePrefix:       e.NamePrefix,
 	}
 
 	ports, err := cloud.ListPorts(ports.ListOpts{
@@ -235,10 +257,30 @@ func (_ *Instance) ShouldCreate(a, e, changes *Instance) (bool, error) {
 	return false, nil
 }
 
+// makeServerName generates name for the instance
+// the instance format is [namePrefix]-[6 character hash]
+func makeServerName(e *Instance) (string, error) {
+	secret, err := fi.CreateSecret()
+	if err != nil {
+		return "", err
+	}
+
+	hash, err := secret.AsString()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.ToLower(fmt.Sprintf("%s-%s", fi.StringValue(e.NamePrefix), hash[0:6])), nil
+}
+
 func (_ *Instance) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, changes *Instance) error {
 	cloud := t.Cloud.(openstack.OpenstackCloud)
 	if a == nil {
-		klog.V(2).Infof("Creating Instance with name: %q", fi.StringValue(e.Name))
+		serverName, err := makeServerName(e)
+		if err != nil {
+			return err
+		}
+		klog.V(2).Infof("Creating Instance with name: %q", serverName)
 
 		imageName := fi.StringValue(e.Image)
 		image, err := cloud.GetImage(imageName)
@@ -253,7 +295,7 @@ func (_ *Instance) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, change
 		}
 
 		opt := servers.CreateOpts{
-			Name:      fi.StringValue(e.Name),
+			Name:      serverName,
 			ImageRef:  image.ID,
 			FlavorRef: flavor.ID,
 			Networks: []servers.Network{

--- a/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
@@ -144,11 +144,29 @@ func (_ *ServerGroup) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, cha
 			iName := strings.ToLower(fmt.Sprintf("%s-%d.%s", fi.StringValue(a.IGName), currentLastIndex, fi.StringValue(a.ClusterName)))
 			instanceName := strings.Replace(iName, ".", "-", -1)
 			opts := servers.ListOpts{
-				Name: fmt.Sprintf("^%s$", instanceName),
+				Name: fmt.Sprintf("^%s", fi.StringValue(a.IGName)),
 			}
-			instances, err := t.Cloud.ListInstances(opts)
+			allInstances, err := t.Cloud.ListInstances(opts)
 			if err != nil {
 				return fmt.Errorf("error fetching instance list: %v", err)
+			}
+
+			instances := []servers.Server{}
+			for _, server := range allInstances {
+				val, ok := server.Metadata["k8s"]
+				if !ok || val != fi.StringValue(a.ClusterName) {
+					continue
+				}
+				metadataName := ""
+				val, ok = server.Metadata[openstack.TagKopsName]
+				if ok {
+					metadataName = val
+				}
+				// name or metadata tag should match to instance name
+				// this is needed for backwards compatibility
+				if server.Name == instanceName || metadataName == instanceName {
+					instances = append(instances, server)
+				}
 			}
 
 			if len(instances) == 1 {


### PR DESCRIPTION
So this will modify the instance name format that we will see in OpenStack instance names AND in Kubernetes cluster. The current problem that we have is that if we delete instance from OpenStack and run `kops update cluster --yes` - the new instance will come back with same name. However, the OpenStack instanceid is changed and it leads to problems (there is mismatch between Kubernetes API node instanceid and real OpenStack instanceid). The current way to fix this is to delete node from Kubernetes API and restart OpenStack instance.

old format: `<ig name>-<index>-<clustername>`
new format: `<ig name>-<6 chars random hash>`

tested with following cases:


### with new code

- create new cluster `calc.k8s.local`

```
% kubectl get nodes
NAME                   STATUS   ROLES    AGE     VERSION
master-zone-1-kivf21   Ready    master   2m16s   v1.19.5
master-zone-2-8hxz8y   Ready    master   2m29s   v1.19.5
master-zone-3-yv9sdw   Ready    master   2m25s   v1.19.5
nodes-zone-1-nm2gcp    Ready    node     67s     v1.19.5
nodes-zone-2-ryxop5    Ready    node     64s     v1.19.5
```

- run kubectl update cluster without changing cluster config (no changes, `kops update cluster --name calc.k8s.local`)
- update k8s version in cluster config and run update cluster (no changes, `kops update cluster --name calc.k8s.local`)
- run rolling-update (`kops rolling-update cluster calc.k8s.local --yes`)

```
% kubectl get nodes
NAME                   STATUS   ROLES    AGE     VERSION
master-zone-1-chvtmx   Ready    master   28m     v1.19.6
master-zone-2-n7zs4y   Ready    master   21m     v1.19.6
master-zone-3-wmskzc   Ready    master   11m     v1.19.6
nodes-zone-1-miqpky    Ready    node     6m23s   v1.19.6
nodes-zone-2-bujc69    Ready    node     48s     v1.19.6
```

- scale down instancegroup nodes from 1 -> 0 (should delete one node, `kops edit ig nodes-zone-2` && `kops update cluster --name calc.k8s.local`)

```
% kubectl get nodes
NAME                   STATUS   ROLES    AGE     VERSION
master-zone-1-chvtmx   Ready    master   32m     v1.19.6
master-zone-2-n7zs4y   Ready    master   26m     v1.19.6
master-zone-3-wmskzc   Ready    master   16m     v1.19.6
nodes-zone-1-miqpky    Ready    node     11m     v1.19.6
```

- delete cluster

### with old code create and then updating with newer code

- create new cluster with old naming format (using old code)

```
% kubectl get nodes
NAME                             STATUS   ROLES    AGE     VERSION
master-zone-1-1-calc-k8s-local   Ready    master   2m38s   v1.19.5
master-zone-2-1-calc-k8s-local   Ready    master   2m35s   v1.19.5
master-zone-3-1-calc-k8s-local   Ready    master   2m2s    v1.19.5
nodes-zone-1-1-calc-k8s-local    Ready    node     94s     v1.19.5
nodes-zone-2-1-calc-k8s-local    Ready    node     90s     v1.19.5
```

- compile new code and use it
- run kubectl update cluster without changing cluster config (no changes, `kops update cluster --name calc.k8s.local`)
- update k8s version in cluster config and run update cluster (no changes, `kops update cluster --name calc.k8s.local`)
- run rolling-update (`kops rolling-update cluster calc.k8s.local --yes`)

```
% kubectl get nodes
NAME                   STATUS   ROLES    AGE     VERSION
master-zone-1-orb9gv   Ready    master   31m     v1.19.6
master-zone-2-diw28n   Ready    master   18m     v1.19.6
master-zone-3-srsk15   Ready    master   12m     v1.19.6
nodes-zone-1-lhgo7i    Ready    node     6m51s   v1.19.6
nodes-zone-2-gyziid    Ready    node     2m12s   v1.19.6
```

- scale down instancegroup nodes from 1 -> 0 (should delete one node, `kops edit ig nodes-zone-2` && `kops update cluster --name calc.k8s.local`)

```
% kubectl get nodes
NAME                   STATUS   ROLES    AGE     VERSION
master-zone-1-orb9gv   Ready    master   33m     v1.19.6
master-zone-2-diw28n   Ready    master   20m     v1.19.6
master-zone-3-srsk15   Ready    master   14m     v1.19.6
nodes-zone-1-lhgo7i    Ready    node     8m35s   v1.19.6
```

- delete cluster

### with old code create and then scaling down with new code

- create new cluster with old naming format (using old code)

```
% kubectl get nodes
NAME                             STATUS   ROLES    AGE     VERSION
master-zone-1-1-calc-k8s-local   Ready    master   2m20s   v1.19.6
master-zone-2-1-calc-k8s-local   Ready    master   2m32s   v1.19.6
master-zone-3-1-calc-k8s-local   Ready    master   2m34s   v1.19.6
nodes-zone-1-1-calc-k8s-local    Ready    node     82s     v1.19.6
nodes-zone-2-1-calc-k8s-local    Ready    node     85s     v1.19.6
```

- compile new code and use it
- scale down instancegroup nodes from 1 -> 0 (should delete one node, `kops edit ig nodes-zone-2` && `kops update cluster --name calc.k8s.local`)

```
% kubectl get nodes
NAME                             STATUS   ROLES    AGE     VERSION
master-zone-1-1-calc-k8s-local   Ready    master   4m17s   v1.19.6
master-zone-2-1-calc-k8s-local   Ready    master   4m29s   v1.19.6
master-zone-3-1-calc-k8s-local   Ready    master   4m31s   v1.19.6
nodes-zone-1-1-calc-k8s-local    Ready    node     3m19s   v1.19.6
```

- delete cluster

this code is backward compatible with old clusters with old format