### PR TITLE
Kubetest2 - Use a shell lexer for passing extra args to `create cluster`

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/octago/sflags v0.2.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.3.0

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -503,6 +503,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200905233945-acf8798be1f7/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -22,6 +22,8 @@ import (
 	osexec "os/exec"
 	"strings"
 
+	"github.com/google/shlex"
+
 	"k8s.io/klog/v2"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/aws"
 	"k8s.io/kops/tests/e2e/kubetest2-kops/do"
@@ -92,7 +94,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string) error {
 	}
 
 	if d.CreateArgs != "" {
-		args = append(args, strings.Split(d.CreateArgs, " ")...)
+		args = append(args, shlex.Split(d.CreateArgs)...)
 	}
 	args = appendIfUnset(args, "--admin-access", adminAccess)
 	args = appendIfUnset(args, "--master-count", "1")


### PR DESCRIPTION
This way any spaces within a quoted value wont cause the value to be broken up into multiple arguments.
The CentOS image in AWS has spaces in its name which is what exposed this issue.

Using this library: https://github.com/google/shlex/blob/master/shlex.go

xref: https://github.com/kubernetes/test-infra/pull/20799

Fixes https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-distro-imagecentos7/1358877320022069248