### PR TITLE
Automated cherry pick of #10567: Fix NLB listener -> target group association for TF & CF

### DIFF
--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -1193,7 +1193,7 @@
           {
             "Type": "forward",
             "TargetGroupArn": {
-              "Ref": "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq"
+              "Ref": "AWSElasticLoadBalancingV2TargetGrouptlscomplexexamplecom5nursn"
             }
           }
         ],
@@ -1212,7 +1212,7 @@
           {
             "Type": "forward",
             "TargetGroupArn": {
-              "Ref": "AWSElasticLoadBalancingV2TargetGrouptlscomplexexamplecom5nursn"
+              "Ref": "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq"
             }
           }
         ],

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -438,7 +438,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
 resource "aws_lb_listener" "api-complex-example-com-443" {
   certificate_arn = "arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
   default_action {
-    target_group_arn = aws_lb_target_group.tcp-complex-example-com-vpjolq.id
+    target_group_arn = aws_lb_target_group.tls-complex-example-com-5nursn.id
     type             = "forward"
   }
   load_balancer_arn = aws_lb.api-complex-example-com.id
@@ -449,7 +449,7 @@ resource "aws_lb_listener" "api-complex-example-com-443" {
 
 resource "aws_lb_listener" "api-complex-example-com-8443" {
   default_action {
-    target_group_arn = aws_lb_target_group.tls-complex-example-com-5nursn.id
+    target_group_arn = aws_lb_target_group.tcp-complex-example-com-vpjolq.id
     type             = "forward"
   }
   load_balancer_arn = aws_lb.api-complex-example-com.id


### PR DESCRIPTION
Cherry pick of #10567 on release-1.19.

#10567: Fix NLB listener -> target group association for TF & CF

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.