### PR TITLE
WIP Kubetest2 - Add a timeout flag and issue SIGABRT to child processes 

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/mitchellh/go-ps v1.0.0
 	github.com/octago/sflags v0.2.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.3.0

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -695,6 +695,8 @@ github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFW
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
+github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -39,15 +39,15 @@ func (d *deployer) DumpClusterLogs() error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(d.env()...)
 	if err := runWithOutput(cmd); err != nil {
-		return err
+		klog.Warning(err)
 	}
 
 	if err := d.dumpClusterManifest(); err != nil {
-		return err
+		klog.Warning(err)
 	}
 
 	if err := d.dumpClusterInfo(); err != nil {
-		return err
+		klog.Warning(err)
 	}
 
 	return nil


### PR DESCRIPTION
The goal here is to catch when the timeouts are happening in prow and ensure our shutdown + log dump processes happens cleanly.

I'm also hoping we can issue a SIGABRT to the e2e.test process which will dump its stack trace, also helping in the timeout troubleshooting.