### PR TITLE
fix: asset task copy docker image

### DIFF
--- a/upup/pkg/fi/assettasks/docker_api.go
+++ b/upup/pkg/fi/assettasks/docker_api.go
@@ -61,8 +61,7 @@ func newDockerAPI() (*dockerAPI, error) {
 // findImage does a `docker images` via the API, and finds the specified image
 func (d *dockerAPI) findImage(name string) (*types.ImageSummary, error) {
 	klog.V(4).Infof("docker query for image %q", name)
-	filter := filters.Args{}
-	filter.Add("reference", name)
+	filter := filters.NewArgs(filters.KeyValuePair{Key: "reference", Value: name})
 	options := types.ImageListOptions{
 		Filters: filter,
 	}


### PR DESCRIPTION
Otherwise `kops update cluster --name XYZ --yes --phase assets` fails with:

```
panic: assignment to entry in nil map

goroutine 216 [running]:
k8s.io/kops/vendor/github.com/docker/docker/api/types/filters.Args.Add(...)
	vendor/github.com/docker/docker/api/types/filters/parse.go:133
k8s.io/kops/upup/pkg/fi/assettasks.(*dockerAPI).findImage(0x4000186128, 0x362192f, 0x14, 0x0, 0x0, 0x22)
	upup/pkg/fi/assettasks/docker_api.go:65 +0x2fc
k8s.io/kops/upup/pkg/fi/assettasks.(*CopyDockerImage).Render(0x4001204fc0, 0x4001292d20, 0x0, 0x4001204fc0, 0x4000a1a140, 0x0, 0x0)
	upup/pkg/fi/assettasks/copydockerimage.go:136 +0x1f4
```

Ideally this would be test covered, but it seems it wasn't before so I'm not sure how to test this.

This seems to have been introduced in https://github.com/kubernetes/kops/pull/10193, which was back-ported to kops 1.19 were we ran into this.