### PR TITLE
Automated cherry pick of #10666: Allow attaching same external load balancer to multiple

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -367,8 +367,12 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 
 	for _, extLB := range ig.Spec.ExternalLoadBalancers {
 		if extLB.LoadBalancerName != nil {
+			loadBalancerName := fi.StringValue(extLB.LoadBalancerName)
+			if loadBalancerName != awsup.GetResourceName32(b.Cluster.Name, "api") && loadBalancerName != awsup.GetResourceName32(b.Cluster.Name, "bastion") {
+				loadBalancerName = name + "-" + loadBalancerName
+			}
 			lb := &awstasks.LoadBalancer{
-				Name:             extLB.LoadBalancerName,
+				Name:             fi.String(loadBalancerName),
 				LoadBalancerName: extLB.LoadBalancerName,
 				Shared:           fi.Bool(true),
 			}
@@ -390,6 +394,7 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 			c.AddTask(tg)
 		}
 	}
+	sort.Stable(awstasks.OrderLoadBalancersByName(t.LoadBalancers))
 	sort.Stable(awstasks.OrderTargetGroupsByName(t.TargetGroups))
 
 	// @step: are we using a mixed instance policy

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -57,6 +57,7 @@
           }
         ],
         "LoadBalancerNames": [
+          "my-external-elb-1",
           "my-external-elb-2",
           "my-external-elb-3"
         ],

--- a/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
@@ -79,10 +79,11 @@ spec:
   subnets:
   - us-test-1a
   externalLoadBalancers:
-  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1
   - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2
+  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1
   - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3
   - loadBalancerName: my-external-elb-2
+  - loadBalancerName: my-external-elb-1
   - loadBalancerName: my-external-elb-3
 
 

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -83,7 +83,7 @@ provider "aws" {
 resource "aws_autoscaling_group" "master-us-test-1a-masters-externallb-example-com" {
   enabled_metrics      = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_configuration = aws_launch_configuration.master-us-test-1a-masters-externallb-example-com.id
-  load_balancers       = ["my-external-elb-2", "my-external-elb-3"]
+  load_balancers       = ["my-external-elb-1", "my-external-elb-2", "my-external-elb-3"]
   max_size             = 1
   metrics_granularity  = "1Minute"
   min_size             = 1

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -117,9 +117,12 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 
 	actual.LoadBalancers = []*LoadBalancer{}
 	for _, lb := range g.LoadBalancerNames {
-
+		loadBalancerName := fi.StringValue(lb)
+		if loadBalancerName != awsup.GetResourceName32(c.Cluster.Name, "api") && loadBalancerName != awsup.GetResourceName32(c.Cluster.Name, "bastion") {
+			loadBalancerName = fi.StringValue(g.AutoScalingGroupName) + "-" + loadBalancerName
+		}
 		actual.LoadBalancers = append(actual.LoadBalancers, &LoadBalancer{
-			Name:             aws.String(*lb),
+			Name:             aws.String(loadBalancerName),
 			LoadBalancerName: aws.String(*lb),
 		})
 	}
@@ -162,6 +165,7 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 			}
 		}
 	}
