### PR TITLE
Add validation for instanceType and ami architecture 

### DIFF
--- a/pkg/apis/kops/validation/BUILD.bazel
+++ b/pkg/apis/kops/validation/BUILD.bazel
@@ -49,10 +49,13 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//cloudmock/aws/mockec2:go_default_library",
         "//pkg/apis/kops:go_default_library",
         "//pkg/nodeidentity/aws:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -306,6 +306,23 @@ func (c *MockAWSCloud) DescribeInstanceType(instanceType string) (*ec2.InstanceT
 			},
 		}
 	}
+
+	if instanceType == "m4.large" || instanceType == "c5.large" {
+		info.ProcessorInfo = &ec2.ProcessorInfo{
+			SupportedArchitectures: []*string{
+				aws.String("x86_64"),
+			},
+		}
+	}
+
+	if instanceType == "a1.large" {
+		info.ProcessorInfo = &ec2.ProcessorInfo{
+			SupportedArchitectures: []*string{
+				aws.String("arm64"),
+			},
+		}
+	}
+
 	return info, nil
 }
 


### PR DESCRIPTION
When an ami and instanceType of different architectures are specified,`kops update cluster` does not fail even though its an invalid combination.

This can cause side effects like creation of unwanted versions of a launch template, failed cluster creations and so on. 

This PR adds checks to validate the chosen instance type architecture against the ami architecture. This PR adds the validation for launch configuration, launch templates and mixed instance policies.

**Open question:** We are making a `DescribeInstanceType` call for each instance when validating for mixed instance policies. This can be expensive as more instances are added. Should we feature flag this validation?

**UPDATE:** I think the number of calls to DescribeInstanceType should be fine as this done only during spec validation and not during cluster creation.

Fixes: https://github.com/kubernetes/kops/issues/10726