### PR TITLE
enableRemoteNodeIdentity actually defaults to true

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3390,7 +3390,7 @@ spec:
                         type: boolean
                       enableRemoteNodeIdentity:
                         description: 'EnableRemoteNodeIdentity enables the remote-node-identity
-                          added in Cilium 1.7.0. Default: false'
+                          added in Cilium 1.7.0. Default: true'
                         type: boolean
                       enableTracing:
                         description: EnableTracing is not implemented and may be removed

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -475,7 +475,7 @@ type CiliumNetworkingSpec struct {
 	// Default: false
 	EtcdManaged bool `json:"etcdManaged,omitempty"`
 	// EnableRemoteNodeIdentity enables the remote-node-identity added in Cilium 1.7.0.
-	// Default: false
+	// Default: true
 	EnableRemoteNodeIdentity *bool `json:"enableRemoteNodeIdentity,omitempty"`
 	// Hubble configures the Hubble service on the Cilium agent.
 	Hubble *HubbleSpec `json:"hubble,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -473,7 +473,7 @@ type CiliumNetworkingSpec struct {
 	// Default: false
 	EtcdManaged bool `json:"etcdManaged,omitempty"`
 	// EnableRemoteNodeIdentity enables the remote-node-identity added in Cilium 1.7.0.
-	// Default: false
+	// Default: true
 	EnableRemoteNodeIdentity *bool `json:"enableRemoteNodeIdentity,omitempty"`
 	// Hubble configures the Hubble service on the Cilium agent.
 	Hubble *HubbleSpec `json:"hubble,omitempty"`


### PR DESCRIPTION
`components/cilium.go` sets this to true if nil