### PR TITLE
Instruct GH to collapse BUILD.bazel diffs by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+**/zz_generated.*.go linguist-generated=true
+BUILD.bazel linguist-generated=true
+bindata.go linguist-generated=true
+/docs/cli/** linguist-generated=true
+/protokube/pkg/gossip/mesh/mesh.pb.go linguist-generated=true
+/protokube/pkg/gossip/mesh/mesh.proto linguist-generated=true
+/vendor/** linguist-generated=true


### PR DESCRIPTION
Since these are generated, viewing their diff is not of much value when viewing a commit or PR.

I would include a trivial change to a BUILD.bazel file to demonstrate but it would fail the gazelle verification CI

See https://github.com/github/linguist#using-gitattributes
