### PR TITLE
Automated cherry pick of #10856: Add liveness probe for calico-kube-controllers

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -39543,12 +39543,12 @@ spec:
               command:
               - /usr/bin/check-status
               - -r
-          startupProbe:
+          livenessProbe:
             exec:
               command:
-                - /usr/bin/check-status
-                - -r
-            initialDelaySeconds: 10
+              - /usr/bin/check-status
+              - -r
+            failureThreshold: 10
 
 ---
 

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4112,12 +4112,12 @@ spec:
               command:
               - /usr/bin/check-status
               - -r
-          startupProbe:
+          livenessProbe:
             exec:
               command:
-                - /usr/bin/check-status
-                - -r
-            initialDelaySeconds: 10
+              - /usr/bin/check-status
+              - -r
+            failureThreshold: 10
 
 ---
 

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -762,7 +762,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		key := "networking.projectcalico.org"
 		versions := map[string]string{
 			"k8s-1.12": "3.9.6-kops.2",
-			"k8s-1.16": "3.17.2-kops.1",
+			"k8s-1.16": "3.17.2-kops.2",
 		}
 
 		{


### PR DESCRIPTION
Cherry pick of #10856 on release-1.20.

#10856: Add liveness probe for calico-kube-controllers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.