### PR TITLE
Kubetest2 - refactor how `kops create cluster` arguments are set

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -64,7 +64,7 @@ See [Conformance Testing in Kubernetes](https://github.com/kubernetes/community/
 
 ### Running against a new cluster
 
-By adding the `--up` flag, `kubetest2` will spin up a new cluster. In most cases, you also need to add a few additional flags, such as `--networking`. See `kubetest2 kops --help` for the full list.
+By adding the `--up` flag, `kubetest2` will spin up a new cluster. Flags can be passed to the `kops create cluster` command via the `--create-args` flag. In most cases, you also need to add a few additional flags. See `kubetest2 kops --help` for the full list.
 
 ```shell
 kubetest2 kops \
@@ -72,9 +72,9 @@ kubetest2 kops \
   --up \
   --cloud-provider=aws \
   --cluster-name=my.testcluster.com \
+  --create-args="--networking calico" \
   --kops-binary-path=${KOPS_ROOT}/bazel-bin/cmd/kops/linux-amd64/kops \
   --kubernetes-version=v1.20.2 \
-  --networking calico \
   --test=kops \
   --
   -- \

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -145,7 +145,7 @@ func (d *deployer) featureFlags() string {
 	for _, env := range d.Env {
 		e := strings.Split(env, "=")
 		if e[0] == "KOPS_FEATURE_FLAGS" && len(e) > 1 {
-			val = fmt.Sprintf("%v,", e[1])
+			val = fmt.Sprintf("%v,%v", val, e[1])
 		}
 	}
 	return val

--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -49,7 +49,6 @@ type deployer struct {
 	Env            []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
 	CreateArgs     string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
 	KopsBinaryPath string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
-	Networking     string   `flag:"networking" desc:"The networking mode to use"`
 	StateStore     string   `flag:"-"`
 
 	TemplatePath string `flag:"template-path" desc:"The path to the manifest template used for cluster creation"`

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -125,10 +125,6 @@ func (d *deployer) createCluster(zones []string, adminAccess string) error {
 		args = append(args, "--master-size", "s-8vcpu-16gb")
 	}
 
-	if d.Networking != "" {
-		args = append(args, "--networking", d.Networking)
-	}
-
 	if d.CreateArgs != "" {
 		// TODO: we should only set the above flags if they're not in CreateArgs
 		// allowing any flag to be overridden

--- a/tests/e2e/kubetest2-kops/deployer/up_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/up_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAppendIfUnset(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		arg      string
+		val      string
+		expected []string
+	}{
+		{
+			"empty",
+			[]string{},
+			"--foo",
+			"bar",
+			[]string{"--foo", "bar"},
+		},
+		{
+			"unset",
+			[]string{"--baz"},
+			"--foo",
+			"bar",
+			[]string{"--baz", "--foo", "bar"},
+		},
+		{
+			"set without value",
+			[]string{"--foo"},
+			"--foo",
+			"bar",
+			[]string{"--foo"},
+		},
+		{
+			"set with different value",
+			[]string{"--foo", "123"},
+			"--foo",
+			"bar",
+			[]string{"--foo", "123"},
+		},
+		{
+			"set with same value",
+			[]string{"--foo", "bar"},
+			"--foo",
+			"bar",
+			[]string{"--foo", "bar"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := appendIfUnset(tc.args, tc.arg, tc.val)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("arguments didnt match: %v vs %v", actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows kubetest's --create-args to take precedence over arguments we were otherwise hardcoding.
Specifically this will be used to hardcode the list of zones for some prow jobs with `--create-args="--zones us-east-1a"` ([example job still on kubetest 1](https://github.com/kubernetes/test-infra/blob/e048fc0aecd929d056ecca442a28dbc3fae8b084/config/jobs/kubernetes/kops/kops-periodics-misc.yaml#L68))

Also removing the --networking flag now that we have `--create-args` and jobs have been migrated to use it in https://github.com/kubernetes/test-infra/pull/20683

