### PR TITLE
[addons/CA] Add name to the port

### DIFF
--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -169,6 +169,7 @@ spec:
             - --v=2
           ports:
           - containerPort: 8085
+            name: http
             protocol: TCP
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
Mostly as a workaround to support a PodMonitor, e.g.

```yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: cluster-autoscaler
spec:
  selector:
    matchLabels:
      app: cluster-autoscaler
  podMetricsEndpoints:
  - port: http
    interval: 10s
    path: /metrics
  namespaceSelector:
    matchNames:
    - kube-system
```

Ref: https://github.com/prometheus-operator/prometheus-operator/issues/3071