### PR TITLE
Add startup probe for calico-kube-controllers

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -37929,6 +37929,12 @@ spec:
               command:
               - /usr/bin/check-status
               - -r
+          startupProbe:
+            exec:
+              command:
+                - /usr/bin/check-status
+                - -r
+            initialDelaySeconds: 10
 
 ---
 

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4112,6 +4112,12 @@ spec:
               command:
               - /usr/bin/check-status
               - -r
+          startupProbe:
+            exec:
+              command:
+                - /usr/bin/check-status
+                - -r
+            initialDelaySeconds: 10
 
 ---
 

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -313,7 +313,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	if kubeDNS.Provider == "CoreDNS" {
 		{
 			key := "coredns.addons.k8s.io"
-			version := "1.7.0-kops.2"
+			version := "1.7.0-kops.3"
 
 			{
 				location := key + "/k8s-1.12.yaml"
@@ -740,7 +740,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		key := "networking.projectcalico.org"
 		versions := map[string]string{
 			"k8s-1.12": "3.9.6-kops.2",
-			"k8s-1.16": "3.17.1-kops.1",
+			"k8s-1.16": "3.17.1-kops.2",
 		}
 
 		{

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -24,7 +24,7 @@ spec:
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
-    version: 1.7.0-kops.2
+    version: 1.7.0-kops.3
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -24,7 +24,7 @@ spec:
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
-    version: 1.7.0-kops.2
+    version: 1.7.0-kops.3
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -24,7 +24,7 @@ spec:
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
-    version: 1.7.0-kops.2
+    version: 1.7.0-kops.3
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -24,7 +24,7 @@ spec:
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
-    version: 1.7.0-kops.2
+    version: 1.7.0-kops.3
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
     manifestHash: e1508d77cb4e527d7a2939babe36dc350dd83745


### PR DESCRIPTION
This should reduce considerably the issues during rolling update when https://github.com/projectcalico/calico/issues/3751 is hit, until next version of Calico is released.