### PR TITLE
Kubetest2 - Fix splitting of --create-args

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -94,7 +94,11 @@ func (d *deployer) createCluster(zones []string, adminAccess string) error {
 	}
 
 	if d.CreateArgs != "" {
-		args = append(args, shlex.Split(d.CreateArgs)...)
+		createArgs, err := shlex.Split(d.CreateArgs)
+		if err != nil {
+			return err
+		}
+		args = append(args, createArgs...)
 	}
 	args = appendIfUnset(args, "--admin-access", adminAccess)
 	args = appendIfUnset(args, "--master-count", "1")


### PR DESCRIPTION
apparently our presubmits don't validate the e2e go submodule. I'll work on fixing that.

`kubetest2-kops/deployer/up.go:97:34: multiple-value shlex.Split() in single-value context `