### PR TITLE
K8s Version Updates February 2021

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -62,13 +62,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.20.0"
-    recommendedVersion: 1.20.2
+    recommendedVersion: 1.20.3
     requiredVersion: 1.20.0
   - range: ">=1.19.0"
-    recommendedVersion: 1.19.7
+    recommendedVersion: 1.19.8
     requiredVersion: 1.19.0
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.15
+    recommendedVersion: 1.18.16
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
     recommendedVersion: 1.17.17
@@ -98,15 +98,15 @@ spec:
   - range: ">=1.20.0-alpha.1"
     #recommendedVersion: "1.19.0-beta.3"
     #requiredVersion: 1.20.0
-    kubernetesVersion: 1.20.2
+    kubernetesVersion: 1.20.3
   - range: ">=1.19.0-beta.3"
     #recommendedVersion: "1.19.0-beta.3"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.7
+    kubernetesVersion: 1.19.8
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.15
+    kubernetesVersion: 1.18.16
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.17.0

--- a/channels/stable
+++ b/channels/stable
@@ -23,25 +23,25 @@ spec:
       providerID: aws
       kubernetesVersion: ">=1.10.0 <1.11.0"
     # Stretch is the default for 1.11 (for nvme)
-    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2020-11-19
+    - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2021-02-05
       providerID: aws
       kubernetesVersion: ">=1.11.0 <1.12.0"
-    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2020-11-19
+    - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2021-02-05
       providerID: aws
       kubernetesVersion: ">=1.12.0 <1.13.0"
-    - name: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2020-11-19
+    - name: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2021-02-05
       providerID: aws
       kubernetesVersion: ">=1.13.0 <1.14.0"
-    - name: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2020-11-19
+    - name: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2021-02-05
       providerID: aws
       kubernetesVersion: ">=1.14.0 <1.15.0"
-    - name: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2020-11-19
+    - name: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2021-02-05
       providerID: aws
       kubernetesVersion: ">=1.15.0 <1.16.0"
-    - name: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-11-19
+    - name: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2021-02-05
       providerID: aws
       kubernetesVersion: ">=1.16.0 <1.17.0"
-    - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-11-19
+    - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2021-02-05
       providerID: aws
       kubernetesVersion: ">=1.17.0 <1.18.0"
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1

--- a/tests/integration/create_cluster/minimal-1.16/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.16/expected-v1alpha2.yaml
@@ -63,7 +63,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-11-19
+  image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2021-02-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -83,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-11-19
+  image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2021-02-05
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/minimal-1.17/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.17/expected-v1alpha2.yaml
@@ -63,7 +63,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-11-19
+  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2021-02-05
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -83,7 +83,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2020-11-19
+  image: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2021-02-05
   machineType: t2.medium
   maxSize: 1
   minSize: 1


### PR DESCRIPTION
Also pushing the image updates from alpha to stable, since I noticed these were pushed to alpha 11 days ago.
K8s releases from earlier today:
- https://github.com/kubernetes/kubernetes/releases/tag/v1.18.16
- https://github.com/kubernetes/kubernetes/releases/tag/v1.19.8
- https://github.com/kubernetes/kubernetes/releases/tag/v1.20.3