### PR TITLE
Automated cherry pick of #10960: feat(spot/addon): bump ocean-controller to 1.0.73

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -43310,7 +43310,7 @@ rules:
   verbs: ["get", "list"]
 - apiGroups: ["apps"]
   resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
-  verbs: ["get","list"]
+  verbs: ["get", "list"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["get", "list"]
@@ -43319,7 +43319,7 @@ rules:
   verbs: ["get", "list"]
 - apiGroups: ["extensions"]
   resources: ["replicasets", "daemonsets"]
-  verbs: ["get","list"]
+  verbs: ["get", "list"]
 - apiGroups: ["policy"]
   resources: ["poddisruptionbudgets"]
   verbs: ["get", "list"]
@@ -43375,22 +43375,22 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
   resourceNames: ["spotinst-kubernetes-cluster-controller"]
-  verbs: ["patch","update"]
+  verbs: ["patch", "update"]
   # ----------------------------------------------------------------------------
   # Required by the Spotinst Apply feature.
   # ----------------------------------------------------------------------------
 - apiGroups: ["apps"]
   resources: ["deployments", "daemonsets"]
-  verbs: ["get", "list", "patch","update","create","delete"]
+  verbs: ["get", "list", "patch", "update", "create", "delete"]
 - apiGroups: ["extensions"]
   resources: ["daemonsets"]
-  verbs: ["get", "list", "patch","update","create","delete"]
+  verbs: ["get", "list", "patch", "update", "create", "delete"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "patch", "update", "create", "delete"]
 - apiGroups: ["batch"]
   resources: ["jobs"]
-  verbs: ["get", "list", "patch","update","create","delete"]
+  verbs: ["get", "list", "patch", "update", "create", "delete"]
   # ----------------------------------------------------------------------------
   # Required by Spotinst Wave.
   # ----------------------------------------------------------------------------
@@ -43468,7 +43468,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.72
+        image: spotinst/kubernetes-cluster-controller:1.0.73
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -47,7 +47,7 @@ rules:
   verbs: ["get", "list"]
 - apiGroups: ["apps"]
   resources: ["deployments", "daemonsets", "statefulsets", "replicasets"]
-  verbs: ["get","list"]
+  verbs: ["get", "list"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["get", "list"]
@@ -56,7 +56,7 @@ rules:
   verbs: ["get", "list"]
 - apiGroups: ["extensions"]
   resources: ["replicasets", "daemonsets"]
-  verbs: ["get","list"]
+  verbs: ["get", "list"]
 - apiGroups: ["policy"]
   resources: ["poddisruptionbudgets"]
   verbs: ["get", "list"]
@@ -112,22 +112,22 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
   resourceNames: ["spotinst-kubernetes-cluster-controller"]
-  verbs: ["patch","update"]
+  verbs: ["patch", "update"]
   # ----------------------------------------------------------------------------
   # Required by the Spotinst Apply feature.
   # ----------------------------------------------------------------------------
 - apiGroups: ["apps"]
   resources: ["deployments", "daemonsets"]
-  verbs: ["get", "list", "patch","update","create","delete"]
+  verbs: ["get", "list", "patch", "update", "create", "delete"]
 - apiGroups: ["extensions"]
   resources: ["daemonsets"]
-  verbs: ["get", "list", "patch","update","create","delete"]
+  verbs: ["get", "list", "patch", "update", "create", "delete"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "patch", "update", "create", "delete"]
 - apiGroups: ["batch"]
   resources: ["jobs"]
-  verbs: ["get", "list", "patch","update","create","delete"]
+  verbs: ["get", "list", "patch", "update", "create", "delete"]
   # ----------------------------------------------------------------------------
   # Required by Spotinst Wave.
   # ----------------------------------------------------------------------------
@@ -205,7 +205,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.72
+        image: spotinst/kubernetes-cluster-controller:1.0.73
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -667,7 +667,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		{
 			id := "v1.14.0"
 			location := key + "/" + id + ".yaml"
-			version := "1.0.72"
+			version := "1.0.73"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),


### PR DESCRIPTION
Cherry pick of #10960 on release-1.20.

#10960: feat(spot/addon): bump ocean-controller to 1.0.73

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.