### PR TITLE
kubetest2 - don't overwrite create args that use equals signs

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -193,7 +193,8 @@ func (d *deployer) zones() ([]string, error) {
 // This shouldn't be used for arguments that can be specified multiple times like --override
 func appendIfUnset(args []string, arg, value string) []string {
 	for _, existingArg := range args {
-		if existingArg == arg {
+		existingKey := strings.Split(existingArg, "=")
+		if existingKey[0] == arg {
 			return args
 		}
 	}

--- a/tests/e2e/kubetest2-kops/deployer/up_test.go
+++ b/tests/e2e/kubetest2-kops/deployer/up_test.go
@@ -64,6 +64,13 @@ func TestAppendIfUnset(t *testing.T) {
 			"bar",
 			[]string{"--foo", "bar"},
 		},
+		{
+			"set with same value and equals sign",
+			[]string{"--foo=bar", "--baz=bar"},
+			"--foo",
+			"bar",
+			[]string{"--foo=bar", "--baz=bar"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Previously we would incorrectly append create cluster arguments if they had already been specified and used --foo=bar notation.
This resulted in arguments being specified multiple times causing undesired behavior.
We now check for both `--foo bar` and `--foo=bar` when attempting to add a `--foo` argument.

fixes this test job: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-grid-scenario-arm64/1368962983325077504

`I0308 16:33:38.407993     609 up.go:125] /tmp/kops448488603 create cluster --name e2e-30c5bc0bf2-6b775.test-cncf-aws.k8s.io --cloud aws --kubernetes-version v1.21.0-beta.0 --ssh-public-key /etc/aws-ssh/aws-ssh-public --override cluster.spec.nodePortAccess=0.0.0.0/0 --yes --channel=alpha --networking=kubenet --container-runtime=docker --zones=us-east-2b --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210223 --admin-access 35.238.151.204/32 --master-count 1 --master-volume-size 48 --node-count 4 --node-volume-size 48 --zones ap-northeast-2a --master-size c5.large`

note how `--master-size` is specified twice (originally with `=` and again without)