### PR TITLE
Use kops binary built by kubetest2-kops in upgrade script

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -60,6 +60,14 @@ func (d *deployer) initialize() error {
 		d.KopsBinaryPath = binaryPath
 		d.KopsBaseURL = baseURL
 	}
+	// These environment variables are defined by the "preset-aws-ssh" prow preset
+	// https://github.com/kubernetes/test-infra/blob/3d3b325c98b739b526ba5d93ce21c90a05e1f46d/config/prow/config.yaml#L653-L670
+	if d.SSHPrivateKeyPath == "" {
+		d.SSHPrivateKeyPath = os.Getenv("AWS_SSH_PRIVATE_KEY_FILE")
+	}
+	if d.SSHPublicKeyPath == "" {
+		d.SSHPublicKeyPath = os.Getenv("AWS_SSH_PUBLIC_KEY_FILE")
+	}
 	return nil
 }
 

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -19,7 +19,6 @@ package deployer
 import (
 	"errors"
 	"fmt"
-	"os"
 	osexec "os/exec"
 	"strings"
 
@@ -163,14 +162,6 @@ func (d *deployer) IsUp() (bool, error) {
 
 // verifyUpFlags ensures fields are set for creation of the cluster
 func (d *deployer) verifyUpFlags() error {
-	// These environment variables are defined by the "preset-aws-ssh" prow preset
-	// https://github.com/kubernetes/test-infra/blob/3d3b325c98b739b526ba5d93ce21c90a05e1f46d/config/prow/config.yaml#L653-L670
-	if d.SSHPrivateKeyPath == "" {
-		d.SSHPrivateKeyPath = os.Getenv("AWS_SSH_PRIVATE_KEY_FILE")
-	}
-	if d.SSHPublicKeyPath == "" {
-		d.SSHPublicKeyPath = os.Getenv("AWS_SSH_PUBLIC_KEY_FILE")
-	}
 	if d.KubernetesVersion == "" {
 		return errors.New("missing required --kubernetes-version flag")
 	}

--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -21,6 +21,7 @@ set -o pipefail
 echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
 
 REPO_ROOT=$(git rev-parse --show-toplevel);
+PATH=$REPO_ROOT/bazel-bin/cmd/kops/$(go env GOOS)-$(go env GOARCH)/kops:$PATH
 
 KUBETEST2_COMMON_ARGS="-v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-} --kops-binary-path=${REPO_ROOT}/bazel-bin/cmd/kops/linux-amd64/kops"
 KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --admin-access=${ADMIN_ACCESS:-}"


### PR DESCRIPTION
fixing https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-upgrade/1351734337896189952#1:build-log.txt%3A929

Also moving some ssh key flag default lookups to happen for all kubetest2-kops commands rather than only ones specifying --up. this should fix the error a few lines below that ^^ `error reading private key "": open : no such file or directory`