### PR TITLE
Automated cherry pick of #10982: Disable Calico Prometheus metrics by default

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -34986,7 +34986,7 @@ spec:
           # Uncomment these lines to enable prometheus metrics.  Since Typha is host-networked,
           # this opens a port on the host, which may need to be secured.
           - name: TYPHA_PROMETHEUSMETRICSENABLED
-            value: "{{- or .Networking.Calico.TyphaPrometheusMetricsEnabled "false" }}"
+            value: "{{- .Networking.Calico.TyphaPrometheusMetricsEnabled }}"
           - name: TYPHA_PROMETHEUSMETRICSPORT
             value: "{{- or .Networking.Calico.TyphaPrometheusMetricsPort "9093" }}"
         livenessProbe:
@@ -35213,16 +35213,16 @@ spec:
               value: "{{- or .Networking.Calico.IptablesBackend "Legacy" }}"
             # Set to enable the experimental Prometheus metrics server
             - name: FELIX_PROMETHEUSMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusMetricsEnabled "false" }}"
+              value: "{{- .Networking.Calico.PrometheusMetricsEnabled }}"
             # TCP port that the Prometheus metrics server should bind to
             - name: FELIX_PROMETHEUSMETRICSPORT
               value: "{{- or .Networking.Calico.PrometheusMetricsPort "9091" }}"
             # Enable Prometheus Go runtime metrics collection
             - name: FELIX_PROMETHEUSGOMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusGoMetricsEnabled "true" }}"
+              value: "{{- .Networking.Calico.PrometheusGoMetricsEnabled }}"
             # Enable Prometheus process metrics collection
             - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusProcessMetricsEnabled "true" }}"
+              value: "{{- .Networking.Calico.PrometheusProcessMetricsEnabled }}"
           securityContext:
             privileged: true
           resources:
@@ -39150,7 +39150,7 @@ spec:
           - name: TYPHA_HEALTHENABLED
             value: "true"
           - name: TYPHA_PROMETHEUSMETRICSENABLED
-            value: "{{- or .Networking.Calico.TyphaPrometheusMetricsEnabled "false" }}"
+            value: "{{- .Networking.Calico.TyphaPrometheusMetricsEnabled }}"
           - name: TYPHA_PROMETHEUSMETRICSPORT
             value: "{{- or .Networking.Calico.TyphaPrometheusMetricsPort "9093" }}"
         livenessProbe:
@@ -39427,16 +39427,16 @@ spec:
               value: "{{- or .Networking.Calico.IptablesBackend "Auto" }}"
             # Set to enable the experimental Prometheus metrics server
             - name: FELIX_PROMETHEUSMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusMetricsEnabled "false" }}"
+              value: "{{- .Networking.Calico.PrometheusMetricsEnabled }}"
             # TCP port that the Prometheus metrics server should bind to
             - name: FELIX_PROMETHEUSMETRICSPORT
               value: "{{- or .Networking.Calico.PrometheusMetricsPort "9091" }}"
             # Enable Prometheus Go runtime metrics collection
             - name: FELIX_PROMETHEUSGOMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusGoMetricsEnabled "true" }}"
+              value: "{{- .Networking.Calico.PrometheusGoMetricsEnabled }}"
             # Enable Prometheus process metrics collection
             - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusProcessMetricsEnabled "true" }}"
+              value: "{{- .Networking.Calico.PrometheusProcessMetricsEnabled }}"
             # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
             - name: FELIX_WIREGUARDENABLED
               value: "{{ .Networking.Calico.WireguardEnabled }}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.12.yaml.template
@@ -604,7 +604,7 @@ spec:
           # Uncomment these lines to enable prometheus metrics.  Since Typha is host-networked,
           # this opens a port on the host, which may need to be secured.
           - name: TYPHA_PROMETHEUSMETRICSENABLED
-            value: "{{- or .Networking.Calico.TyphaPrometheusMetricsEnabled "false" }}"
+            value: "{{- .Networking.Calico.TyphaPrometheusMetricsEnabled }}"
           - name: TYPHA_PROMETHEUSMETRICSPORT
             value: "{{- or .Networking.Calico.TyphaPrometheusMetricsPort "9093" }}"
         livenessProbe:
@@ -831,16 +831,16 @@ spec:
               value: "{{- or .Networking.Calico.IptablesBackend "Legacy" }}"
             # Set to enable the experimental Prometheus metrics server
             - name: FELIX_PROMETHEUSMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusMetricsEnabled "false" }}"
+              value: "{{- .Networking.Calico.PrometheusMetricsEnabled }}"
             # TCP port that the Prometheus metrics server should bind to
             - name: FELIX_PROMETHEUSMETRICSPORT
               value: "{{- or .Networking.Calico.PrometheusMetricsPort "9091" }}"
             # Enable Prometheus Go runtime metrics collection
             - name: FELIX_PROMETHEUSGOMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusGoMetricsEnabled "true" }}"
+              value: "{{- .Networking.Calico.PrometheusGoMetricsEnabled }}"
             # Enable Prometheus process metrics collection
             - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusProcessMetricsEnabled "true" }}"
+              value: "{{- .Networking.Calico.PrometheusProcessMetricsEnabled }}"
           securityContext:
             privileged: true
           resources:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3656,7 +3656,7 @@ spec:
           - name: TYPHA_HEALTHENABLED
             value: "true"
           - name: TYPHA_PROMETHEUSMETRICSENABLED
-            value: "{{- or .Networking.Calico.TyphaPrometheusMetricsEnabled "false" }}"
+            value: "{{- .Networking.Calico.TyphaPrometheusMetricsEnabled }}"
           - name: TYPHA_PROMETHEUSMETRICSPORT
             value: "{{- or .Networking.Calico.TyphaPrometheusMetricsPort "9093" }}"
         livenessProbe:
@@ -3933,16 +3933,16 @@ spec:
               value: "{{- or .Networking.Calico.IptablesBackend "Auto" }}"
             # Set to enable the experimental Prometheus metrics server
             - name: FELIX_PROMETHEUSMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusMetricsEnabled "false" }}"
+              value: "{{- .Networking.Calico.PrometheusMetricsEnabled }}"
             # TCP port that the Prometheus metrics server should bind to
             - name: FELIX_PROMETHEUSMETRICSPORT
               value: "{{- or .Networking.Calico.PrometheusMetricsPort "9091" }}"
             # Enable Prometheus Go runtime metrics collection
             - name: FELIX_PROMETHEUSGOMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusGoMetricsEnabled "true" }}"
+              value: "{{- .Networking.Calico.PrometheusGoMetricsEnabled }}"
             # Enable Prometheus process metrics collection
             - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
-              value: "{{- or .Networking.Calico.PrometheusProcessMetricsEnabled "true" }}"
+              value: "{{- .Networking.Calico.PrometheusProcessMetricsEnabled }}"
             # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
             - name: FELIX_WIREGUARDENABLED
               value: "{{ .Networking.Calico.WireguardEnabled }}"


### PR DESCRIPTION
Cherry pick of #10982 on release-1.20.

#10982: Disable Calico Prometheus metrics by default

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.