### PR TITLE
Allow cilium 1.10

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -702,8 +702,8 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Could not parse as semantic version"))
 		}
 
-		if !(version.Minor >= 6 && version.Minor <= 9) {
-			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Only versions 1.6 through 1.9 are supported"))
+		if !(version.Minor >= 6 && version.Minor <= 10) {
+			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Only versions 1.6 through 1.10 are supported"))
 		}
 
 		if version.Minor == 6 && cluster.IsKubernetesGTE("1.16") {

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/cilium.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/cilium.go
@@ -64,7 +64,7 @@ func addCiliumAddon(b *BootstrapChannelBuilder, addons *api.Addons) error {
 					NeedsRollingUpdate: "all",
 				})
 			}
-		} else if ver.Minor == 9 {
+		} else if ver.Minor == 9 || ver.Minor == 10 {
 			version := "1.9.0-kops.1"
 			{
 				id := "k8s-1.12"


### PR DESCRIPTION
We just reuse the 1.9 templates. Seems to work for now.