### PR TITLE
Remove instance-selector label

### DIFF
--- a/cmd/kops/toolbox_instance_selector.go
+++ b/cmd/kops/toolbox_instance_selector.go
@@ -500,12 +500,6 @@ func decorateWithMixedInstancesPolicy(instanceGroup *kops.InstanceGroup, usageCl
 		return nil, fmt.Errorf("error node usage class not supported")
 	}
 
-	generatedWithLabelKey := "kops.k8s.io/instance-selector"
-	if ig.Spec.CloudLabels == nil {
-		ig.Spec.CloudLabels = make(map[string]string)
-	}
-	ig.Spec.CloudLabels[generatedWithLabelKey] = "1"
-
 	return ig, nil
 }
 


### PR DESCRIPTION
`kops toolbox instance-selector` fails due to https://github.com/kubernetes/kops/pull/10910 which improves the label validation. Making kops.k8s.io/instance-selector: "1" a node label rather than a cloud label should bypass this validation check. I also think it should make more sense to make it a node label rather than a cloud label.