### PR TITLE
Spotinst: Replace corev1.Taint to fix HCL2 serialization

### DIFF
--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -1349,7 +1349,6 @@ type terraformElastigroup struct {
 	EphemeralBlockDevice []*terraformElastigroupBlockDevice      `json:"ephemeral_block_device,omitempty" cty:"ephemeral_block_device"`
 	Integration          *terraformElastigroupIntegration        `json:"integration_kubernetes,omitempty" cty:"integration_kubernetes"`
 	Tags                 []*terraformKV                          `json:"tags,omitempty" cty:"tags"`
-	Lifecycle            *terraformLifecycle                     `json:"lifecycle,omitempty" cty:"lifecycle"`
 
 	MinSize         *int64  `json:"min_size,omitempty" cty:"min_size"`
 	MaxSize         *int64  `json:"max_size,omitempty" cty:"max_size"`
@@ -1435,8 +1434,10 @@ type terraformKV struct {
 	Value *string `json:"value" cty:"value"`
 }
 
-type terraformLifecycle struct {
-	IgnoreChanges []string `json:"ignore_changes,omitempty" cty:"ignore_changes"`
+type terraformTaint struct {
+	Key    *string `json:"key" cty:"key"`
+	Value  *string `json:"value" cty:"value"`
+	Effect *string `json:"effect" cty:"effect"`
 }
 
 func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Elastigroup) error {
@@ -1644,16 +1645,6 @@ func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 							Key:   fi.String(k),
 							Value: fi.String(v),
 						})
-					}
-				}
-
-				// Ignore capacity changes because the auto scaler updates the
-				// desired capacity overtime.
-				if fi.BoolValue(tf.Integration.Enabled) {
-					tf.Lifecycle = &terraformLifecycle{
-						IgnoreChanges: []string{
-							"desired_capacity",
-						},
 					}
 				}
 			}

--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -750,6 +750,7 @@ type terraformLaunchSpec struct {
 	InstanceTypes            []string                       `json:"instance_types,omitempty" cty:"instance_types"`
 	SubnetIDs                []*terraform.Literal           `json:"subnet_ids,omitempty" cty:"subnet_ids"`
 	SecurityGroups           []*terraform.Literal           `json:"security_groups,omitempty" cty:"security_groups"`
+	Taints                   []*terraformTaint              `json:"taints,omitempty" cty:"taints"`
 	Labels                   []*terraformKV                 `json:"labels,omitempty" cty:"labels"`
 	Tags                     []*terraformKV                 `json:"tags,omitempty" cty:"tags"`
 	Headrooms                []*terraformAutoScalerHeadroom `json:"autoscale_headrooms,omitempty" cty:"autoscale_headrooms"`
@@ -881,6 +882,21 @@ func (_ *LaunchSpec) RenderTerraform(t *terraform.TerraformTarget, a, e, changes
 						Key:   fi.String(k),
 						Value: fi.String(v),
 					})
