### PR TITLE
kubetest2 - Use --ssh-user to dump logs

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -68,6 +68,9 @@ func (d *deployer) initialize() error {
 	if d.SSHPublicKeyPath == "" {
 		d.SSHPublicKeyPath = os.Getenv("AWS_SSH_PUBLIC_KEY_FILE")
 	}
+	if d.SSHUser == "" {
+		d.SSHUser = os.Getenv("KUBE_SSH_USER")
+	}
 	return nil
 }
 

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -56,9 +56,9 @@ type deployer struct {
 
 	KubernetesVersion string `flag:"kubernetes-version" desc:"The kubernetes version to use in the cluster"`
 
-	SSHPrivateKeyPath string   `flag:"ssh-private-key" desc:"The path to the private key used for SSH access to instances"`
-	SSHPublicKeyPath  string   `flag:"ssh-public-key" desc:"The path to the public key passed to the cloud provider"`
-	SSHUser           []string `flag:"ssh-user" desc:"The SSH users to use for SSH access to instances"`
+	SSHPrivateKeyPath string `flag:"ssh-private-key" desc:"The path to the private key used for SSH access to instances"`
+	SSHPublicKeyPath  string `flag:"ssh-public-key" desc:"The path to the public key passed to the cloud provider"`
+	SSHUser           string `flag:"ssh-user" desc:"The SSH user to use for SSH access to instances"`
 
 	ArtifactsDir string `flag:"-"`
 

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -33,6 +33,7 @@ func (d *deployer) DumpClusterLogs() error {
 		"--name", d.ClusterName,
 		"--dir", d.ArtifactsDir,
 		"--private-key", d.SSHPrivateKeyPath,
+		"--ssh-user", d.SSHUser,
 	}
 	klog.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)


### PR DESCRIPTION
Requires https://github.com/kubernetes/kops/pull/10675

This does not need to be cherry-picked.

This wires in kubetest2-kops' `--ssh-user` flag to `kops toolbox dump`, defaulting to the value [recognized by the e2e suite](https://github.com/kubernetes/kubernetes/blob/943b1dbf53c405004f35090ccef0dcf3c8065b7a/test/e2e/framework/ssh/ssh.go#L172-L174) and [set in the prow jobs](https://github.com/kubernetes/test-infra/blob/9fc10910eea6910d1763c624ea608cdd26f34ccf/config/jobs/kubernetes/kops/build-grid.py#L105-L106). The kubetest2 flag was previously unused.