### PR TITLE
Validate cluster cloud labels

### DIFF
--- a/pkg/apis/kops/validation/cluster.go
+++ b/pkg/apis/kops/validation/cluster.go
@@ -139,7 +139,7 @@ func validateClusterCloudLabels(cluster *kops.Cluster, fldPath *field.Path) (all
 	for _, reservedKey := range reservedKeys {
 		_, hasKey := labels[reservedKey]
 		if hasKey {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child(reservedKey), fmt.Sprintf("%q is a reserved label and cannot be set in the cluster spec", reservedKey)))
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child(reservedKey), fmt.Sprintf("%q is a reserved label and cannot be used as a custom label", reservedKey)))
 		}
 	}
 
@@ -152,7 +152,7 @@ func validateClusterCloudLabels(cluster *kops.Cluster, fldPath *field.Path) (all
 	for _, reservedPrefix := range reservedPrefixes {
 		for label := range labels {
 			if strings.HasPrefix(label, reservedPrefix) {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child(label), fmt.Sprintf("%q is a reserved label prefix and cannot be set in the cluster spec", reservedPrefix)))
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child(label), fmt.Sprintf("%q is a reserved label prefix and cannot be used as a custom label", reservedPrefix)))
 
 			}
 		}

--- a/pkg/apis/kops/validation/cluster.go
+++ b/pkg/apis/kops/validation/cluster.go
@@ -17,6 +17,9 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
@@ -50,6 +53,8 @@ func ValidateClusterUpdate(obj *kops.Cluster, status *kops.ClusterStatus, old *k
 			}
 		}
 	}
+
+	allErrs = append(allErrs, validateClusterCloudLabels(obj, field.NewPath("spec", "cloudLabels"))...)
 
 	return allErrs
 }
@@ -115,6 +120,42 @@ func validateEtcdMemberUpdate(fp *field.Path, obj kops.EtcdMemberSpec, status *k
 
 	if fi.BoolValue(obj.EncryptedVolume) != fi.BoolValue(old.EncryptedVolume) {
 		allErrs = append(allErrs, field.Forbidden(fp.Child("encryptedVolume"), "encryptedVolume cannot be changed"))
+	}
+
+	return allErrs
+}
+
+func validateClusterCloudLabels(cluster *kops.Cluster, fldPath *field.Path) (allErrs field.ErrorList) {
+	labels := cluster.Spec.CloudLabels
+	if labels == nil {
+		return allErrs
+	}
+
+	reservedKeys := []string{
+		"Name",
+		"KubernetesCluster",
+	}
+
+	for _, reservedKey := range reservedKeys {
+		_, hasKey := labels[reservedKey]
+		if hasKey {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child(reservedKey), fmt.Sprintf("%q is a reserved label and cannot be set in the cluster spec", reservedKey)))
+		}
+	}
+
+	reservedPrefixes := []string{
+		"kops.k8s.io/",
+		"k8s.io/",
+		"kubernetes.io/",
+	}
+
+	for _, reservedPrefix := range reservedPrefixes {
+		for label := range labels {
+			if strings.HasPrefix(label, reservedPrefix) {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child(label), fmt.Sprintf("%q is a reserved label prefix and cannot be set in the cluster spec", reservedPrefix)))
+
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -127,7 +127,7 @@ func ValidateInstanceGroup(g *kops.InstanceGroup, cloud fi.Cloud) field.ErrorLis
 	}
 
 	if g.Spec.CloudLabels != nil {
-		allErrs = append(allErrs, validateCloudLabels(g, field.NewPath("spec", "cloudLabels"))...)
+		allErrs = append(allErrs, validateIGCloudLabels(g, field.NewPath("spec", "cloudLabels"))...)
 	}
 
 	if cloud != nil && cloud.ProviderID() == kops.CloudProviderAWS {
@@ -275,7 +275,7 @@ func validateNodeLabels(labels map[string]string, fldPath *field.Path) (allErrs 
 	return allErrs
 }
 
-func validateCloudLabels(ig *kops.InstanceGroup, fldPath *field.Path) (allErrs field.ErrorList) {
+func validateIGCloudLabels(ig *kops.InstanceGroup, fldPath *field.Path) (allErrs field.ErrorList) {
 	labels := ig.Spec.CloudLabels
 	if labels == nil {
 		return allErrs


### PR DESCRIPTION
Users can now set labels such as `Name` on all resources kOps creates. This breaks consequtive runs of `kops update cluster` as kOps cannot find its resources.

Fixes #10596