### PR TITLE
Update go to 1.16 for PR jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.8
+          go-version: 1.16
 
       - uses: actions/checkout@v2
         with:
@@ -33,7 +33,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.8
+        go-version: 1.16
 
     - uses: actions/checkout@v2
       with:
@@ -50,7 +50,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.8
+        go-version: 1.16
 
     - uses: actions/checkout@v2
       with:
@@ -67,7 +67,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.8
+          go-version: 1.16
 
       - uses: actions/checkout@v2
         with:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.15.8",
+    go_version = "1.16",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")


### PR DESCRIPTION
https://blog.golang.org/go1.16 go 1.16 is released