### PR TITLE
Automated cherry pick of #10828: validation.go: remove checks on CNI

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -548,6 +548,10 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		optionTaken = true
 	}
 
+	if v.CNI != nil && optionTaken {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("cni"), "only one networking option permitted"))
+	}
+
 	if v.Weave != nil {
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("weave"), "only one networking option permitted"))

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -541,13 +541,6 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		optionTaken = true
 	}
 
-	if v.CNI != nil {
-		if optionTaken {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("cni"), "only one networking option permitted"))
-		}
-		optionTaken = true
-	}
-
 	if v.Kopeio != nil {
 		if optionTaken {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kopeio"), "only one networking option permitted"))


### PR DESCRIPTION
Cherry pick of #10828 on release-1.20.

#10828: validation.go: remove checks on CNI

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.