### PR TITLE
Automated cherry pick of #10742: Use expected LaunchTemplateId in updating ASG when

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -454,7 +454,7 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 
 		if changes.LaunchTemplate != nil {
 			spec := &autoscaling.LaunchTemplateSpecification{
-				LaunchTemplateId: changes.LaunchTemplate.ID,
+				LaunchTemplateId: e.LaunchTemplate.ID,
 				Version:          aws.String("$Latest"),
 			}
 			if e.UseMixedInstancesPolicy() {
@@ -489,7 +489,7 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			if setup(request).LaunchTemplate == nil {
 				setup(request).LaunchTemplate = &autoscaling.LaunchTemplate{
 					LaunchTemplateSpecification: &autoscaling.LaunchTemplateSpecification{
-						LaunchTemplateId: changes.LaunchTemplate.ID,
+						LaunchTemplateId: e.LaunchTemplate.ID,
 						Version:          aws.String("$Latest"),
 					},
 				}


### PR DESCRIPTION
Cherry pick of #10742 on release-1.19.

#10742: Use expected LaunchTemplateId in updating ASG when

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.