### PR TITLE
kubetest2 - Add support for specifying a kubernetes version marker file

### DIFF
--- a/tests/e2e/e2e.mk
+++ b/tests/e2e/e2e.mk
@@ -30,10 +30,10 @@ test-e2e-aws-simple-1-20: test-e2e-install
 		--up --down \
 		--cloud-provider=aws \
 		--kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
-		--kubernetes-version=v1.20.2 \
+		--kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
 		--template-path=tests/e2e/templates/simple.yaml.tmpl \
 		--test=kops \
 		-- \
-		--test-package-version=v1.20.2 \
+		--test-package-marker=stable-1.20.txt \
 		--parallel 25 \
 		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler"

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -3,6 +3,7 @@ module k8s.io/kops/tests/e2e
 go 1.15
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/octago/sflags v0.2.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.3.0

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -169,6 +169,7 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kops/tests/e2e/kubetest2-kops/do"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/gce"
 	"k8s.io/kops/tests/e2e/pkg/util"
+	"k8s.io/kops/tests/e2e/pkg/version"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
@@ -165,6 +166,13 @@ func (d *deployer) verifyUpFlags() error {
 	if d.KubernetesVersion == "" {
 		return errors.New("missing required --kubernetes-version flag")
 	}
+
+	v, err := version.ParseKubernetesVersion(d.KubernetesVersion)
+	if err != nil {
+		return err
+	}
+	d.KubernetesVersion = v
+
 	return nil
 }
 

--- a/tests/e2e/pkg/version/kubernetes.go
+++ b/tests/e2e/pkg/version/kubernetes.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/blang/semver"
+	"k8s.io/kops/tests/e2e/pkg/util"
+)
+
+// ParseKubernetesVersion will parse the provided k8s version
+// Either a semver or marker URL is accepted
+func ParseKubernetesVersion(version string) (string, error) {
+	if _, err := url.Parse(version); err == nil {
+		var b bytes.Buffer
+		err = util.HTTPGETWithHeaders(version, nil, &b)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(b.String()), nil
+	}
+	if _, err := semver.ParseTolerant(version); err == nil {
+		return version, nil
+	}
+	return "", fmt.Errorf("unexpected kubernetes version: %v", version)
+}


### PR DESCRIPTION
This way we can provide a marker url (like in e2e.mk) rather than hard-coding patch versions. 