### PR TITLE
Update k8s versions in stable channel and bump ubuntu ami version in alpha channel

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -44,7 +44,7 @@ spec:
     - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-11-19
       providerID: aws
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201112.1
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
       providerID: aws
       kubernetesVersion: ">=1.18.0"
     - providerID: gce

--- a/channels/stable
+++ b/channels/stable
@@ -63,10 +63,10 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.14
+    recommendedVersion: 1.18.15
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
-    recommendedVersion: 1.17.16
+    recommendedVersion: 1.17.17
     requiredVersion: 1.17.0
   - range: ">=1.16.0"
     recommendedVersion: 1.16.15
@@ -90,18 +90,18 @@ spec:
     recommendedVersion: 1.11.10
     requiredVersion: 1.11.10
   kopsVersions:
-  - range: ">=1.19.0-alpha.1"
-    #recommendedVersion: "1.19.0-alpha.1"
+  - range: ">=1.19.0-beta.3"
+    #recommendedVersion: "1.19.0-beta.3"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.6
+    kubernetesVersion: 1.19.7
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.14
+    kubernetesVersion: 1.18.15
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.17.0
-    kubernetesVersion: 1.17.16
+    kubernetesVersion: 1.17.17
   - range: ">=1.16.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.16.0


### PR DESCRIPTION
[This](https://github.com/kubernetes/kops/pull/10576) PR was merged 9 days ago to alpha, so seems pretty safe to push to stable.
Also, a new Ubuntu ami version was made available two days ago globally (including CN and GOV clouds), so updating alpha channel with that.
https://cloud-images.ubuntu.com/locator/ec2/ 