### PR TITLE
Fix create args for upgrade test

### DIFF
--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -45,7 +45,7 @@ trap finish EXIT
 kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--up \
 		--kubernetes-version=v1.18.15 \
-    --networking calico
+    --create-args="--networking calico"
 
 KUBECONFIG=${HOME}/.kube/config
 TEST_ARGS="--kubeconfig=${KUBECONFIG}"


### PR DESCRIPTION
fixes this failure: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-upgrade/1356573350847057920