### PR TITLE
Automated cherry pick of #10978: Removing duplicate local and output values in

### DIFF
--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name                 = "existing-iam.example.com"
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-existing-iam-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-existing-iam-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-existing-iam-example-com.id]
-  master_security_group_ids    = [aws_security_group.masters-existing-iam-example-com.id, aws_security_group.masters-existing-iam-example-com.id, aws_security_group.masters-existing-iam-example-com.id]
+  master_security_group_ids    = [aws_security_group.masters-existing-iam-example-com.id]
   node_autoscaling_group_ids   = [aws_autoscaling_group.nodes-existing-iam-example-com.id]
   node_security_group_ids      = [aws_security_group.nodes-existing-iam-example-com.id]
   node_subnet_ids              = [aws_subnet.us-test-1a-existing-iam-example-com.id]
@@ -23,7 +23,7 @@ output "master_autoscaling_group_ids" {
 }
 
 output "master_security_group_ids" {
-  value = [aws_security_group.masters-existing-iam-example-com.id, aws_security_group.masters-existing-iam-example-com.id, aws_security_group.masters-existing-iam-example-com.id]
+  value = [aws_security_group.masters-existing-iam-example-com.id]
 }
 
 output "node_autoscaling_group_ids" {

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name                 = "ha.example.com"
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-ha-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-ha-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-ha-example-com.id]
-  master_security_group_ids    = [aws_security_group.masters-ha-example-com.id, aws_security_group.masters-ha-example-com.id, aws_security_group.masters-ha-example-com.id]
+  master_security_group_ids    = [aws_security_group.masters-ha-example-com.id]
   masters_role_arn             = aws_iam_role.masters-ha-example-com.arn
   masters_role_name            = aws_iam_role.masters-ha-example-com.name
   node_autoscaling_group_ids   = [aws_autoscaling_group.nodes-ha-example-com.id]
@@ -27,7 +27,7 @@ output "master_autoscaling_group_ids" {
 }
 
 output "master_security_group_ids" {
-  value = [aws_security_group.masters-ha-example-com.id, aws_security_group.masters-ha-example-com.id, aws_security_group.masters-ha-example-com.id]
+  value = [aws_security_group.masters-ha-example-com.id]
 }
 
 output "masters_role_arn" {

--- a/tests/integration/update_cluster/launch_templates/kubernetes.tf
+++ b/tests/integration/update_cluster/launch_templates/kubernetes.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name                 = "launchtemplates.example.com"
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-launchtemplates-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-launchtemplates-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-launchtemplates-example-com.id]
-  master_security_group_ids    = [aws_security_group.masters-launchtemplates-example-com.id, aws_security_group.masters-launchtemplates-example-com.id, aws_security_group.masters-launchtemplates-example-com.id]
+  master_security_group_ids    = [aws_security_group.masters-launchtemplates-example-com.id]
   masters_role_arn             = aws_iam_role.masters-launchtemplates-example-com.arn
   masters_role_name            = aws_iam_role.masters-launchtemplates-example-com.name
   node_autoscaling_group_ids   = [aws_autoscaling_group.nodes-launchtemplates-example-com.id]
@@ -27,7 +27,7 @@ output "master_autoscaling_group_ids" {
 }
 
 output "master_security_group_ids" {
-  value = [aws_security_group.masters-launchtemplates-example-com.id, aws_security_group.masters-launchtemplates-example-com.id, aws_security_group.masters-launchtemplates-example-com.id]
+  value = [aws_security_group.masters-launchtemplates-example-com.id]
 }
 
 output "masters_role_arn" {

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name                 = "mixedinstances.example.com"
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-mixedinstances-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-mixedinstances-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-mixedinstances-example-com.id]
-  master_security_group_ids    = [aws_security_group.masters-mixedinstances-example-com.id, aws_security_group.masters-mixedinstances-example-com.id, aws_security_group.masters-mixedinstances-example-com.id]
+  master_security_group_ids    = [aws_security_group.masters-mixedinstances-example-com.id]
   masters_role_arn             = aws_iam_role.masters-mixedinstances-example-com.arn
   masters_role_name            = aws_iam_role.masters-mixedinstances-example-com.name
   node_autoscaling_group_ids   = [aws_autoscaling_group.nodes-mixedinstances-example-com.id]
