### PR TITLE
Automated cherry pick of #10966: Add explicit RBAC permissions for finalizers subresources

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -4853,6 +4853,16 @@ rules:
   - ""
   resources:
   - pods
+  - pods/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get
@@ -4889,12 +4899,16 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/finalizers
   - ciliumnetworkpolicies/status
   - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/finalizers
   - ciliumendpoints/status
   - ciliumnodes
+  - ciliumnodes/finalizers
   - ciliumnodes/status
   - ciliumidentities
   verbs:
@@ -4946,14 +4960,19 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/finalizers
   - ciliumnetworkpolicies/status
   - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/finalizers
   - ciliumendpoints/status
   - ciliumnodes
+  - ciliumnodes/finalizers
   - ciliumnodes/status
   - ciliumidentities
+  - ciliumidentities/finalizers
   - ciliumidentities/status
   verbs:
   - '*'

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -237,6 +237,16 @@ rules:
   - ""
   resources:
   - pods
+  - pods/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get
@@ -273,12 +283,16 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/finalizers
   - ciliumnetworkpolicies/status
   - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/finalizers
   - ciliumendpoints/status
   - ciliumnodes
+  - ciliumnodes/finalizers
   - ciliumnodes/status
   - ciliumidentities
   verbs:
@@ -330,14 +344,19 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
+  - ciliumnetworkpolicies/finalizers
   - ciliumnetworkpolicies/status
   - ciliumclusterwidenetworkpolicies
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies/status
   - ciliumendpoints
+  - ciliumendpoints/finalizers
   - ciliumendpoints/status
   - ciliumnodes
+  - ciliumnodes/finalizers
   - ciliumnodes/status
   - ciliumidentities
+  - ciliumidentities/finalizers
   - ciliumidentities/status
   verbs:
   - '*'

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -89,7 +89,7 @@ spec:
   - id: k8s-1.12
     kubernetesVersion: '>=1.12.0'
     manifest: networking.cilium.io/k8s-1.12-v1.8.yaml
-    manifestHash: f3d7ec3355cdbf1157cb082e514ac431fd6d90a5
+    manifestHash: 442e9be711b81e0ff39f3da0330b8344ef84ac8b
     name: networking.cilium.io
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
Cherry pick of #10966 on release-1.19.

#10966: Add explicit RBAC permissions for finalizers subresources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.