### PR TITLE
Kubetest2 - Fix kops' --kubernetes-version with k8s version markers

### DIFF
--- a/tests/e2e/e2e.mk
+++ b/tests/e2e/e2e.mk
@@ -26,7 +26,7 @@ test-e2e-install:
 test-e2e-aws-simple-1-20: test-e2e-install
 	kubetest2 kops \
 		-v 2 \
-		--up --down \
+		--build --up --down \
 		--cloud-provider=aws \
 		--kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
 		--kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \


### PR DESCRIPTION
Have kops' --kubernetes-version flag value include the bucket's url

This matches the kubetest1 behavior.
See an example kops create cluster command here: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-misc-arm64-conformance/1369076996193128448#1:build-log.txt%3A174
The kubetest 1 logic is here: https://github.com/kubernetes/test-infra/blob/37b80c5e3b3c5e1d0fdabd734ed54176849d1953/kubetest/kops.go#L390-L400

