### PR TITLE
Kubetest - add networking support + misc fixes

### DIFF
--- a/tests/e2e/e2e.mk
+++ b/tests/e2e/e2e.mk
@@ -23,17 +23,13 @@ test-e2e-install:
 		go install ./kubetest2-tester-kops && \
 		go install ./kubetest2-kops
 
-# temporary until we update test-infra jobs
-.PHONY: test-e2e
-test-e2e: test-e2e-aws-simple-1-20
-
 .PHONY: test-e2e-aws-simple-1-20
 test-e2e-aws-simple-1-20: test-e2e-install
 	kubetest2 kops \
 		-v 2 \
-		--build --up --down \
+		--up --down \
 		--cloud-provider=aws \
-		--kops-binary-path=$(KOPS_ROOT)/bazel-bin/cmd/kops/$(GOOS)-$(GOARCH)/kops \
+		--kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
 		--kubernetes-version=v1.20.2 \
 		--template-path=tests/e2e/templates/simple.yaml.tmpl \
 		--test=kops \

--- a/tests/e2e/e2e.mk
+++ b/tests/e2e/e2e.mk
@@ -36,4 +36,4 @@ test-e2e-aws-simple-1-20: test-e2e-install
 		-- \
 		--test-package-version=v1.20.2 \
 		--parallel 25 \
-		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort"
+		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler"

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/klog/v2 v2.4.0
-	sigs.k8s.io/kubetest2 v0.0.0-20210106183352-5a41a5dbafe5
+	sigs.k8s.io/kubetest2 v0.0.0-20210115020551-4275dd0a0d63
 )

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -1598,8 +1598,6 @@ sigs.k8s.io/boskos v0.0.0-20200526191642-45fc818e2d00/go.mod h1:L1ubP7d1CCMSQSjK
 sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc/go.mod h1:ZO5RV+VxJS9mb6DvZ1yAjywoyq/wQ8b0vDoZxcIA5kE=
 sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKGhb2sCtAXiT8=
 sigs.k8s.io/controller-runtime v0.5.4/go.mod h1:JZUwSMVbxDupo0lTJSSFP5pimEyxGynROImSsqIOx1A=
-sigs.k8s.io/kubetest2 v0.0.0-20210106183352-5a41a5dbafe5 h1:j1UdMwMRAvGvHFVoQ7TMrQbZxLnKHQLgTlKLFc6rYi4=
-sigs.k8s.io/kubetest2 v0.0.0-20210106183352-5a41a5dbafe5/go.mod h1:XT/MnLvPcrJkJo0+3DGIlXljSZxqvU7HNyXI/ny3Flg=
 sigs.k8s.io/kubetest2 v0.0.0-20210115020551-4275dd0a0d63 h1:pHCLLY0QjOp3cBTYCjCQdYfYP8lo+/eSyd3vdWkaQTE=
 sigs.k8s.io/kubetest2 v0.0.0-20210115020551-4275dd0a0d63/go.mod h1:XT/MnLvPcrJkJo0+3DGIlXljSZxqvU7HNyXI/ny3Flg=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -1600,6 +1600,8 @@ sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKG
 sigs.k8s.io/controller-runtime v0.5.4/go.mod h1:JZUwSMVbxDupo0lTJSSFP5pimEyxGynROImSsqIOx1A=
 sigs.k8s.io/kubetest2 v0.0.0-20210106183352-5a41a5dbafe5 h1:j1UdMwMRAvGvHFVoQ7TMrQbZxLnKHQLgTlKLFc6rYi4=
 sigs.k8s.io/kubetest2 v0.0.0-20210106183352-5a41a5dbafe5/go.mod h1:XT/MnLvPcrJkJo0+3DGIlXljSZxqvU7HNyXI/ny3Flg=
