### PR TITLE
Automated cherry pick of #10934: Add new CPUCredits field to instance group spec

### DIFF
--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -101,6 +101,10 @@ spec:
                 description: CompressUserData compresses parts of the user data to
                   save space
                 type: boolean
+              cpuCredits:
+                description: CPUCredits is the credit option for CPU Usage on burstable
+                  instance types (AWS only)
+                type: string
               detailedInstanceMonitoring:
                 description: DetailedInstanceMonitoring defines if detailed-monitoring
                   is enabled (AWS only)

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -129,6 +129,8 @@ type InstanceGroupSpec struct {
 	MaxPrice *string `json:"maxPrice,omitempty"`
 	// SpotDurationInMinutes reserves a spot block for the period specified
 	SpotDurationInMinutes *int64 `json:"spotDurationInMinutes,omitempty"`
+	// CPUCredits is the credit option for CPU Usage on burstable instance types (AWS only)
+	CPUCredits *string `json:"cpuCredits,omitempty"`
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
 	// AdditionalSecurityGroups attaches additional security groups (e.g. i-123456)

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -126,6 +126,8 @@ type InstanceGroupSpec struct {
 	MaxPrice *string `json:"maxPrice,omitempty"`
 	// SpotDurationInMinutes indicates this is a spot-block group, with the specified value as the spot reservation time
 	SpotDurationInMinutes *int64 `json:"spotDurationInMinutes,omitempty"`
+	// CPUCredits is the credit option for CPU Usage on burstable instance types (AWS only)
+	CPUCredits *string `json:"cpuCredits,omitempty"`
 	// AssociatePublicIP is true if we want instances to have a public IP
 	AssociatePublicIP *bool `json:"associatePublicIp,omitempty"`
 	// AdditionalSecurityGroups attaches additional security groups (e.g. i-123456)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3860,6 +3860,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	}
 	out.MaxPrice = in.MaxPrice
 	out.SpotDurationInMinutes = in.SpotDurationInMinutes
+	out.CPUCredits = in.CPUCredits
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
 	out.CloudLabels = in.CloudLabels
@@ -4011,6 +4012,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	}
 	out.MaxPrice = in.MaxPrice
 	out.SpotDurationInMinutes = in.SpotDurationInMinutes
+	out.CPUCredits = in.CPUCredits
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
 	out.CloudLabels = in.CloudLabels

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2061,6 +2061,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.CPUCredits != nil {
+		in, out := &in.CPUCredits, &out.CPUCredits
+		*out = new(string)
+		**out = **in
+	}
 	if in.AssociatePublicIP != nil {
 		in, out := &in.AssociatePublicIP, &out.AssociatePublicIP
 		*out = new(bool)

--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -79,6 +79,10 @@ func awsValidateInstanceGroup(ig *kops.InstanceGroup, cloud awsup.AWSCloud) fiel
 		allErrs = append(allErrs, awsValidateInstanceMetadata(field.NewPath("spec", "instanceMetadata"), ig.Spec.InstanceMetadata)...)
 	}
 
+	if ig.Spec.CPUCredits != nil {
+		allErrs = append(allErrs, awsValidateCPUCredits(field.NewPath("spec"), &ig.Spec, cloud)...)
+	}
+
 	return allErrs
 }
 
@@ -275,5 +279,12 @@ func awsValidateLoadBalancerSubnets(fieldPath *field.Path, spec kops.ClusterSpec
 		}
 	}
 
+	return allErrs
+}
+
+func awsValidateCPUCredits(fieldPath *field.Path, spec *kops.InstanceGroupSpec, cloud awsup.AWSCloud) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, IsValidValue(fieldPath.Child("cpuCredits"), spec.CPUCredits, []string{"standard", "unlimited"})...)
 	return allErrs
 }

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2227,6 +2227,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.CPUCredits != nil {
+		in, out := &in.CPUCredits, &out.CPUCredits
+		*out = new(string)
+		**out = **in
+	}
 	if in.AssociatePublicIP != nil {
 		in, out := &in.AssociatePublicIP, &out.AssociatePublicIP
 		*out = new(bool)

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -177,6 +177,13 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 			lt.RootVolumeThroughput = fi.Int64(int64(fi.Int32Value(ig.Spec.RootVolumeThroughput)))
 		}
 	}
+
+	if ig.Spec.CPUCredits != nil {
+		lt.CPUCredits = ig.Spec.CPUCredits
+	} else {
+		lt.CPUCredits = fi.String("")
+	}
+
 	return lt, nil
 }
 

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -421,6 +421,9 @@
               }
             }
           ],
+          "CreditSpecification": {
+            "CpuCredits": "standard"
+          },
           "IamInstanceProfile": {
             "Name": {
               "Ref": "AWSIAMInstanceProfilenodescomplexexamplecom"

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -109,6 +109,7 @@ spec:
   detailedInstanceMonitoring: true
   rootVolumeDeleteOnTermination: false
   rootVolumeEncryption: true
+  cpuCredits: standard
   volumes:
   - device: /dev/xvdd
     deleteOnTermination: false

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -109,6 +109,7 @@ spec:
   detailedInstanceMonitoring: true
   rootVolumeDeleteOnTermination: false
   rootVolumeEncryption: true
+  cpuCredits: standard
   volumes:
   - device: /dev/xvdd
     deleteOnTermination: false

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -418,6 +418,9 @@ resource "aws_launch_template" "nodes-complex-example-com" {
       volume_type           = "gp2"
     }
   }
+  credit_specification {
+    cpu_credits = "standard"
+  }
   iam_instance_profile {
     name = aws_iam_instance_profile.nodes-complex-example-com.id
   }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -39,6 +39,8 @@ type LaunchTemplate struct {
 	AssociatePublicIP *bool
 	// BlockDeviceMappings is a block device mappings
 	BlockDeviceMappings []*BlockDeviceMapping
+	// CPUCredits is the credit option for CPU Usage on some instance types
+	CPUCredits *string
 	// HTTPPutResponseHopLimit is the desired HTTP PUT response hop limit for instance metadata requests.
 	HTTPPutResponseHopLimit *int64
 	// HTTPTokens is the state of token usage for your instance metadata requests.

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -135,6 +135,11 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 			SpotOptions: s,
 		}
 	}
