### PR TITLE
Reject update when architectures for each instance do not match

### DIFF
--- a/pkg/apis/kops/validation/helpers.go
+++ b/pkg/apis/kops/validation/helpers.go
@@ -49,3 +49,18 @@ func IsValidValue(fldPath *field.Path, v *string, validValues []string) field.Er
 	}
 	return allErrs
 }
+
+func ExtractDuplicationString(sliceA, sliceB []*string) []*string {
+	sliceC := append(sliceA, sliceB...)
+	sliceD := make([]*string, 0)
+
+	m := make(map[string]struct{}, 0)
+	for _, el := range sliceC {
+		if _, ok := m[*el]; ok == false {
+			m[*el] = struct{}{}
+		} else {
+			sliceD = append(sliceD, el)
+		}
+	}
+	return sliceD
+}


### PR DESCRIPTION
closes: https://github.com/kubernetes/kops/issues/10726

I fixed to return an error when instances of different architectures are mixed.

---
I will add a test for this method, so this pull request is still WIP.