### PR TITLE
Dial-down logging on flagbuilder

### DIFF
--- a/pkg/flagbuilder/build_flags.go
+++ b/pkg/flagbuilder/build_flags.go
@@ -46,7 +46,7 @@ func BuildFlagsList(options interface{}) ([]string, error) {
 
 	walker := func(path *reflectutils.FieldPath, field *reflect.StructField, val reflect.Value) error {
 		if field == nil {
-			klog.V(8).Infof("ignoring non-field: %s", path)
+			klog.V(10).Infof("ignoring non-field: %s", path)
 			return nil
 		}
 		tag := field.Tag.Get("flag")


### PR DESCRIPTION
We still run nodeup at V=8, so the distinction between V=10 and V=8
matters.

This message really is just development logging, so downgrade to V=10.