### PR TITLE
Spotinst: Bump the Ocean Controller to 1.0.70

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -41870,7 +41870,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.69
+        image: spotinst/kubernetes-cluster-controller:1.0.70
         livenessProbe:
           httpGet:
             path: /healthcheck
@@ -41956,6 +41956,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       serviceAccountName: spotinst-kubernetes-cluster-controller
+      dnsPolicy: Default
       tolerations:
       - key: node.kubernetes.io/not-ready
         effect: NoExecute

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -199,7 +199,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.69
+        image: spotinst/kubernetes-cluster-controller:1.0.70
         livenessProbe:
           httpGet:
             path: /healthcheck
@@ -285,6 +285,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       serviceAccountName: spotinst-kubernetes-cluster-controller
+      dnsPolicy: Default
       tolerations:
       - key: node.kubernetes.io/not-ready
         effect: NoExecute

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -645,7 +645,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		{
 			id := "v1.14.0"
 			location := key + "/" + id + ".yaml"
-			version := "1.0.69"
+			version := "1.0.70"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),


### PR DESCRIPTION
This PR upgrades the Ocean Controller to 1.0.70.