### PR TITLE
Automated cherry pick of #10721: Cleanup kops-controller Route53 record during cluster

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -1855,7 +1855,7 @@ func ListRoute53Records(cloud fi.Cloud, clusterName string) ([]*resources.Resour
 
 				remove := false
 				// TODO: Compute the actual set of names?
-				if prefix == ".api" || prefix == ".api.internal" || prefix == ".bastion" {
+				if prefix == ".api" || prefix == ".api.internal" || prefix == ".bastion" || prefix == ".kops-controller.internal" {
 					remove = true
 				} else if strings.HasPrefix(prefix, ".etcd-") {
 					remove = true


### PR DESCRIPTION
Cherry pick of #10721 on release-1.19.

#10721: Cleanup kops-controller Route53 record during cluster

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.