### PR TITLE
Automated cherry pick of #10328: Don't try to detach masters

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -603,13 +603,14 @@ func (c *RollingUpdateCluster) UpdateSingleInstance(cloudMember *cloudinstances.
 		if cloudMember.CloudInstanceGroup.InstanceGroup.IsMaster() {
 			klog.Warning("cannot detach master instances. Assuming --surge=false")
 
-		}
-		err := c.detachInstance(cloudMember)
-		if err != nil {
-			return fmt.Errorf("failed to detach instance: %v", err)
-		}
-		if err := c.maybeValidate(" after detaching instance", c.ValidateCount); err != nil {
-			return err
+		} else {
+			err := c.detachInstance(cloudMember)
+			if err != nil {
+				return fmt.Errorf("failed to detach instance: %v", err)
+			}
+			if err := c.maybeValidate(" after detaching instance", c.ValidateCount); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #10328 on release-1.19.

#10328: Don't try to detach masters

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.