### PR TITLE
Give kubetest2 its own makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include tests/e2e/e2e.mk
 
 # kops source root directory (without trailing /)
-KOPS_ROOT?=$(patsubst %/,%,$(abspath $(dir $(lastword $(MAKEFILE_LIST)))))
+KOPS_ROOT?=$(patsubst %/,%,$(abspath $(dir $(firstword $(MAKEFILE_LIST)))))
 DOCKER_REGISTRY?=gcr.io/must-override
 S3_BUCKET?=s3://must-override/
 UPLOAD_DEST?=$(S3_BUCKET)
@@ -184,26 +185,6 @@ test: ${BINDATA_TARGETS}  # Run tests locally
 .PHONY: test-windows
 test-windows: ${BINDATA_TARGETS}  # Run tests locally
 	go test -v $(go list ./... | grep -v /nodeup/)
-
-.PHONY: test-e2e
-test-e2e:
-	cd /home/prow/go/src/k8s.io/kops/tests/e2e && \
-		export GO111MODULE=on && \
-		go get sigs.k8s.io/kubetest2@latest && \
-		go install ./kubetest2-tester-kops && \
-		go install ./kubetest2-kops
-	kubetest2 kops \
-		-v 2 \
-		--build --up --down \
-		--cloud-provider=aws \
-		--kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops \
-		--kubernetes-version=v1.19.4 \
-		--template-path=tests/e2e/templates/simple.yaml.tmpl \
-		--test=kops \
-		-- \
-		--test-package-version=v1.19.4 \
-		--parallel 25 \
-		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort"
 
 .PHONY: ${DIST}/linux/amd64/nodeup
 ${DIST}/linux/amd64/nodeup: ${BINDATA_TARGETS}

--- a/tests/e2e/e2e.mk
+++ b/tests/e2e/e2e.mk
@@ -1,0 +1,43 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
+.PHONY: test-e2e-aws-simple
+test-e2e-install:
+	cd $(KOPS_ROOT)/tests/e2e && \
+		export GO111MODULE=on && \
+		go get sigs.k8s.io/kubetest2@latest && \
+		go install ./kubetest2-tester-kops && \
+		go install ./kubetest2-kops
+
+# temporary until we update test-infra jobs
+.PHONY: test-e2e
+test-e2e: test-e2e-aws-simple-1-20
+
+.PHONY: test-e2e-aws-simple-1-20
+test-e2e-aws-simple-1-20: test-e2e-install
+	kubetest2 kops \
+		-v 2 \
+		--build --up --down \
+		--cloud-provider=aws \
+		--kops-binary-path=$(KOPS_ROOT)/bazel-bin/cmd/kops/$(GOOS)-$(GOARCH)/kops \
+		--kubernetes-version=v1.20.2 \
+		--template-path=tests/e2e/templates/simple.yaml.tmpl \
+		--test=kops \
+		-- \
+		--test-package-version=v1.20.2 \
+		--parallel 25 \
+		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort"

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/klog/v2 v2.4.0
-	sigs.k8s.io/kubetest2 v0.0.0-20201130212850-d9dad7c8699c
+	sigs.k8s.io/kubetest2 v0.0.0-20210106183352-5a41a5dbafe5
 )

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -1229,6 +1229,7 @@ golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1597,8 +1598,8 @@ sigs.k8s.io/boskos v0.0.0-20200526191642-45fc818e2d00/go.mod h1:L1ubP7d1CCMSQSjK
 sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc/go.mod h1:ZO5RV+VxJS9mb6DvZ1yAjywoyq/wQ8b0vDoZxcIA5kE=
 sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKGhb2sCtAXiT8=
 sigs.k8s.io/controller-runtime v0.5.4/go.mod h1:JZUwSMVbxDupo0lTJSSFP5pimEyxGynROImSsqIOx1A=
-sigs.k8s.io/kubetest2 v0.0.0-20201130212850-d9dad7c8699c h1:SwmDcP7Hj+PlLWS7yIkS+z7gW5sOKZgwUvzJ8bUYabM=
-sigs.k8s.io/kubetest2 v0.0.0-20201130212850-d9dad7c8699c/go.mod h1:NA4zjHQURWeb1eUIymZQN6kKpb65S6D/ga3XiiDHaQM=
+sigs.k8s.io/kubetest2 v0.0.0-20210106183352-5a41a5dbafe5 h1:j1UdMwMRAvGvHFVoQ7TMrQbZxLnKHQLgTlKLFc6rYi4=
+sigs.k8s.io/kubetest2 v0.0.0-20210106183352-5a41a5dbafe5/go.mod h1:XT/MnLvPcrJkJo0+3DGIlXljSZxqvU7HNyXI/ny3Flg=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/mdtoc v1.0.1/go.mod h1:COYBtOjsaCg7o7SC4eaLwEXPuVRSuiVuLLRrHd7kShw=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=


### PR DESCRIPTION
This will help avoid cluttering up the main Makefile even further. I'm imagining we could put all our variants, perhaps even grid combinations (k8s version + distro + networking + cloud). That should greatly simplify the periodic job definitions.

Using GOOS and GOARCH for running the kops binary

Also try deploying and testing against k8s 1.20.2. ~I'm not optimistic based on previous runs but we'll see how it goes this time. I may end up reverting back to 1.19 until we can figure out whats causing the failures.~