### PR TITLE
Automated cherry pick of #10619: Use correct tag when creating node labels from azure cloud

### DIFF
--- a/pkg/nodeidentity/azure/BUILD.bazel
+++ b/pkg/nodeidentity/azure/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/nodeidentity:go_default_library",
+        "//upup/pkg/fi:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/azure/auth:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/nodeidentity/azure/identify.go
+++ b/pkg/nodeidentity/azure/identify.go
@@ -27,13 +27,15 @@ import (
 	expirationcache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/nodeidentity"
+	"k8s.io/kops/upup/pkg/fi"
 )
 
 const (
 	// InstanceGroupNameTag is the key of the tag used to identify an
 	// instance group that VM ScaleSet belongs.
 	InstanceGroupNameTag = "kops.k8s.io_instancegroup"
-
+	// ClusterNodeTemplateLabel is the prefix used on node labels when copying to cloud tags.
+	ClusterNodeTemplateLabel = "k8s.io_cluster_node-template_label_"
 	// cacheTTL is the expiration time of nodeidentity.Info cache.
 	cacheTTL = 60 * time.Minute
 )
@@ -107,8 +109,8 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 	}
 
 	for k, v := range vmss.Tags {
-		if strings.HasPrefix(k, InstanceGroupNameTag) {
-			info.Labels[strings.TrimPrefix(k, InstanceGroupNameTag)] = *v
+		if strings.HasPrefix(k, ClusterNodeTemplateLabel) {
+			info.Labels[strings.TrimPrefix(k, ClusterNodeTemplateLabel)] = fi.StringValue(v)
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #10619 on release-1.20.

#10619: Use correct tag when creating node labels from azure cloud

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.