### PR TITLE
Spotinst: Specify whether scale-down activities should be restricted

### DIFF
--- a/docs/getting_started/spot-ocean.md
+++ b/docs/getting_started/spot-ocean.md
@@ -171,6 +171,7 @@ metadata:
 | `spotinst.io/autoscaler-scale-down-evaluation-periods` | Specify the number of evaluation periods that should accumulate before a scale down action takes place. | `5` |
 | `spotinst.io/autoscaler-resource-limits-max-vcpu` | Specify the maximum number of virtual CPUs that can be allocated to the cluster. | none |
 | `spotinst.io/autoscaler-resource-limits-max-memory` | Specify the maximum amount of total physical memory (in GiB units) that can be allocated to the cluster. | none |
+| `spotinst.io/restrict-scale-down` | Specify whether the scale-down activities should be restricted. | none |
 
 ## Documentation
 

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
-	github.com/spotinst/spotinst-sdk-go v1.75.0
+	github.com/spotinst/spotinst-sdk-go v1.76.0
 	github.com/stretchr/testify v1.6.1
 	github.com/weaveworks/mesh v0.0.0-20170419100114-1f158d31de55
 	github.com/zclconf/go-cty v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -954,8 +954,8 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/spotinst/spotinst-sdk-go v1.75.0 h1:4eg0J1STZPnLxPiIYYYq7DYrApIkpzBpJAgzjFIgQfs=
-github.com/spotinst/spotinst-sdk-go v1.75.0/go.mod h1:sSRVZTSdUAPxeELD/urZkxcfU/DcxO1/UIdOxagqFBc=
+github.com/spotinst/spotinst-sdk-go v1.76.0 h1:tlFKrUAu7h3FgZM3Xy7436XR5lYo5Q/uePEy0AX5Ydw=
+github.com/spotinst/spotinst-sdk-go v1.76.0/go.mod h1:sSRVZTSdUAPxeELD/urZkxcfU/DcxO1/UIdOxagqFBc=
 github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0ZuF3Y65PNF6dIwbJPZqfmtCXxFm9ckv0agOY=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/pkg/model/spotinstmodel/instance_group.go
+++ b/pkg/model/spotinstmodel/instance_group.go
@@ -118,6 +118,10 @@ const (
 	// instance group to specify the resource limits configuration used by the auto scaler.
 	InstanceGroupLabelAutoScalerResourceLimitsMaxVCPU   = "spotinst.io/autoscaler-resource-limits-max-vcpu"
 	InstanceGroupLabelAutoScalerResourceLimitsMaxMemory = "spotinst.io/autoscaler-resource-limits-max-memory"
+
+	// InstanceGroupLabelRestrictScaleDown is the metadata label used on the
+	// instance group to specify whether the scale-down activities should be restricted.
+	InstanceGroupLabelRestrictScaleDown = "spotinst.io/restrict-scale-down"
 )
 
 // InstanceGroupModelBuilder configures InstanceGroup objects
@@ -522,6 +526,12 @@ func (b *InstanceGroupModelBuilder) buildLaunchSpec(c *fi.ModelBuilderContext,
 
 		case InstanceGroupLabelSpotPercentage:
 			launchSpec.SpotPercentage, err = parseInt(v)
+			if err != nil {
+				return err
+			}
+
+		case InstanceGroupLabelRestrictScaleDown:
+			launchSpec.RestrictScaleDown, err = parseBool(v)
 			if err != nil {
 				return err
 			}

--- a/vendor/github.com/spotinst/spotinst-sdk-go/service/ocean/providers/aws/launch_spec.go
+++ b/vendor/github.com/spotinst/spotinst-sdk-go/service/ocean/providers/aws/launch_spec.go
@@ -33,6 +33,8 @@ type LaunchSpec struct {
 	Taints                   []*Taint              `json:"taints,omitempty"`
 	Tags                     []*Tag                `json:"tags,omitempty"`
 	AssociatePublicIPAddress *bool                 `json:"associatePublicIpAddress,omitempty"`
+	RestrictScaleDown        *bool                 `json:"restrictScaleDown,omitempty"`
+
 	// Read-only fields.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
@@ -487,6 +489,13 @@ func (o *LaunchSpec) SetStrategy(v *LaunchSpecStrategy) *LaunchSpec {
 func (o *LaunchSpec) SetAssociatePublicIPAddress(v *bool) *LaunchSpec {
 	if o.AssociatePublicIPAddress = v; o.AssociatePublicIPAddress == nil {
 		o.nullFields = append(o.nullFields, "AssociatePublicIPAddress")
+	}
+	return o
+}
+
+func (o *LaunchSpec) SetRestrictScaleDown(v *bool) *LaunchSpec {
+	if o.RestrictScaleDown = v; o.RestrictScaleDown == nil {
+		o.nullFields = append(o.nullFields, "RestrictScaleDown")
 	}
 	return o
 }

--- a/vendor/github.com/spotinst/spotinst-sdk-go/spotinst/version.go
+++ b/vendor/github.com/spotinst/spotinst-sdk-go/spotinst/version.go
@@ -1,7 +1,7 @@
 package spotinst
 
 // SDKVersion is the current version of the SDK.
-const SDKVersion = "1.75.0"
+const SDKVersion = "1.76.0"
 
 // SDKName is the name of the SDK.
 const SDKName = "spotinst-sdk-go"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -513,7 +513,7 @@ github.com/spf13/pflag
 # github.com/spf13/viper v1.7.0
 ## explicit
 github.com/spf13/viper
-# github.com/spotinst/spotinst-sdk-go v1.75.0
+# github.com/spotinst/spotinst-sdk-go v1.76.0
 ## explicit
 github.com/spotinst/spotinst-sdk-go/service/elastigroup
 github.com/spotinst/spotinst-sdk-go/service/elastigroup/providers/aws


### PR DESCRIPTION
### Description
This PR allows users to specify whether the scale-down activities should be restricted in Ocean Launch Spec.

### Usage Example
```yaml
apiVersion: kops.k8s.io/v1alpha2
kind: InstanceGroup
metadata:
  labels:
    ...
    spotinst.io/restrict-scale-down: "true"
  name: ...
spec:
  ...
```