+				}
+			}
+
+			// Taints.
+			if len(opts.Taints) > 0 {
+				tf.Taints = make([]*terraformTaint, len(opts.Taints))
+				for i, taint := range opts.Taints {
+					t := &terraformTaint{
+						Key:    fi.String(taint.Key),
+						Effect: fi.String(string(taint.Effect)),
+					}
+					if taint.Value != "" {
+						t.Value = fi.String(taint.Value)
+					}
+					tf.Taints[i] = t
 				}
 			}
 		}

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -1020,7 +1020,6 @@ type terraformOcean struct {
 	SubnetIDs              []*terraform.Literal `json:"subnet_ids,omitempty" cty:"subnet_ids"`
 	AutoScaler             *terraformAutoScaler `json:"autoscaler,omitempty" cty:"autoscaler"`
 	Tags                   []*terraformKV       `json:"tags,omitempty" cty:"tags"`
-	Lifecycle              *terraformLifecycle  `json:"lifecycle,omitempty" cty:"lifecycle"`
 
 	MinSize         *int64 `json:"min_size,omitempty" cty:"min_size"`
 	MaxSize         *int64 `json:"max_size,omitempty" cty:"max_size"`
@@ -1031,17 +1030,15 @@ type terraformOcean struct {
 	DrainingTimeout          *int64 `json:"draining_timeout,omitempty" cty:"draining_timeout"`
 	GracePeriod              *int64 `json:"grace_period,omitempty" cty:"grace_period"`
 
-	Monitoring               *bool                          `json:"monitoring,omitempty" cty:"monitoring"`
-	EBSOptimized             *bool                          `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
-	ImageID                  *string                        `json:"image_id,omitempty" cty:"image_id"`
-	AssociatePublicIPAddress *bool                          `json:"associate_public_ip_address,omitempty" cty:"associate_public_ip_address"`
-	RootVolumeSize           *int32                         `json:"root_volume_size,omitempty" cty:"root_volume_size"`
-	UserData                 *terraform.Literal             `json:"user_data,omitempty" cty:"user_data"`
-	IAMInstanceProfile       *terraform.Literal             `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
-	KeyName                  *terraform.Literal             `json:"key_name,omitempty" cty:"key_name"`
-	SecurityGroups           []*terraform.Literal           `json:"security_groups,omitempty" cty:"security_groups"`
-	Labels                   []*terraformKV                 `json:"labels,omitempty" cty:"labels"`
-	Headrooms                []*terraformAutoScalerHeadroom `json:"autoscale_headrooms,omitempty" cty:"autoscale_headrooms"`
+	Monitoring               *bool                `json:"monitoring,omitempty" cty:"monitoring"`
+	EBSOptimized             *bool                `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
+	ImageID                  *string              `json:"image_id,omitempty" cty:"image_id"`
+	AssociatePublicIPAddress *bool                `json:"associate_public_ip_address,omitempty" cty:"associate_public_ip_address"`
+	RootVolumeSize           *int32               `json:"root_volume_size,omitempty" cty:"root_volume_size"`
+	UserData                 *terraform.Literal   `json:"user_data,omitempty" cty:"user_data"`
+	IAMInstanceProfile       *terraform.Literal   `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
+	KeyName                  *terraform.Literal   `json:"key_name,omitempty" cty:"key_name"`
+	SecurityGroups           []*terraform.Literal `json:"security_groups,omitempty" cty:"security_groups"`
 }
 
 func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Ocean) error {
@@ -1199,16 +1196,6 @@ func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Oce
 					tf.AutoScaler.ResourceLimits = &terraformAutoScalerResourceLimits{
 						MaxVCPU:   limits.MaxVCPU,
 						MaxMemory: limits.MaxVCPU,
-					}
-				}
-
-				// Ignore capacity changes because the auto scaler updates the
-				// desired capacity overtime.
-				if fi.BoolValue(tf.AutoScaler.Enabled) {
-					tf.Lifecycle = &terraformLifecycle{
-						IgnoreChanges: []string{
-							"desired_capacity",
-						},
 					}
 				}
 			}

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -24,6 +24,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 )
 
@@ -99,6 +100,12 @@ func (t *TerraformTarget) finishHCL2(taskMap map[string]fi.Task) error {
 			"source":  cty.StringVal("hashicorp/aws"),
 			"version": cty.StringVal(">= 2.46.0"),
 		})
+		if featureflag.Spotinst.Enabled() {
+			writeMap(requiredProvidersBody, "spotinst", map[string]cty.Value{
+				"source":  cty.StringVal("spotinst/spotinst"),
+				"version": cty.StringVal(">= 1.33.0"),
+			})
+		}
 	}
 
 	bytes := hclwrite.Format(f.Bytes())


### PR DESCRIPTION
This PR fixes Terraform output of Ocean resources (refs: #10671, #10674, #10679, #10806).

/cc @rifelpet
/cc @hakman
/cc @alejandroandreu