### PR TITLE
Cleanup kops-controller Route53 record during cluster deletion

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -1855,7 +1855,7 @@ func ListRoute53Records(cloud fi.Cloud, clusterName string) ([]*resources.Resour
 
 				remove := false
 				// TODO: Compute the actual set of names?
-				if prefix == ".api" || prefix == ".api.internal" || prefix == ".bastion" {
+				if prefix == ".api" || prefix == ".api.internal" || prefix == ".bastion" || prefix == ".kops-controller.internal" {
 					remove = true
 				} else if strings.HasPrefix(prefix, ".etcd-") {
 					remove = true


### PR DESCRIPTION
ref: #10709

For k8s 1.19 kops-controller has a DNS record:

https://github.com/kubernetes/kops/blob/1885ccee1730d6b6b6326f5bdfaaf02cac19e74a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template#L39

but we dont clean it up during `kops delete cluster`. This ensures the record is deleted.


This should be cherry-picked to 1.19