### PR TITLE
Download kubectl to /opt/kops/bin on Flatcar OS

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -398,7 +398,7 @@ func (c *NodeupModelContext) UseSecureKubelet() bool {
 func (c *NodeupModelContext) KubectlPath() string {
 	kubeletCommand := "/usr/local/bin"
 	if c.Distribution == distributions.DistributionFlatcar {
-		kubeletCommand = "/opt/bin"
+		kubeletCommand = "/opt/kops/bin"
 	}
 	if c.Distribution == distributions.DistributionContainerOS {
 		kubeletCommand = "/home/kubernetes/bin"

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -461,6 +461,11 @@ func (t *ProtokubeBuilder) buildEnvFile() (*nodetasks.File, error) {
 		envVars[envVar.Name] = envVar.Value
 	}
 
+	switch t.Distribution {
+	case distributions.DistributionFlatcar:
+		envVars["PATH"] = fmt.Sprintf("/opt/kops/bin:%v", os.Getenv("PATH"))
+	}
+
 	var sysconfig = ""
 	for key, value := range envVars {
 		sysconfig += key + "=" + value + "\n"


### PR DESCRIPTION
Also add it to protokube's PATH.

[All of our flatcar jobs](https://testgrid.k8s.io/kops-distro-flatcar#Summary) are currently failing because channels arent being applied.
A newly added error log reports that kubectl isn't in protokube's PATH.

This adds the kubectl's location (/opt/bin) to protokube's PATH.

See https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-distro-imageflatcar/1371379886664454144/artifacts/54.206.100.130/protokube.log (search `error running kubectl` )