### PR TITLE
Upgrade k8s 1.20 to latest patch version

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -62,7 +62,7 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.20.0"
-    recommendedVersion: 1.20.3
+    recommendedVersion: 1.20.4
     requiredVersion: 1.20.0
   - range: ">=1.19.0"
     recommendedVersion: 1.19.8
@@ -98,7 +98,7 @@ spec:
   - range: ">=1.20.0-alpha.1"
     #recommendedVersion: "1.19.0-beta.3"
     #requiredVersion: 1.20.0
-    kubernetesVersion: 1.20.3
+    kubernetesVersion: 1.20.4
   - range: ">=1.19.0-beta.3"
     #recommendedVersion: "1.19.0-beta.3"
     #requiredVersion: 1.19.0


### PR DESCRIPTION
The 1.20 patch arrived a bit late, aligning alpha to reflect latest k8s patch version.
https://github.com/kubernetes/kubernetes/releases/tag/v1.20.4