### PR TITLE
Automated cherry pick of #10957: Add support for enable-cadvisor-json-endpoints with Kubelet

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1689,6 +1689,9 @@ spec:
                   dockerDisableSharedPID:
                     description: DockerDisableSharedPID uses a shared PID namespace for containers in a pod.
                     type: boolean
+                  enableCadvisorJsonEndpoints:
+                    description: EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
+                    type: boolean
                   enableCustomMetrics:
                     description: Enable gathering custom metrics.
                     type: boolean
@@ -1977,6 +1980,9 @@ spec:
                     type: string
                   dockerDisableSharedPID:
                     description: DockerDisableSharedPID uses a shared PID namespace for containers in a pod.
+                    type: boolean
+                  enableCadvisorJsonEndpoints:
+                    description: EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
                     type: boolean
                   enableCustomMetrics:
                     description: Enable gathering custom metrics.

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -272,6 +272,9 @@ spec:
                   dockerDisableSharedPID:
                     description: DockerDisableSharedPID uses a shared PID namespace for containers in a pod.
                     type: boolean
+                  enableCadvisorJsonEndpoints:
+                    description: EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
+                    type: boolean
                   enableCustomMetrics:
                     description: Enable gathering custom metrics.
                     type: boolean

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -211,6 +211,8 @@ type KubeletConfigSpec struct {
 	EventQPS *int32 `json:"eventQPS,omitempty" flag:"event-qps" flag-empty:"0"`
 	// EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
 	EventBurst *int32 `json:"eventBurst,omitempty" flag:"event-burst"`
+	// EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
+	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -211,6 +211,8 @@ type KubeletConfigSpec struct {
 	EventQPS *int32 `json:"eventQPS,omitempty" flag:"event-qps" flag-empty:"0"`
 	// EventBurst temporarily allows event records to burst to this number, while still not exceeding EventQPS. Only used if EventQPS > 0.
 	EventBurst *int32 `json:"eventBurst,omitempty" flag:"event-burst"`
+	// EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
+	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4623,6 +4623,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.HousekeepingInterval = in.HousekeepingInterval
 	out.EventQPS = in.EventQPS
 	out.EventBurst = in.EventBurst
+	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
 	return nil
 }
 
@@ -4714,6 +4715,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.HousekeepingInterval = in.HousekeepingInterval
 	out.EventQPS = in.EventQPS
 	out.EventBurst = in.EventBurst
+	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3124,6 +3124,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.EnableCadvisorJsonEndpoints != nil {
+		in, out := &in.EnableCadvisorJsonEndpoints, &out.EnableCadvisorJsonEndpoints
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -503,6 +503,12 @@ func validateKubelet(k *kops.KubeletConfigSpec, c *kops.Cluster, kubeletPath *fi
 			}
 		}
 
+		if k.EnableCadvisorJsonEndpoints != nil {
+			if c.IsKubernetesLT("1.18") && c.IsKubernetesGTE("1.21") {
+				allErrs = append(allErrs, field.Forbidden(kubeletPath.Child("enableCadvisorJsonEndpoints"), "enableCadvisorJsonEndpoints requires Kubernetes 1.18-1.20"))
+			}
+		}
+
 	}
 	return allErrs
 }

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3306,6 +3306,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.EnableCadvisorJsonEndpoints != nil {
+		in, out := &in.EnableCadvisorJsonEndpoints, &out.EnableCadvisorJsonEndpoints
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Cherry pick of #10957 on release-1.19.

#10957: Add support for enable-cadvisor-json-endpoints with Kubelet

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.