### PR TITLE
Improve instance type validation error message

### DIFF
--- a/pkg/apis/kops/validation/aws.go
+++ b/pkg/apis/kops/validation/aws.go
@@ -153,7 +153,7 @@ func awsValidateInstanceTypeAndImage(instanceTypeFieldPath *field.Path, imageFie
 		}
 		if !found {
 			allErrs = append(allErrs, field.Invalid(instanceTypeFieldPath, instanceType,
-				fmt.Sprintf("machine type architecture does not match image architecture: %+v - %q", machineInfo.ProcessorInfo, imageArch)))
+				fmt.Sprintf("machine type architecture does not match image architecture: %s - %s", strings.Join(fi.StringSliceValue(machineInfo.ProcessorInfo.SupportedArchitectures), ","), imageArch)))
 		}
 	}
 

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -301,6 +301,18 @@ func TestMixedInstancePolicies(t *testing.T) {
 func TestInstanceMetadataOptions(t *testing.T) {
 	cloud := awsup.BuildMockAWSCloud("us-east-1", "abc")
 
+	mockEC2 := &mockec2.MockEC2{}
+	cloud.MockEC2 = mockEC2
+
+	mockEC2.Images = append(mockEC2.Images, &ec2.Image{
+		CreationDate:   aws.String("2016-10-21T20:07:19.000Z"),
+		ImageId:        aws.String("ami-073c8c0760395aab8"),
+		Name:           aws.String("focal"),
+		OwnerId:        aws.String(awsup.WellKnownAccountUbuntu),
+		RootDeviceName: aws.String("/dev/xvda"),
+		Architecture:   aws.String("x86_64"),
+	})
+
 	tests := []struct {
 		ig       *kops.InstanceGroup
 		expected []string
@@ -316,6 +328,7 @@ func TestInstanceMetadataOptions(t *testing.T) {
 						HTTPPutResponseHopLimit: fi.Int64(1),
 						HTTPTokens:              fi.String("abc"),
 					},
+					MachineType: "t3.medium",
 				},
 			},
 			expected: []string{"Unsupported value::spec.instanceMetadata.httpTokens"},
@@ -331,6 +344,7 @@ func TestInstanceMetadataOptions(t *testing.T) {
 						HTTPPutResponseHopLimit: fi.Int64(-1),
 						HTTPTokens:              fi.String("required"),
 					},
+					MachineType: "t3.medium",
 				},
 			},
 			expected: []string{"Invalid value::spec.instanceMetadata.httpPutResponseHopLimit"},

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -308,7 +308,7 @@ func (c *MockAWSCloud) DescribeInstanceType(instanceType string) (*ec2.InstanceT
 	}
 
 	switch instanceType {
-	case "c5.large", "m3.medium", "m4.large", "m5.large", "m5.xlarge", "t2.micro", "t2.medium", "t3.medium", "t3.large":
+	case "c5.large", "m3.medium", "m4.large", "m5.large", "m5.xlarge", "t2.micro", "t2.medium", "t3.medium", "t3.large", "c4.large":
 		info.ProcessorInfo = &ec2.ProcessorInfo{
 			SupportedArchitectures: []*string{
 				aws.String("x86_64"),


### PR DESCRIPTION
This should be reasonably safe as the machineInfo field should not be nil on a valid instance type. Would like some opinions on this. 