### PR TITLE
Use Bazel 3.4.1 for postsubmit jobs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'gcr.io/k8s-testimages/bazelbuild:v20200824-5d057db-2.2.0'
+- name: 'gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-experimental'
   id: images
   entrypoint: make
   env:
@@ -20,7 +20,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'gcr.io/k8s-testimages/bazelbuild:v20200824-5d057db-2.2.0'
+- name: 'gcr.io/k8s-testimages/kubekins-e2e:v20210113-cc576af-experimental'
   id: artifacts
   entrypoint: make
   env:


### PR DESCRIPTION
Presubmits jobs are failing because of missing Bazel 3.4.1 from #10550:
https://testgrid.k8s.io/kops-misc#kops-postsubmit-push-to-staging

There is no `bazelbuild` image for that, so experimenting with `kubekins-e2e` image that is used in presubmit jobs.

/cc @olemarkus @rifelpet 