### PR TITLE
feat: implement azure get api ingress status fn

### DIFF
--- a/docs/getting_started/azure.md
+++ b/docs/getting_started/azure.md
@@ -174,7 +174,7 @@ The command line flags prefixed with `--azure-` are for
 Azure-specific configurations.
 
 ```bash
-$ export KOPS_FEATURE_FLAGS=AlphaAllowAzure
+$ export KOPS_FEATURE_FLAGS=Azure
 
 $ kops create cluster \
   --cloud azure \

--- a/upup/pkg/fi/cloudup/azure/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/azure/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "azure_cloud.go",
         "azure_utils.go",
         "disk.go",
+        "networkinterface.go",
         "resourcegroup.go",
         "roleassignment.go",
         "routetable.go",

--- a/upup/pkg/fi/cloudup/azure/networkinterface.go
+++ b/upup/pkg/fi/cloudup/azure/networkinterface.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-06-01/network"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+// NetworkInterfacesClient is a client for managing Network Interfaces.
+type NetworkInterfacesClient interface {
+	ListScaleSetsNetworkInterfaces(ctx context.Context, resourceGroupName, vmssName string) ([]network.Interface, error)
+}
+
+type networkInterfacesClientImpl struct {
+	c *network.InterfacesClient
+}
+
+var _ NetworkInterfacesClient = &networkInterfacesClientImpl{}
+
+func (c *networkInterfacesClientImpl) ListScaleSetsNetworkInterfaces(ctx context.Context, resourceGroupName, vmssName string) ([]network.Interface, error) {
+	var l []network.Interface
+	for iter, err := c.c.ListVirtualMachineScaleSetNetworkInterfacesComplete(ctx, resourceGroupName, vmssName); iter.NotDone(); err = iter.Next() {
+		if err != nil {
+			return nil, err
+		}
+		l = append(l, iter.Value())
+	}
+	return l, nil
+}
+
+func newNetworkInterfacesClientImpl(subscriptionID string, authorizer autorest.Authorizer) *networkInterfacesClientImpl {
+	c := network.NewInterfacesClient(subscriptionID)
+	c.Authorizer = authorizer
+	return &networkInterfacesClientImpl{
+		c: &c,
+	}
+}

--- a/upup/pkg/fi/cloudup/azuretasks/testing.go
+++ b/upup/pkg/fi/cloudup/azuretasks/testing.go
@@ -46,15 +46,16 @@ const (
 
 // MockAzureCloud is a mock implementation of AzureCloud.
 type MockAzureCloud struct {
-	Location              string
-	ResourceGroupsClient  *MockResourceGroupsClient
-	VirtualNetworksClient *MockVirtualNetworksClient
-	SubnetsClient         *MockSubnetsClient
-	RouteTablesClient     *MockRouteTablesClient
-	VMScaleSetsClient     *MockVMScaleSetsClient
-	VMScaleSetVMsClient   *MockVMScaleSetVMsClient
-	DisksClient           *MockDisksClient
-	RoleAssignmentsClient *MockRoleAssignmentsClient
+	Location                string
+	ResourceGroupsClient    *MockResourceGroupsClient
+	VirtualNetworksClient   *MockVirtualNetworksClient
+	SubnetsClient           *MockSubnetsClient
+	RouteTablesClient       *MockRouteTablesClient
+	VMScaleSetsClient       *MockVMScaleSetsClient
+	VMScaleSetVMsClient     *MockVMScaleSetVMsClient
+	DisksClient             *MockDisksClient
+	RoleAssignmentsClient   *MockRoleAssignmentsClient
+	NetworkInterfacesClient *MockNetworkInterfacesClient
 }
 
 var _ azure.AzureCloud = &MockAzureCloud{}
@@ -86,6 +87,9 @@ func NewMockAzureCloud(location string) *MockAzureCloud {
 		},
 		RoleAssignmentsClient: &MockRoleAssignmentsClient{
 			RAs: map[string]authz.RoleAssignment{},
+		},
+		NetworkInterfacesClient: &MockNetworkInterfacesClient{
+			NIs: map[string]network.Interface{},
 		},
 	}
 }
@@ -193,6 +197,11 @@ func (c *MockAzureCloud) Disk() azure.DisksClient {
 // RoleAssignment returns the role assignment client.
 func (c *MockAzureCloud) RoleAssignment() azure.RoleAssignmentsClient {
 	return c.RoleAssignmentsClient
+}
+
+// NetworkInterface returns the network interface client.
+func (c *MockAzureCloud) NetworkInterface() azure.NetworkInterfacesClient {
+	return c.NetworkInterfacesClient
 }
 
 // MockResourceGroupsClient is a mock implementation of resource group client.
@@ -478,4 +487,21 @@ func (c *MockRoleAssignmentsClient) Delete(ctx context.Context, scope, raName st
 	}
 	delete(c.RAs, raName)
 	return nil
+}
+
+// MockNetworkInterfacesClient is a mock implementation of network interfaces client.
+type MockNetworkInterfacesClient struct {
+	NIs map[string]network.Interface
+}
+
+var _ azure.NetworkInterfacesClient = &MockNetworkInterfacesClient{}
+
+// List returns a slice of VM Scale Set Network Interfaces.
+func (c *MockNetworkInterfacesClient) ListScaleSetsNetworkInterfaces(ctx context.Context, resourceGroupName, vmssName string) ([]network.Interface, error) {
+	// Ignore resourceGroupName and vmssName for simplicity.
+	var l []network.Interface
+	for _, ni := range c.NIs {
+		l = append(l, ni)
+	}
+	return l, nil
 }


### PR DESCRIPTION
Fix:
- Updates azure getting started doc to instruct correct feature flag value

Feature:
- Creates azureup network interfaces client with List method

Update:
- Uses vmScaleSet client and new network interfaces client to get masters ip for api ingress status