### PR TITLE
Automated cherry pick of #10566: Fix file not found error detection in fs://

### DIFF
--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vfs
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -114,7 +115,7 @@ func (p *FSPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 // ReadFile implements Path::ReadFile
 func (p *FSPath) ReadFile() ([]byte, error) {
 	file, err := ioutil.ReadFile(p.location)
-	if err == syscall.ENOENT {
+	if errors.Is(err, syscall.ENOENT) {
 		err = os.ErrNotExist
 	}
 	return file, err


### PR DESCRIPTION
Cherry pick of #10566 on release-1.19.

#10566: Fix file not found error detection in fs://

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.