### PR TITLE
Honor OS update policy at InstanceGroup level too

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -4070,10 +4070,10 @@ spec:
                 type: object
               updatePolicy:
                 description: 'UpdatePolicy determines the policy for applying upgrades
-                  automatically. Valid values:   ''external'' do not apply updates
-                  automatically - they are applied manually or by an external system   missing:
-                  default policy (currently OS security upgrades that do not require
-                  a reboot)'
+                  automatically. Valid values:   ''automatic'' (default): apply updates
+                  automatically (apply OS security upgrades, avoiding rebooting when
+                  possible)   ''external'': do not apply updates automatically; they
+                  are applied manually or by an external system'
                 type: string
               useHostCertificates:
                 description: UseHostCertificates will mount /etc/ssl/certs to inside

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -58,7 +58,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: InstanceGroupSpec is the specification for an instanceGroup
+            description: InstanceGroupSpec is the specification for an InstanceGroup
             properties:
               additionalSecurityGroups:
                 description: AdditionalSecurityGroups attaches additional security
@@ -89,7 +89,7 @@ spec:
                 type: boolean
               autoscale:
                 description: Autoscale determines if autoscaling will be enabled for
-                  the group if cluster autoscaler is enabled
+                  this instance group if cluster autoscaler is enabled
                 type: boolean
               cloudLabels:
                 additionalProperties:
@@ -111,7 +111,7 @@ spec:
                 type: boolean
               externalLoadBalancers:
                 description: ExternalLoadBalancers define loadbalancers that should
-                  be attached to the instancegroup
+                  be attached to this instance group
                 items:
                   description: LoadBalancer defines a load balancer
                   properties:
@@ -706,11 +706,11 @@ spec:
                 additionalProperties:
                   type: string
                 description: NodeLabels indicates the kubernetes labels for nodes
-                  in this group
+                  in this instance group
                 type: object
               role:
-                description: 'Type determines the role of instances in this group:
-                  masters or nodes'
+                description: 'Type determines the role of instances in this instance
+                  group: masters or nodes'
                 type: string
               rollingUpdate:
                 description: RollingUpdate defines the rolling-update behavior
@@ -817,20 +817,21 @@ spec:
                 type: array
               taints:
                 description: Taints indicates the kubernetes taints for nodes in this
-                  group
+                  instance group
                 items:
                   type: string
                 type: array
               tenancy:
-                description: Describes the tenancy of the instance group. Can be either
-                  default or dedicated. Currently only applies to AWS.
+                description: Describes the tenancy of this instance group. Can be
+                  either default or dedicated. Currently only applies to AWS.
                 type: string
               updatePolicy:
                 description: 'UpdatePolicy determines the policy for applying upgrades
-                  automatically. Valid values:   ''automatic'' (default): apply updates
-                  automatically (apply OS security upgrades, avoiding rebooting when
-                  possible)   ''external'': do not apply updates automatically; they
-                  are applied manually or by an external system'
+                  automatically. If specified, this value overrides a value specified
+                  in the Cluster''s "spec.updatePolicy" field. Valid values:   ''automatic''
+                  (default): apply updates automatically (apply OS security upgrades,
+                  avoiding rebooting when possible)   ''external'': do not apply updates
+                  automatically; they are applied manually or by an external system'
                 type: string
               volumeMounts:
                 description: VolumeMounts a collection of volume mounts

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -825,6 +825,13 @@ spec:
                 description: Describes the tenancy of the instance group. Can be either
                   default or dedicated. Currently only applies to AWS.
                 type: string