+	sort.Stable(OrderLoadBalancersByName(actual.LoadBalancers))
 
 	actual.TargetGroups = []*TargetGroup{}
 	if len(g.TargetGroupARNs) > 0 {

--- a/upup/pkg/fi/cloudup/awstasks/load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/load_balancer.go
@@ -667,6 +667,15 @@ func (_ *LoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *LoadBalan
 	return nil
 }
 
+// OrderLoadBalancersByName implements sort.Interface for []OrderLoadBalancersByName, based on name
+type OrderLoadBalancersByName []*LoadBalancer
+
+func (a OrderLoadBalancersByName) Len() int      { return len(a) }
+func (a OrderLoadBalancersByName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a OrderLoadBalancersByName) Less(i, j int) bool {
+	return fi.StringValue(a[i].Name) < fi.StringValue(a[j].Name)
+}
+
 type terraformLoadBalancer struct {
 	LoadBalancerName *string                          `json:"name" cty:"name"`
 	Listener         []*terraformLoadBalancerListener `json:"listener" cty:"listener"`
@@ -801,12 +810,12 @@ func (_ *LoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e, chang
 func (e *LoadBalancer) TerraformLink(params ...string) *terraform.Literal {
 	shared := fi.BoolValue(e.Shared)
 	if shared {
-		if e.Name == nil {
+		if e.LoadBalancerName == nil {
 			klog.Fatalf("Name must be set, if LB is shared: %s", e)
 		}
 
-		klog.V(4).Infof("reusing existing LB with name %q", *e.Name)
-		return terraform.LiteralFromStringValue(*e.Name)
+		klog.V(4).Infof("reusing existing LB with name %q", *e.LoadBalancerName)
+		return terraform.LiteralFromStringValue(*e.LoadBalancerName)
 	}
 
 	prop := "id"
@@ -950,12 +959,12 @@ func (_ *LoadBalancer) RenderCloudformation(t *cloudformation.CloudformationTarg
 func (e *LoadBalancer) CloudformationLink() *cloudformation.Literal {
 	shared := fi.BoolValue(e.Shared)
 	if shared {
-		if e.Name == nil {
+		if e.LoadBalancerName == nil {
 			klog.Fatalf("Name must be set, if LB is shared: %s", e)
 		}
 
-		klog.V(4).Infof("reusing existing LB with name %q", *e.Name)
-		return cloudformation.LiteralString(*e.Name)
+		klog.V(4).Infof("reusing existing LB with name %q", *e.LoadBalancerName)
+		return cloudformation.LiteralString(*e.LoadBalancerName)
 	}
 
 	return cloudformation.Ref("AWS::ElasticLoadBalancing::LoadBalancer", *e.Name)

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -17,7 +17,9 @@ limitations under the License.
 package awsup
 
 import (
+	"encoding/base32"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"strings"
 	"sync"
@@ -179,6 +181,68 @@ func AWSErrorMessage(err error) string {
 		return awsError.Message()
 	}
 	return ""
+}
+
+// GetResourceName32 will attempt to calculate a meaningful name for a resource given a prefix
+// Will never return a string longer than 32 chars
+func GetResourceName32(cluster string, prefix string) string {
+	s := prefix + "-" + strings.Replace(cluster, ".", "-", -1)
+
+	// We always compute the hash and add it, lest we trick users into assuming that we never do this
+	opt := TruncateStringOptions{
+		MaxLength:     32,
+		AlwaysAddHash: true,
+		HashLength:    6,
+	}
+	return TruncateString(s, opt)
+}
+
+// TruncateStringOptions contains parameters for how we truncate strings
+type TruncateStringOptions struct {
+	// AlwaysAddHash will always cause the hash to be appended.
+	// Useful to stop users assuming that the name will never be truncated.
+	AlwaysAddHash bool
+
+	// MaxLength controls the maximum length of the string.
+	MaxLength int
+
+	// HashLength controls the length of the hash to be appended.
+	HashLength int
+}
+
+// TruncateString will attempt to truncate a string to a max, adding a prefix to avoid collisions.
+// Will never return a string longer than maxLength chars
+func TruncateString(s string, opt TruncateStringOptions) string {
+	if opt.MaxLength == 0 {
+		klog.Fatalf("MaxLength must be set")
+	}
+
+	if !opt.AlwaysAddHash && len(s) <= opt.MaxLength {
+		return s
+	}
+
+	if opt.HashLength == 0 {
+		opt.HashLength = 6
+	}
+
+	// We always compute the hash and add it, lest we trick users into assuming that we never do this
+	h := fnv.New32a()
+	if _, err := h.Write([]byte(s)); err != nil {
+		klog.Fatalf("error hashing values: %v", err)
+	}
+	hashString := base32.HexEncoding.EncodeToString(h.Sum(nil))
+	hashString = strings.ToLower(hashString)
+	if len(hashString) > opt.HashLength {
+		hashString = hashString[:opt.HashLength]
+	}
+
+	maxBaseLength := opt.MaxLength - len(hashString) - 1
+	if len(s) > maxBaseLength {
+		s = s[:maxBaseLength]
+	}
+	s = s + "-" + hashString
+
+	return s
 }
 
 // GetTargetGroupNameFromARN will attempt to parse a target group ARN and return its name


### PR DESCRIPTION
Cherry pick of #10666 on release-1.18.

#10666: Allow attaching same external load balancer to multiple

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.