### PR TITLE
Automated cherry pick of #10825: Fix kdi 'must specify' error

### DIFF
--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -237,7 +237,7 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 	}
 
 	if !options.Yes {
-		fmt.Fprintf(out, "\nMust specify --yes to delete instancegroup\n")
+		fmt.Fprintf(out, "\nMust specify --yes to delete instance\n")
 		return nil
 	}
 


### PR DESCRIPTION
Cherry pick of #10825 on release-1.19.

#10825: Fix kdi 'must specify' error

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.