### PR TITLE
Cleanup some nodeup & protokube logging

### DIFF
--- a/channels/pkg/channels/apply.go
+++ b/channels/pkg/channels/apply.go
@@ -69,7 +69,7 @@ func execKubectl(args ...string) (string, error) {
 	if err != nil {
 		klog.Infof("error running %s", human)
 		klog.Info(string(output))
-		return string(output), fmt.Errorf("error running kubectl")
+		return string(output), fmt.Errorf("error running kubectl: %v", err)
 	}
 
 	return string(output), err

--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -135,10 +135,6 @@ func (k *KubeBoot) syncOnce(ctx context.Context) error {
 				}
 			}
 		}
-	} else if k.ManageEtcd {
-		klog.V(4).Infof("Not in role master; won't scan for volumes")
-	} else {
-		klog.V(4).Infof("protokube management of etcd not enabled; won't scan for volumes")
 	}
 
 	if k.Master {

--- a/util/pkg/proxy/proxy.go
+++ b/util/pkg/proxy/proxy.go
@@ -27,7 +27,6 @@ import (
 
 func GetProxyEnvVars(proxies *kops.EgressProxySpec) []v1.EnvVar {
 	if proxies == nil {
-		klog.V(8).Info("proxies is == nil, returning empty list")
 		return []v1.EnvVar{}
 	}
 


### PR DESCRIPTION
Removing some noise I see in protokube and nodeup logs. Also log a channels error that we're seeing on flatcar to help with troubleshooting.

https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-distro-imageflatcar/1371259092688965632/artifacts/3.34.196.168/protokube.log

```
I0315 00:53:47.644156    6154 apply.go:67] Running command: kubectl apply -f /tmp/channel266979825/manifest.yaml
I0315 00:53:47.644171    6154 apply.go:70] error running kubectl apply -f /tmp/channel266979825/manifest.yaml
I0315 00:53:47.644176    6154 apply.go:71]
error updating "limit-range.addons.k8s.io": error applying update from "s3://k8s-kops-prow/e2e-785a7f373f-91d99.test-cncf-aws.k8s.io/addons/limit-range.addons.k8s.io/v1.5.0.yaml": error running kubectl
```