### PR TITLE
Revert upgrade script to build kops

### DIFF
--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -24,7 +24,7 @@ export KOPS_FEATURE_FLAGS="SpecOverrideFlag,${KOPS_FEATURE_FLAGS:-}"
 REPO_ROOT=$(git rev-parse --show-toplevel);
 PATH=$REPO_ROOT/bazel-bin/cmd/kops/$(go env GOOS)-$(go env GOARCH):$PATH
 
-KUBETEST2_COMMON_ARGS="-v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-}"
+KUBETEST2_COMMON_ARGS="-v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-} --kops-binary-path=${REPO_ROOT}/bazel-bin/cmd/kops/linux-amd64/kops"
 KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --admin-access=${ADMIN_ACCESS:-}"
 
 export GO111MODULE=on
@@ -34,15 +34,7 @@ cd ${REPO_ROOT}/tests/e2e
 go install ./kubetest2-kops
 go install ./kubetest2-tester-kops
 
-if [[ "${JOB_TYPE}" == "periodic" ]]; then
-  KOPS=$(mktemp).kops
-  KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt"
-  KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --kops-binary-path=${KOPS}"
-else
-  KOPS=${REPO_ROOT}/bazel-bin/cmd/kops/$(go env GOOS)-$(go env GOARCH)/kops
-  KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --kops-binary-path=${KOPS}"
-  kubetest2 kops ${KUBETEST2_COMMON_ARGS} --build --kops-root=${REPO_ROOT} --stage-location=${STAGE_LOCATION:-}
-fi
+kubetest2 kops ${KUBETEST2_COMMON_ARGS} --build --kops-root=${REPO_ROOT} --stage-location=${STAGE_LOCATION:-}
 
 # Always tear-down the cluster when we're done
 function finish {
@@ -58,15 +50,15 @@ kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 KUBECONFIG=${HOME}/.kube/config
 TEST_ARGS="--kubeconfig=${KUBECONFIG}"
 if [[ "${CLOUD_PROVIDER}" == "aws" ]]; then
-  ZONES=`${KOPS} get cluster ${CLUSTER_NAME} -ojson | jq -r .spec.subnets[].zone`
+  ZONES=`kops get cluster ${CLUSTER_NAME} -ojson | jq -r .spec.subnets[].zone`
   CLUSTER_TAG="${CLUSTER_NAME}"
   TEST_ARGS="${TEST_ARGS} --provider=aws --cluster-tag=${CLUSTER_TAG}"
   # For historical reasons, the flag name for e2e tests on AWS is --gce-zone
   TEST_ARGS="${TEST_ARGS} --gce-zone=${ZONES[0]}"
 fi
 if [[ "${CLOUD_PROVIDER}" == "gce" ]]; then
-  ZONES=`${KOPS} get ig --name ${CLUSTER_NAME} -ojson | jq -r .[0].spec.zones[]`
-  GCE_PROJECT=`${KOPS} get cluster ${CLUSTER_NAME} -ojson |jq -r .spec.project`
+  ZONES=`kops get ig --name ${CLUSTER_NAME} -ojson | jq -r .[0].spec.zones[]`
+  GCE_PROJECT=`kops get cluster ${CLUSTER_NAME} -ojson |jq -r .spec.project`
   TEST_ARGS="${TEST_ARGS} --provider=gce --gce-zone=${ZONES[0]} --gce-project=${GCE_PROJECT}"
 fi
 
@@ -80,11 +72,11 @@ kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--test-args="${TEST_ARGS}"
 
 
-${KOPS} set cluster ${CLUSTER_NAME} cluster.spec.kubernetesVersion=v1.19.7
-${KOPS} update cluster
-${KOPS} update cluster --admin --yes
+kops set cluster ${CLUSTER_NAME} cluster.spec.kubernetesVersion=v1.19.7
+kops update cluster
+kops update cluster --admin --yes
 
-${KOPS} rolling-update cluster
-${KOPS} rolling-update cluster --yes --validation-timeout 30m
+kops rolling-update cluster
+kops rolling-update cluster --yes --validation-timeout 30m
 
-${KOPS} validate cluster
+kops validate cluster

--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -47,6 +47,15 @@ kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--kubernetes-version=v1.18.15 \
     --create-args="--networking calico"
 
+kops set cluster ${CLUSTER_NAME} cluster.spec.kubernetesVersion=v1.19.7
+kops update cluster
+kops update cluster --admin --yes
+
+kops rolling-update cluster
+kops rolling-update cluster --yes --validation-timeout 30m
+
+kops validate cluster
+
 KUBECONFIG=${HOME}/.kube/config
 TEST_ARGS="--kubeconfig=${KUBECONFIG}"
 if [[ "${CLOUD_PROVIDER}" == "aws" ]]; then
@@ -71,12 +80,3 @@ kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|TCP.CLOSE_WAIT|Projected.configMap.optional.updates" \
 		--test-args="${TEST_ARGS}"
 
-
-kops set cluster ${CLUSTER_NAME} cluster.spec.kubernetesVersion=v1.19.7
-kops update cluster
-kops update cluster --admin --yes
-
-kops rolling-update cluster
-kops rolling-update cluster --yes --validation-timeout 30m
-
-kops validate cluster


### PR DESCRIPTION
There were too many issues with downloading kops from a version marker with this setup.
We'll need to move this logic into kubetest2 itself since it has sufficient knowledge for eg. KOPS_BASE_URL, where the kops binary was downloaded, etc.

Also rearrange script to upgrade the cluster first, then run tests