### PR TITLE
kubetest2 - support terraform with `kops create cluster`

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -118,6 +118,10 @@ func (d *deployer) createCluster(zones []string, adminAccess string) error {
 		args = appendIfUnset(args, "--master-size", "s-8vcpu-16gb")
 	}
 
+	if d.terraform != nil {
+		args = append(args, "--target", "terraform", "--out", d.terraform.Dir())
+	}
+
 	klog.Info(strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(d.env()...)
@@ -127,6 +131,13 @@ func (d *deployer) createCluster(zones []string, adminAccess string) error {
 	if err != nil {
 		return err
 	}
+
+	if d.terraform != nil {
+		if err := d.terraform.InitApply(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Previously we were only recognizing it with `kops create --filename` (when kubetest2's `--template-path` is set)

extends https://github.com/kubernetes/kops/pull/10697

it turns out we werent actually using terraform in the new testgrid job: https://testgrid.k8s.io/kops-misc#kops-grid-scenario-terraform