### PR TITLE
Update etcd-manager to 3.0.20210228

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -171,7 +171,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20210122
+  - image: kopeio/etcd-manager:3.0.20210228
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -83,7 +83,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210122
+      image: kopeio/etcd-manager:3.0.20210228
       name: etcd-manager
       resources:
         requests:
@@ -148,7 +148,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210122
+      image: kopeio/etcd-manager:3.0.20210228
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -83,7 +83,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210122
+      image: kopeio/etcd-manager:3.0.20210228
       name: etcd-manager
       resources:
         requests:
@@ -154,7 +154,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210122
+      image: kopeio/etcd-manager:3.0.20210228
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -86,7 +86,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: kopeio/etcd-manager:3.0.20210122
+      image: kopeio/etcd-manager:3.0.20210228
       name: etcd-manager
       resources:
         requests:
@@ -154,7 +154,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: kopeio/etcd-manager:3.0.20210122
+      image: kopeio/etcd-manager:3.0.20210228
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -92,7 +92,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: kopeio/etcd-manager:3.0.20210122
+      image: kopeio/etcd-manager:3.0.20210228
       name: etcd-manager
       resources:
         requests:
@@ -172,7 +172,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: kopeio/etcd-manager:3.0.20210122
+      image: kopeio/etcd-manager:3.0.20210228
       name: etcd-manager
       resources:
         requests:


### PR DESCRIPTION
Changes:

* Add user agent to etcd-manager requests [#395](https://github.com/kopeio/etcd-manager/pull/395)
* Add etcd-manager metrics, add openstack API metrics [#396](https://github.com/kopeio/etcd-manager/pull/396)
* Make discovery poll interval configurable [#397](https://github.com/kopeio/etcd-manager/pull/397)
* Add log levels to prevent too verbose logging [#394](https://github.com/kopeio/etcd-manager/pull/394)