### PR TITLE
kubetest 2 - fix parsing of k8s version semver values

### DIFF
--- a/tests/e2e/pkg/version/kubernetes.go
+++ b/tests/e2e/pkg/version/kubernetes.go
@@ -29,6 +29,9 @@ import (
 // ParseKubernetesVersion will parse the provided k8s version
 // Either a semver or marker URL is accepted
 func ParseKubernetesVersion(version string) (string, error) {
+	if _, err := semver.ParseTolerant(version); err == nil {
+		return version, nil
+	}
 	if _, err := url.Parse(version); err == nil {
 		var b bytes.Buffer
 		err = util.HTTPGETWithHeaders(version, nil, &b)
@@ -36,9 +39,6 @@ func ParseKubernetesVersion(version string) (string, error) {
 			return "", err
 		}
 		return strings.TrimSpace(b.String()), nil
-	}
-	if _, err := semver.ParseTolerant(version); err == nil {
-		return version, nil
 	}
 	return "", fmt.Errorf("unexpected kubernetes version: %v", version)
 }


### PR DESCRIPTION
it turns out semver strings parse as URLs, so try parsing values as a semver first before falling back to URL.

See https://play.golang.org/p/ta_6cUzd8eH

fixes https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-upgrade/1352098187967467520#1:build-log.txt%3A361