### PR TITLE
Automated cherry pick of #10857: Add support for cluster autoscaler 1.20.x

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -25,7 +25,7 @@ spec:
 Read more in the [official documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/).
 
 #### Cluster autoscaler
-{{ kops_feature_table(kops_added_default='1.19', k8s_min='1.15') }}
+{{ kops_feature_table(kops_added_default='1.19') }}
 
 Cluster autoscaler can be enabled to automatically adjust the size of the kubernetes cluster.
 
@@ -41,6 +41,15 @@ spec:
 
 Read more about cluster autoscaler in the [official documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
 
+##### Disabling cluster autoscaler for a given instance group
+{{ kops_feature_table(kops_added_default='1.20') }}
+
+You can disable the autoscaler for a given instance group by adding the following to the instance group spec.
+
+```yaml
+spec:
+  autoscale: false
+```
 
 #### Cert-manager
 {{ kops_feature_table(kops_added_default='1.20', k8s_min='1.16') }}

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -87,6 +87,10 @@ spec:
                 description: AssociatePublicIP is true if we want instances to have
                   a public IP
                 type: boolean
+              autoscale:
+                description: Autoscale determines if autoscaling will be enabled for
+                  the group if cluster autoscaler is enabled
+                type: boolean
               cloudLabels:
                 additionalProperties:
                   type: string

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -92,6 +92,8 @@ type InstanceGroupSpec struct {
 	MinSize *int32 `json:"minSize,omitempty"`
 	// MaxSize is the maximum size of the pool
 	MaxSize *int32 `json:"maxSize,omitempty"`
+	// Autoscale determines if autoscaling will be enabled for the group if cluster autoscaler is enabled
+	Autoscale *bool `json:"autoscale,omitempty"`
 	// MachineType is the instance class
 	MachineType string `json:"machineType,omitempty"`
 	// RootVolumeSize is the size of the EBS root volume to use, in GB

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -89,6 +89,8 @@ type InstanceGroupSpec struct {
 	MinSize *int32 `json:"minSize,omitempty"`
 	// MaxSize is the maximum size of the pool
 	MaxSize *int32 `json:"maxSize,omitempty"`
+	// Autoscale determines if autoscaling will be enabled for the group if cluster autoscaler is enabled
+	Autoscale *bool `json:"autoscale,omitempty"`
 	// MachineType is the instance class
 	MachineType string `json:"machineType,omitempty"`
 	// RootVolumeSize is the size of the EBS root volume to use, in GB

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3813,6 +3813,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.Image = in.Image
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
+	out.Autoscale = in.Autoscale
 	out.MachineType = in.MachineType
 	out.RootVolumeSize = in.RootVolumeSize
 	out.RootVolumeType = in.RootVolumeType
@@ -3963,6 +3964,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	out.Image = in.Image
 	out.MinSize = in.MinSize
 	out.MaxSize = in.MaxSize
+	out.Autoscale = in.Autoscale
 	out.MachineType = in.MachineType
 	out.RootVolumeSize = in.RootVolumeSize
 	out.RootVolumeType = in.RootVolumeType

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1975,6 +1975,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Autoscale != nil {
+		in, out := &in.Autoscale, &out.Autoscale
+		*out = new(bool)
+		**out = **in
+	}
 	if in.RootVolumeSize != nil {
 		in, out := &in.RootVolumeSize, &out.RootVolumeSize
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2141,6 +2141,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Autoscale != nil {
+		in, out := &in.Autoscale, &out.Autoscale
+		*out = new(bool)
+		**out = **in
+	}
 	if in.RootVolumeSize != nil {
 		in, out := &in.RootVolumeSize, &out.RootVolumeSize
 		*out = new(int32)

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -43,6 +43,8 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 		v, err := util.ParseKubernetesVersion(clusterSpec.KubernetesVersion)
 		if err == nil {
 			switch v.Minor {
+			case 20:
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0"
 			case 19:
 				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.1"
 			case 18:

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -28285,7 +28285,7 @@ func cloudupResourcesAddonsCertmanagerIoK8s116YamlTemplate() (*asset, error) {
 }
 
 var _cloudupResourcesAddonsClusterAutoscalerAddonsK8sIoK8s115YamlTemplate = []byte(`{{ with .ClusterAutoscaler }}
-# Sourced from https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws/examples
+# Sourced from https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-release-1.20/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -28421,7 +28421,6 @@ spec:
       labels:
         app: cluster-autoscaler
       annotations:
-        prometheus.io/path: "/metrics"
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
     spec:
@@ -28444,7 +28443,9 @@ spec:
             - --cloud-provider={{ $.CloudProvider }}
             - --expander={{ .Expander }}
             {{ range $name, $spec := GetNodeInstanceGroups }}
+            {{ if WithDefaultBool $spec.Autoscale true }}
             - --nodes={{ $spec.MinSize }}:{{ $spec.MaxSize }}:{{ $name }}.{{ ClusterName }}
+            {{ end }}
             {{ end }}
             - --scale-down-utilization-threshold={{ .ScaleDownUtilizationThreshold }}
             - --skip-nodes-with-local-storage={{ .SkipNodesWithLocalStorage }}

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -1,5 +1,5 @@
 {{ with .ClusterAutoscaler }}
-# Sourced from https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws/examples
+# Sourced from https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-release-1.20/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-multi-asg.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -135,7 +135,6 @@ spec:
       labels:
         app: cluster-autoscaler
       annotations:
-        prometheus.io/path: "/metrics"
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
     spec:
@@ -158,7 +157,9 @@ spec:
             - --cloud-provider={{ $.CloudProvider }}
             - --expander={{ .Expander }}
             {{ range $name, $spec := GetNodeInstanceGroups }}
+            {{ if WithDefaultBool $spec.Autoscale true }}
             - --nodes={{ $spec.MinSize }}:{{ $spec.MaxSize }}:{{ $name }}.{{ ClusterName }}
+            {{ end }}
             {{ end }}
             - --scale-down-utilization-threshold={{ .ScaleDownUtilizationThreshold }}
             - --skip-nodes-with-local-storage={{ .SkipNodesWithLocalStorage }}


### PR DESCRIPTION
Cherry pick of #10857 on release-1.20.

#10857: Add support for cluster autoscaler 1.20.x

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.