### PR TITLE
Automated cherry pick of #10940: Sort external policies when checking for changes

### DIFF
--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -252,6 +253,7 @@ func (b *IAMModelBuilder) buildIAMTasks(role iam.Subject, iamName string, c *fi.
 				p := *(b.Cluster.Spec.ExternalPolicies)
 				externalPolicies = append(externalPolicies, p[roleKey]...)
 			}
+			sort.Strings(externalPolicies)
 
 			name := fmt.Sprintf("%s-policyoverride", roleKey)
 			t := &awstasks.IAMRolePolicy{

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net/url"
+	"sort"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -76,6 +77,7 @@ func (e *IAMRolePolicy) Find(c *fi.Context) (*IAMRolePolicy, error) {
 				policies = append(policies, aws.StringValue(policy.PolicyArn))
 			}
 		}
+		sort.Strings(policies)
 
 		actual.ID = e.ID
 		actual.Name = e.Name


### PR DESCRIPTION
Cherry pick of #10940 on release-1.19.

#10940: Sort external policies when checking for changes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.