### PR TITLE
Use the same package marker for kubectl as for e2e binary

### DIFF
--- a/tests/e2e/pkg/tester/kubectl.go
+++ b/tests/e2e/pkg/tester/kubectl.go
@@ -41,7 +41,7 @@ func (t *Tester) AcquireKubectl() (string, error) {
 		cmd := exec.Command(
 			"gsutil",
 			"cat",
-			fmt.Sprintf("gs://%s/%s/latest.txt", t.TestPackageBucket, t.TestPackageDir),
+			fmt.Sprintf("gs://%s/%s/%v", t.TestPackageBucket, t.TestPackageDir, t.TestPackageMarker),
 		)
 		lines, err := exec.OutputLines(cmd)
 		if err != nil {
@@ -52,7 +52,7 @@ func (t *Tester) AcquireKubectl() (string, error) {
 		}
 		t.TestPackageVersion = lines[0]
 
-		klog.Infof("Kubectl package version was not specified. Defaulting to latest: %s", t.TestPackageVersion)
+		klog.Infof("Kubectl package version was not specified. Defaulting to version from %s: %s", t.TestPackageMarker, t.TestPackageVersion)
 	}
 
 	clientTar := fmt.Sprintf("kubernetes-client-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
When a package marker is provided to the tester, we should use it for downloading the correct kubectl version in addition to the e2e binary version. Copies the logic [here](https://github.com/kubernetes-sigs/kubetest2/pull/83/files#diff-f88766cb5eca5518cdcb44058bd793584616c8ca38227bf0103b7ebfad0ef610).