### PR TITLE
Precreate the kops-controller DNS name

### DIFF
--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider/rrstype"
 	"k8s.io/kops/pkg/apis/kops"
+	apimodel "k8s.io/kops/pkg/apis/kops/model"
 	kopsdns "k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model"
@@ -258,6 +259,11 @@ func buildPrecreateDNSHostnames(cluster *kops.Cluster) []string {
 			name := etcClusterName + "-" + etcdClusterMember.Name + dnsInternalSuffix
 			dnsHostnames = append(dnsHostnames, name)
 		}
+	}
+
+	if apimodel.UseKopsControllerForNodeBootstrap(cluster) {
+		name := "kops-controller.internal." + cluster.ObjectMeta.Name
+		dnsHostnames = append(dnsHostnames, name)
 	}
 
 	return dnsHostnames


### PR DESCRIPTION
We're seeing test failures in prow because nodes are not able to resolve the kops-controller dns record.

Judging by timestamps, dns-controller adds the record after it is first queried by nodeup.
The negative TTL is long enough that the cluster doesn't validate within the alotted time.
Rather than increasing the validation timeout I think its better to precreate the DNS record the same way we do for the other records.

[example job](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-distro-imagerhel7/1361419015221678080), [nodeup logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-distro-imagerhel7/1361419015221678080/artifacts/3.8.162.43/journal.log), and [dns-controller logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-distro-imagerhel7/1361419015221678080/artifacts/cluster-info/kube-system/dns-controller-7447cb64fd-v4cpp/logs.txt)