### PR TITLE
Provide required --kubernetes-version flags to kubetest2-kops --up

### DIFF
--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -22,6 +22,9 @@ echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
 
 REPO_ROOT=$(git rev-parse --show-toplevel);
 
+OLD_K8S_MARKER=stable-1.19.txt
+NEW_K8S_MARKER=stable-1.20.txt
+
 KUBETEST2_COMMON_ARGS="-v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-} --kops-binary-path=${REPO_ROOT}/bazel-bin/cmd/kops/linux-amd64/kops"
 KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --admin-access=${ADMIN_ACCESS:-}"
 
@@ -40,7 +43,9 @@ function finish {
 }
 trap finish EXIT
 
-kubetest2 kops ${KUBETEST2_COMMON_ARGS} --up
+kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
+		--up \
+		--kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/${OLD_K8S_MARKER}
 
 KUBECONFIG=${HOME}/.kube/config
 TEST_ARGS="--kubeconfig=${KUBECONFIG}"
@@ -61,13 +66,13 @@ kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--cloud-provider=${CLOUD_PROVIDER} \
 		--test=kops \
 		-- \
-		--test-package-version=v1.19.4 \
+		--test-package-marker=${OLD_K8S_MARKER} \
 		--parallel 25 \
 		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort" \
 		--test-args="${TEST_ARGS}"
 
 
-kops set cluster ${CLUSTER_NAME} cluster.spec.kubernetesVersion=1.20.0
+kops set cluster ${CLUSTER_NAME} cluster.spec.kubernetesVersion=https://storage.googleapis.com/kubernetes-release/release/${NEW_K8S_MARKER}
 kops update cluster
 kops update cluster --admin --yes
 


### PR DESCRIPTION
Also use version markers rather than hard-coded patch versions

Also dropping the --kubenretes-version requirement for kubetest2-kops --test because it is never used. Initially I was thinking we could use it to determine the e2e.test version to pull down but the ginkgo tester has its own --test-package-* flags for that. Perhaps in the future we can consolidate them into just the --kubernetes-version flag

Hoping to fix this periodic job: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-upgrade/1351188585260257280

```
 Error: missing required --kubernetes-version flag
```
