### PR TITLE
Automated cherry pick of #10728: Fill Role names in kops-controller-config instead of instance

### DIFF
--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/elbv2:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/iam:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/route53:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/dns/v2/zones:go_default_library",

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
@@ -254,6 +255,17 @@ func (h *IntegrationTestHarness) SetupMockAWS() *awsup.MockAWSCloud {
 	})
 	mockELBV2.CreateTargetGroup(&elbv2.CreateTargetGroupInput{
 		Name: aws.String("my-external-tg-3"),
+	})
+
+	mockIAM.CreateRole(&iam.CreateRoleInput{
+		RoleName: aws.String("kops-custom-node-role"),
+	})
+	mockIAM.CreateInstanceProfile(&iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String("kops-custom-node-role"),
+	})
+	mockIAM.AddRoleToInstanceProfile(&iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String("kops-custom-node-role"),
+		RoleName:            aws.String("kops-custom-node-role"),
 	})
 
 	return cloud

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -472,6 +472,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 
 	tf := &TemplateFunctions{
 		KopsModelContext: *modelContext,
+		cloud:            cloud,
 	}
 
 	{

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -1751,3 +1751,18 @@ func (c *awsCloudImplementation) AccountInfo() (string, string, error) {
 	}
 	return arn.AccountID, arn.Partition, nil
 }
+
+// GetRolesInInstanceProfile return role names which are associated with the instance profile specified by profileName.
+func GetRolesInInstanceProfile(c AWSCloud, profileName string) ([]string, error) {
+	output, err := c.IAM().GetInstanceProfile(&iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String(profileName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	var roleNames []string
+	for _, role := range output.InstanceProfile.Roles {
+		roleNames = append(roleNames, *role.RoleName)
+	}
+	return roleNames, nil
+}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -139,6 +139,7 @@ func runChannelBuilderTest(t *testing.T, key string, addonManifests []string) {
 
 	tf := &TemplateFunctions{
 		KopsModelContext: kopsModel,
+		cloud:            cloud,
 	}
 	tf.AddTo(templates.TemplateFunctions, secretStore)
 


### PR DESCRIPTION
Cherry pick of #10728 on release-1.19.

#10728: Fill Role names in kops-controller-config instead of instance

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.