### PR TITLE
Revert making imdsv2 default

### DIFF
--- a/docs/releases/1.20-NOTES.md
+++ b/docs/releases/1.20-NOTES.md
@@ -11,7 +11,6 @@
 * Default settings for AWS instances are updated to take advantage of recent performance and security features:
     * Default root volume encryption changes to enabled
     * Default root volume type changes from `gp2` to `gp3`
-    * Default instance metadata service (IMDS) v2 changes from `optional` to `required` for newly created clusters
 
 * Added [template funtions](https://kops.sigs.k8s.io/operations/cluster_template/#template-functions) for kubernetes version based on channel data.
 

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -65,7 +65,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -64,8 +64,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -86,8 +84,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -84,8 +84,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -106,8 +104,6 @@ metadata:
   name: master-us-test-1b
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -128,8 +124,6 @@ metadata:
   name: master-us-test-1c
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -150,8 +144,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -172,8 +164,6 @@ metadata:
   name: nodes-us-test-1b
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -194,8 +184,6 @@ metadata:
   name: nodes-us-test-1c
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -85,7 +85,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -108,7 +107,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -131,7 +129,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -84,8 +84,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -106,8 +104,6 @@ metadata:
   name: master-us-test-1b
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -128,8 +124,6 @@ metadata:
   name: master-us-test-1c
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -150,8 +144,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -172,8 +164,6 @@ metadata:
   name: nodes-us-test-1b
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -194,8 +184,6 @@ metadata:
   name: nodes-us-test-1c
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -85,7 +85,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -108,7 +107,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -131,7 +129,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -77,7 +77,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -100,7 +99,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -123,7 +121,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -76,8 +76,6 @@ metadata:
   name: master-us-test-1a-1
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -98,8 +96,6 @@ metadata:
   name: master-us-test-1a-2
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -120,8 +116,6 @@ metadata:
   name: master-us-test-1a-3
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -142,8 +136,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -92,8 +92,6 @@ metadata:
   name: master-us-test-1a-1
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -114,8 +112,6 @@ metadata:
   name: master-us-test-1a-2
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -136,8 +132,6 @@ metadata:
   name: master-us-test-1a-3
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -158,8 +152,6 @@ metadata:
   name: master-us-test-1b-1
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -180,8 +172,6 @@ metadata:
   name: master-us-test-1b-2
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -202,8 +192,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1
@@ -224,8 +212,6 @@ metadata:
   name: nodes-us-test-1b
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -93,7 +93,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -116,7 +115,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -139,7 +137,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -162,7 +159,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1
@@ -185,7 +181,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -94,7 +94,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -93,8 +93,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -115,8 +113,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.18/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.18/expected-v1alpha2.yaml
@@ -65,7 +65,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.18/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.18/expected-v1alpha2.yaml
@@ -64,8 +64,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -86,8 +84,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.19/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.19/expected-v1alpha2.yaml
@@ -65,7 +65,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.19/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.19/expected-v1alpha2.yaml
@@ -64,8 +64,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -86,8 +84,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
@@ -65,7 +65,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
@@ -64,8 +64,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -86,8 +84,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -94,7 +94,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -93,8 +93,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -115,8 +113,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -68,7 +68,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -67,8 +67,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -89,8 +87,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -99,8 +99,6 @@ spec:
   - sg-exampleid3
   - sg-exampleid4
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -124,8 +122,6 @@ spec:
   - sg-exampleid
   - sg-exampleid2
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -100,7 +100,6 @@ spec:
   - sg-exampleid4
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -74,7 +74,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -73,8 +73,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -95,8 +93,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -66,8 +66,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -88,8 +86,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -67,7 +67,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -66,8 +66,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -88,8 +86,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -67,7 +67,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -66,7 +66,6 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
   instanceMetadata:
-    httpPutResponseHopLimit: 2
     httpTokens: required
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -65,8 +65,6 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -87,8 +85,6 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
-  instanceMetadata:
-    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -674,21 +674,6 @@ func setupMasters(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap 
 				g.Spec.Zones = []string{zone}
 			}
 
-			if api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderAWS && (g.Spec.InstanceMetadata == nil || g.Spec.InstanceMetadata.HTTPTokens == nil) {
-				// Support for IMDSv2 was added in Kubernetes 1.18
-				k8sVersion, err := version.ParseKubernetesVersion(cluster.Spec.KubernetesVersion)
-				if err == nil && version.IsKubernetesGTE("1.18", *k8sVersion) {
-					if g.Spec.InstanceMetadata == nil {
-						g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{}
-					}
-					g.Spec.InstanceMetadata.HTTPTokens = fi.String(ec2.LaunchTemplateHttpTokensStateRequired)
-					if strings.Contains(g.Spec.Image, "debian-stretch") {
-						// Debian 9 (Stretch) is too old to support IMDSv2
-						g.Spec.InstanceMetadata.HTTPTokens = fi.String(ec2.LaunchTemplateHttpTokensStateOptional)
-					}
-				}
-			}
-
 			masters = append(masters, g)
 		}
 	}
@@ -801,21 +786,6 @@ func setupNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap ma
 		g.Spec.Subnets = []string{subnet.Name}
 		if cp := api.CloudProviderID(cluster.Spec.CloudProvider); cp == api.CloudProviderGCE || cp == api.CloudProviderAzure {
 			g.Spec.Zones = []string{zone}
-		}
-
-		if api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderAWS && (g.Spec.InstanceMetadata == nil || g.Spec.InstanceMetadata.HTTPTokens == nil) {
-			// Support for IMDSv2 was added in Kubernetes 1.18
-			k8sVersion, err := version.ParseKubernetesVersion(cluster.Spec.KubernetesVersion)
-			if err == nil && version.IsKubernetesGTE("1.18", *k8sVersion) {
-				if g.Spec.InstanceMetadata == nil {
-					g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{}
-				}
-				g.Spec.InstanceMetadata.HTTPTokens = fi.String(ec2.LaunchTemplateHttpTokensStateRequired)
-				if strings.Contains(g.Spec.Image, "debian-stretch") {
-					// Debian 9 (Stretch) is too old to support IMDSv2
-					g.Spec.InstanceMetadata.HTTPTokens = fi.String(ec2.LaunchTemplateHttpTokensStateOptional)
-				}
-			}
 		}
 
 		nodes = append(nodes, g)

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -679,9 +679,7 @@ func setupMasters(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap 
 				k8sVersion, err := version.ParseKubernetesVersion(cluster.Spec.KubernetesVersion)
 				if err == nil && version.IsKubernetesGTE("1.18", *k8sVersion) {
 					if g.Spec.InstanceMetadata == nil {
-						g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{
-							HTTPPutResponseHopLimit: fi.Int64(2),
-						}
+						g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{}
 					}
 					g.Spec.InstanceMetadata.HTTPTokens = fi.String(ec2.LaunchTemplateHttpTokensStateRequired)
 					if strings.Contains(g.Spec.Image, "debian-stretch") {


### PR DESCRIPTION
It has caused some issues with various CNIs, so we need to wait until 1.21 until we can consider this one again.