### PR TITLE
kubetest2 - increase validation timeout for the upgrade scenario

### DIFF
--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -76,6 +76,6 @@ kops update cluster
 kops update cluster --admin --yes
 
 kops rolling-update cluster
-kops rolling-update cluster --yes
+kops rolling-update cluster --yes --validation-timeout 30m
 
 kops validate cluster


### PR DESCRIPTION
Due to https://github.com/projectcalico/calico/issues/3751, Calico needs longer interval for validating masters.