### PR TITLE
Throw error if path being set by kops set is not present in struct

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -504,7 +504,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		cluster.Spec.MasterPublicName = c.MasterPublicName
 	}
 
-	if err := commands.SetClusterFields(c.Overrides, cluster, instanceGroups); err != nil {
+	if err := commands.SetClusterFields(c.Overrides, cluster); err != nil {
 		return err
 	}
 

--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -61,7 +61,7 @@ func RunSetCluster(ctx context.Context, f *util.Factory, cmd *cobra.Command, out
 		return err
 	}
 
-	if err := SetClusterFields(options.Fields, cluster, instanceGroups); err != nil {
+	if err := SetClusterFields(options.Fields, cluster); err != nil {
 		return err
 	}
 
@@ -73,7 +73,7 @@ func RunSetCluster(ctx context.Context, f *util.Factory, cmd *cobra.Command, out
 }
 
 // SetClusterFields sets field values in the cluster
-func SetClusterFields(fields []string, cluster *api.Cluster, instanceGroups []*api.InstanceGroup) error {
+func SetClusterFields(fields []string, cluster *api.Cluster) error {
 	for _, field := range fields {
 		kv := strings.SplitN(field, "=", 2)
 		if len(kv) != 2 {

--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -84,7 +84,7 @@ func SetClusterFields(fields []string, cluster *api.Cluster) error {
 		key = strings.TrimPrefix(key, "cluster.")
 
 		if err := reflectutils.SetString(cluster, key, kv[1]); err != nil {
-			return fmt.Errorf("failed to set %s=%s: %v", kv[0], kv[1], err)
+			return err
 		}
 	}
 	return nil

--- a/pkg/commands/set_cluster_test.go
+++ b/pkg/commands/set_cluster_test.go
@@ -29,7 +29,7 @@ func TestSetClusterBadInput(t *testing.T) {
 		"bad-set-input",
 	}
 
-	err := SetClusterFields(fields, &kops.Cluster{}, []*kops.InstanceGroup{})
+	err := SetClusterFields(fields, &kops.Cluster{})
 	if err == nil {
 		t.Errorf("expected a field parsing error, but received none")
 	}
@@ -310,10 +310,9 @@ func TestSetClusterFields(t *testing.T) {
 	}
 
 	for _, g := range grid {
-		var igs []*kops.InstanceGroup
 		c := g.Input
 
-		err := SetClusterFields(g.Fields, &c, igs)
+		err := SetClusterFields(g.Fields, &c)
 		if err != nil {
 			t.Errorf("unexpected error from setClusterFields %v: %v", g.Fields, err)
 			continue
@@ -362,10 +361,9 @@ func TestSetCiliumFields(t *testing.T) {
 	}
 
 	for _, g := range grid {
-		var igs []*kops.InstanceGroup
 		c := g.Input
 
-		err := SetClusterFields(g.Fields, &c, igs)
+		err := SetClusterFields(g.Fields, &c)
 		if err != nil {
 			t.Errorf("unexpected error from setClusterFields %v: %v", g.Fields, err)
 			continue

--- a/pkg/commands/set_instancegroups.go
+++ b/pkg/commands/set_instancegroups.go
@@ -101,7 +101,7 @@ func SetInstancegroupFields(fields []string, instanceGroup *api.InstanceGroup) e
 		key = strings.TrimPrefix(key, "instancegroup.")
 
 		if err := reflectutils.SetString(instanceGroup, key, kv[1]); err != nil {
-			return fmt.Errorf("failed to set %s=%s: %v", kv[0], kv[1], err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
Currently, when using kops set cluster <cluster_name> <path>=<value>, if the path is not present it fails silently. eg: 
`kops set cluster test-cluster.k8s.local spec.abc.def.ghi=jkl ` will not throw any error despite the fields not being present in the kops.Cluster struct. This can lead to confusion and mistakes. 

This PR explicitly throws an error if a field being set using `kops set` does not exist in the associated struct. 

Fixes: https://github.com/kubernetes/kops/issues/10647

Depends on: https://github.com/kubernetes/kops/pull/10690