### PR TITLE
Exclude terraform.lock.hcl files from Git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ network_closure.sh
 # Terraform plans get put here
 /out/
 .terraform
+.terraform.lock.hcl
 
 # Docker _src sync
 /docker/_src


### PR DESCRIPTION
**What this PR does / why we need it**:
After executing the Terraform v0.14 integration tests, ensure `.terraform.lock.hcl` files are excluded (ignored) from being added to the Git repositiory.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
