### PR TITLE
Automated cherry pick of #10583: Install dbus if needed for protokube with kope.io

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/util/pkg/architectures"
+	"k8s.io/kops/util/pkg/distributions"
 	"k8s.io/kops/util/pkg/proxy"
 
 	"github.com/blang/semver/v4"
@@ -100,6 +101,13 @@ func (t *ProtokubeBuilder) Build(c *fi.ModelBuilderContext) error {
 		return err
 	}
 	c.AddTask(service)
+
+	// DBUS is needed for the /var/run/dbus mount on kope.io images (based on Debian 9),
+	// at least until we can move to etcd-manager or start protokube as a service
+	// See https://github.com/kubernetes/kops/issues/10122#issuecomment-752969613
+	if t.Distribution == distributions.DistributionDebian9 {
+		c.AddTask(&nodetasks.Package{Name: "dbus"})
+	}
 
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #10583 on release-1.19.

#10583: Install dbus if needed for protokube with kope.io

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.