+	if fi.StringValue(t.CPUCredits) != "" {
+		data.CreditSpecification = &ec2.CreditSpecificationRequest{
+			CpuCredits: t.CPUCredits,
+		}
+	}
 	// @step: attempt to create the launch template
 	if a == nil {
 		input := &ec2.CreateLaunchTemplateInput{
@@ -216,6 +221,11 @@ func (t *LaunchTemplate) Find(c *fi.Context) (*LaunchTemplate, error) {
 	}
 	sort.Sort(OrderSecurityGroupsById(actual.SecurityGroups))
 
+	if lt.LaunchTemplateData.CreditSpecification != nil && lt.LaunchTemplateData.CreditSpecification.CpuCredits != nil {
+		actual.CPUCredits = lt.LaunchTemplateData.CreditSpecification.CpuCredits
+	} else {
+		actual.CPUCredits = aws.String("")
+	}
 	// @step: check if monitoring it enabled
 	if lt.LaunchTemplateData.Monitoring != nil {
 		actual.InstanceMonitoring = lt.LaunchTemplateData.Monitoring.Enabled

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_cloudformation.go
@@ -79,6 +79,11 @@ type cloudformationLaunchTemplateMarketOptions struct {
 	SpotOptions *cloudformationLaunchTemplateMarketOptionsSpotOptions `json:"SpotOptions,omitempty"`
 }
 
+type cloudformationLaunchTemplateCreditSpecification struct {
+	// CPUCredits The credit option for CPU usage on some instance types
+	CPUCredits *string `json:"CpuCredits,omitempty"`
+}
+
 type cloudformationLaunchTemplateBlockDeviceEBS struct {
 	// VolumeType is the ebs type to use
 	VolumeType *string `json:"VolumeType,omitempty"`
@@ -122,6 +127,8 @@ type cloudformationLaunchTemplateInstanceMetadataOptions struct {
 type cloudformationLaunchTemplateData struct {
 	// BlockDeviceMappings is the device mappings
 	BlockDeviceMappings []*cloudformationLaunchTemplateBlockDevice `json:"BlockDeviceMappings,omitempty"`
+	// CreditSpecification is the credit option for CPU Usage on some instance types
+	CreditSpecification *cloudformationLaunchTemplateCreditSpecification `json:"CreditSpecification,omitempty"`
 	// EBSOptimized indicates if the root device is ebs optimized
 	EBSOptimized *bool `json:"EbsOptimized,omitempty"`
 	// IAMInstanceProfile is the IAM profile to assign to the nodes
@@ -206,6 +213,12 @@ func (t *LaunchTemplate) RenderCloudformation(target *cloudformation.Cloudformat
 			marketSpotOptions.InstanceInterruptionBehavior = e.InstanceInterruptionBehavior
 		}
 		launchTemplateData.MarketOptions = &cloudformationLaunchTemplateMarketOptions{MarketType: fi.String("spot"), SpotOptions: &marketSpotOptions}
+	}
+
+	if fi.StringValue(e.CPUCredits) != "" {
+		launchTemplateData.CreditSpecification = &cloudformationLaunchTemplateCreditSpecification{
+			CPUCredits: e.CPUCredits,
+		}
 	}
 
 	cf := &cloudformationLaunchTemplate{

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -105,6 +105,10 @@ type terraformLaunchTemplateBlockDevice struct {
 	EBS []*terraformLaunchTemplateBlockDeviceEBS `json:"ebs,omitempty" cty:"ebs"`
 }
 
+type terraformLaunchTemplateCreditSpecification struct {
+	CPUCredits *string `json:"cpu_credits,omitempty" cty:"cpu_credits"`
+}
+
 type terraformLaunchTemplateTagSpecification struct {
 	// ResourceType is the type of resource to tag.
 	ResourceType *string `json:"resource_type,omitempty" cty:"resource_type"`
@@ -129,6 +133,8 @@ type terraformLaunchTemplate struct {
 
 	// BlockDeviceMappings is the device mappings
 	BlockDeviceMappings []*terraformLaunchTemplateBlockDevice `json:"block_device_mappings,omitempty" cty:"block_device_mappings"`
+	// CreditSpecification is the credit option for CPU Usage on some instance types
+	CreditSpecification *terraformLaunchTemplateCreditSpecification `json:"credit_specification,omitempty" cty:"credit_specification"`
 	// EBSOptimized indicates if the root device is ebs optimized
 	EBSOptimized *bool `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
 	// IAMInstanceProfile is the IAM profile to assign to the nodes
@@ -215,6 +221,11 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 				MarketType:  fi.String("spot"),
 				SpotOptions: []*terraformLaunchTemplateMarketOptionsSpotOptions{&marketSpotOptions},
 			},
+		}
+	}
+	if fi.StringValue(e.CPUCredits) != "" {
+		tf.CreditSpecification = &terraformLaunchTemplateCreditSpecification{
+			CPUCredits: e.CPUCredits,
 		}
 	}
 	for _, x := range e.SecurityGroups {


### PR DESCRIPTION
Cherry pick of #10934 on release-1.20.

#10934: Add new CPUCredits field to instance group spec

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.