### PR TITLE
Automated cherry pick of #10833: Precreate the kops-controller DNS name

### DIFF
--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider/rrstype"
 	"k8s.io/kops/pkg/apis/kops"
+	apimodel "k8s.io/kops/pkg/apis/kops/model"
 	kopsdns "k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/model"
@@ -256,6 +257,11 @@ func buildPrecreateDNSHostnames(cluster *kops.Cluster) []string {
 			name := etcClusterName + "-" + etcdClusterMember.Name + dnsInternalSuffix
 			dnsHostnames = append(dnsHostnames, name)
 		}
+	}
+
+	if apimodel.UseKopsControllerForNodeBootstrap(cluster) {
+		name := "kops-controller.internal." + cluster.ObjectMeta.Name
+		dnsHostnames = append(dnsHostnames, name)
 	}
 
 	return dnsHostnames


### PR DESCRIPTION
Cherry pick of #10833 on release-1.19.

#10833: Precreate the kops-controller DNS name

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.