### PR TITLE
Fix file not found error detection in fs:// 

### DIFF
--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vfs
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -114,7 +115,7 @@ func (p *FSPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 // ReadFile implements Path::ReadFile
 func (p *FSPath) ReadFile() ([]byte, error) {
 	file, err := ioutil.ReadFile(p.location)
-	if err == syscall.ENOENT {
+	if errors.Is(err, syscall.ENOENT) {
 		err = os.ErrNotExist
 	}
 	return file, err


### PR DESCRIPTION
The fs:// VFS protocol doesn't detect nonexistent files correctly. This results in files not being found actually bubbling up to the user rather than being treated as if the file doesn't exist.

The [syscall docs](https://pkg.go.dev/syscall#Errno) suggest using `errors.Is`.

Without this fix, `kops update cluster --yes` reports:

```
error reading last kops version used to update: open /path/to/state/foo.k8s.local/kops-version.txt: no such file or directory
```

Given the low impact of this and that kops-version.txt is being introduced in 1.19 I'd propose we cherry-pick this to release-1.19