### PR TITLE
Automated cherry pick of #10585: containerd: Add /etc/crictl config to enable crictl #10651: Add back support for kubenet style networking with containerd

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -79,7 +79,6 @@ go_library(
         "//pkg/kopscodecs:go_default_library",
         "//pkg/kubeconfig:go_default_library",
         "//pkg/kubemanifest:go_default_library",
-        "//pkg/model/components:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/pretty:go_default_library",
         "//pkg/resources:go_default_library",

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/kubeconfig"
 	"k8s.io/kops/pkg/kubemanifest"
-	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup"
 	"k8s.io/kops/upup/pkg/fi/utils"
@@ -480,9 +479,6 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 
 	if c.ContainerRuntime != "" {
 		cluster.Spec.ContainerRuntime = c.ContainerRuntime
-	}
-	if c.ContainerRuntime == "containerd" && components.UsesKubenet(cluster.Spec.Networking) {
-		return fmt.Errorf("--networking with CNI plugin is required for containerd")
 	}
 
 	if c.NetworkCIDR != "" {

--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -93,6 +93,9 @@ func (b *ContainerdBuilder) Build(c *fi.ModelBuilderContext) error {
 			}
 			c.AddTask(fileTask)
 		}
+
+		// Add configuration file for easier use of crictl
+		b.addCrictlConfig(c)
 	}
 
 	var containerRuntimeVersion string
@@ -277,4 +280,17 @@ func (b *ContainerdBuilder) skipInstall() bool {
 	}
 
 	return d.SkipInstall
+}
+
+// addCritctlConfig creates /etc/crictl.yaml, which lets crictl work out-of-the-box.
+func (b *ContainerdBuilder) addCrictlConfig(c *fi.ModelBuilderContext) {
+	conf := `
+runtime-endpoint: unix:///run/containerd/containerd.sock
+`
+
+	c.AddTask(&nodetasks.File{
+		Path:     "/etc/crictl.yaml",
+		Contents: fi.NewStringResource(conf),
+		Type:     nodetasks.FileType_File,
+	})
 }

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -2,6 +2,12 @@ contents: ""
 path: /etc/containerd/config-kops.toml
 type: file
 ---
+contents: |2
+
+  runtime-endpoint: unix:///run/containerd/containerd.sock
+path: /etc/crictl.yaml
+type: file
+---
 contents: CONTAINERD_OPTS=
 path: /etc/sysconfig/containerd
 type: file

--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
@@ -1,3 +1,29 @@
+contents: |
+  {
+      "cniVersion": "0.4.0",
+      "name": "containerd-net",
+      "plugins": [
+          {
+              "type": "bridge",
+              "bridge": "cni0",
+              "isGateway": true,
+              "ipMasq": true,
+              "promiscMode": true,
+              "ipam": {
+                  "type": "host-local",
+                  "ranges": [[{"subnet": "{{.PodCIDR}}"}]],
+                  "routes": [{ "dst": "0.0.0.0/0" }]
+              }
+          },
+          {
+              "type": "portmap",
+              "capabilities": {"portMappings": true}
+          }
+      ]
+  }
+path: /etc/containerd/config-cni.template
+type: file
+---
 contents: ""
 path: /etc/containerd/config-kops.toml
 type: file

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -552,16 +552,10 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 	}
 
 	if v.Kubenet != nil {
-		if c.ContainerRuntime == "containerd" {
-			allErrs = append(allErrs, field.Invalid(fldPath, "kubenet", "kubenet networking is not supported with containerd"))
-		}
 		optionTaken = true
 	}
 
 	if v.External != nil {
-		if c.ContainerRuntime == "containerd" {
-			allErrs = append(allErrs, field.Invalid(fldPath, "external", "external networking is not supported with containerd"))
-		}
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("external"), "only one networking option permitted"))
 		}
@@ -576,9 +570,6 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 	}
 
 	if v.Kopeio != nil {
-		if c.ContainerRuntime == "containerd" {
-			allErrs = append(allErrs, field.Invalid(fldPath, "kopeio", "kopeio networking is not supported with containerd"))
-		}
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kopeio"), "only one networking option permitted"))
 		}
@@ -663,9 +654,6 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 	}
 
 	if v.GCE != nil {
-		if c.ContainerRuntime == "containerd" {
-			allErrs = append(allErrs, field.Invalid(fldPath, "gce", "gce networking is not supported with containerd"))
-		}
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("gce"), "only one networking option permitted"))
 		}

--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -61,6 +61,12 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 			for name, endpoints := range containerd.RegistryMirrors {
 				config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "mirrors", name, "endpoint"}, endpoints)
 			}
+			if UsesKubenet(clusterSpec.Networking) {
+				// Using containerd with Kubenet requires special configuration.
+				// This is a temporary backwards-compatible solution for kubenet users and will be deprecated when Kubenet is deprecated:
+				// https://github.com/containerd/containerd/blob/master/docs/cri/config.md#cni-config-template
+				config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "cni", "conf_template"}, "/etc/containerd/config-cni.template")
+			}
 			containerd.ConfigOverride = fi.String(config.String())
 		}
 


### PR DESCRIPTION
Cherry pick of #10585 #10651 on release-1.19.

#10585: containerd: Add /etc/crictl config to enable crictl
#10651: Add back support for kubenet style networking with containerd

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.