### PR TITLE
Add deprecation notice for launch templates. 

### DIFF
--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -144,6 +144,8 @@ has been updated by a newer version of kOps unless it is given the `--allow-kops
 
 * The experimental node authorizor is now ignored if you are using kubernetes 1.19. The feature will be removed in 1.20. Worker nodes will instead be authorized using kops-controller.
 
+* Support for AWS LaunchConfiguration has been deprecated and will be removed in kOps 1.21.
+
 # Full change list since 1.18.0 release
 
 ## v1.18.0-alpha.3 to v1.19.0-alpha.1

--- a/docs/releases/1.20-NOTES.md
+++ b/docs/releases/1.20-NOTES.md
@@ -50,6 +50,8 @@
 
 * Due to lack of maintainers, the Aliyun/Alibaba Cloud support has been deprecated. The current implementation will be left as-is until the implementation needs updates or otherwise becomes incompatible. At that point, it will be removed. We very much welcome anyone willing to contribute to this cloud provider.
 
+* Support for AWS LaunchConfiguration has been deprecated and will be removed in kOps 1.21.
+
 # Full change list since 1.19.0 release
 
 ## 1.19.0-beta.3 to 1.20.0-alpha.1


### PR DESCRIPTION
As discussed in office hours, we will be working on deprecating launch configurations in favour of launch templates. Add the deprecation notice to the release notes of the 1.19 and 1.20 release. 