### PR TITLE
Fix docs build failure

### DIFF
--- a/docs/operations/cluster_template.md
+++ b/docs/operations/cluster_template.md
@@ -16,7 +16,7 @@ metadata:
   kops.k8s.io/cluster: {{ '{{.clusterName}}.{{.dnsZone}}' }}
   name: nodes
 spec:
-  image: {{ ChannelRecommendedImage .cloud .kubernetesVersion }}
+  image: {{ '{{ ChannelRecommendedImage .cloud .kubernetesVersion }}' }}
   kubernetesVersion: {{ '{{ ChannelRecommendedKubernetesUpgradeVersion .kubernetesVersion }}' }}
   machineType: m4.large
   maxPrice: "0.5"


### PR DESCRIPTION
On master, `make build-docs` is failing with the following error message. 

```
**UndefinedError**: 'ChannelRecommendedImage' is undefined



Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/macros/plugin.py", line 263, in render
    return md_template.render(**self.variables)
  File "/usr/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 19, in top-level template code
  File "/usr/lib/python3.8/site-packages/jinja2/environment.py", line 471, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'ChannelRecommendedImage' is undefined

```

Tried adding a bunch of braces around it and got it working somehow.... 