### PR TITLE
Fix panic when exporting kubecfg for AWS cluster without load balancer

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -153,6 +153,9 @@ func FindDNSName(awsCloud awsup.AWSCloud, cluster *kops.Cluster) (string, error)
 
 func FindElasticLoadBalancerByNameTag(awsCloud awsup.AWSCloud, cluster *kops.Cluster) (DNSTarget, error) {
 	name := "api." + cluster.Name
+	if cluster.Spec.API == nil || cluster.Spec.API.LoadBalancer == nil {
+		return nil, nil
+	}
 	if cluster.Spec.API.LoadBalancer.Class == kops.LoadBalancerClassClassic {
 		if lb, err := FindLoadBalancerByNameTag(awsCloud, name); err != nil {
 			return nil, fmt.Errorf("error looking for AWS ELB: %v", err)


### PR DESCRIPTION
ref: https://github.com/kubernetes/kops/issues/10717

specifically the panic logged [here](https://github.com/kubernetes/kops/issues/10717#issuecomment-772433770)

This should be cherry-picked to 1.19.