### PR TITLE
Use the kubeApiServerConfig clientCAFile field

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -429,6 +429,16 @@ spec:
     serviceNodePortRange: 30000-33000
 ```
 
+### Customize client-ca file 
+
+This value is passed as `--client-ca-file` for `kube-apiserver`. (default: `/srv/kubernetes/ca.crt`)
+
+```yaml
+spec:
+  kubeAPIServer:
+    clientCAFile: /srv/kubernetes/client-ca.crt
+```
+
 ### Disable Basic Auth
 
 Support for basic authentication was removed in Kubernetes 1.19. For previous versions

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -438,6 +438,11 @@ spec:
   kubeAPIServer:
     clientCAFile: /srv/kubernetes/client-ca.crt
 ```
+There are certain cases that the user may want to use a customized client CA file other than the default one generated for Kubernetes. In that case, the user can use this flag to specify the client-ca file to use.
+
+To prepare the customized client-ca file on master nodes, the user can either use the [fileAssets](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#fileassets) feature to push an client-ca file, or embed the customized client-ca file in the master AMI.
+
+See also [Kubernetes certificates](https://kubernetes.io/docs/concepts/cluster-administration/certificates/)
 
 ### Disable Basic Auth
 

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -442,6 +442,10 @@ There are certain cases that the user may want to use a customized client CA fil
 
 To prepare the customized client-ca file on master nodes, the user can either use the [fileAssets](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#fileassets) feature to push an client-ca file, or embed the customized client-ca file in the master AMI.
 
+In the case that the user would use a customized client-ca file, it is common that the kubernetes CA (`/srv/kubernetes/ca/crt`) need to be appended to the end of the client-ca file. One way to append the ca.crt to the end of the customized client-ca file is to write an [kop-hook](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#hooks) to do the append logic.
+
+Kops also has CA rotation feature, which would refresh the kubernetes cert files, including the ca.crt. If a customized client-ca file is used, when kops cert rotation happens, the user is responsible to update the ca.crt in the customized client-ca file. The refresh ca.crt logic can also be achieved by writing a kops hook.
+
 See also [Kubernetes certificates](https://kubernetes.io/docs/concepts/cluster-administration/certificates/)
 
 ### Disable Basic Auth

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -440,11 +440,11 @@ spec:
 ```
 There are certain cases that the user may want to use a customized client CA file other than the default one generated for Kubernetes. In that case, the user can use this flag to specify the client-ca file to use.
 
-To prepare the customized client-ca file on master nodes, the user can either use the [fileAssets](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#fileassets) feature to push an client-ca file, or embed the customized client-ca file in the master AMI.
+To prepare the customized client-ca file on master nodes, the user can either use the [fileAssets](https://kops.sigs.k8s.io/cluster_spec/#fileassets) feature to push an client-ca file, or embed the customized client-ca file in the master AMI.
 
-In the case that the user would use a customized client-ca file, it is common that the kubernetes CA (`/srv/kubernetes/ca/crt`) need to be appended to the end of the client-ca file. One way to append the ca.crt to the end of the customized client-ca file is to write an [kop-hook](https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#hooks) to do the append logic.
+In the case that the user would use a customized client-ca file, it is common that the kubernetes CA (`/srv/kubernetes/ca/crt`) need to be appended to the end of the client-ca file. One way to append the ca.crt to the end of the customized client-ca file is to write an [kop-hook](https://kops.sigs.k8s.io/cluster_spec/#hooks) to do the append logic.
 
-Kops also has CA rotation feature, which would refresh the kubernetes cert files, including the ca.crt. If a customized client-ca file is used, when kops cert rotation happens, the user is responsible to update the ca.crt in the customized client-ca file. The refresh ca.crt logic can also be achieved by writing a kops hook.
+Kops will have [CA rotation](https://kops.sigs.k8s.io/rotate-secrets/) feature soon, which would refresh the kubernetes cert files, including the ca.crt. If a customized client-ca file is used, when kops cert rotation happens, the user is responsible to update the ca.crt in the customized client-ca file. The refresh ca.crt logic can also be achieved by writing a kops hook.
 
 See also [Kubernetes certificates](https://kubernetes.io/docs/concepts/cluster-administration/certificates/)
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1269,7 +1269,8 @@ spec:
                       kubernetes API
                     type: string
                   clientCAFile:
-                    description: 'TODO: Remove unused ClientCAFile'
+                    description: ClientCAFile is the file used by apisever that contains
+                      the client CA
                     type: string
                   cloudProvider:
                     description: CloudProvider is the name of the cloudProvider we

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -298,6 +298,9 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 	}
 
 	kubeAPIServer.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
+	if b.Cluster.Spec.KubeAPIServer.ClientCAFile != "" {
+		kubeAPIServer.ClientCAFile = b.Cluster.Spec.KubeAPIServer.ClientCAFile
+	}
 	kubeAPIServer.TLSCertFile = filepath.Join(b.PathSrvKubernetes(), "server.crt")
 	kubeAPIServer.TLSPrivateKeyFile = filepath.Join(b.PathSrvKubernetes(), "server.key")
 

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -296,10 +296,9 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 			kubeAPIServer.ServiceAccountSigningKeyFile = &s
 		}
 	}
-
-	kubeAPIServer.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
-	if b.Cluster.Spec.KubeAPIServer.ClientCAFile != "" {
-		kubeAPIServer.ClientCAFile = b.Cluster.Spec.KubeAPIServer.ClientCAFile
+	// If clientCAFile is not specified, set it to the default value ${PathSrvKubernetes}/ca.crt
+	if kubeAPIServer.ClientCAFile == "" {
+		kubeAPIServer.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
 	}
 	kubeAPIServer.TLSCertFile = filepath.Join(b.PathSrvKubernetes(), "server.crt")
 	kubeAPIServer.TLSPrivateKeyFile = filepath.Join(b.PathSrvKubernetes(), "server.key")

--- a/nodeup/pkg/model/kube_apiserver_test.go
+++ b/nodeup/pkg/model/kube_apiserver_test.go
@@ -131,6 +131,12 @@ func Test_KubeAPIServer_BuildFlags(t *testing.T) {
 			},
 			"--insecure-port=0 --profiling=false --secure-port=0",
 		},
+		{
+			kops.KubeAPIServerConfig{
+				ClientCAFile: "client-ca.crt",
+			},
+			"--client-ca-file=client-ca.crt --insecure-port=0 --secure-port=0",
+		},
 	}
 
 	for _, g := range grid {

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -311,7 +311,7 @@ type KubeAPIServerConfig struct {
 	EtcdKeyFile string `json:"etcdKeyFile,omitempty" flag:"etcd-keyfile"`
 	// TODO: Remove unused BasicAuthFile
 	BasicAuthFile string `json:"basicAuthFile,omitempty" flag:"basic-auth-file"`
-	// TODO: Remove unused ClientCAFile
+	// ClientCAFile is the file used by apisever that contains the client CA
 	ClientCAFile string `json:"clientCAFile,omitempty" flag:"client-ca-file"`
 	// TODO: Remove unused TLSCertFile
 	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -311,7 +311,7 @@ type KubeAPIServerConfig struct {
 	EtcdKeyFile string `json:"etcdKeyFile,omitempty" flag:"etcd-keyfile"`
 	// TODO: Remove unused BasicAuthFile
 	BasicAuthFile string `json:"basicAuthFile,omitempty" flag:"basic-auth-file"`
-	// TODO: Remove unused ClientCAFile
+	// ClientCAFile is the file used by apisever that contains the client CA
 	ClientCAFile string `json:"clientCAFile,omitempty" flag:"client-ca-file"`
 	// TODO: Remove unused TLSCertFile
 	TLSCertFile string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`


### PR DESCRIPTION
Hello!

We have a usecase that would need to be able to specify a different client-CA file for the kube-apiserver. Also, it seems that there were prior discussion about this requirement too(https://github.com/kubernetes/kops/issues/3243), although it was closed for inactivity.

This change just enables the ClientCAFile field of the KubeAPIServerConfig struct, So that the user can specify the ClientCAFile and the apiserver config yaml would reflect it.

Thanks a lot!