### PR TITLE
Fix node label conversion in Azure

### DIFF
--- a/pkg/model/azuremodel/context.go
+++ b/pkg/model/azuremodel/context.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azuremodel
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/kops/pkg/apis/kops"
@@ -97,8 +98,12 @@ func (c *AzureModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) ma
 	}
 
 	// Apply labels for cluster node labels.
+	i := 0
 	for k, v := range ig.Spec.NodeLabels {
-		labels[clusterNodeTemplateLabel+k] = v
+		// Store the label key in the tag value
+		// so that we don't need to espace "/" in the label key.
+		labels[fmt.Sprintf("%s%d", clusterNodeTemplateLabel, i)] = fmt.Sprintf("%s=%s", k, v)
+		i++
 	}
 
 	// Apply labels for cluster node taints.

--- a/pkg/model/azuremodel/context_test.go
+++ b/pkg/model/azuremodel/context_test.go
@@ -43,14 +43,15 @@ func TestCloudTagsForInstanceGroup(t *testing.T) {
 
 	actual := c.CloudTagsForInstanceGroup(c.InstanceGroups[0])
 	expected := map[string]*string{
-		"cluster_label_key": fi.String("cluster_label_value"),
-		"ig_label_key":      fi.String("ig_label_value"),
-		"test_label":        fi.String("from_ig"),
-		"k8s.io_cluster_node-template_label_node_label_key": fi.String("node_label_value"),
-		"k8s.io_cluster_node-template_taint_taint_key":      fi.String("taint_value"),
-		"k8s.io_role_node":          fi.String("1"),
-		"kops.k8s.io_instancegroup": fi.String("nodes"),
+		"cluster_label_key":                            fi.String("cluster_label_value"),
+		"ig_label_key":                                 fi.String("ig_label_value"),
+		"test_label":                                   fi.String("from_ig"),
+		"k8s.io_cluster_node-template_label_0":         fi.String("node_label/key=node_label_value"),
+		"k8s.io_cluster_node-template_taint_taint_key": fi.String("taint_value"),
+		"k8s.io_role_node":                             fi.String("1"),
+		"kops.k8s.io_instancegroup":                    fi.String("nodes"),
 	}
+
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("expected tags %+v, but got %+v", expected, actual)
 	}

--- a/pkg/nodeidentity/azure/BUILD.bazel
+++ b/pkg/nodeidentity/azure/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/nodeidentity:go_default_library",
-        "//upup/pkg/fi:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/azure/auth:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",


### PR DESCRIPTION
As Azure doesn't allow "/" in label keys, we used to convert "/" to
"_", but we didn't convert back "_" to "/" in kops-controller. This
commit fixes this.

Change the conversion semantics so that "/" is converted to "_s".  "_"
is converted to "__" so that we can distinguish the original "_" and
"_s".