### PR TITLE
Add CloudLabels as --extra-tags to aws-ebs-csi driver

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1111,7 +1111,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --k8s-tag-cluster-id={{ ClusterName }}
-            - --extra-tags=KubernetesCluster={{ ClusterName }}
+            - --extra-tags={{ CsiExtraTags }}
             - --v=5
           env:
             - name: CSI_ENDPOINT

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -352,7 +352,7 @@ spec:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --k8s-tag-cluster-id={{ ClusterName }}
-            - --extra-tags=KubernetesCluster={{ ClusterName }}
+            - --extra-tags={{ CsiExtraTags }}
             - --v=5
           env:
             - name: CSI_ENDPOINT

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -1021,7 +1021,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		if b.Cluster.Spec.CloudConfig != nil && b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver != nil && fi.BoolValue(b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled) {
 			key := "aws-ebs-csi-driver.addons.k8s.io"
 
-			version := "0.8.0-kops.1"
+			version := "0.8.0-kops.2"
 			{
 				id := "k8s-1.17"
 				location := key + "/" + id + ".yaml"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -207,6 +207,14 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 		dest["WeaveSecret"] = func() string { return weavesecretString }
 	}
 
+	dest["CsiExtraTags"] = func() string {
+		s := fmt.Sprintf("KubernetesCluster=%s", cluster.ObjectMeta.Name)
+		for n, v := range cluster.Spec.CloudLabels {
+			s += fmt.Sprintf(",%s=%s", n, v)
+		}
+		return s
+	}
+
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -72,8 +72,8 @@ spec:
   - id: k8s-1.17
     kubernetesVersion: '>=1.17.0'
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7b0fe2a3ab1cafa4caa9d3128efe5a7c65bfb7e8
+    manifestHash: 0a192bd7133322e628fb5d83c11baa6865a3ae69
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
-    version: 0.8.0-kops.1
+    version: 0.8.0-kops.2


### PR DESCRIPTION
This PR adds `cloudLabels` from the cluster spec as tags to EBS volumes created by the aws-ebs-csi driver. This allows us to fulfil company wide policies on tagging rules.