### PR TITLE
Automated cherry pick of #10853: Update Go to v1.15.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.7
+          go-version: 1.15.8
 
       - uses: actions/checkout@v2
         with:
@@ -33,7 +33,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.15.8
 
     - uses: actions/checkout@v2
       with:
@@ -50,7 +50,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.7
+        go-version: 1.15.8
 
     - uses: actions/checkout@v2
       with:
@@ -67,7 +67,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.7
+          go-version: 1.15.8
 
       - uses: actions/checkout@v2
         with:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,8 +29,8 @@ go_rules_dependencies()
 go_download_sdk(
     name = "go_sdk",
     sdks = {
-        "darwin_amd64": ("go1.15.7.darwin-amd64.tar.gz", "af423736fffded2b588bab13b8963ad071eb47600ec83d0304a9a3ab95ef49a0"),
-        "linux_amd64": ("go1.15.7.linux-amd64.tar.gz", "0d142143794721bb63ce6c8a6180c4062bcf8ef4715e7d6d6609f3a8282629b3"),
+        "darwin_amd64": ("go1.15.8.darwin-amd64.tar.gz", "7df8977d3befd2ec41479abed1c93aac93cb320dcbe4808950d28948911da854"),
+        "linux_amd64": ("go1.15.8.linux-amd64.tar.gz", "d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b"),
     },
 )
 


### PR DESCRIPTION
Cherry pick of #10853 on release-1.19.

#10853: Update Go to v1.15.8

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.