### PR TITLE
Automated cherry pick of #11015: azure: fix null pointer when updating in place cluster

### DIFF
--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -182,7 +182,7 @@ func (s *VMScaleSet) Find(c *fi.Context) (*VMScaleSet, error) {
 	}
 
 	var loadBalancerID *loadBalancerID
-	if *ipConfig.LoadBalancerBackendAddressPools != nil {
+	if ipConfig.LoadBalancerBackendAddressPools != nil {
 		for _, i := range *ipConfig.LoadBalancerBackendAddressPools {
 			if !strings.Contains(*i.ID, "api") {
 				continue


### PR DESCRIPTION
Cherry pick of #11015 on release-1.20.

#11015: azure: fix null pointer when updating in place cluster

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.