### PR TITLE
Spotinst: Avoid unnecessary duplication of tasks

### DIFF
--- a/pkg/model/spotinstmodel/instance_group.go
+++ b/pkg/model/spotinstmodel/instance_group.go
@@ -376,9 +376,6 @@ func (b *InstanceGroupModelBuilder) buildOcean(c *fi.ModelBuilderContext, igs ..
 		klog.V(4).Infof("Detected default launch spec: %q", b.AutoscalingGroupName(ig))
 	}
 
-	// Rename the instance group to avoid duplicate tasks with same name.
-	ig.Name = fi.StringValue(ocean.Name)
-
 	// Image.
 	ocean.ImageID = fi.String(ig.Spec.Image)
 
@@ -493,8 +490,8 @@ func (b *InstanceGroupModelBuilder) buildOcean(c *fi.ModelBuilderContext, igs ..
 	}
 
 	// Create a Launch Spec for each instance group.
-	for _, ig := range igs {
-		if err := b.buildLaunchSpec(c, ig, ocean); err != nil {
+	for _, g := range igs {
+		if err := b.buildLaunchSpec(c, g, ig, ocean); err != nil {
 			return fmt.Errorf("error building launch spec: %v", err)
 		}
 	}
@@ -506,7 +503,7 @@ func (b *InstanceGroupModelBuilder) buildOcean(c *fi.ModelBuilderContext, igs ..
 }
 
 func (b *InstanceGroupModelBuilder) buildLaunchSpec(c *fi.ModelBuilderContext,
-	ig *kops.InstanceGroup, ocean *spotinsttasks.Ocean) (err error) {
+	ig, igOcean *kops.InstanceGroup, ocean *spotinsttasks.Ocean) (err error) {
 
 	klog.V(4).Infof("Building instance group as LaunchSpec: %q", b.AutoscalingGroupName(ig))
 	launchSpec := &spotinsttasks.LaunchSpec{
@@ -544,9 +541,13 @@ func (b *InstanceGroupModelBuilder) buildLaunchSpec(c *fi.ModelBuilderContext,
 	ocean.MaxSize = fi.Int64(fi.Int64Value(ocean.MaxSize) + fi.Int64Value(maxSize))
 
 	// User data.
-	launchSpec.UserData, err = b.BootstrapScriptBuilder.ResourceNodeUp(c, ig)
-	if err != nil {
-		return fmt.Errorf("error building user data: %v", err)
+	if ig.Name == igOcean.Name {
+		launchSpec.UserData = ocean.UserData
+	} else {
+		launchSpec.UserData, err = b.BootstrapScriptBuilder.ResourceNodeUp(c, ig)
+		if err != nil {
+			return fmt.Errorf("error building user data: %v", err)
+		}
 	}
 
 	// Instance profile.


### PR DESCRIPTION
This PR fixes the regression introduced by #9699 ([reported](https://github.com/kubernetes/kops/pull/9699/files#r562026418) by @povils): renaming the instance group results in nodeup failing to start with the following errors:
```
$ journalctl --no-pager -o cat -u kops-configuration
Starting Run kops bootstrap (nodeup)...
nodeup version 1.20.0-alpha.1
I0121 17:47:52.707955    1846 s3context.go:213] found bucket in region "us-west-2"
I0121 17:47:52.708041    1846 s3fs.go:290] Reading file "s3://<CONFIG_BASE>/cluster.spec"
I0121 17:47:52.742606    1846 s3fs.go:290] Reading file "s3://<CONFIG_BASE>/instancegroup/nodes.<CLUSTER_NAME>"
W0121 17:47:52.750671    1846 main.go:133] got error running nodeup (will retry in 30s): error loading InstanceGroup "s3://<CONFIG_BASE>/instancegroup/nodes.<CLUSTER_NAME>": file does not exist
```