### PR TITLE
Add support for enable-cadvisor-json-endpoints with Kubelet

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2318,6 +2318,10 @@ spec:
                     description: DockerDisableSharedPID uses a shared PID namespace
                       for containers in a pod.
                     type: boolean
+                  enableCadvisorJsonEndpoints:
+                    description: EnableCadvisorJsonEndpoints enables cAdvisor json
+                      `/spec` and `/stats/*` endpoints. Defaults to False.
+                    type: boolean
                   enableCustomMetrics:
                     description: Enable gathering custom metrics.
                     type: boolean
@@ -2719,6 +2723,10 @@ spec:
                   dockerDisableSharedPID:
                     description: DockerDisableSharedPID uses a shared PID namespace
                       for containers in a pod.
+                    type: boolean
+                  enableCadvisorJsonEndpoints:
+                    description: EnableCadvisorJsonEndpoints enables cAdvisor json
+                      `/spec` and `/stats/*` endpoints. Defaults to False.
                     type: boolean
                   enableCustomMetrics:
                     description: Enable gathering custom metrics.

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -342,6 +342,10 @@ spec:
                     description: DockerDisableSharedPID uses a shared PID namespace
                       for containers in a pod.
                     type: boolean
+                  enableCadvisorJsonEndpoints:
+                    description: EnableCadvisorJsonEndpoints enables cAdvisor json
+                      `/spec` and `/stats/*` endpoints. Defaults to False.
+                    type: boolean
                   enableCustomMetrics:
                     description: Enable gathering custom metrics.
                     type: boolean

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -215,6 +215,8 @@ type KubeletConfigSpec struct {
 	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty" flag:"container-log-max-size"`
 	// ContainerLogMaxFiles is the maximum number of container log files that can be present for a container. The number must be >= 2.
 	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty" flag:"container-log-max-files"`
+	// EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
+	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -215,6 +215,8 @@ type KubeletConfigSpec struct {
 	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty" flag:"container-log-max-size"`
 	// ContainerLogMaxFiles is the maximum number of container log files that can be present for a container. The number must be >= 2.
 	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty" flag:"container-log-max-files"`
+	// EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
+	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4931,6 +4931,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.EventBurst = in.EventBurst
 	out.ContainerLogMaxSize = in.ContainerLogMaxSize
 	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
+	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
 	return nil
 }
 
@@ -5024,6 +5025,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.EventBurst = in.EventBurst
 	out.ContainerLogMaxSize = in.ContainerLogMaxSize
 	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
+	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3325,6 +3325,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.EnableCadvisorJsonEndpoints != nil {
+		in, out := &in.EnableCadvisorJsonEndpoints, &out.EnableCadvisorJsonEndpoints
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -517,6 +517,12 @@ func validateKubelet(k *kops.KubeletConfigSpec, c *kops.Cluster, kubeletPath *fi
 			}
 		}
 
+		if k.EnableCadvisorJsonEndpoints != nil {
+			if c.IsKubernetesLT("1.18") && c.IsKubernetesGTE("1.21") {
+				allErrs = append(allErrs, field.Forbidden(kubeletPath.Child("enableCadvisorJsonEndpoints"), "enableCadvisorJsonEndpoints requires Kubernetes 1.18-1.20"))
+			}
+		}
+
 	}
 	return allErrs
 }

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3507,6 +3507,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.EnableCadvisorJsonEndpoints != nil {
+		in, out := &in.EnableCadvisorJsonEndpoints, &out.EnableCadvisorJsonEndpoints
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Kubernetes 1.18 disables this by default.
For backwards compatibility with monitoring tools, it would be nice to
be able to re-enable this.

https://github.com/kubernetes/kubernetes/issues/68522