### PR TITLE
Use expected LaunchTemplateId in updating ASG when MixedInstancePolicy is changed

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -454,7 +454,7 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 
 		if changes.LaunchTemplate != nil {
 			spec := &autoscaling.LaunchTemplateSpecification{
-				LaunchTemplateId: changes.LaunchTemplate.ID,
+				LaunchTemplateId: e.LaunchTemplate.ID,
 				Version:          aws.String("$Latest"),
 			}
 			if e.UseMixedInstancesPolicy() {
@@ -489,7 +489,7 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			if setup(request).LaunchTemplate == nil {
 				setup(request).LaunchTemplate = &autoscaling.LaunchTemplate{
 					LaunchTemplateSpecification: &autoscaling.LaunchTemplateSpecification{
-						LaunchTemplateId: changes.LaunchTemplate.ID,
+						LaunchTemplateId: e.LaunchTemplate.ID,
 						Version:          aws.String("$Latest"),
 					},
 				}


### PR DESCRIPTION
refs: #10718 

When user changes only mixedInstancePolicy, LaunchTemplateId is not changed. 
But current logic expect changes to LaunchTemplateId; therefore nil pointer dereference has occur.

In this case, it is not necessary to change LaunchTemplateId in AutoScalingGroup, so I fixed it.

---
I don't know the reason for this logic. If anyone knows why, please tell me.