+sigs.k8s.io/kubetest2 v0.0.0-20210115020551-4275dd0a0d63 h1:pHCLLY0QjOp3cBTYCjCQdYfYP8lo+/eSyd3vdWkaQTE=
+sigs.k8s.io/kubetest2 v0.0.0-20210115020551-4275dd0a0d63/go.mod h1:XT/MnLvPcrJkJo0+3DGIlXljSZxqvU7HNyXI/ny3Flg=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/mdtoc v1.0.1/go.mod h1:COYBtOjsaCg7o7SC4eaLwEXPuVRSuiVuLLRrHd7kShw=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -65,6 +65,9 @@ func (d *deployer) verifyBuildFlags() error {
 	if !fi.Mode().IsDir() {
 		return errors.New("--kops-root must be a directory")
 	}
+	if d.KopsVersionMarker != "" {
+		return errors.New("cannot use --kops-version-marker with --build")
+	}
 
 	d.BuildOptions.KopsRoot = d.KopsRoot
 	d.BuildOptions.StageLocation = d.StageLocation

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -51,11 +51,6 @@ func (d *deployer) initialize() error {
 			return fmt.Errorf("init failed to check up flags: %v", err)
 		}
 	}
-	if d.commonOptions.ShouldUp() || d.commonOptions.ShouldTest() {
-		if d.KubernetesVersion == "" {
-			return errors.New("missing required --kubernetes-version flag")
-		}
-	}
 	return nil
 }
 

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -41,6 +41,9 @@ type deployer struct {
 	KopsRoot      string `flag:"kops-root" desc:"Path to root of the kops repo. Used with --build."`
 	StageLocation string `flag:"stage-location" desc:"Storage location for kops artifacts. Only gs:// paths are supported."`
 
+	KopsVersionMarker string `flag:"kops-version-marker" desc:"The URL to the kops version marker. Conflicts with --build and --kops-binary-path"`
+	KopsBaseURL       string `flag:"-"`
+
 	ClusterName    string   `flag:"cluster-name" desc:"The FQDN to use for the cluster name"`
 	CloudProvider  string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
 	Env            []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -45,6 +45,7 @@ type deployer struct {
 	CloudProvider  string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
 	Env            []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
 	KopsBinaryPath string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
+	Networking     string   `flag:"networking" desc:"The networking mode to use"`
 	StateStore     string   `flag:"-"`
 
 	TemplatePath string `flag:"template-path" desc:"The path to the manifest template used for cluster creation"`

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/kops/tests/e2e/kubetest2-kops/aws"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/do"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/gce"
-	"k8s.io/kops/tests/e2e/kubetest2-kops/util"
+	"k8s.io/kops/tests/e2e/pkg/util"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -124,6 +124,10 @@ func (d *deployer) createCluster(zones []string, adminAccess string) error {
 		args = append(args, "--master-size", "s-8vcpu-16gb")
 	}
 
+	if d.Networking != "" {
+		args = append(args, "--networking", d.Networking)
+	}
+
 	klog.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(d.env()...)

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deployer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	osexec "os/exec"
@@ -170,7 +171,9 @@ func (d *deployer) verifyUpFlags() error {
 	if d.SSHPublicKeyPath == "" {
 		d.SSHPublicKeyPath = os.Getenv("AWS_SSH_PUBLIC_KEY_FILE")
 	}
-
+	if d.KubernetesVersion == "" {
+		return errors.New("missing required --kubernetes-version flag")
+	}
 	return nil
 }
 

--- a/tests/e2e/pkg/kops/download.go
+++ b/tests/e2e/pkg/kops/download.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kops
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime"
+
+	"k8s.io/kops/tests/e2e/pkg/util"
+)
+
+// DownloadKops will download the kops binary from the version marker URL
+// Returning the path to the local kops binary and the URL to use for KOPS_BASE_URL
+// Example markerURL: https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+func DownloadKops(markerURL string) (string, string, error) {
+	var b bytes.Buffer
+	if err := util.HTTPGETWithHeaders(markerURL, nil, &b); err != nil {
+		return "", "", err
+	}
+	kopsBaseURL := b.String()
+
+	tmp, err := ioutil.TempFile("", "kops")
+	if err != nil {
+		return "", "", err
+	}
+
+	kopsURL := fmt.Sprintf("%v/%v/%v/kops", kopsBaseURL, runtime.GOOS, runtime.GOARCH)
+	if err := util.HTTPGETWithHeaders(kopsURL, nil, tmp); err != nil {
+		return "", "", err
+	}
+	if err := tmp.Close(); err != nil {
+		return "", "", err
+	}
+	if err := os.Chmod(tmp.Name(), 0755); err != nil {
+		return "", "", err
+	}
+	return tmp.Name(), kopsBaseURL, nil
+}

