### PR TITLE
Create default loadbalancer when SSL certificate is specified

### DIFF
--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -963,7 +963,7 @@ func setupAPI(opt *NewClusterOptions, cluster *api.Cluster) error {
 		// in pkg/model/azuremodel/api_loadbalancer.go.
 		cluster.Spec.API = nil
 		return nil
-	} else if opt.APILoadBalancerType != "" {
+	} else if opt.APILoadBalancerType != "" || opt.APISSLCertificate != "" {
 		cluster.Spec.API.LoadBalancer = &api.LoadBalancerAccessSpec{}
 	} else {
 		switch cluster.Spec.Topology.Masters {


### PR DESCRIPTION
Fixes #10648 

Generate a default load balancer when the SSL certificate is specified, so that the original process would work well.