### PR TITLE
Add overrides testing in lifecycle integration tests

### DIFF
--- a/cloudmock/aws/mockautoscaling/group.go
+++ b/cloudmock/aws/mockautoscaling/group.go
@@ -101,6 +101,67 @@ func (m *MockAutoscaling) CreateAutoScalingGroup(input *autoscaling.CreateAutoSc
 	return &autoscaling.CreateAutoScalingGroupOutput{}, nil
 }
 
+func (m *MockAutoscaling) UpdateAutoScalingGroup(request *autoscaling.UpdateAutoScalingGroupInput) (*autoscaling.UpdateAutoScalingGroupOutput, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	klog.V(2).Infof("Mock UpdateAutoScalingGroup %v", request)
+
+	if _, ok := m.Groups[*request.AutoScalingGroupName]; !ok {
+		return nil, fmt.Errorf("Autoscaling group not found: %v", *request.AutoScalingGroupName)
+	}
+	group := m.Groups[*request.AutoScalingGroupName]
+
+	if request.AvailabilityZones != nil {
+		group.AvailabilityZones = request.AvailabilityZones
+	}
+	if request.CapacityRebalance != nil {
+		group.CapacityRebalance = request.CapacityRebalance
+	}
+	if request.DesiredCapacity != nil {
+		group.DesiredCapacity = request.DesiredCapacity
+	}
+	if request.HealthCheckGracePeriod != nil {
+		group.HealthCheckGracePeriod = request.HealthCheckGracePeriod
+	}
+	if request.HealthCheckType != nil {
+		group.HealthCheckType = request.HealthCheckType
+	}
+	if request.LaunchConfigurationName != nil {
+		group.LaunchConfigurationName = request.LaunchConfigurationName
+	}
+	if request.LaunchTemplate != nil {
+		group.LaunchTemplate = request.LaunchTemplate
+	}
+	if request.MaxInstanceLifetime != nil {
+		group.MaxInstanceLifetime = request.MaxInstanceLifetime
+	}
+	if request.MaxSize != nil {
+		group.MaxSize = request.MaxSize
+	}
+	if request.MinSize != nil {
+		group.MinSize = request.MinSize
+	}
+	if request.MixedInstancesPolicy != nil {
+		group.MixedInstancesPolicy = request.MixedInstancesPolicy
+	}
+	if request.NewInstancesProtectedFromScaleIn != nil {
+		group.NewInstancesProtectedFromScaleIn = request.NewInstancesProtectedFromScaleIn
+	}
+	if request.PlacementGroup != nil {
+		group.PlacementGroup = request.PlacementGroup
+	}
+	if request.ServiceLinkedRoleARN != nil {
+		group.ServiceLinkedRoleARN = request.ServiceLinkedRoleARN
+	}
+	if request.TerminationPolicies != nil {
+		group.TerminationPolicies = request.TerminationPolicies
+	}
+	if request.VPCZoneIdentifier != nil {
+		group.VPCZoneIdentifier = request.VPCZoneIdentifier
+	}
+	return &autoscaling.UpdateAutoScalingGroupOutput{}, nil
+}
+
 func (m *MockAutoscaling) EnableMetricsCollection(request *autoscaling.EnableMetricsCollectionInput) (*autoscaling.EnableMetricsCollectionOutput, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/cloudmock/aws/mockec2/launch_templates.go
+++ b/cloudmock/aws/mockec2/launch_templates.go
@@ -26,8 +26,9 @@ import (
 )
 
 type launchTemplateInfo struct {
-	data *ec2.ResponseLaunchTemplateData
-	name *string
+	data    *ec2.ResponseLaunchTemplateData
+	name    *string
+	version int
 }
 
 // DescribeLaunchTemplatesPages mocks the describing the launch templates
@@ -132,108 +133,39 @@ func (m *MockEC2) CreateLaunchTemplate(request *ec2.CreateLaunchTemplateInput) (
 	if m.LaunchTemplates[id] != nil {
 		return nil, fmt.Errorf("duplicate LaunchTemplateId %s", id)
 	}
-	resp := &ec2.ResponseLaunchTemplateData{
-		DisableApiTermination: request.LaunchTemplateData.DisableApiTermination,
-		EbsOptimized:          request.LaunchTemplateData.EbsOptimized,
-		ImageId:               request.LaunchTemplateData.ImageId,
-		InstanceType:          request.LaunchTemplateData.InstanceType,
-		KeyName:               request.LaunchTemplateData.KeyName,
-		SecurityGroupIds:      request.LaunchTemplateData.SecurityGroupIds,
-		SecurityGroups:        request.LaunchTemplateData.SecurityGroups,
-		UserData:              request.LaunchTemplateData.UserData,
-	}
 	m.LaunchTemplates[id] = &launchTemplateInfo{
-		data: resp,
-		name: request.LaunchTemplateName,
-	}
-
-	if request.LaunchTemplateData.MetadataOptions != nil {
-		resp.MetadataOptions = &ec2.LaunchTemplateInstanceMetadataOptions{
-			HttpTokens:              request.LaunchTemplateData.MetadataOptions.HttpTokens,
-			HttpPutResponseHopLimit: request.LaunchTemplateData.MetadataOptions.HttpPutResponseHopLimit,
-		}
-	}
-	if request.LaunchTemplateData.Monitoring != nil {
-		resp.Monitoring = &ec2.LaunchTemplatesMonitoring{Enabled: request.LaunchTemplateData.Monitoring.Enabled}
-	}
-	if request.LaunchTemplateData.CpuOptions != nil {
-		resp.CpuOptions = &ec2.LaunchTemplateCpuOptions{
-			CoreCount:      request.LaunchTemplateData.CpuOptions.CoreCount,
-			ThreadsPerCore: request.LaunchTemplateData.CpuOptions.ThreadsPerCore,
-		}
-	}
-	if len(request.LaunchTemplateData.BlockDeviceMappings) > 0 {
-		for _, x := range request.LaunchTemplateData.BlockDeviceMappings {
-			var ebs *ec2.LaunchTemplateEbsBlockDevice
-			if x.Ebs != nil {
-				ebs = &ec2.LaunchTemplateEbsBlockDevice{
-					DeleteOnTermination: x.Ebs.DeleteOnTermination,
-					Encrypted:           x.Ebs.Encrypted,
-					Iops:                x.Ebs.Iops,
-					KmsKeyId:            x.Ebs.KmsKeyId,
-					SnapshotId:          x.Ebs.SnapshotId,
-					Throughput:          x.Ebs.Throughput,
-					VolumeSize:          x.Ebs.VolumeSize,
-					VolumeType:          x.Ebs.VolumeType,
-				}
-			}
-			resp.BlockDeviceMappings = append(resp.BlockDeviceMappings, &ec2.LaunchTemplateBlockDeviceMapping{
-				DeviceName:  x.DeviceName,
-				Ebs:         ebs,
-				NoDevice:    x.NoDevice,
-				VirtualName: x.VirtualName,
-			})
-		}
-	}
-	if request.LaunchTemplateData.CreditSpecification != nil {
-		resp.CreditSpecification = &ec2.CreditSpecification{CpuCredits: request.LaunchTemplateData.CreditSpecification.CpuCredits}
-	}
-	if request.LaunchTemplateData.IamInstanceProfile != nil {
-		resp.IamInstanceProfile = &ec2.LaunchTemplateIamInstanceProfileSpecification{
-			Arn:  request.LaunchTemplateData.IamInstanceProfile.Arn,
-			Name: request.LaunchTemplateData.IamInstanceProfile.Name,
-		}
-	}
-	if request.LaunchTemplateData.InstanceMarketOptions != nil {
-		resp.InstanceMarketOptions = &ec2.LaunchTemplateInstanceMarketOptions{
-			MarketType: request.LaunchTemplateData.InstanceMarketOptions.MarketType,
-			SpotOptions: &ec2.LaunchTemplateSpotMarketOptions{
-				BlockDurationMinutes:         request.LaunchTemplateData.InstanceMarketOptions.SpotOptions.BlockDurationMinutes,
-				InstanceInterruptionBehavior: request.LaunchTemplateData.InstanceMarketOptions.SpotOptions.InstanceInterruptionBehavior,
-				MaxPrice:                     request.LaunchTemplateData.InstanceMarketOptions.SpotOptions.MaxPrice,
-				SpotInstanceType:             request.LaunchTemplateData.InstanceMarketOptions.SpotOptions.SpotInstanceType,
-				ValidUntil:                   request.LaunchTemplateData.InstanceMarketOptions.SpotOptions.ValidUntil,
-			},
-		}
-	}
-	if len(request.LaunchTemplateData.NetworkInterfaces) > 0 {
-		for _, x := range request.LaunchTemplateData.NetworkInterfaces {
-			resp.NetworkInterfaces = append(resp.NetworkInterfaces, &ec2.LaunchTemplateInstanceNetworkInterfaceSpecification{
-				AssociatePublicIpAddress:       x.AssociatePublicIpAddress,
-				DeleteOnTermination:            x.DeleteOnTermination,
-				Description:                    x.Description,
-				DeviceIndex:                    x.DeviceIndex,
-				Groups:                         x.Groups,
-				Ipv6AddressCount:               x.Ipv6AddressCount,
-				NetworkInterfaceId:             x.NetworkInterfaceId,
-				PrivateIpAddress:               x.PrivateIpAddress,
-				PrivateIpAddresses:             x.PrivateIpAddresses,
-				SecondaryPrivateIpAddressCount: x.SecondaryPrivateIpAddressCount,
-				SubnetId:                       x.SubnetId,
-			})
-		}
-	}
-	if len(request.LaunchTemplateData.TagSpecifications) > 0 {
-		for _, x := range request.LaunchTemplateData.TagSpecifications {
-			resp.TagSpecifications = append(resp.TagSpecifications, &ec2.LaunchTemplateTagSpecification{
-				ResourceType: x.ResourceType,
-				Tags:         x.Tags,
-			})
-		}
+		data:    responseLaunchTemplateData(request.LaunchTemplateData),
+		name:    request.LaunchTemplateName,
+		version: 1,
 	}
 	m.addTags(id, tagSpecificationsToTags(request.TagSpecifications, ec2.ResourceTypeLaunchTemplate)...)
 
-	return &ec2.CreateLaunchTemplateOutput{}, nil
+	return &ec2.CreateLaunchTemplateOutput{
+		LaunchTemplate: &ec2.LaunchTemplate{
+			LaunchTemplateId: aws.String(id),
+		},
+	}, nil
+}
+
+func (m *MockEC2) CreateLaunchTemplateVersion(request *ec2.CreateLaunchTemplateVersionInput) (*ec2.CreateLaunchTemplateVersionOutput, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	klog.V(2).Infof("Mock CreateLaunchTemplateVersion: %v", request)
+
+	name := request.LaunchTemplateName
+	found := false
+	for _, ltInfo := range m.LaunchTemplates {
+		if aws.StringValue(ltInfo.name) == aws.StringValue(name) {
+			found = true
+			ltInfo.data = responseLaunchTemplateData(request.LaunchTemplateData)
+			ltInfo.version++
+		}
+	}
+	if !found {
+		return nil, nil // TODO: error
+	}
+	return &ec2.CreateLaunchTemplateVersionOutput{}, nil
 }
 
 // DeleteLaunchTemplate mocks the deletion of a launch template
@@ -255,4 +187,103 @@ func (m *MockEC2) DeleteLaunchTemplate(request *ec2.DeleteLaunchTemplateInput) (
 	}
 
 	return o, nil
+}
+
+func responseLaunchTemplateData(req *ec2.RequestLaunchTemplateData) *ec2.ResponseLaunchTemplateData {
+	resp := &ec2.ResponseLaunchTemplateData{
+		DisableApiTermination: req.DisableApiTermination,
+		EbsOptimized:          req.EbsOptimized,
+		ImageId:               req.ImageId,
+		InstanceType:          req.InstanceType,
+		KeyName:               req.KeyName,
+		SecurityGroupIds:      req.SecurityGroupIds,
+		SecurityGroups:        req.SecurityGroups,
+		UserData:              req.UserData,
+	}
+
+	if req.MetadataOptions != nil {
+		resp.MetadataOptions = &ec2.LaunchTemplateInstanceMetadataOptions{
+			HttpTokens:              req.MetadataOptions.HttpTokens,
+			HttpPutResponseHopLimit: req.MetadataOptions.HttpPutResponseHopLimit,
+		}
+	}
+	if req.Monitoring != nil {
+		resp.Monitoring = &ec2.LaunchTemplatesMonitoring{Enabled: req.Monitoring.Enabled}
+	}
+	if req.CpuOptions != nil {
+		resp.CpuOptions = &ec2.LaunchTemplateCpuOptions{
+			CoreCount:      req.CpuOptions.CoreCount,
+			ThreadsPerCore: req.CpuOptions.ThreadsPerCore,
+		}
+	}
+	if len(req.BlockDeviceMappings) > 0 {
+		for _, x := range req.BlockDeviceMappings {
+			var ebs *ec2.LaunchTemplateEbsBlockDevice
+			if x.Ebs != nil {
+				ebs = &ec2.LaunchTemplateEbsBlockDevice{
+					DeleteOnTermination: x.Ebs.DeleteOnTermination,
+					Encrypted:           x.Ebs.Encrypted,
+					Iops:                x.Ebs.Iops,
+					KmsKeyId:            x.Ebs.KmsKeyId,
+					SnapshotId:          x.Ebs.SnapshotId,
+					Throughput:          x.Ebs.Throughput,
+					VolumeSize:          x.Ebs.VolumeSize,
+					VolumeType:          x.Ebs.VolumeType,
+				}
+			}
+			resp.BlockDeviceMappings = append(resp.BlockDeviceMappings, &ec2.LaunchTemplateBlockDeviceMapping{
+				DeviceName:  x.DeviceName,
+				Ebs:         ebs,
+				NoDevice:    x.NoDevice,
+				VirtualName: x.VirtualName,
+			})
+		}
+	}
+	if req.CreditSpecification != nil {
+		resp.CreditSpecification = &ec2.CreditSpecification{CpuCredits: req.CreditSpecification.CpuCredits}
+	}
+	if req.IamInstanceProfile != nil {
+		resp.IamInstanceProfile = &ec2.LaunchTemplateIamInstanceProfileSpecification{
+			Arn:  req.IamInstanceProfile.Arn,
+			Name: req.IamInstanceProfile.Name,
+		}
+	}
+	if req.InstanceMarketOptions != nil {
+		resp.InstanceMarketOptions = &ec2.LaunchTemplateInstanceMarketOptions{
+			MarketType: req.InstanceMarketOptions.MarketType,
+			SpotOptions: &ec2.LaunchTemplateSpotMarketOptions{
+				BlockDurationMinutes:         req.InstanceMarketOptions.SpotOptions.BlockDurationMinutes,
+				InstanceInterruptionBehavior: req.InstanceMarketOptions.SpotOptions.InstanceInterruptionBehavior,
+				MaxPrice:                     req.InstanceMarketOptions.SpotOptions.MaxPrice,
+				SpotInstanceType:             req.InstanceMarketOptions.SpotOptions.SpotInstanceType,
+				ValidUntil:                   req.InstanceMarketOptions.SpotOptions.ValidUntil,
+			},
+		}
+	}
+	if len(req.NetworkInterfaces) > 0 {
+		for _, x := range req.NetworkInterfaces {
+			resp.NetworkInterfaces = append(resp.NetworkInterfaces, &ec2.LaunchTemplateInstanceNetworkInterfaceSpecification{
+				AssociatePublicIpAddress:       x.AssociatePublicIpAddress,
+				DeleteOnTermination:            x.DeleteOnTermination,
+				Description:                    x.Description,
+				DeviceIndex:                    x.DeviceIndex,
+				Groups:                         x.Groups,
+				Ipv6AddressCount:               x.Ipv6AddressCount,
+				NetworkInterfaceId:             x.NetworkInterfaceId,
+				PrivateIpAddress:               x.PrivateIpAddress,
+				PrivateIpAddresses:             x.PrivateIpAddresses,
+				SecondaryPrivateIpAddressCount: x.SecondaryPrivateIpAddressCount,
+				SubnetId:                       x.SubnetId,
+			})
+		}
+	}
+	if len(req.TagSpecifications) > 0 {
+		for _, x := range req.TagSpecifications {
+			resp.TagSpecifications = append(resp.TagSpecifications, &ec2.LaunchTemplateTagSpecification{
+				ResourceType: x.ResourceType,
+				Tags:         x.Tags,
+			})
+		}
+	}
+	return resp
 }

