### PR TITLE
Increase CoreDNS default ttl

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -28186,6 +28186,7 @@ data:
         kubernetes {{ KubeDNS.Domain }}. in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
+          ttl 30
         }
         prometheus :9153
         forward . /etc/resolv.conf {

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -70,6 +70,7 @@ data:
         kubernetes {{ KubeDNS.Domain }}. in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
+          ttl 30
         }
         prometheus :9153
         forward . /etc/resolv.conf {

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 1.4.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 0af83c370d13df45c6a2db67fa8f28e41502b6e1
+    manifestHash: c39ee62b44bc391d426293c951bfcdbbd28950c9
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 1.4.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 0af83c370d13df45c6a2db67fa8f28e41502b6e1
+    manifestHash: c39ee62b44bc391d426293c951bfcdbbd28950c9
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 1.4.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 0af83c370d13df45c6a2db67fa8f28e41502b6e1
+    manifestHash: c39ee62b44bc391d426293c951bfcdbbd28950c9
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 1.4.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 0af83c370d13df45c6a2db67fa8f28e41502b6e1
+    manifestHash: c39ee62b44bc391d426293c951bfcdbbd28950c9
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io


### PR DESCRIPTION
Increase the CoreDNS default ttl to be inline with kubernetes upstream https://github.com/kubernetes/kubernetes/pull/76238 and the previous kube-dns ttl.


We switching from kube-dns to CoreDNS, we noticed a visible bump in coredns-nodelocal request duration and an increase in cache misses.

![image](https://user-images.githubusercontent.com/864578/105092023-fcf34280-5aa0-11eb-98b5-9c51e10549f2.png)
![image](https://user-images.githubusercontent.com/864578/105092051-067caa80-5aa1-11eb-823b-92d1af5bc94f.png)

This change should make the switch less impactful for others.
