### PR TITLE
Allow managed images for Azure instance groups

### DIFF
--- a/pkg/model/azuremodel/vmscaleset_test.go
+++ b/pkg/model/azuremodel/vmscaleset_test.go
@@ -176,14 +176,14 @@ func TestGetStorageProfile(t *testing.T) {
 	}
 }
 
-func TestParseImageURN(t *testing.T) {
+func TestParseImage(t *testing.T) {
 	testCases := []struct {
-		urn      string
+		image    string
 		success  bool
 		imageRef *compute.ImageReference
 	}{
 		{
-			urn:     "Canonical:UbuntuServer:18.04-LTS:latest",
+			image:   "Canonical:UbuntuServer:18.04-LTS:latest",
 			success: true,
 			imageRef: &compute.ImageReference{
 				Publisher: to.StringPtr("Canonical"),
@@ -193,17 +193,24 @@ func TestParseImageURN(t *testing.T) {
 			},
 		},
 		{
-			urn:     "invalidformat",
+			image:   "/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/<provider>/images/<image>",
+			success: true,
+			imageRef: &compute.ImageReference{
+				ID: to.StringPtr("/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/<provider>/images/<image>"),
+			},
+		},
+		{
+			image:   "invalidformat",
 			success: false,
 		},
 		{
-			urn:     "inv:ali:dfo:rma:t",
+			image:   "inv:ali:dfo:rma:t",
 			success: false,
 		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
-			imageRef, err := parseImageURN(tc.urn)
+			imageRef, err := parseImage(tc.image)
 			if !tc.success {
 				if err == nil {
 					t.Fatalf("unexpected success")


### PR DESCRIPTION
Allows us to use our own managed images for virtual machine scale sets and not just ones that are published to the marketplace.

Related to
`Be able to configure some more parameters for VM Scale Set such as Windows` in #10412

Not sure if it's necessary we should check for a 
`/subscriptions/<subscription id>/resourceGroups/<resource group>/providers/<provider>/images/<image>` format