+              updatePolicy:
+                description: 'UpdatePolicy determines the policy for applying upgrades
+                  automatically. Valid values:   ''automatic'' (default): apply updates
+                  automatically (apply OS security upgrades, avoiding rebooting when
+                  possible)   ''external'': do not apply updates automatically; they
+                  are applied manually or by an external system'
+                type: string
               volumeMounts:
                 description: VolumeMounts a collection of volume mounts
                 items:

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -133,8 +133,8 @@ type ClusterSpec struct {
 	IsolateMasters *bool `json:"isolateMasters,omitempty"`
 	// UpdatePolicy determines the policy for applying upgrades automatically.
 	// Valid values:
-	//   'external' do not apply updates automatically - they are applied manually or by an external system
-	//   missing: default policy (currently OS security upgrades that do not require a reboot)
+	//   'automatic' (default): apply updates automatically (apply OS security upgrades, avoiding rebooting when possible)
+	//   'external': do not apply updates automatically; they are applied manually or by an external system
 	UpdatePolicy *string `json:"updatePolicy,omitempty"`
 	// ExternalPolicies allows the insertion of pre-existing managed policies on IG Roles
 	ExternalPolicies *map[string][]string `json:"externalPolicies,omitempty"`

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -82,9 +82,9 @@ var (
 	SupportedFilesystems = []string{BtfsFilesystem, Ext4Filesystem, XFSFilesystem}
 )
 
-// InstanceGroupSpec is the specification for a instanceGroup
+// InstanceGroupSpec is the specification for an InstanceGroup
 type InstanceGroupSpec struct {
-	// Type determines the role of instances in this group: masters or nodes
+	// Type determines the role of instances in this instance group: masters or nodes
 	Role InstanceGroupRole `json:"role,omitempty"`
 	// Image is the instance (ami etc) we should use
 	Image string `json:"image,omitempty"`
@@ -92,7 +92,7 @@ type InstanceGroupSpec struct {
 	MinSize *int32 `json:"minSize,omitempty"`
 	// MaxSize is the maximum size of the pool
 	MaxSize *int32 `json:"maxSize,omitempty"`
-	// Autoscale determines if autoscaling will be enabled for the group if cluster autoscaler is enabled
+	// Autoscale determines if autoscaling will be enabled for this instance group if cluster autoscaler is enabled
 	Autoscale *bool `json:"autoscale,omitempty"`
 	// MachineType is the instance class
 	MachineType string `json:"machineType,omitempty"`
@@ -114,7 +114,7 @@ type InstanceGroupSpec struct {
 	RootVolumeEncryption *bool `json:"rootVolumeEncryption,omitempty"`
 	// RootVolumeEncryptionKey provides the key identifier for root volume encryption
 	RootVolumeEncryptionKey *string `json:"rootVolumeEncryptionKey,omitempty"`
-	// Volumes is a collection of additional volumes to create for instances within this InstanceGroup
+	// Volumes is a collection of additional volumes to create for instances within this instance group
 	Volumes []VolumeSpec `json:"volumes,omitempty"`
 	// VolumeMounts a collection of volume mounts
 	VolumeMounts []VolumeMountSpec `json:"volumeMounts,omitempty"`
@@ -123,7 +123,7 @@ type InstanceGroupSpec struct {
 	// Zones is the names of the Zones where machines in this instance group should be placed
 	// This is needed for regional subnets (e.g. GCE), to restrict placement to particular zones
 	Zones []string `json:"zones,omitempty"`
-	// Hooks is a list of hooks for this instanceGroup, note: these can override the cluster wide ones if required
+	// Hooks is a list of hooks for this instance group, note: these can override the cluster wide ones if required
 	Hooks []HookSpec `json:"hooks,omitempty"`
 	// MaxPrice indicates this is a spot-pricing group, with the specified value as our max-price bid
 	MaxPrice *string `json:"maxPrice,omitempty"`
@@ -137,15 +137,15 @@ type InstanceGroupSpec struct {
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 	// CloudLabels defines additional tags or labels on cloud provider resources
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
-	// NodeLabels indicates the kubernetes labels for nodes in this group
+	// NodeLabels indicates the kubernetes labels for nodes in this instance group
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 	// FileAssets is a collection of file assets for this instance group
 	FileAssets []FileAssetSpec `json:"fileAssets,omitempty"`
-	// Describes the tenancy of the instance group. Can be either default or dedicated. Currently only applies to AWS.
+	// Describes the tenancy of this instance group. Can be either default or dedicated. Currently only applies to AWS.
 	Tenancy string `json:"tenancy,omitempty"`
 	// Kubelet overrides kubelet config from the ClusterSpec
 	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
-	// Taints indicates the kubernetes taints for nodes in this group
+	// Taints indicates the kubernetes taints for nodes in this instance group
 	Taints []string `json:"taints,omitempty"`
 	// MixedInstancesPolicy defined a optional backing of an AWS ASG by a EC2 Fleet (AWS Only)
 	MixedInstancesPolicy *MixedInstancesPolicySpec `json:"mixedInstancesPolicy,omitempty"`
@@ -153,7 +153,7 @@ type InstanceGroupSpec struct {
 	AdditionalUserData []UserData `json:"additionalUserData,omitempty"`
 	// SuspendProcesses disables the listed Scaling Policies
 	SuspendProcesses []string `json:"suspendProcesses,omitempty"`
-	// ExternalLoadBalancers define loadbalancers that should be attached to the instancegroup
+	// ExternalLoadBalancers define loadbalancers that should be attached to this instance group
 	ExternalLoadBalancers []LoadBalancer `json:"externalLoadBalancers,omitempty"`
 	// DetailedInstanceMonitoring defines if detailed-monitoring is enabled (AWS only)
 	DetailedInstanceMonitoring *bool `json:"detailedInstanceMonitoring,omitempty"`
@@ -177,6 +177,7 @@ type InstanceGroupSpec struct {
 	// InstanceMetadata defines the EC2 instance metadata service options (AWS Only)
 	InstanceMetadata *InstanceMetadataOptions `json:"instanceMetadata,omitempty"`
 	// UpdatePolicy determines the policy for applying upgrades automatically.
+	// If specified, this value overrides a value specified in the Cluster's "spec.updatePolicy" field.
 	// Valid values:
 	//   'automatic' (default): apply updates automatically (apply OS security upgrades, avoiding rebooting when possible)
 	//   'external': do not apply updates automatically; they are applied manually or by an external system

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -176,6 +176,11 @@ type InstanceGroupSpec struct {
 	CompressUserData *bool `json:"compressUserData,omitempty"`
 	// InstanceMetadata defines the EC2 instance metadata service options (AWS Only)
 	InstanceMetadata *InstanceMetadataOptions `json:"instanceMetadata,omitempty"`
+	// UpdatePolicy determines the policy for applying upgrades automatically.
+	// Valid values:
+	//   'automatic' (default): apply updates automatically (apply OS security upgrades, avoiding rebooting when possible)
+	//   'external': do not apply updates automatically; they are applied manually or by an external system
+	UpdatePolicy *string `json:"updatePolicy,omitempty"`
 }
 
 const (
@@ -190,7 +195,7 @@ const (
 // SpotAllocationStrategies is a collection of supported strategies
 var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified, SpotAllocationStrategyCapacityOptimized}
 
-// InstanceMetadata defines the EC2 instance metadata service options (AWS Only)
+// InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)
 type InstanceMetadataOptions struct {
 	// HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for instance metadata requests.
 	// The larger the number, the further instance metadata requests can travel. The default value is 1.

--- a/pkg/apis/kops/labels.go
+++ b/pkg/apis/kops/labels.go
@@ -23,6 +23,9 @@ const (
 	// AnnotationValueManagementImported is the annotation value that indicates a cluster was imported, typically as part of an upgrade
 	AnnotationValueManagementImported = "imported"
 
-	// UpdatePolicyExternal is a value for ClusterSpec.UpdatePolicy indicating that upgrades are done externally, and we should disable automatic upgrades
+	// UpdatePolicyAutomatic is a value for ClusterSpec.UpdatePolicy and InstanceGroup.UpdatePolicy indicating that upgrades are performed automatically
+	UpdatePolicyAutomatic = "automatic"
+
+	// UpdatePolicyExternal is a value for ClusterSpec.UpdatePolicy and InstanceGroup.UpdatePolicy indicating that upgrades are done externally, and we should disable automatic upgrades
 	UpdatePolicyExternal = "external"
 )

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -132,8 +132,8 @@ type ClusterSpec struct {
 	IsolateMasters *bool `json:"isolateMasters,omitempty"`
 	// UpdatePolicy determines the policy for applying upgrades automatically.
 	// Valid values:
-	//   'external' do not apply updates automatically - they are applied manually or by an external system
-	//   missing: default policy (currently OS security upgrades that do not require a reboot)
+	//   'automatic' (default): apply updates automatically (apply OS security upgrades, avoiding rebooting when possible)
+	//   'external': do not apply updates automatically; they are applied manually or by an external system
 	UpdatePolicy *string `json:"updatePolicy,omitempty"`
 	// ExternalPolicies allows the insertion of pre-existing managed policies on IG Roles
 	ExternalPolicies *map[string][]string `json:"externalPolicies,omitempty"`

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -79,9 +79,9 @@ var (
 	SupportedFilesystems = []string{BtfsFilesystem, Ext4Filesystem, XFSFilesystem}
 )
 
-// InstanceGroupSpec is the specification for an instanceGroup
+// InstanceGroupSpec is the specification for an InstanceGroup
 type InstanceGroupSpec struct {
-	// Type determines the role of instances in this group: masters or nodes
+	// Type determines the role of instances in this instance group: masters or nodes
 	Role InstanceGroupRole `json:"role,omitempty"`
 	// Image is the instance (ami etc) we should use
 	Image string `json:"image,omitempty"`
@@ -89,7 +89,7 @@ type InstanceGroupSpec struct {
 	MinSize *int32 `json:"minSize,omitempty"`
 	// MaxSize is the maximum size of the pool
 	MaxSize *int32 `json:"maxSize,omitempty"`
-	// Autoscale determines if autoscaling will be enabled for the group if cluster autoscaler is enabled
+	// Autoscale determines if autoscaling will be enabled for this instance group if cluster autoscaler is enabled
 	Autoscale *bool `json:"autoscale,omitempty"`
 	// MachineType is the instance class
 	MachineType string `json:"machineType,omitempty"`
@@ -134,16 +134,16 @@ type InstanceGroupSpec struct {
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 	// CloudLabels defines additional tags or labels on cloud provider resources
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
-	// NodeLabels indicates the kubernetes labels for nodes in this group
+	// NodeLabels indicates the kubernetes labels for nodes in this instance group
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 	// FileAssets is a collection of file assets for this instance group
 	FileAssets []FileAssetSpec `json:"fileAssets,omitempty"`
-	// Describes the tenancy of the instance group. Can be either default or dedicated.
+	// Describes the tenancy of this instance group. Can be either default or dedicated.
 	// Currently only applies to AWS.
 	Tenancy string `json:"tenancy,omitempty"`
 	// Kubelet overrides kubelet config from the ClusterSpec
 	Kubelet *KubeletConfigSpec `json:"kubelet,omitempty"`
-	// Taints indicates the kubernetes taints for nodes in this group
+	// Taints indicates the kubernetes taints for nodes in this instance group
 	Taints []string `json:"taints,omitempty"`
 	// MixedInstancesPolicy defined a optional backing of an AWS ASG by a EC2 Fleet (AWS Only)
 	MixedInstancesPolicy *MixedInstancesPolicySpec `json:"mixedInstancesPolicy,omitempty"`
@@ -151,7 +151,7 @@ type InstanceGroupSpec struct {
 	AdditionalUserData []UserData `json:"additionalUserData,omitempty"`
 	// SuspendProcesses disables the listed Scaling Policies
 	SuspendProcesses []string `json:"suspendProcesses,omitempty"`
-	// ExternalLoadBalancers define loadbalancers that should be attached to the instancegroup
+	// ExternalLoadBalancers define loadbalancers that should be attached to this instance group
 	ExternalLoadBalancers []LoadBalancer `json:"externalLoadBalancers,omitempty"`
 	// DetailedInstanceMonitoring defines if detailed-monitoring is enabled (AWS only)
 	DetailedInstanceMonitoring *bool `json:"detailedInstanceMonitoring,omitempty"`
@@ -175,6 +175,7 @@ type InstanceGroupSpec struct {
 	// InstanceMetadata defines the EC2 instance metadata service options (AWS Only)
 	InstanceMetadata *InstanceMetadataOptions `json:"instanceMetadata,omitempty"`
 	// UpdatePolicy determines the policy for applying upgrades automatically.
+	// If specified, this value overrides a value specified in the Cluster's "spec.updatePolicy" field.
 	// Valid values:
 	//   'automatic' (default): apply updates automatically (apply OS security upgrades, avoiding rebooting when possible)
 	//   'external': do not apply updates automatically; they are applied manually or by an external system

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -174,6 +174,11 @@ type InstanceGroupSpec struct {
 	CompressUserData *bool `json:"compressUserData,omitempty"`
 	// InstanceMetadata defines the EC2 instance metadata service options (AWS Only)
 	InstanceMetadata *InstanceMetadataOptions `json:"instanceMetadata,omitempty"`
+	// UpdatePolicy determines the policy for applying upgrades automatically.
+	// Valid values:
+	//   'automatic' (default): apply updates automatically (apply OS security upgrades, avoiding rebooting when possible)
+	//   'external': do not apply updates automatically; they are applied manually or by an external system
+	UpdatePolicy *string `json:"updatePolicy,omitempty"`
 }
 
 const (
@@ -188,7 +193,7 @@ const (
 // SpotAllocationStrategies is a collection of supported strategies
 var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified, SpotAllocationStrategyCapacityOptimized}
 
-// InstanceMetadata defines the EC2 instance metadata service options (AWS Only)
+// InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)
 type InstanceMetadataOptions struct {
 	// HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for instance metadata requests.
 	// The larger the number, the further instance metadata requests can travel. The default value is 1.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3952,6 +3952,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	} else {
 		out.InstanceMetadata = nil
 	}
+	out.UpdatePolicy = in.UpdatePolicy
 	return nil
 }
 
@@ -4104,6 +4105,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	} else {
 		out.InstanceMetadata = nil
 	}
+	out.UpdatePolicy = in.UpdatePolicy
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2174,6 +2174,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(InstanceMetadataOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.UpdatePolicy != nil {
+		in, out := &in.UpdatePolicy, &out.UpdatePolicy
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -140,6 +140,8 @@ func ValidateInstanceGroup(g *kops.InstanceGroup, cloud fi.Cloud) field.ErrorLis
 		allErrs = append(allErrs, validateExternalLoadBalancer(&lb, path)...)
 	}
 
+	allErrs = append(allErrs, IsValidValue(field.NewPath("spec", "updatePolicy"), g.Spec.UpdatePolicy, []string{kops.UpdatePolicyAutomatic, kops.UpdatePolicyExternal})...)
+
 	return allErrs
 }
 

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -338,3 +338,49 @@ func TestIGCloudLabelIsIGName(t *testing.T) {
 		testErrors(t, g.label, errs, g.expected)
 	}
 }
+
+func TestIGUpdatePolicy(t *testing.T) {
+	const unsupportedValueError = "Unsupported value::spec.updatePolicy"
+	for _, test := range []struct {
+		label    string
+		policy   *string
+		expected []string
+	}{
+		{
+			label: "missing",
+		},
+		{
+			label:  "automatic",
+			policy: fi.String(kops.UpdatePolicyAutomatic),
+		},
+		{
+			label:  "external",
+			policy: fi.String(kops.UpdatePolicyExternal),
+		},
+		{
+			label:    "empty",
+			policy:   fi.String(""),
+			expected: []string{unsupportedValueError},
+		},
+		{
+			label:    "unknown",
+			policy:   fi.String("something-else"),
+			expected: []string{unsupportedValueError},
+		},
+	} {
+		ig := kops.InstanceGroup{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "some-ig",
+			},
+			Spec: kops.InstanceGroupSpec{
+				Role:        "Node",
+				CloudLabels: make(map[string]string),
+			},
+		}
+		t.Run(test.label, func(t *testing.T) {
+			ig.Spec.UpdatePolicy = test.policy
+			errs := ValidateInstanceGroup(&ig, nil)
+			testErrors(t, test.label, errs, test.expected)
+		})
+	}
+}

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -105,7 +105,7 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 	}
 
 	// UpdatePolicy
-	allErrs = append(allErrs, IsValidValue(fieldPath.Child("updatePolicy"), spec.UpdatePolicy, []string{kops.UpdatePolicyExternal})...)
+	allErrs = append(allErrs, IsValidValue(fieldPath.Child("updatePolicy"), spec.UpdatePolicy, []string{kops.UpdatePolicyAutomatic, kops.UpdatePolicyExternal})...)
 
 	// Hooks
 	for i := range spec.Hooks {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2340,6 +2340,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(InstanceMetadataOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.UpdatePolicy != nil {
+		in, out := &in.UpdatePolicy, &out.UpdatePolicy
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/upup/pkg/fi/cloudup/validation_test.go
+++ b/upup/pkg/fi/cloudup/validation_test.go
@@ -112,14 +112,49 @@ func TestValidateFull_ClusterName_Required(t *testing.T) {
 
 func TestValidateFull_UpdatePolicy_Valid(t *testing.T) {
 	c := buildDefaultCluster(t)
-	c.Spec.UpdatePolicy = fi.String(api.UpdatePolicyExternal)
-	expectNoErrorFromValidate(t, c)
+	for _, test := range []struct {
+		label  string
+		policy *string
+	}{
+		{
+			label: "missing",
+		},
+		{
+			label:  "automatic",
+			policy: fi.String(api.UpdatePolicyAutomatic),
+		},
+		{
+			label:  "external",
+			policy: fi.String(api.UpdatePolicyExternal),
+		},
+	} {
+		t.Run(test.label, func(t *testing.T) {
+			c.Spec.UpdatePolicy = test.policy
+			expectNoErrorFromValidate(t, c)
+		})
+	}
 }
 
 func TestValidateFull_UpdatePolicy_Invalid(t *testing.T) {
 	c := buildDefaultCluster(t)
-	c.Spec.UpdatePolicy = fi.String("not-a-real-value")
-	expectErrorFromValidate(t, c, "spec.updatePolicy")
+	for _, test := range []struct {
+		label  string
+		policy string
+	}{
+		{
+			label:  "empty",
+			policy: "",
+		},
+		{
+			label:  "populated",
+			policy: "not-a-real-value",
+		},
+	} {
+		t.Run(test.label, func(t *testing.T) {
+			c.Spec.UpdatePolicy = &test.policy
+			expectErrorFromValidate(t, c, "spec.updatePolicy")
+		})
+	}
 }
 
 func Test_Validate_Kubenet_With_14(t *testing.T) {

--- a/upup/pkg/fi/nodeup/nodetasks/package.go
+++ b/upup/pkg/fi/nodeup/nodetasks/package.go
@@ -198,6 +198,9 @@ func (e *Package) findDpkg(c *fi.Context) (*Package, error) {
 		}
 	}
 
+	// TODO: Take InstanceGroup-level overriding of the Cluster-level update policy into account
+	// here. Doing so requires that we make the current InstanceGroup available within Package's
+	// methods.
 	if fi.StringValue(c.Cluster.Spec.UpdatePolicy) != kops.UpdatePolicyExternal || !installed {
 		return nil, nil
 	}
@@ -246,6 +249,9 @@ func (e *Package) findYum(c *fi.Context) (*Package, error) {
 		healthy = fi.Bool(true)
 	}
 
+	// TODO: Take InstanceGroup-level overriding of the Cluster-level update policy into account
+	// here. Doing so requires that we make the current InstanceGroup available within Package's
+	// methods.
 	if fi.StringValue(c.Cluster.Spec.UpdatePolicy) != kops.UpdatePolicyExternal || !installed {
 		return nil, nil
 	}


### PR DESCRIPTION
As with the _Cluster_ "spec.updatePolicy" field, add a similar field at the _InstanceGroup_ level, allowing overriding of the cluster-level choice in each _InstanceGroup_.

Introduce a new value for the field ("automatic") as equivalent to the default value applied when the field is absent. Honoring this new value allows disabling automatic updates at the cluster level, but then enabling them again for particular _InstanceGroups_. Without such a positive affirmation, it's not possible to override a cluster-level "external" policy at the _InstanceGroup_ level, as there's no way to specify positively that you want to recover the default value. Instead, expressing the explicit "automatic" value is clear and unambiguous.

See [this thread in the "kops-users" channel](https://kubernetes.slack.com/archives/C3QUFP0QM/p1614031129048800) of the "Kubernetes" Slack workspace for preceding discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/kops/10913)
<!-- Reviewable:end -->
