### PR TITLE
Increase IMDSv2 hop limit on control plane nodes

### DIFF
--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -65,6 +65,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -85,6 +85,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -107,6 +108,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -129,6 +131,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -85,6 +85,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -107,6 +108,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -129,6 +131,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -77,6 +77,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -99,6 +100,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -121,6 +123,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -93,6 +93,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -115,6 +116,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -137,6 +139,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -159,6 +162,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -181,6 +185,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -94,6 +94,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.18/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.18/expected-v1alpha2.yaml
@@ -65,6 +65,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.19/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.19/expected-v1alpha2.yaml
@@ -65,6 +65,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
@@ -65,6 +65,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -94,6 +94,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -68,6 +68,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -100,6 +100,7 @@ spec:
   - sg-exampleid4
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -74,6 +74,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -67,6 +67,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -67,6 +67,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -66,6 +66,7 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
+    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -679,7 +679,9 @@ func setupMasters(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap 
 				k8sVersion, err := version.ParseKubernetesVersion(cluster.Spec.KubernetesVersion)
 				if err == nil && version.IsKubernetesGTE("1.18", *k8sVersion) {
 					if g.Spec.InstanceMetadata == nil {
-						g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{}
+						g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{
+							HTTPPutResponseHopLimit: fi.Int64(2),
+						}
 					}
 					g.Spec.InstanceMetadata.HTTPTokens = fi.String(ec2.LaunchTemplateHttpTokensStateRequired)
 					if strings.Contains(g.Spec.Image, "debian-stretch") {


### PR DESCRIPTION
Non-hostNetworking fails to talk to the instance metadata otherwise. Breaking e.g CSI controller

See https://github.com/kubernetes/cloud-provider-aws/issues/169

Note: This should work for kubenet, but other CNIs may need other hop limits. E.g with Cilium, I had to use 3 to get this to work. Will have to investigate a bit more first. Meanwhile this should fix the broken test.