### PR TITLE
Add additional IOPS validation for AWS EBS gp3 volumes

### DIFF
--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -183,7 +183,7 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 				return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 50. For %s ratio is %f", *t.Name, float64(*t.VolumeIops)/float64(*t.SizeGB))
 			}
 		} else {
-			if float64(*t.VolumeIops)/float64(*t.SizeGB) > 500.0 {
+			if float64(*t.VolumeIops)/float64(*t.SizeGB) > 500.0 && (volumeType != "gp3" || *t.VolumeIops > 3000) {
 				return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 500. For %s ratio is %f", *t.Name, float64(*t.VolumeIops)/float64(*t.SizeGB))
 			}
 		}


### PR DESCRIPTION
This PR fixes the problem described in #10842. 

As described in the issue, AWS allows gp3 volumes of any size to have a baseline of 3000 IOPS. This PR adds the additional condition necessary to validate IOPS to size ratio correctly.