### PR TITLE
iptables: Use the lock when checking for existing rules

### DIFF
--- a/nodeup/pkg/model/firewall.go
+++ b/nodeup/pkg/model/firewall.go
@@ -73,13 +73,13 @@ func (b *FirewallBuilder) buildFirewallScript() *nodetasks.File {
 
 # The GCI image has host firewall which drop most inbound/forwarded packets.
 # We need to add rules to accept all TCP/UDP/ICMP packets.
-if iptables -L INPUT | grep "Chain INPUT (policy DROP)" > /dev/null; then
+if iptables -w -L INPUT | grep "Chain INPUT (policy DROP)" > /dev/null; then
 echo "Add rules to accept all inbound TCP/UDP/ICMP packets"
 iptables -A INPUT -w -p TCP -j ACCEPT
 iptables -A INPUT -w -p UDP -j ACCEPT
 iptables -A INPUT -w -p ICMP -j ACCEPT
 fi
-if iptables -L FORWARD | grep "Chain FORWARD (policy DROP)" > /dev/null; then
+if iptables -w -L FORWARD | grep "Chain FORWARD (policy DROP)" > /dev/null; then
 echo "Add rules to accept all forwarded TCP/UDP/ICMP packets"
 iptables -A FORWARD -w -p TCP -j ACCEPT
 iptables -A FORWARD -w -p UDP -j ACCEPT


### PR DESCRIPTION
Otherwise we sometimes get an "in-use" message, telling us to use the
lock, if another iptables process is running concurrently.