### PR TITLE
Allow multi-CNI setups to set usesSecondaryIP

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -548,6 +548,10 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		optionTaken = true
 	}
 
+	if v.CNI != nil && optionTaken {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("cni"), "only one networking option permitted"))
+	}
+
 	if v.Weave != nil {
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("weave"), "only one networking option permitted"))

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -541,13 +541,6 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		optionTaken = true
 	}
 
-	if v.CNI != nil {
-		if optionTaken {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("cni"), "only one networking option permitted"))
-		}
-		optionTaken = true
-	}
-
 	if v.Kopeio != nil {
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kopeio"), "only one networking option permitted"))


### PR DESCRIPTION
This PR removes a previously introduced check on the CNI plugin presence. 

The original PR https://github.com/kubernetes/kops/pull/8617 seems to introduce some checks on the use of incompatible CNI plugins, but in fact the CNI plugin is used to set the `--node-ip` Kubelet option in case the `useSecondaryIP` flag is set to true. A Kops cluster operator should be able to declare that when using a CNI plugin like Calico for example.