### PR TITLE
Updates to Alpha versions - k8s & kOps

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -90,8 +90,8 @@ spec:
     recommendedVersion: 1.11.10
     requiredVersion: 1.11.10
   kopsVersions:
-  - range: ">=1.19.0-alpha.1"
-    #recommendedVersion: "1.19.0-alpha.1"
+  - range: ">=1.19.0-beta.3"
+    #recommendedVersion: "1.19.0-beta.3"
     #requiredVersion: 1.19.0
     kubernetesVersion: 1.19.7
   - range: ">=1.18.0-alpha.1"

--- a/channels/alpha
+++ b/channels/alpha
@@ -63,10 +63,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.14
+    recommendedVersion: 1.18.15
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.16
+    recommendedVersion: 1.17.17
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
     recommendedVersion: 1.16.15
@@ -93,15 +93,15 @@ spec:
   - range: ">=1.19.0-alpha.1"
     #recommendedVersion: "1.19.0-alpha.1"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.6
+    kubernetesVersion: 1.19.7
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.14
+    kubernetesVersion: 1.18.15
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.16
+    kubernetesVersion: 1.17.17
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.16.0


### PR DESCRIPTION
Updating Kubernetes versions with today's releases:
- https://github.com/kubernetes/kubernetes/releases/tag/v1.17.17
- https://github.com/kubernetes/kubernetes/releases/tag/v1.18.15
- https://github.com/kubernetes/kubernetes/releases/tag/v1.19.7

Also, I noticed that we're still pointing to kOps 1.19-alpha1 while there's already a beta3 version out, so figured we should also bump that one, jic.
- https://github.com/kubernetes/kops/releases/tag/v1.19.0-beta.3