### PR TITLE
Remove extraneous field from integration test

### DIFF
--- a/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
@@ -37,9 +37,6 @@ spec:
   networking:
     cni: {}
   nonMasqueradeCIDR: 100.64.0.0/10
-  roleCustomIamRoles:
-    Master: foo
-    Node: bar
   sshAccess:
   - 0.0.0.0/0
   subnets:


### PR DESCRIPTION
The api design for using existing instance profiles must have changed during its PR and I never removed the old field from the integration test.
grep shows that this field doesn't exist anywhere else in the codebase.