### PR TITLE
Automated cherry pick of #10961: fix: don't skip lb attachments when hybrid is enabled

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -428,10 +428,11 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 	t.LoadBalancers = []*awstasks.ClassicLoadBalancer{}
 	t.TargetGroups = []*awstasks.TargetGroup{}
 
-	// When Spotinst Elastigroups are used, there is no need to create
-	// a separate task for the attachment of the load balancer since this
-	// is already done as part of the Elastigroup's creation, if needed.
-	if !featureflag.Spotinst.Enabled() {
+	// Spotinst handles load balancer attachments internally, so there's no
+	// need to create separate attachments for both managed (+Spotinst) and
+	// hybrid (+SpotinstHybrid) instance groups.
+	if !featureflag.Spotinst.Enabled() ||
+		(featureflag.SpotinstHybrid.Enabled() && !spotinstmodel.HybridInstanceGroup(ig)) {
 		if b.UseLoadBalancerForAPI() && ig.Spec.Role == kops.InstanceGroupRoleMaster {
 			if b.UseNetworkLoadBalancer() {
 				t.TargetGroups = append(t.TargetGroups, b.LinkToTargetGroup("tcp"))


### PR DESCRIPTION
Cherry pick of #10961 on release-1.20.

#10961: fix: don't skip lb attachments when hybrid is enabled

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.