--- a/tests/e2e/pkg/util/http.go
+++ b/tests/e2e/pkg/util/http.go
@@ -32,8 +32,8 @@ func init() {
 	httpTransport.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 }
 
-// httpGETWithHeaders writes the response of an HTTP GET request
-func httpGETWithHeaders(url string, headers map[string]string, writer io.Writer) error {
+// HTTPGETWithHeaders writes the response of an HTTP GET request
+func HTTPGETWithHeaders(url string, headers map[string]string, writer io.Writer) error {
 	klog.Infof("curl %s", url)
 	c := &http.Client{Transport: httpTransport}
 	req, err := http.NewRequest("GET", url, nil)

--- a/tests/e2e/pkg/util/publicip.go
+++ b/tests/e2e/pkg/util/publicip.go
@@ -37,7 +37,7 @@ var externalIPServiceURLs = []string{
 func ExternalIPRange() (string, error) {
 	var b bytes.Buffer
 
-	err := httpGETWithHeaders(externalIPMetadataURL, map[string]string{"Metadata-Flavor": "Google"}, &b)
+	err := HTTPGETWithHeaders(externalIPMetadataURL, map[string]string{"Metadata-Flavor": "Google"}, &b)
 	if err != nil {
 		// This often fails due to workload identity
 		log.Printf("failed to get external ip from metadata service: %v", err)
@@ -50,7 +50,7 @@ func ExternalIPRange() (string, error) {
 	for attempt := 0; attempt < 5; attempt++ {
 		for _, u := range externalIPServiceURLs {
 			b.Reset()
-			err = httpGETWithHeaders(u, nil, &b)
+			err = HTTPGETWithHeaders(u, nil, &b)
 			if err != nil {
 				// The external service may well be down
 				log.Printf("failed to get external ip from %s: %v", u, err)

--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -22,9 +22,6 @@ echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
 
 REPO_ROOT=$(git rev-parse --show-toplevel);
 
-OLD_K8S_MARKER=stable-1.19.txt
-NEW_K8S_MARKER=stable-1.20.txt
-
 KUBETEST2_COMMON_ARGS="-v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-} --kops-binary-path=${REPO_ROOT}/bazel-bin/cmd/kops/linux-amd64/kops"
 KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --admin-access=${ADMIN_ACCESS:-}"
 
@@ -45,7 +42,7 @@ trap finish EXIT
 
 kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--up \
-		--kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/${OLD_K8S_MARKER}
+		--kubernetes-version=v1.19.7
 
 KUBECONFIG=${HOME}/.kube/config
 TEST_ARGS="--kubeconfig=${KUBECONFIG}"
@@ -66,13 +63,13 @@ kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--cloud-provider=${CLOUD_PROVIDER} \
 		--test=kops \
 		-- \
-		--test-package-marker=${OLD_K8S_MARKER} \
+		--test-package-version=v1.19.7 \
 		--parallel 25 \
 		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort" \
 		--test-args="${TEST_ARGS}"
 
 
-kops set cluster ${CLUSTER_NAME} cluster.spec.kubernetesVersion=https://storage.googleapis.com/kubernetes-release/release/${NEW_K8S_MARKER}
+kops set cluster ${CLUSTER_NAME} cluster.spec.kubernetesVersion=v1.20.2
 kops update cluster
 kops update cluster --admin --yes
 

--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -42,7 +42,8 @@ trap finish EXIT
 
 kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--up \
-		--kubernetes-version=v1.19.7
+		--kubernetes-version=v1.19.7 \
+    --networking calico
 
 KUBECONFIG=${HOME}/.kube/config
 TEST_ARGS="--kubeconfig=${KUBECONFIG}"

--- a/tests/e2e/templates/simple.yaml.tmpl
+++ b/tests/e2e/templates/simple.yaml.tmpl
@@ -26,7 +26,7 @@ spec:
   masterPublicName: api.{{.clusterName}}
   networkCIDR: 172.20.0.0/16
   networking:
-    kubenet: {}
+    calico: {}
   nodePortAccess:
     - 0.0.0.0/0
   nonMasqueradeCIDR: 100.64.0.0/10


### PR DESCRIPTION
switch to using version markers for the simple aws kubetest2 job

only require --kubernetes-version for --up rather than --up or --test