### PR TITLE
Automated cherry pick of #10610: Increase CoreDNS default ttl

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1534,6 +1534,7 @@ data:
         kubernetes {{ KubeDNS.Domain }}. in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
+          ttl 30
         }
         prometheus :9153
         forward . /etc/resolv.conf {

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -70,6 +70,7 @@ data:
         kubernetes {{ KubeDNS.Domain }}. in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa
+          ttl 30
         }
         prometheus :9153
         forward . /etc/resolv.conf {


### PR DESCRIPTION
Cherry pick of #10610 on release-1.19.

#10610: Increase CoreDNS default ttl

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.