### PR TITLE
Automated cherry pick of #10944: gce doesn't suffix the IG names with ClusterName

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -28444,7 +28444,7 @@ spec:
             - --expander={{ .Expander }}
             {{ range $name, $spec := GetNodeInstanceGroups }}
             {{ if WithDefaultBool $spec.Autoscale true }}
-            - --nodes={{ $spec.MinSize }}:{{ $spec.MaxSize }}:{{ $name }}.{{ ClusterName }}
+            - --nodes={{ $spec.MinSize }}:{{ $spec.MaxSize }}:{{ $name }}{{- if not (eq $.CloudProvider "gce") }}.{{ ClusterName }}{{ end -}}
             {{ end }}
             {{ end }}
             - --scale-down-utilization-threshold={{ .ScaleDownUtilizationThreshold }}

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -158,7 +158,7 @@ spec:
             - --expander={{ .Expander }}
             {{ range $name, $spec := GetNodeInstanceGroups }}
             {{ if WithDefaultBool $spec.Autoscale true }}
-            - --nodes={{ $spec.MinSize }}:{{ $spec.MaxSize }}:{{ $name }}.{{ ClusterName }}
+            - --nodes={{ $spec.MinSize }}:{{ $spec.MaxSize }}:{{ $name }}{{- if not (eq $.CloudProvider "gce") }}.{{ ClusterName }}{{ end -}}
             {{ end }}
             {{ end }}
             - --scale-down-utilization-threshold={{ .ScaleDownUtilizationThreshold }}


### PR DESCRIPTION
Cherry pick of #10944 on release-1.20.

#10944: gce doesn't suffix the IG names with ClusterName

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.