### PR TITLE
Enable CSIMigrationAWS if CSI EBS driver is installed

### DIFF
--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -158,6 +158,9 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 		if _, found := kcm.FeatureGates["CSIMigrationAWSComplete"]; !found {
 			kcm.FeatureGates["CSIMigrationAWSComplete"] = "true"
 		}
+		if _, found := kcm.FeatureGates["CSIMigrationAWS"]; !found {
+			kcm.FeatureGates["CSIMigrationAWS"] = "true"
+		}
 	}
 
 	return nil

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -209,6 +209,9 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if clusterSpec.CloudConfig != nil && clusterSpec.CloudConfig.AWSEBSCSIDriver != nil && fi.BoolValue(clusterSpec.CloudConfig.AWSEBSCSIDriver.Enabled) {
+		if _, found := clusterSpec.Kubelet.FeatureGates["CSIMigrationAWS"]; !found {
+			clusterSpec.Kubelet.FeatureGates["CSIMigrationAWS"] = "true"
+		}
 		if _, found := clusterSpec.Kubelet.FeatureGates["CSIMigrationAWSComplete"]; !found {
 			clusterSpec.Kubelet.FeatureGates["CSIMigrationAWSComplete"] = "true"
 		}


### PR DESCRIPTION
CSIMigrationAWSComplete feature gate does not work unless also CSIMigrationAWS is enabled

per https://github.com/kubernetes/kops/issues/10777#issuecomment-776537706 we need to enable an additional feature gate to disable the in-tree EBS plugin