### PR TITLE
Automated cherry pick of #10747: Add validation for ami arch to instance type arch #10884: Improve machine type and image validation

### DIFF
--- a/pkg/apis/kops/validation/BUILD.bazel
+++ b/pkg/apis/kops/validation/BUILD.bazel
@@ -49,10 +49,13 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//cloudmock/aws/mockec2:go_default_library",
         "//pkg/apis/kops:go_default_library",
         "//pkg/nodeidentity/aws:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -173,6 +173,7 @@ func (h *IntegrationTestHarness) SetupMockAWS() *awsup.MockAWSCloud {
 		Name:           aws.String("k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21"),
 		OwnerId:        aws.String(awsup.WellKnownAccountKopeio),
 		RootDeviceName: aws.String("/dev/xvda"),
+		Architecture:   aws.String("x86_64"),
 	})
 
 	mockEC2.Images = append(mockEC2.Images, &ec2.Image{
@@ -181,6 +182,7 @@ func (h *IntegrationTestHarness) SetupMockAWS() *awsup.MockAWSCloud {
 		Name:           aws.String("k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09"),
 		OwnerId:        aws.String(awsup.WellKnownAccountKopeio),
 		RootDeviceName: aws.String("/dev/xvda"),
+		Architecture:   aws.String("x86_64"),
 	})
 
 	mockEC2.Images = append(mockEC2.Images, &ec2.Image{
@@ -189,6 +191,7 @@ func (h *IntegrationTestHarness) SetupMockAWS() *awsup.MockAWSCloud {
 		Name:           aws.String("k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16"),
 		OwnerId:        aws.String(awsup.WellKnownAccountKopeio),
 		RootDeviceName: aws.String("/dev/xvda"),
+		Architecture:   aws.String("x86_64"),
 	})
 
 	mockEC2.CreateVpcWithId(&ec2.CreateVpcInput{

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -307,15 +307,14 @@ func (c *MockAWSCloud) DescribeInstanceType(instanceType string) (*ec2.InstanceT
 		}
 	}
 
-	if instanceType == "m4.large" || instanceType == "c5.large" {
+	switch instanceType {
+	case "c5.large", "m3.medium", "m4.large", "m5.large", "m5.xlarge", "t2.micro", "t2.medium", "t3.medium", "t3.large":
 		info.ProcessorInfo = &ec2.ProcessorInfo{
 			SupportedArchitectures: []*string{
 				aws.String("x86_64"),
 			},
 		}
-	}
-
-	if instanceType == "a1.large" {
+	case "a1.large":
 		info.ProcessorInfo = &ec2.ProcessorInfo{
 			SupportedArchitectures: []*string{
 				aws.String("arm64"),

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -306,6 +306,23 @@ func (c *MockAWSCloud) DescribeInstanceType(instanceType string) (*ec2.InstanceT
 			},
 		}
 	}
+
+	if instanceType == "m4.large" || instanceType == "c5.large" {
+		info.ProcessorInfo = &ec2.ProcessorInfo{
+			SupportedArchitectures: []*string{
+				aws.String("x86_64"),
+			},
+		}
+	}
+
+	if instanceType == "a1.large" {
+		info.ProcessorInfo = &ec2.ProcessorInfo{
+			SupportedArchitectures: []*string{
+				aws.String("arm64"),
+			},
+		}
+	}
+
 	return info, nil
 }
 


### PR DESCRIPTION
Cherry pick of #10747 #10884 on release-1.20.

#10747: Add validation for ami arch to instance type arch
#10884: Improve machine type and image validation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.