### PR TITLE
Use EnsureTask instead of prepending IG names to external ELB tasks

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -450,17 +450,13 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 
 	for _, extLB := range ig.Spec.ExternalLoadBalancers {
 		if extLB.LoadBalancerName != nil {
-			loadBalancerName := fi.StringValue(extLB.LoadBalancerName)
-			if loadBalancerName != awsup.GetResourceName32(b.Cluster.Name, "api") && loadBalancerName != awsup.GetResourceName32(b.Cluster.Name, "bastion") {
-				loadBalancerName = name + "-" + loadBalancerName
-			}
 			lb := &awstasks.ClassicLoadBalancer{
-				Name:             fi.String(loadBalancerName),
+				Name:             extLB.LoadBalancerName,
 				LoadBalancerName: extLB.LoadBalancerName,
 				Shared:           fi.Bool(true),
 			}
 			t.LoadBalancers = append(t.LoadBalancers, lb)
-			c.AddTask(lb)
+			c.EnsureTask(lb)
 		}
 
 		if extLB.TargetGroupARN != nil {

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -89,6 +89,9 @@
             ]
           }
         ],
+        "LoadBalancerNames": [
+          "my-external-lb-1"
+        ],
         "TargetGroupARNs": [
           {
             "Ref": "AWSElasticLoadBalancingV2TargetGrouptcpcomplexexamplecomvpjolq"
@@ -182,6 +185,9 @@
               "GroupTotalInstances"
             ]
           }
+        ],
+        "LoadBalancerNames": [
+          "my-external-lb-1"
         ]
       }
     },

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -83,6 +83,8 @@ spec:
   - sg-exampleid3
   - sg-exampleid4
   associatePublicIp: true
+  externalLoadBalancers:
+    - loadBalancerName: my-external-lb-1
   suspendProcesses:
   - AZRebalance
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
@@ -120,6 +122,8 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
 spec:
   associatePublicIp: true
+  externalLoadBalancers:
+    - loadBalancerName: my-external-lb-1
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -83,6 +83,8 @@ spec:
   - sg-exampleid3
   - sg-exampleid4
   associatePublicIp: true
+  externalLoadBalancers:
+    - loadBalancerName: my-external-lb-1
   suspendProcesses:
   - AZRebalance
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
@@ -120,6 +122,8 @@ metadata:
     kops.k8s.io/cluster: complex.example.com
 spec:
   associatePublicIp: true
+  externalLoadBalancers:
+    - loadBalancerName: my-external-lb-1
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -86,6 +86,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
     id      = aws_launch_template.master-us-test-1a-masters-complex-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-complex-example-com.latest_version
   }
+  load_balancers      = ["my-external-lb-1"]
   max_size            = 1
   metrics_granularity = "1Minute"
   min_size            = 1
@@ -150,6 +151,7 @@ resource "aws_autoscaling_group" "nodes-complex-example-com" {
     id      = aws_launch_template.nodes-complex-example-com.id
     version = aws_launch_template.nodes-complex-example-com.latest_version
   }
+  load_balancers      = ["my-external-lb-1"]
   max_size            = 2
   metrics_granularity = "1Minute"
   min_size            = 2

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -717,7 +717,7 @@ func (e *AutoscalingGroup) AutoscalingLoadBalancers() []*string {
 	var list []*string
 
 	for _, v := range e.LoadBalancers {
-		list = append(list, v.Name)
+		list = append(list, v.LoadBalancerName)
 	}
 
 	return list

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -115,12 +115,8 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 
 	actual.LoadBalancers = []*ClassicLoadBalancer{}
 	for _, lb := range g.LoadBalancerNames {
-		loadBalancerName := fi.StringValue(lb)
-		if loadBalancerName != awsup.GetResourceName32(c.Cluster.Name, "api") && loadBalancerName != awsup.GetResourceName32(c.Cluster.Name, "bastion") {
-			loadBalancerName = fi.StringValue(g.AutoScalingGroupName) + "-" + loadBalancerName
-		}
 		actual.LoadBalancers = append(actual.LoadBalancers, &ClassicLoadBalancer{
-			Name:             aws.String(loadBalancerName),
+			Name:             aws.String(*lb),
 			LoadBalancerName: aws.String(*lb),
 		})
 	}


### PR DESCRIPTION
Fixes #10715

Partially reverts https://github.com/kubernetes/kops/pull/10666

This way we end up with one CLB task per CLB regardless of how many ASGs it is attached to. Less brittle than creating many CLB tasks with concatenated names and exceptions for known CLBs.

The `Name` -> `LoadBalancerName` shouldn't make a functional difference, just improving consistency with how we attach CLBs to ASGs being created vs updated.
