### PR TITLE
Make cluster proportional autoscaler image configurable.

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1867,6 +1867,10 @@ spec:
                     description: CoreDNSImage is used to override the default image
                       used for CoreDNS
                     type: string
+                  cpaImage:
+                    description: CPAImage is used to override the default image used
+                      for Cluster Proportional Autoscaler
+                    type: string
                   cpuRequest:
                     anyOf:
                     - type: integer

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -405,6 +405,8 @@ type KubeDNSConfig struct {
 	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
 	// CoreDNSImage is used to override the default image used for CoreDNS
 	CoreDNSImage string `json:"coreDNSImage,omitempty"`
+	// CPAImage is used to override the default image used for Cluster Proportional Autoscaler
+	CPAImage string `json:"cpaImage,omitempty"`
 	// Domain is the dns domain
 	Domain string `json:"domain,omitempty"`
 	// ExternalCoreFile is used to provide a complete CoreDNS CoreFile by the user - ignores other provided flags which modify the CoreFile.

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -407,6 +407,8 @@ type KubeDNSConfig struct {
 	CacheMaxConcurrent int `json:"cacheMaxConcurrent,omitempty"`
 	// CoreDNSImage is used to override the default image used for CoreDNS
 	CoreDNSImage string `json:"coreDNSImage,omitempty"`
+	// CPAImage is used to override the default image used for Cluster Proportional Autoscaler
+	CPAImage string `json:"cpaImage,omitempty"`
 	// Domain is the dns domain
 	Domain string `json:"domain,omitempty"`
 	// ExternalCoreFile is used to provide a complete CoreDNS CoreFile by the user - ignores other provided flags which modify the CoreFile.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4542,6 +4542,7 @@ func autoConvert_v1alpha2_KubeDNSConfig_To_kops_KubeDNSConfig(in *KubeDNSConfig,
 	out.CacheMaxSize = in.CacheMaxSize
 	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	out.CoreDNSImage = in.CoreDNSImage
+	out.CPAImage = in.CPAImage
 	out.Domain = in.Domain
 	out.ExternalCoreFile = in.ExternalCoreFile
 	out.Image = in.Image
@@ -4574,6 +4575,7 @@ func autoConvert_kops_KubeDNSConfig_To_v1alpha2_KubeDNSConfig(in *kops.KubeDNSCo
 	out.CacheMaxSize = in.CacheMaxSize
 	out.CacheMaxConcurrent = in.CacheMaxConcurrent
 	out.CoreDNSImage = in.CoreDNSImage
+	out.CPAImage = in.CPAImage
 	out.Domain = in.Domain
 	out.ExternalCoreFile = in.ExternalCoreFile
 	out.Image = in.Image

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -27743,7 +27743,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3
+        image: {{ if KubeDNS.CPAImage }}{{ KubeDNS.CPAImage }}{{ else }}k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3{{ end }}
         resources:
             requests:
                 cpu: "20m"
@@ -28720,7 +28720,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3
+        image: {{ if KubeDNS.CPAImage }}{{ KubeDNS.CPAImage }}{{ else }}k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3{{ end }}
         resources:
             requests:
                 cpu: "20m"

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -104,7 +104,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3
+        image: {{ if KubeDNS.CPAImage }}{{ KubeDNS.CPAImage }}{{ else }}k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3{{ end }}
         resources:
             requests:
                 cpu: "20m"

--- a/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml.template
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3
+        image: {{ if KubeDNS.CPAImage }}{{ KubeDNS.CPAImage }}{{ else }}k8s.gcr.io/cpa/cluster-proportional-autoscaler:1.8.3{{ end }}
         resources:
             requests:
                 cpu: "20m"


### PR DESCRIPTION
Similar to how we can configure coreDNS image we will like to configure
cluster Proportional autoscaler so we can use our internal docker
registry rather than gcr.io.