### PR TITLE
Automated cherry pick of #11027: Fix rendering of multiple Docker insecure registries

### DIFF
--- a/nodeup/pkg/model/docker_test.go
+++ b/nodeup/pkg/model/docker_test.go
@@ -101,6 +101,10 @@ func TestDockerBuilder_BuildFlags(t *testing.T) {
 			kops.DockerConfig{ExecOpt: []string{"native.cgroupdriver=systemd"}},
 			"--exec-opt=native.cgroupdriver=systemd",
 		},
+		{
+			kops.DockerConfig{InsecureRegistries: []string{"registry1", "registry2"}},
+			"--insecure-registry=registry1 --insecure-registry=registry2",
+		},
 	}
 
 	for _, g := range grid {

--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -47,7 +47,7 @@ type DockerConfig struct {
 	// InsecureRegistry enable insecure registry communication @question according to dockers this a list??
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
 	// InsecureRegistries enables multiple insecure docker registry communications
-	InsecureRegistries []string `json:"insecureRegistries,omitempty" flag:"insecure-registry"`
+	InsecureRegistries []string `json:"insecureRegistries,omitempty" flag:"insecure-registry,repeat"`
 	// LiveRestore enables live restore of docker when containers are still running
 	LiveRestore *bool `json:"liveRestore,omitempty" flag:"live-restore"`
 	// LogDriver is the default driver for container logs (default "json-file")

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -47,7 +47,7 @@ type DockerConfig struct {
 	// InsecureRegistry enable insecure registry communication @question according to dockers this a list??
 	InsecureRegistry *string `json:"insecureRegistry,omitempty" flag:"insecure-registry"`
 	// InsecureRegistries enables multiple insecure docker registry communications
-	InsecureRegistries []string `json:"insecureRegistries,omitempty" flag:"insecure-registry"`
+	InsecureRegistries []string `json:"insecureRegistries,omitempty" flag:"insecure-registry,repeat"`
 	// LiveRestore enables live restore of docker when containers are still running
 	LiveRestore *bool `json:"liveRestore,omitempty" flag:"live-restore"`
 	// LogDriver is the default driver for container logs (default "json-file")


### PR DESCRIPTION
Cherry pick of #11027 on release-1.20.

#11027: Fix rendering of multiple Docker insecure registries

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.