### PR TITLE
Update kubetest2 library

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/klog/v2 v2.4.0
-	sigs.k8s.io/kubetest2 v0.0.0-20210115020551-4275dd0a0d63
+	sigs.k8s.io/kubetest2 v0.0.0-20210119223558-43699a7ba223
 )

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -1599,8 +1599,8 @@ sigs.k8s.io/boskos v0.0.0-20200526191642-45fc818e2d00/go.mod h1:L1ubP7d1CCMSQSjK
 sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc/go.mod h1:ZO5RV+VxJS9mb6DvZ1yAjywoyq/wQ8b0vDoZxcIA5kE=
 sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKGhb2sCtAXiT8=
 sigs.k8s.io/controller-runtime v0.5.4/go.mod h1:JZUwSMVbxDupo0lTJSSFP5pimEyxGynROImSsqIOx1A=
-sigs.k8s.io/kubetest2 v0.0.0-20210115020551-4275dd0a0d63 h1:pHCLLY0QjOp3cBTYCjCQdYfYP8lo+/eSyd3vdWkaQTE=
-sigs.k8s.io/kubetest2 v0.0.0-20210115020551-4275dd0a0d63/go.mod h1:XT/MnLvPcrJkJo0+3DGIlXljSZxqvU7HNyXI/ny3Flg=
+sigs.k8s.io/kubetest2 v0.0.0-20210119223558-43699a7ba223 h1:IVyT4m/+VBEvllWo9bjbJ+YL3d+6Ml3V8yt7NIcAGA4=
+sigs.k8s.io/kubetest2 v0.0.0-20210119223558-43699a7ba223/go.mod h1:XT/MnLvPcrJkJo0+3DGIlXljSZxqvU7HNyXI/ny3Flg=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/mdtoc v1.0.1/go.mod h1:COYBtOjsaCg7o7SC4eaLwEXPuVRSuiVuLLRrHd7kShw=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=


### PR DESCRIPTION
This picks up the --test-package-marker support used by the kops grid jobs.

See https://github.com/kubernetes-sigs/kubetest2/compare/4275dd0a0d63...43699a7ba223