### PR TITLE
Allow SSH user to be overridden for `toolbox dump`

### DIFF
--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -62,11 +62,13 @@ type ToolboxDumpOptions struct {
 
 	Dir        string
 	PrivateKey string
+	SSHUser    string
 }
 
 func (o *ToolboxDumpOptions) InitDefaults() {
 	o.Output = OutputYaml
 	o.PrivateKey = "~/.ssh/id_rsa"
+	o.SSHUser = "ubuntu"
 }
 
 func NewCmdToolboxDump(f *util.Factory, out io.Writer) *cobra.Command {
@@ -100,6 +102,7 @@ func NewCmdToolboxDump(f *util.Factory, out io.Writer) *cobra.Command {
 
 	cmd.Flags().StringVar(&options.Dir, "dir", options.Dir, "target directory; if specified will collect logs and other information.")
 	cmd.Flags().StringVar(&options.PrivateKey, "private-key", options.PrivateKey, "private key to use for SSH acccess to instances")
+	cmd.Flags().StringVar(&options.SSHUser, "ssh-user", options.SSHUser, "the remote user for SSH access to instances")
 
 	return cmd
 }
@@ -183,10 +186,9 @@ func RunToolboxDump(ctx context.Context, f *util.Factory, out io.Writer, options
 			}
 		}
 
-		// TODO: We need to find the correct SSH user, ideally per IP
-		sshUser := "ubuntu"
 		sshConfig := &ssh.ClientConfig{
-			User: sshUser,
+			Config: ssh.Config{},
+			User:   options.SSHUser,
 			Auth: []ssh.AuthMethod{
 				ssh.PublicKeys(signer),
 			},

--- a/docs/cli/kops_toolbox_dump.md
+++ b/docs/cli/kops_toolbox_dump.md
@@ -27,6 +27,7 @@ kops toolbox dump [flags]
   -h, --help                 help for dump
   -o, --output string        output format.  One of: yaml, json (default "yaml")
       --private-key string   private key to use for SSH acccess to instances (default "~/.ssh/id_rsa")
+      --ssh-user string      the remote user for SSH access to instances (default "ubuntu")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Allows us to use `toolbox dump` on other distros besides ubuntu.

I'd like this to be cherry-picked to release-1.19 (no need to block on 1.19.0 though) so that I can use this in kubetest2 and have kubetest2 be able to dump logs with kops 1.19 builds.