### PR TITLE
Trim space on kops version markers

### DIFF
--- a/tests/e2e/pkg/kops/download.go
+++ b/tests/e2e/pkg/kops/download.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
+	"strings"
 
 	"k8s.io/kops/tests/e2e/pkg/util"
 )
@@ -34,7 +35,7 @@ func DownloadKops(markerURL, downloadPath string) (string, string, error) {
 	if err := util.HTTPGETWithHeaders(markerURL, nil, &b); err != nil {
 		return "", "", err
 	}
-	kopsBaseURL := b.String()
+	kopsBaseURL := strings.TrimSpace(b.String())
 
 	var kopsFile *os.File
 	if downloadPath == "" {


### PR DESCRIPTION
Fixes the extra newline character in this job failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-misc-updown/1370242214826872832#1:build-log.txt%3A91