### PR TITLE
Automated cherry pick of #10635: enableRemoteNodeIdentity actually defaults to true

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2472,7 +2472,7 @@ spec:
                         description: EnablePrometheusMetrics enables the Cilium "/metrics" endpoint for both the agent and the operator.
                         type: boolean
                       enableRemoteNodeIdentity:
-                        description: 'EnableRemoteNodeIdentity enables the remote-node-identity added in Cilium 1.7.0. Default: false'
+                        description: 'EnableRemoteNodeIdentity enables the remote-node-identity added in Cilium 1.7.0. Default: true'
                         type: boolean
                       enableTracing:
                         description: EnableTracing is not implemented and may be removed in the future. Setting this has no effect.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -475,7 +475,7 @@ type CiliumNetworkingSpec struct {
 	// Default: false
 	EtcdManaged bool `json:"etcdManaged,omitempty"`
 	// EnableRemoteNodeIdentity enables the remote-node-identity added in Cilium 1.7.0.
-	// Default: false
+	// Default: true
 	EnableRemoteNodeIdentity *bool `json:"enableRemoteNodeIdentity,omitempty"`
 	// Hubble configures the Hubble service on the Cilium agent.
 	Hubble *HubbleSpec `json:"hubble,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -473,7 +473,7 @@ type CiliumNetworkingSpec struct {
 	// Default: false
 	EtcdManaged bool `json:"etcdManaged,omitempty"`
 	// EnableRemoteNodeIdentity enables the remote-node-identity added in Cilium 1.7.0.
-	// Default: false
+	// Default: true
 	EnableRemoteNodeIdentity *bool `json:"enableRemoteNodeIdentity,omitempty"`
 	// Hubble configures the Hubble service on the Cilium agent.
 	Hubble *HubbleSpec `json:"hubble,omitempty"`


### PR DESCRIPTION
Cherry pick of #10635 on release-1.19.

#10635: enableRemoteNodeIdentity actually defaults to true

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.