### PR TITLE
kubetest2: Call Test, not Execute

### DIFF
--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -68,7 +68,7 @@ func (t *Tester) addHostArgument() error {
 		return fmt.Errorf("kubeconfig did not contain server")
 	}
 
-	klog.Info("Adding --host=%s", server)
+	klog.Infof("Adding --host=%s", server)
 	t.TestArgs += " --host=" + server
 	return nil
 }
@@ -98,7 +98,7 @@ func (t *Tester) execute() error {
 		return err
 	}
 
-	return t.Execute()
+	return t.Test()
 }
 
 func NewDefaultTester() *Tester {


### PR DESCRIPTION
Execute will reparse the flags; we want to reuse the test execution
but not the flag setup.