### PR TITLE
Deprecate aliyun

### DIFF
--- a/docs/releases/1.20-NOTES.md
+++ b/docs/releases/1.20-NOTES.md
@@ -47,6 +47,8 @@
 
 * The experimental node-authorizer that could be enabled using `nodeAuthorization` has been removed. Setting this value is now forbidden.
 
+* Due to lack of maintainers, the Aliyun/Alibaba Cloud support has been deprecated. The current implementation will be left as-is until the implementation needs updates or otherwise becomes incompatible. At that point, it will be removed. We very much welcome anyone willing to contribute to this cloud provider.
+
 # Full change list since 1.19.0 release
 
 ## 1.19.0-beta.3 to 1.20.0-alpha.1

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -433,6 +433,10 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 
 	case kops.CloudProviderALI:
 		{
+			fmt.Println("")
+			fmt.Println("aliyun support has been deprecated due to lack of maintainers. It may be removed in a future version of kOps.")
+			fmt.Println("")
+
 			if !AlphaAllowALI.Enabled() {
 				return fmt.Errorf("aliyun support is currently alpha, and is feature-gated.  export KOPS_FEATURE_FLAGS=AlphaAllowALI")
 			}


### PR DESCRIPTION
We no longer have any contributors to this cloud provider.
Example of issues we may be facing in near future is that the implementation is currently largely based on the unofficial github.com/denverdino/aliyungo instead of github.com/aliyun/alibaba-cloud-sdk-go 

Hopefully this prompts someone to step up rather than that we have to punt it.

/milestone v1.20