### PR TITLE
Automated cherry pick of #10966: Add explicit RBAC permissions for finalizers subresources

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -31237,6 +31237,16 @@ rules:
   - ""
   resources:
   - pods
+  - pods/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get
@@ -31273,12 +31283,16 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/finalizers
   - ciliumnetworkpolicies/status
   - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/finalizers
   - ciliumendpoints/status
   - ciliumnodes
+  - ciliumnodes/finalizers
   - ciliumnodes/status
   - ciliumidentities
   verbs:
@@ -31330,14 +31344,19 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/finalizers
   - ciliumnetworkpolicies/status
   - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/finalizers
   - ciliumendpoints/status
   - ciliumnodes
+  - ciliumnodes/finalizers
   - ciliumnodes/status
   - ciliumidentities
+  - ciliumidentities/finalizers
   - ciliumidentities/status
   verbs:
   - '*'

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -237,6 +237,16 @@ rules:
   - ""
   resources:
   - pods
+  - pods/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get
@@ -273,12 +283,16 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/finalizers
   - ciliumnetworkpolicies/status
   - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/finalizers
   - ciliumendpoints/status
   - ciliumnodes
+  - ciliumnodes/finalizers
   - ciliumnodes/status
   - ciliumidentities
   verbs:
@@ -330,14 +344,19 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/finalizers
   - ciliumnetworkpolicies/status
   - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/finalizers
   - ciliumendpoints/status
   - ciliumnodes
+  - ciliumnodes/finalizers
   - ciliumnodes/status
   - ciliumidentities
+  - ciliumidentities/finalizers
   - ciliumidentities/status
   verbs:
   - '*'


### PR DESCRIPTION
Cherry pick of #10966 on release-1.20.

#10966: Add explicit RBAC permissions for finalizers subresources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.