### PR TITLE
Automated cherry pick of #10924: Fix nil pointer deference for image ID with spotinst

### DIFF
--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -479,7 +479,7 @@ func (_ *LaunchSpec) update(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) err
 				return err
 			}
 
-			if *actual.ImageID != *image.ImageId {
+			if fi.StringValue(actual.ImageID) != fi.StringValue(image.ImageId) {
 				spec.SetImageId(image.ImageId)
 			}
 


### PR DESCRIPTION
Cherry pick of #10924 on release-1.19.

#10924: Fix nil pointer deference for image ID with spotinst

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.