### PR TITLE
[DigitalOcean] add e2e tests

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -81,6 +81,7 @@ func (d *deployer) verifyKopsFlags() error {
 	switch d.CloudProvider {
 	case "aws":
 	case "gce":
+	case "digitalocean":
 	default:
 		return errors.New("unsupported --cloud-provider value")
 	}

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/aws"
+	"k8s.io/kops/tests/e2e/kubetest2-kops/do"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/gce"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/util"
 	"sigs.k8s.io/kubetest2/pkg/exec"
@@ -73,8 +74,11 @@ func (d *deployer) Up() error {
 		args = append(args, "--master-size", "e2-standard-2")
 	}
 
-	if d.CloudProvider == "do" {
-		zones := []string{"tor1"}
+	if d.CloudProvider == "digitalocean" {
+		zones, err := do.RandomZones(1)
+		if err != nil {
+			return err
+		}
 		args = append(args, "--zones", strings.Join(zones, ","))
 		args = append(args, "--master-size", "s-8vcpu-16gb")
 	}

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -38,6 +38,20 @@ func (d *deployer) Up() error {
 		return err
 	}
 
+	zones := []string{}
+	imagesize := ""
+	volumesize := "48"
+	if d.CloudProvider == "aws" {
+		zones, err = aws.RandomZones(1)
+		if err != nil {
+			return err
+		}
+		imagesize = "c5.large"
+	} else if d.CloudProvider == "digitalocean" {
+		zones = []string{"tor1"}
+		imagesize = "s-8vcpu-16gb"
+	}
+
 	args := []string{
 		d.KopsBinaryPath, "create", "cluster",
 		"--name", d.ClusterName,
@@ -46,8 +60,10 @@ func (d *deployer) Up() error {
 		"--kubernetes-version", d.KubernetesVersion,
 		"--master-count", "1",
 		"--master-volume-size", "48",
+		"--master-size", imagesize,
+		"--master-volume-size", volumesize,
 		"--node-count", "4",
-		"--node-volume-size", "48",
+		"--node-volume-size", volumesize,
 		"--override", "cluster.spec.nodePortAccess=0.0.0.0/0",
 		"--ssh-public-key", d.SSHPublicKeyPath,
 		"--yes",

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -38,20 +38,6 @@ func (d *deployer) Up() error {
 		return err
 	}
 
-	zones := []string{}
-	imagesize := ""
-	volumesize := "48"
-	if d.CloudProvider == "aws" {
-		zones, err = aws.RandomZones(1)
-		if err != nil {
-			return err
-		}
-		imagesize = "c5.large"
-	} else if d.CloudProvider == "digitalocean" {
-		zones = []string{"tor1"}
-		imagesize = "s-8vcpu-16gb"
-	}
-
 	args := []string{
 		d.KopsBinaryPath, "create", "cluster",
 		"--name", d.ClusterName,
@@ -60,10 +46,8 @@ func (d *deployer) Up() error {
 		"--kubernetes-version", d.KubernetesVersion,
 		"--master-count", "1",
 		"--master-volume-size", "48",
-		"--master-size", imagesize,
-		"--master-volume-size", volumesize,
 		"--node-count", "4",
-		"--node-volume-size", volumesize,
+		"--node-volume-size", "48",
 		"--override", "cluster.spec.nodePortAccess=0.0.0.0/0",
 		"--ssh-public-key", d.SSHPublicKeyPath,
 		"--yes",
@@ -87,6 +71,12 @@ func (d *deployer) Up() error {
 		args = append(args, "--zones", strings.Join(zones, ","))
 
 		args = append(args, "--master-size", "e2-standard-2")
+	}
+
+	if d.CloudProvider == "do" {
+		zones := []string{"tor1"}
+		args = append(args, "--zones", strings.Join(zones, ","))
+		args = append(args, "--master-size", "s-8vcpu-16gb")
 	}
 
 	klog.Info(strings.Join(args, " "))

--- a/tests/e2e/kubetest2-kops/do/zones.go
+++ b/tests/e2e/kubetest2-kops/do/zones.go
@@ -34,7 +34,7 @@ var allZones = []string{
 var ErrNoEligibleRegion = errors.New("No eligible DO region found with enough zones")
 
 // ErrMoreThanOneZone indicates the requested number of zones was more than one
-var ErrMoreThanOneZone = errors.New("More than 1 zone is choosen. DO only works with 1 zone")
+var ErrMoreThanOneZone = errors.New("More than 1 zone is chosen. DO only works with 1 zone")
 
 // RandomZones returns a random set of availability zones within a region
 func RandomZones(count int) ([]string, error) {

--- a/tests/e2e/kubetest2-kops/do/zones.go
+++ b/tests/e2e/kubetest2-kops/do/zones.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"errors"
+	"math/rand"
+)
+
+var allZones = []string{
+	"nyc1",
+	"nyc2",
+	"nyc3",
+	"sfo1",
+	"sfo2",
+	"tor1",
+}
+
+// ErrNoEligibleRegion indicates the requested number of zones is not available in any region
+var ErrNoEligibleRegion = errors.New("No eligible DO region found with enough zones")
+
+// ErrMoreThanOneZone indicates the requested number of zones was more than one
+var ErrMoreThanOneZone = errors.New("More than 1 zone is choosen. DO only works with 1 zone")
+
+// RandomZones returns a random set of availability zones within a region
+func RandomZones(count int) ([]string, error) {
+
+	if count > 1 {
+		return nil, ErrMoreThanOneZone
+	}
+
+	n := rand.Int() % len(allZones)
+	chosenZone := allZones[n]
+
+	chosenZones := make([]string, 0)
+	chosenZones = append(chosenZones, chosenZone)
+
+	return chosenZones, nil
+}


### PR DESCRIPTION
Initial work for adding e2e tests for DO.

Tested locally and it seems to work fine after adding the below command arguments.
` go run kubetest2-kops/main.go --up --cloud-provider digitalocean --cluster-name test.myclustername.com \
        --env KOPS_STATE_STORE=do://***-kops-space \
	--env DIGITALOCEAN_ACCESS_TOKEN=bd5f*****472dae3 \
	--env S3_ENDPOINT=sfo2.digitaloceanspaces.com \
	--env S3_ACCESS_KEY_ID=PPO******NSRW \
	--env S3_SECRET_ACCESS_KEY=rm******oIc \
	--kops-binary-path /home/kops \
	--ssh-public-key ~/.ssh/id_rsa.pub \
	--kubernetes-version 1.19.2`

I'll separately work with @timoreimann and @rifelpet to include the necessary environment variables.