--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -166,6 +166,7 @@ go_test(
         "//cloudmock/aws/mockec2:go_default_library",
         "//cmd/kops/util:go_default_library",
         "//pkg/apis/kops:go_default_library",
+        "//pkg/commands:go_default_library",
         "//pkg/featureflag:go_default_library",
         "//pkg/jsonutils:go_default_library",
         "//pkg/kopscodecs:go_default_library",

--- a/tests/integration/update_cluster/complex/cluster.overrides.txt
+++ b/tests/integration/update_cluster/complex/cluster.overrides.txt
@@ -1,0 +1,3 @@
+spec.api.loadBalancer.sslCertificate=arn:aws:acm:us-east-1:123456789012:certificate/123456789012-1234-1234-1234-12345678
+---
+spec.api.loadBalancer.additionalSecurityGroups=sg-123456

--- a/tests/integration/update_cluster/complex/instancegroup.nodes.overrides.txt
+++ b/tests/integration/update_cluster/complex/instancegroup.nodes.overrides.txt
@@ -1,0 +1,3 @@
+spec.mixedInstancesPolicy.instances=[m5.xlarge,m5.large]
+---
+spec.mixedInstancesPolicy.instances=[m5.xlarge]


### PR DESCRIPTION
This allows specific changes to be tested on an existing cluster during an `update cluster --yes` and ensuring a subsequent `update cluster` dryrun correctly reports no changes.

To specify changes, create a `cluster.overrides.txt` or `instancegroup.<name>.overrides.txt` file in the update_cluster integration test's directory as demonstrated here.

Each line is a field=value format, each batch of changes is separated by a `---` line.
Each batch will be ran through `update cluster --yes` on its own.

In particular, reverting https://github.com/kubernetes/kops/pull/10742 correctly caused a panic, so these tests are now capable of exposing those types of bugs.