### PR TITLE
containerd: Add /etc/crictl config to enable crictl

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -93,6 +93,9 @@ func (b *ContainerdBuilder) Build(c *fi.ModelBuilderContext) error {
 			}
 			c.AddTask(fileTask)
 		}
+
+		// Add configuration file for easier use of crictl
+		b.addCrictlConfig(c)
 	}
 
 	var containerRuntimeVersion string
@@ -277,4 +280,17 @@ func (b *ContainerdBuilder) skipInstall() bool {
 	}
 
 	return d.SkipInstall
+}
+
+// addCritctlConfig creates /etc/crictl.yaml, which lets crictl work out-of-the-box.
+func (b *ContainerdBuilder) addCrictlConfig(c *fi.ModelBuilderContext) {
+	conf := `
+runtime-endpoint: unix:///run/containerd/containerd.sock
+`
+
+	c.AddTask(&nodetasks.File{
+		Path:     "/etc/crictl.yaml",
+		Contents: fi.NewStringResource(conf),
+		Type:     nodetasks.FileType_File,
+	})
 }

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -2,6 +2,12 @@ contents: ""
 path: /etc/containerd/config-kops.toml
 type: file
 ---
+contents: |2
+
+  runtime-endpoint: unix:///run/containerd/containerd.sock
+path: /etc/crictl.yaml
+type: file
+---
 contents: CONTAINERD_OPTS=
 path: /etc/sysconfig/containerd
 type: file


### PR DESCRIPTION
This configuration file means users don't have to pass the endpoint
to run crictl.