### PR TITLE
Automated cherry pick of #10918: fix: prevent igs with same suffix from being deleted

### DIFF
--- a/pkg/resources/spotinst/resources.go
+++ b/pkg/resources/spotinst/resources.go
@@ -99,7 +99,7 @@ func listInstanceGroups(svc InstanceGroupService, clusterName string) ([]*resour
 
 	var resourceTrackers []*resources.Resource
 	for _, group := range groups {
-		if strings.HasSuffix(group.Name(), clusterName) &&
+		if strings.HasSuffix(group.Name(), fmt.Sprintf(".%s", clusterName)) &&
 			!strings.HasPrefix(strings.ToLower(group.Name()), "spotinst::ocean::") {
 			resource := &resources.Resource{
 				ID:      group.Id(),


### PR DESCRIPTION
Cherry pick of #10918 on release-1.20.

#10918: fix: prevent igs with same suffix from being deleted

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.