### PR TITLE
Remove trailing newline from kubernetes version marker

### DIFF
--- a/tests/e2e/pkg/version/kubernetes.go
+++ b/tests/e2e/pkg/version/kubernetes.go
@@ -44,7 +44,7 @@ func ParseKubernetesVersion(version string) (string, error) {
 		// https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt -> v1.21.0-beta.1.112+576aa2d2470b28%0A
 		// becomes https://storage.googleapis.com/kubernetes-release-dev/ci/v1.21.0-beta.1.112+576aa2d2470b28%0A
 		pathParts := strings.Split(u.Path, "/")
-		pathParts[len(pathParts)-1] = b.String()
+		pathParts[len(pathParts)-1] = strings.TrimSpace(b.String())
 		u.Path = strings.Join(pathParts, "/")
 		return strings.TrimSpace(u.String()), nil
 	}


### PR DESCRIPTION
Should fix the trailing "%0A" here: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-misc-arm64-ci/1369566440318832640#1:build-log.txt%3A90