@@ -27,7 +27,7 @@ output "master_autoscaling_group_ids" {
 }
 
 output "master_security_group_ids" {
-  value = [aws_security_group.masters-mixedinstances-example-com.id, aws_security_group.masters-mixedinstances-example-com.id, aws_security_group.masters-mixedinstances-example-com.id]
+  value = [aws_security_group.masters-mixedinstances-example-com.id]
 }
 
 output "masters_role_arn" {

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name                 = "mixedinstances.example.com"
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-mixedinstances-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-mixedinstances-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-mixedinstances-example-com.id]
-  master_security_group_ids    = [aws_security_group.masters-mixedinstances-example-com.id, aws_security_group.masters-mixedinstances-example-com.id, aws_security_group.masters-mixedinstances-example-com.id]
+  master_security_group_ids    = [aws_security_group.masters-mixedinstances-example-com.id]
   masters_role_arn             = aws_iam_role.masters-mixedinstances-example-com.arn
   masters_role_name            = aws_iam_role.masters-mixedinstances-example-com.name
   node_autoscaling_group_ids   = [aws_autoscaling_group.nodes-mixedinstances-example-com.id]
@@ -27,7 +27,7 @@ output "master_autoscaling_group_ids" {
 }
 
 output "master_security_group_ids" {
-  value = [aws_security_group.masters-mixedinstances-example-com.id, aws_security_group.masters-mixedinstances-example-com.id, aws_security_group.masters-mixedinstances-example-com.id]
+  value = [aws_security_group.masters-mixedinstances-example-com.id]
 }
 
 output "masters_role_arn" {

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -152,9 +152,12 @@ func writeLocalsOutputs(body *hclwrite.Body, outputs map[string]*terraformOutput
 			writeLiteral(outputBody, "value", v.Value)
 			writeLiteral(localsBody, tfName, v.Value)
 		} else {
-			SortLiterals(v.ValueArray)
-			writeLiteralList(outputBody, "value", v.ValueArray)
-			writeLiteralList(localsBody, tfName, v.ValueArray)
+			deduped, err := DedupLiterals(v.ValueArray)
+			if err != nil {
+				return err
+			}
+			writeLiteralList(outputBody, "value", deduped)
+			writeLiteralList(localsBody, tfName, deduped)
 		}
 
 		if existingOutputVars[tfName] {

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2_test.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2_test.go
@@ -86,6 +86,27 @@ output "key1" {
 			},
 			errExpected: true,
 		},
+		{
+			name: "duplicate values",
+			values: map[string]*terraformOutputVariable{
+				"key1": {
+					Key: "key1",
+					ValueArray: []*Literal{
+						LiteralFromStringValue("value1"),
+						LiteralFromStringValue("value1"),
+						LiteralFromStringValue("value2"),
+					},
+				},
+			},
+			expected: `
+locals {
+  key1 = ["value1", "value2"]
+}
+
+output "key1" {
+  value = ["value1", "value2"]
+}`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/upup/pkg/fi/cloudup/terraform/target_json.go
+++ b/upup/pkg/fi/cloudup/terraform/target_json.go
@@ -73,7 +73,6 @@ func (t *TerraformTarget) finishJSON(taskMap map[string]fi.Task) error {
 		if v.Value != nil {
 			tfVar["value"] = v.Value
 		} else {
-			SortLiterals(v.ValueArray)
 			deduped, err := DedupLiterals(v.ValueArray)
 			if err != nil {
 				return err
@@ -94,7 +93,6 @@ func (t *TerraformTarget) finishJSON(taskMap map[string]fi.Task) error {
 		if v.Value != nil {
 			localVariables[tfName] = v.Value
 		} else {
-			SortLiterals(v.ValueArray)
 			deduped, err := DedupLiterals(v.ValueArray)
 			if err != nil {
 				return err


### PR DESCRIPTION
Cherry pick of #10978 on release-1.20.

#10978: Removing duplicate local and output values in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.