### PR TITLE
Fix OpenStack delete functions

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -90,6 +90,14 @@ var writeBackoff = wait.Backoff{
 	Steps:    5,
 }
 
+// deleteBackoff is the backoff strategy for openstack delete retries.
+var deleteBackoff = wait.Backoff{
+	Duration: time.Second,
+	Factor:   5,
+	Jitter:   0.1,
+	Steps:    4,
+}
+
 type OpenstackCloud interface {
 	fi.Cloud
 

--- a/upup/pkg/fi/cloudup/openstack/keypair.go
+++ b/upup/pkg/fi/cloudup/openstack/keypair.go
@@ -79,13 +79,15 @@ func (c *openstackCloud) DeleteKeyPair(name string) error {
 }
 
 func deleteKeyPair(c OpenstackCloud, name string) error {
-	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := keypairs.Delete(c.ComputeClient(), name).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting keypair: %v", err)
 		}
-
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/openstack/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/openstack/loadbalancer.go
@@ -64,12 +64,15 @@ func deleteMonitor(c OpenstackCloud, monitorID string) error {
 	if c.LoadBalancerClient() == nil {
 		return fmt.Errorf("loadbalancer support not available in this deployment")
 	}
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := monitors.Delete(c.LoadBalancerClient(), monitorID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting pool: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err
@@ -89,12 +92,15 @@ func deletePool(c OpenstackCloud, poolID string) error {
 		return fmt.Errorf("loadbalancer support not available in this deployment")
 	}
 
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := v2pools.Delete(c.LoadBalancerClient(), poolID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting pool: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err
@@ -114,12 +120,15 @@ func deleteListener(c OpenstackCloud, listenerID string) error {
 		return fmt.Errorf("loadbalancer support not available in this deployment")
 	}
 
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := listeners.Delete(c.LoadBalancerClient(), listenerID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting listener: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err
@@ -139,12 +148,15 @@ func deleteLB(c OpenstackCloud, lbID string, opts loadbalancers.DeleteOpts) erro
 		return fmt.Errorf("loadbalancer support not available in this deployment")
 	}
 
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := loadbalancers.Delete(c.LoadBalancerClient(), lbID, opts).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting loadbalancer: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/openstack/network.go
+++ b/upup/pkg/fi/cloudup/openstack/network.go
@@ -220,12 +220,15 @@ func (c *openstackCloud) DeleteNetwork(networkID string) error {
 }
 
 func deleteNetwork(c OpenstackCloud, networkID string) error {
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := networks.Delete(c.NetworkingClient(), networkID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting network: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/openstack/port.go
+++ b/upup/pkg/fi/cloudup/openstack/port.go
@@ -130,12 +130,15 @@ func (c *openstackCloud) DeletePort(portID string) error {
 }
 
 func deletePort(c OpenstackCloud, portID string) error {
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := ports.Delete(c.NetworkingClient(), portID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting port: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/openstack/router.go
+++ b/upup/pkg/fi/cloudup/openstack/router.go
@@ -106,12 +106,15 @@ func (c *openstackCloud) DeleteRouterInterface(routerID string, opt routers.Remo
 }
 
 func deleteRouterInterface(c OpenstackCloud, routerID string, opt routers.RemoveInterfaceOptsBuilder) error {
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		_, err := routers.RemoveInterface(c.NetworkingClient(), routerID, opt).Extract()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting router interface: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err
@@ -127,12 +130,15 @@ func (c *openstackCloud) DeleteRouter(routerID string) error {
 }
 
 func deleteRouter(c OpenstackCloud, routerID string) error {
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := routers.Delete(c.NetworkingClient(), routerID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting router: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/openstack/security_group.go
+++ b/upup/pkg/fi/cloudup/openstack/security_group.go
@@ -136,12 +136,15 @@ func (c *openstackCloud) DeleteSecurityGroup(sgID string) error {
 }
 
 func deleteSecurityGroup(c OpenstackCloud, sgID string) error {
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := sg.Delete(c.NetworkingClient(), sgID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting security group: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -164,12 +164,15 @@ func (c *openstackCloud) DeleteServerGroup(groupID string) error {
 }
 
 func deleteServerGroup(c OpenstackCloud, groupID string) error {
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := servergroups.Delete(c.ComputeClient(), groupID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting server group: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/openstack/subnet.go
+++ b/upup/pkg/fi/cloudup/openstack/subnet.go
@@ -106,12 +106,15 @@ func (c *openstackCloud) DeleteSubnet(subnetID string) error {
 }
 
 func deleteSubnet(c OpenstackCloud, subnetID string) error {
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := subnets.Delete(c.NetworkingClient(), subnetID).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting subnet: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/openstack/volume.go
+++ b/upup/pkg/fi/cloudup/openstack/volume.go
@@ -136,12 +136,15 @@ func (c *openstackCloud) DeleteVolume(volumeID string) error {
 }
 
 func deleteVolume(c OpenstackCloud, volumeID string) error {
-	done, err := vfs.RetryWithBackoff(writeBackoff, func() (bool, error) {
+	done, err := vfs.RetryWithBackoff(deleteBackoff, func() (bool, error) {
 		err := cinder.Delete(c.BlockStorageClient(), volumeID, cinder.DeleteOpts{}).ExtractErr()
 		if err != nil && !isNotFound(err) {
 			return false, fmt.Errorf("error deleting volume: %v", err)
 		}
-		return true, nil
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, nil
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR fixes #10724 with these two changes:

1) Add missing RetryWithBackoff to DeleteInstanceWithID
2) Fix broken retry logic in all other delete functions. In the current implementation, as the first Delete request will almost certainly return nil, the function will return true and the retry will not try again, resulting in potentially some assets not getting deleted from OpenStack

Also, the current writeBackoff is a bit too aggressive and I introduced less hasty deleteBackoff.

The change has been tested with OpenStack. I verified that all APIs we are hitting will eventually return the 404 (type) we are looking for.