### PR TITLE
Fix typos in docs/getting_started

### DIFF
--- a/docs/getting_started/digitalocean.md
+++ b/docs/getting_started/digitalocean.md
@@ -56,7 +56,7 @@ kops delete cluster my-cluster.example.com --yes
 * follow steps as mentioned [here](https://kops.sigs.k8s.io/operations/updates_and_upgrades/#manual-update)
 
 # to install csi driver for DO block storage
-* follow steps as mentiond [here](https://github.com/digitalocean/csi-digitalocean#installing-to-kubernetes)
+* follow steps as mentioned [here](https://github.com/digitalocean/csi-digitalocean#installing-to-kubernetes)
 
 ```
 

--- a/docs/getting_started/production.md
+++ b/docs/getting_started/production.md
@@ -22,7 +22,7 @@ Read through the [topology page](../topology.md) to understand the options you h
 
 ## Cluster spec
 
-The `kops` command allows you to configure some aspects of your cluster, but for almost any production cluster, you want to change settings that is not accecible through CLI. The cluster spec can be exported as a yaml file and checked into version control.
+The `kops` command allows you to configure some aspects of your cluster, but for almost any production cluster, you want to change settings that is not accessible through CLI. The cluster spec can be exported as a yaml file and checked into version control.
 
 Read through the [cluster spec page](../cluster_spec.md) and familiarize yourself with the key options that kOps offers.
 

--- a/docs/getting_started/production.md
+++ b/docs/getting_started/production.md
@@ -22,7 +22,7 @@ Read through the [topology page](../topology.md) to understand the options you h
 
 ## Cluster spec
 
-The `kops` command allows you to configure some aspects of your cluster, but for almost any production cluster, you want to change settings that is not accessible through CLI. The cluster spec can be exported as a yaml file and checked into version control.
+The `kops` command allows you to configure some aspects of your cluster, but for almost any production cluster, you will want to change settings that are not accessible through the CLI. The cluster spec can be exported as a yaml file and checked into version control.
 
 Read through the [cluster spec page](../cluster_spec.md) and familiarize yourself with the key options that kOps offers.
 


### PR DESCRIPTION
Found a typo while going through these docs. I then ran a quick check on everything under `getting_started/` and found another one.

Admins: feel free to patch directly instead of approving the PR.