### PR TITLE
kubetest2 upgrade script - PATH needs to be a directory

### DIFF
--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -21,7 +21,7 @@ set -o pipefail
 echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
 
 REPO_ROOT=$(git rev-parse --show-toplevel);
-PATH=$REPO_ROOT/bazel-bin/cmd/kops/$(go env GOOS)-$(go env GOARCH)/kops:$PATH
+PATH=$REPO_ROOT/bazel-bin/cmd/kops/$(go env GOOS)-$(go env GOARCH):$PATH
 
 KUBETEST2_COMMON_ARGS="-v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-} --kops-binary-path=${REPO_ROOT}/bazel-bin/cmd/kops/linux-amd64/kops"
 KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --admin-access=${ADMIN_ACCESS:-}"


### PR DESCRIPTION
another attempt at fixing https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-upgrade/1351855654456791040