### PR TITLE
Docs: Fix ServiceAccountVolume proposed configuration for Istio

### DIFF
--- a/docs/operations/service_account_token_volumes.md
+++ b/docs/operations/service_account_token_volumes.md
@@ -9,7 +9,4 @@ Some services, such as Istio and Envoy's Secret Discovery Service (SDS), take ad
         - api
         - istio-ca
         serviceAccountIssuer: kubernetes.default.svc
-        serviceAccountKeyFile:
-        - /srv/kubernetes/server.key
-        serviceAccountSigningKeyFile: /srv/kubernetes/server.key
 ```


### PR DESCRIPTION
Seems that after merging https://github.com/kubernetes/kops/pull/9534 there is no need to specify paths for key-files for service Account Token Volume Projection. 

Instead, the current configuration proposed in docs is making Istio unable to verify JWT token with errors.

In this commit, we remove the paths, letting Kops handles the default ones that are working as expected.