### PR TITLE
Automated cherry pick of #10900: add usage of subnet and routetable shared resources in azure

### DIFF
--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -744,6 +744,11 @@ func (c *Cluster) AzureResourceGroupName() string {
 	return c.Name
 }
 
+// IsSharedAzureRouteTable returns true if the route table is shared.
+func (c *Cluster) IsSharedAzureRouteTable() bool {
+	return c.Spec.CloudConfig.Azure.RouteTableName != ""
+}
+
 // EnvVar represents an environment variable present in a Container.
 type EnvVar struct {
 	// Name of the environment variable. Must be a C_IDENTIFIER.

--- a/pkg/model/azuremodel/network.go
+++ b/pkg/model/azuremodel/network.go
@@ -37,6 +37,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		ResourceGroup: b.LinkToResourceGroup(),
 		CIDR:          fi.String(b.Cluster.Spec.NetworkCIDR),
 		Tags:          map[string]*string{},
+		Shared:        fi.Bool(b.Cluster.SharedVPC()),
 	}
 	c.AddTask(networkTask)
 
@@ -47,6 +48,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			ResourceGroup:  b.LinkToResourceGroup(),
 			VirtualNetwork: b.LinkToVirtualNetwork(),
 			CIDR:           fi.String(subnetSpec.CIDR),
+			Shared:         fi.Bool(b.Cluster.SharedVPC()),
 		}
 		c.AddTask(subnetTask)
 	}
@@ -56,6 +58,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		Lifecycle:     b.Lifecycle,
 		ResourceGroup: b.LinkToResourceGroup(),
 		Tags:          map[string]*string{},
+		Shared:        fi.Bool(b.Cluster.IsSharedAzureRouteTable()),
 	}
 	c.AddTask(rtTask)
 

--- a/pkg/resources/azure/azure.go
+++ b/pkg/resources/azure/azure.go
@@ -166,6 +166,7 @@ func (g *resourceGetter) toVirtualNetworkResource(vnet *network.VirtualNetwork) 
 		Name:    *vnet.Name,
 		Deleter: g.deleteVirtualNetwork,
 		Blocks:  []string{toKey(typeResourceGroup, g.resourceGroupName())},
+		Shared:  g.cluster.SharedVPC(),
 	}
 }
 
@@ -199,6 +200,7 @@ func (g *resourceGetter) toSubnetResource(subnet *network.Subnet, vnetName strin
 			toKey(typeVirtualNetwork, vnetName),
 			toKey(typeResourceGroup, g.resourceGroupName()),
 		},
+		Shared: g.cluster.SharedVPC(),
 	}
 }
 
@@ -231,6 +233,7 @@ func (g *resourceGetter) toRouteTableResource(rt *network.RouteTable) *resources
 		Name:    *rt.Name,
 		Deleter: g.deleteRouteTable,
 		Blocks:  []string{toKey(typeResourceGroup, g.resourceGroupName())},
+		Shared:  g.cluster.IsSharedAzureRouteTable(),
 	}
 }
 

--- a/upup/pkg/fi/cloudup/azure/azure_cloud.go
+++ b/upup/pkg/fi/cloudup/azure/azure_cloud.go
@@ -215,6 +215,9 @@ func (c *azureCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([
 				})
 			}
 		}
+		if ingresses == nil {
+			return nil, fmt.Errorf("error getting API Ingress Status so make sure to update your kubecfg accordingly")
+		}
 	}
 
 	return ingresses, nil

--- a/upup/pkg/fi/cloudup/azuretasks/routetable.go
+++ b/upup/pkg/fi/cloudup/azuretasks/routetable.go
@@ -34,6 +34,7 @@ type RouteTable struct {
 	Lifecycle     *fi.Lifecycle
 	ResourceGroup *ResourceGroup
 	Tags          map[string]*string
+	Shared        *bool
 }
 
 var _ fi.Task = &RouteTable{}

--- a/upup/pkg/fi/cloudup/azuretasks/subnet.go
+++ b/upup/pkg/fi/cloudup/azuretasks/subnet.go
@@ -35,6 +35,7 @@ type Subnet struct {
 	ResourceGroup  *ResourceGroup
 	VirtualNetwork *VirtualNetwork
 	CIDR           *string
+	Shared         *bool
 }
 
 var _ fi.Task = &Subnet{}


### PR DESCRIPTION
Cherry pick of #10900 on release-1.20.

#10900: add usage of subnet and routetable shared resources in azure

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.