### PR TITLE
Automated cherry pick of #10720: Fix panic when exporting kubecfg for AWS cluster without load

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -153,6 +153,9 @@ func FindDNSName(awsCloud awsup.AWSCloud, cluster *kops.Cluster) (string, error)
 
 func FindElasticLoadBalancerByNameTag(awsCloud awsup.AWSCloud, cluster *kops.Cluster) (DNSTarget, error) {
 	name := "api." + cluster.Name
+	if cluster.Spec.API == nil || cluster.Spec.API.LoadBalancer == nil {
+		return nil, nil
+	}
 	if cluster.Spec.API.LoadBalancer.Class == kops.LoadBalancerClassClassic {
 		if lb, err := FindLoadBalancerByNameTag(awsCloud, name); err != nil {
 			return nil, fmt.Errorf("error looking for AWS ELB: %v", err)


### PR DESCRIPTION
Cherry pick of #10720 on release-1.19.

#10720: Fix panic when exporting kubecfg for AWS cluster without load

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.