### PR TITLE
Add --create-args kubetest2 flag

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -138,7 +138,14 @@ func (d *deployer) featureFlags() string {
 		"+SpecOverrideFlag",
 		"+AlphaAllowGCE",
 	}
-	return strings.Join(ff, ",")
+	val := strings.Join(ff, ",")
+	for _, env := range d.Env {
+		e := strings.Split(env, "=")
+		if e[0] == "KOPS_FEATURE_FLAGS" && len(e) > 1 {
+			val = fmt.Sprintf("%v,", e[1])
+		}
+	}
+	return val
 }
 
 // defaultClusterName returns a kops cluster name to use when ClusterName is not set

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -47,6 +47,7 @@ type deployer struct {
 	ClusterName    string   `flag:"cluster-name" desc:"The FQDN to use for the cluster name"`
 	CloudProvider  string   `flag:"cloud-provider" desc:"Which cloud provider to use"`
 	Env            []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
+	CreateArgs     string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
 	KopsBinaryPath string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
 	Networking     string   `flag:"networking" desc:"The networking mode to use"`
 	StateStore     string   `flag:"-"`

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -129,6 +129,12 @@ func (d *deployer) createCluster(zones []string, adminAccess string) error {
 		args = append(args, "--networking", d.Networking)
 	}
 
+	if d.CreateArgs != "" {
+		// TODO: we should only set the above flags if they're not in CreateArgs
+		// allowing any flag to be overridden
+		args = append(args, strings.Split(d.CreateArgs, " ")...)
+	}
+
 	klog.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(d.env()...)


### PR DESCRIPTION
This allows us to customize the images, instance types, etc.

kubetest (1) named this --kops-args, I think --create-args is more appropriate because its only passed to `create cluster`

https://github.com/kubernetes/test-infra/blob/f503f3e9a230d5eab64c220c8a9e4380bb6a65db/config/jobs/kubernetes/kops/kops-periodics-misc.yaml#L27

Also support --env=KOPS_FEATURE_FLAGS=foo and having its value correctly passed to the kops invocations.
