### PR TITLE
Quote `grep` patterns in docs/rotate-secrets.md

### DIFF
--- a/docs/rotate-secrets.md
+++ b/docs/rotate-secrets.md
@@ -7,9 +7,9 @@
 Delete all secrets & keypairs that kOps is holding:
 
 ```shell
-kops get secrets  | grep ^Secret | awk '{print $2}' | xargs -I {} kops delete secret secret {}
+kops get secrets  | grep '^Secret' | awk '{print $2}' | xargs -I {} kops delete secret secret {}
 
-kops get secrets  | grep ^Keypair | awk '{print $2}' | xargs -I {} kops delete secret keypair {}
+kops get secrets  | grep '^Keypair' | awk '{print $2}' | xargs -I {} kops delete secret keypair {}
 ```
 
 ## Recreate all secrets


### PR DESCRIPTION
This should work more reliably independent of shell config.