### PR TITLE
Spotinst: Prevent instance groups with the same suffix from being deleted

### DIFF
--- a/pkg/resources/spotinst/resources.go
+++ b/pkg/resources/spotinst/resources.go
@@ -99,7 +99,7 @@ func listInstanceGroups(svc InstanceGroupService, clusterName string) ([]*resour
 
 	var resourceTrackers []*resources.Resource
 	for _, group := range groups {
-		if strings.HasSuffix(group.Name(), clusterName) &&
+		if strings.HasSuffix(group.Name(), fmt.Sprintf(".%s", clusterName)) &&
 			!strings.HasPrefix(strings.ToLower(group.Name()), "spotinst::ocean::") {
 			resource := &resources.Resource{
 				ID:      group.Id(),


### PR DESCRIPTION
This PR prevents instance groups with the same suffix from being deleted. For example, all instance groups associated with a cluster with the name `foo-bar.k8s.local` should be ignored when a cluster with the name `bar.k8s.local` is being deleted.