### PR TITLE
Add support for container-log-max-size/files with kubelet

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2236,6 +2236,16 @@ spec:
                     description: configureCBR0 enables the kubelet to configure cbr0
                       based on Node.Spec.PodCIDR.
                     type: boolean
+                  containerLogMaxFiles:
+                    description: ContainerLogMaxFiles is the maximum number of container
+                      log files that can be present for a container. The number must
+                      be >= 2.
+                    format: int32
+                    type: integer
+                  containerLogMaxSize:
+                    description: ContainerLogMaxSize is the maximum size (e.g. 10Mi)
+                      of container log file before it is rotated.
+                    type: string
                   cpuCFSQuota:
                     description: CPUCFSQuota enables CPU CFS quota enforcement for
                       containers that specify CPU limits
@@ -2628,6 +2638,16 @@ spec:
                     description: configureCBR0 enables the kubelet to configure cbr0
                       based on Node.Spec.PodCIDR.
                     type: boolean
+                  containerLogMaxFiles:
+                    description: ContainerLogMaxFiles is the maximum number of container
+                      log files that can be present for a container. The number must
+                      be >= 2.
+                    format: int32
+                    type: integer
+                  containerLogMaxSize:
+                    description: ContainerLogMaxSize is the maximum size (e.g. 10Mi)
+                      of container log file before it is rotated.
+                    type: string
                   cpuCFSQuota:
                     description: CPUCFSQuota enables CPU CFS quota enforcement for
                       containers that specify CPU limits

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -312,6 +312,16 @@ spec:
                     description: configureCBR0 enables the kubelet to configure cbr0
                       based on Node.Spec.PodCIDR.
                     type: boolean
+                  containerLogMaxFiles:
+                    description: ContainerLogMaxFiles is the maximum number of container
+                      log files that can be present for a container. The number must
+                      be >= 2.
+                    format: int32
+                    type: integer
+                  containerLogMaxSize:
+                    description: ContainerLogMaxSize is the maximum size (e.g. 10Mi)
+                      of container log file before it is rotated.
+                    type: string
                   cpuCFSQuota:
                     description: CPUCFSQuota enables CPU CFS quota enforcement for
                       containers that specify CPU limits

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -211,6 +211,10 @@ type KubeletConfigSpec struct {
 	EventQPS *int32 `json:"eventQPS,omitempty" flag:"event-qps" flag-empty:"0"`
 	// EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
 	EventBurst *int32 `json:"eventBurst,omitempty" flag:"event-burst"`
+	// ContainerLogMaxSize is the maximum size (e.g. 10Mi) of container log file before it is rotated.
+	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty" flag:"container-log-max-size"`
+	// ContainerLogMaxFiles is the maximum number of container log files that can be present for a container. The number must be >= 2.
+	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty" flag:"container-log-max-files"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -211,6 +211,10 @@ type KubeletConfigSpec struct {
 	EventQPS *int32 `json:"eventQPS,omitempty" flag:"event-qps" flag-empty:"0"`
 	// EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
 	EventBurst *int32 `json:"eventBurst,omitempty" flag:"event-burst"`
+	// ContainerLogMaxSize is the maximum size (e.g. 10Mi) of container log file before it is rotated.
+	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty" flag:"container-log-max-size"`
+	// ContainerLogMaxFiles is the maximum number of container log files that can be present for a container. The number must be >= 2.
+	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty" flag:"container-log-max-files"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4853,6 +4853,8 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.HousekeepingInterval = in.HousekeepingInterval
 	out.EventQPS = in.EventQPS
 	out.EventBurst = in.EventBurst
+	out.ContainerLogMaxSize = in.ContainerLogMaxSize
+	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
 	return nil
 }
 
@@ -4944,6 +4946,8 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.HousekeepingInterval = in.HousekeepingInterval
 	out.EventQPS = in.EventQPS
 	out.EventBurst = in.EventBurst
+	out.ContainerLogMaxSize = in.ContainerLogMaxSize
+	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3274,6 +3274,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ContainerLogMaxFiles != nil {
+		in, out := &in.ContainerLogMaxFiles, &out.ContainerLogMaxFiles
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3456,6 +3456,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ContainerLogMaxFiles != nil {
+		in, out := &in.ContainerLogMaxFiles, &out.ContainerLogMaxFiles
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Adding log rotation and log retention options for containerd:
xRef: https://github.com/kubernetes/kubernetes/pull/59898

Kubelet defaults:
```go
	if obj.ContainerLogMaxSize == "" {
		obj.ContainerLogMaxSize = "10Mi"
	}
	if obj.ContainerLogMaxFiles == nil {
		obj.ContainerLogMaxFiles = utilpointer.Int32Ptr(5)
	}
```