### PR TITLE
azure: fix null pointer when updating in place cluster

### DIFF
--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -182,7 +182,7 @@ func (s *VMScaleSet) Find(c *fi.Context) (*VMScaleSet, error) {
 	}
 
 	var loadBalancerID *loadBalancerID
-	if *ipConfig.LoadBalancerBackendAddressPools != nil {
+	if ipConfig.LoadBalancerBackendAddressPools != nil {
 		for _, i := range *ipConfig.LoadBalancerBackendAddressPools {
 			if !strings.Contains(*i.ID, "api") {
 				continue


### PR DESCRIPTION
Null pointer exception occurs when trying to update cluster in place on azure. This occurs because other virtual machine scale sets aside from the master do not have backend loadbalancer pools. 

This checks to make sure that the name of the scale set contains "masters" to differentiate between the master and other virtual machine scale sets. 