### PR TITLE
Update kubectl documentation with new flags

### DIFF
--- a/docs/getting_started/kubectl.md
+++ b/docs/getting_started/kubectl.md
@@ -12,3 +12,5 @@ kops export kubecfg ${NAME}
 ```
 
 Warning: Note that the exported configuration gives you full admin privileges using TLS certificates that are not easy to rotate. For regular kubectl usage, you should consider using another method for authenticating to the cluster.
+
+If you are using kops >= 1.19.0, kops export kubecfg will also require passing either the --admin or --user flag if the context does not already exist. For more information, see the section "Changes to kubernetes config export" in the [release notes].(https://github.com/kubernetes/kops/releases/tag/v1.19.0)

--- a/docs/getting_started/kubectl.md
+++ b/docs/getting_started/kubectl.md
@@ -13,4 +13,4 @@ kops export kubecfg ${NAME}
 
 Warning: Note that the exported configuration gives you full admin privileges using TLS certificates that are not easy to rotate. For regular kubectl usage, you should consider using another method for authenticating to the cluster.
 
-If you are using kops >= 1.19.0, kops export kubecfg will also require passing either the --admin or --user flag if the context does not already exist. For more information, see the section "Changes to kubernetes config export" in the [release notes].(https://github.com/kubernetes/kops/releases/tag/v1.19.0)
+If you are using kops >= 1.19.0, kops export kubecfg will also require passing either the --admin or --user flag if the context does not already exist. For more information, see the [release notes](https://kops.sigs.k8s.io/releases/1.19-notes/#changes-to-kubernetes-config-export).


### PR DESCRIPTION
I've lost a bit of time trying to generate the config for connection to a k8s cluster, since I didn't notice there is a new mandatory flag with kops 1.19.
I think mentioning in the documentation can save from some headcache, and avoiding issues as #10723