### PR TITLE
Automated cherry pick of #10813: containerd installation: always configure, even if we don't

### DIFF
--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -1,7 +1,31 @@
+contents: |
+  {
+      "cniVersion": "0.4.0",
+      "name": "k8s-pod-network",
+      "plugins": [
+          {
+              "type": "ptp",
+              "ipam": {
+                  "type": "host-local",
+                  "ranges": [[{"subnet": "{{.PodCIDR}}"}]],
+                  "routes": [{ "dst": "0.0.0.0/0" }]
+              }
+          },
+          {
+              "type": "portmap",
+              "capabilities": {"portMappings": true}
+          }
+      ]
+  }
+path: /etc/containerd/config-cni.template
+type: file
+---
 contents: ""
 path: /etc/containerd/config-kops.toml
 type: file
 ---
+afterFiles:
+- /etc/containerd/config-kops.toml
 contents: |-
   [Service]
   Environment=CONTAINERD_CONFIG=/etc/containerd/config-kops.toml
@@ -18,3 +42,34 @@ onChangeExecute:
   - '&'
 path: /etc/systemd/system/containerd.service.d/10-kops.conf
 type: file
+---
+contents: |
+  #!/bin/bash
+  # Built by kOps - do not edit
+
+  iptables -w -t nat -N IP-MASQ
+  iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
+  iptables -w -t nat -A IP-MASQ -d 100.64.0.0/10 -m comment --comment "ip-masq: pod cidr is not subject to MASQUERADE" -j RETURN
+  iptables -w -t nat -A IP-MASQ -m comment --comment "ip-masq: outbound traffic is subject to MASQUERADE (must be last in chain)" -j MASQUERADE
+mode: "0755"
+path: /opt/kops/bin/cni-iptables-setup
+type: file
+---
+Name: cni-iptables-setup.service
+definition: |
+  [Unit]
+  Description=Configure iptables for kubernetes CNI
+  Documentation=https://github.com/kubernetes/kops
+  Before=network.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  ExecStart=/opt/kops/bin/cni-iptables-setup
+
+  [Install]
+  WantedBy=basic.target
+enabled: true
+manageState: true
+running: true
+smartRestart: true


### PR DESCRIPTION
Cherry pick of #10813 on release-1.19.

#10813: containerd installation: always configure, even if we don't

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.