### PR TITLE
Automated cherry pick of #10767: fix: asset task copy docker image

### DIFF
--- a/upup/pkg/fi/assettasks/docker_api.go
+++ b/upup/pkg/fi/assettasks/docker_api.go
@@ -61,8 +61,7 @@ func newDockerAPI() (*dockerAPI, error) {
 // findImage does a `docker images` via the API, and finds the specified image
 func (d *dockerAPI) findImage(name string) (*types.ImageSummary, error) {
 	klog.V(4).Infof("docker query for image %q", name)
-	filter := filters.Args{}
-	filter.Add("reference", name)
+	filter := filters.NewArgs(filters.KeyValuePair{Key: "reference", Value: name})
 	options := types.ImageListOptions{
 		Filters: filter,
 	}


### PR DESCRIPTION
Cherry pick of #10767 on release-1.20.

#10767: fix: asset task copy docker image

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.