### PR TITLE
Automated cherry pick of #11046: Add channels entries for image architecture

### DIFF
--- a/docs/operations/cluster_template.md
+++ b/docs/operations/cluster_template.md
@@ -16,7 +16,7 @@ metadata:
   kops.k8s.io/cluster: {{ '{{.clusterName}}.{{.dnsZone}}' }}
   name: nodes
 spec:
-  image: {{ '{{ ChannelRecommendedImage .cloud .kubernetesVersion }}' }}
+  image: {{ '{{ ChannelRecommendedImage .cloud .kubernetesVersion .architecture }}' }}
   kubernetesVersion: {{ '{{ ChannelRecommendedKubernetesUpgradeVersion .kubernetesVersion }}' }}
   machineType: m4.large
   maxPrice: "0.5"
@@ -131,7 +131,7 @@ This function returns the kubernetes version recommended for the running kops ve
 
 This function returns the recommended kubernetes version given that you currently run `<kubernetesVersion>`. Typically this is the latest patch version supported by the given channel.
 
-##### ChannelRecommendedImage <cloudProvider> <kuberneteVersion>
+##### ChannelRecommendedImage <cloudProvider> <kuberneteVersion> <architecture>
 
 This function returns the recommended image for the given cloud provider and kubernetes version.
 

--- a/pkg/apis/kops/BUILD.bazel
+++ b/pkg/apis/kops/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//pkg/apis/kops/util:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",
+        "//util/pkg/architectures:go_default_library",
         "//util/pkg/vfs:go_default_library",
         "//vendor/github.com/blang/semver/v4:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops/util"
+	"k8s.io/kops/util/pkg/architectures"
 	"k8s.io/kops/util/pkg/vfs"
 )
 
@@ -77,6 +78,8 @@ type ChannelImageSpec struct {
 	Labels map[string]string `json:"labels,omitempty"`
 
 	ProviderID string `json:"providerID,omitempty"`
+
+	ArchitectureID string `json:"architectureID,omitempty"`
 
 	Name string `json:"name,omitempty"`
 
@@ -259,11 +262,14 @@ const (
 )
 
 // FindImage returns the image for the cloudprovider, or nil if none found
-func (c *Channel) FindImage(provider CloudProviderID, kubernetesVersion semver.Version) *ChannelImageSpec {
+func (c *Channel) FindImage(provider CloudProviderID, kubernetesVersion semver.Version, architecture architectures.Architecture) *ChannelImageSpec {
 	var matches []*ChannelImageSpec
 
 	for _, image := range c.Spec.Images {
 		if image.ProviderID != string(provider) {
+			continue
+		}
+		if image.ArchitectureID != "" && image.ArchitectureID != string(architecture) {
 			continue
 		}
 		if image.KubernetesVersion != "" {
@@ -327,7 +333,7 @@ func RecommendedKubernetesVersion(c *Channel, kopsVersionString string) *semver.
 // Returns true if the given image name has the stable or alpha channel images prefix. Otherwise false.
 func (c *Channel) HasUpstreamImagePrefix(image string) bool {
 	return strings.HasPrefix(image, "kope.io/k8s-") ||
-		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-") ||
+		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-") ||
 		strings.HasPrefix(image, "cos-cloud/cos-stable-") ||
 		strings.HasPrefix(image, "ubuntu-os-cloud/ubuntu-")
 }

--- a/pkg/util/templater/BUILD.bazel
+++ b/pkg/util/templater/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//:go_default_library",
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/util:go_default_library",
+        "//util/pkg/architectures:go_default_library",
         "//vendor/github.com/Masterminds/sprig/v3:go_default_library",
         "//vendor/github.com/blang/semver/v4:go_default_library",
     ],

--- a/pkg/util/templater/template_functions.go
+++ b/pkg/util/templater/template_functions.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kops"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/util"
+	"k8s.io/kops/util/pkg/architectures"
 )
 
 // templateFuncsMap returns a map if the template functions for this template
@@ -63,9 +64,9 @@ func (r *Templater) templateFuncsMap(tm *template.Template) template.FuncMap {
 
 	}
 
-	funcs["ChannelRecommendedImage"] = func(cloud, k8sVersion string) string {
+	funcs["ChannelRecommendedImage"] = func(cloud, k8sVersion string, architecture architectures.Architecture) string {
 		ver, _ := semver.ParseTolerant(k8sVersion)
-		imageSpec := r.channel.FindImage(kopsapi.CloudProviderID(cloud), ver)
+		imageSpec := r.channel.FindImage(kopsapi.CloudProviderID(cloud), ver, architecture)
 		return imageSpec.Name
 	}
 

--- a/pkg/util/templater/templater_test.go
+++ b/pkg/util/templater/templater_test.go
@@ -97,8 +97,13 @@ func TestRenderChannelFunctions(t *testing.T) {
 		},
 		{
 			Context:  map[string]interface{}{},
-			Template: `{{ ChannelRecommendedImage "aws" "1.4.2" }}`,
-			Expected: "kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21",
+			Template: `{{ ChannelRecommendedImage "aws" "1.19.2" "amd64" }}`,
+			Expected: "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1",
+		},
+		{
+			Context:  map[string]interface{}{},
+			Template: `{{ ChannelRecommendedImage "aws" "1.19.2" "arm64" }}`,
+			Expected: "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210119.1",
 		},
 	}
 	makeRenderTests(t, cases)

--- a/tests/integration/channel/BUILD.bazel
+++ b/tests/integration/channel/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//tests/integration/channel/simple:go_default_library",
+        "//util/pkg/architectures:go_default_library",
         "//vendor/github.com/blang/semver/v4:go_default_library",
     ],
 )

--- a/tests/integration/channel/integration_test.go
+++ b/tests/integration/channel/integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blang/semver/v4"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/tests/integration/channel/simple"
+	"k8s.io/kops/util/pkg/architectures"
 )
 
 // TestKopsUpgrades tests the version logic for kops versions
@@ -221,21 +222,35 @@ func TestFindImage(t *testing.T) {
 
 	grid := []struct {
 		KubernetesVersion string
+		Architecture      string
 		ExpectedImage     string
 	}{
 		{
-			KubernetesVersion: "1.4.4",
-			ExpectedImage:     "kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21",
+			KubernetesVersion: "1.1.0",
+			Architecture:      "amd64",
+			ExpectedImage:     "kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2021-02-05",
 		},
 		{
-			KubernetesVersion: "1.5.1",
-			ExpectedImage:     "kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09",
+			KubernetesVersion: "1.17.2",
+			Architecture:      "amd64",
+			ExpectedImage:     "kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2021-02-05",
+		},
+		{
+			KubernetesVersion: "1.19.1",
+			Architecture:      "amd64",
+			ExpectedImage:     "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1",
+		},
+		{
+			KubernetesVersion: "1.19.1",
+			Architecture:      "arm64",
+			ExpectedImage:     "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210119.1",
 		},
 	}
 	for _, g := range grid {
 		kubernetesVersion := semver.MustParse(g.KubernetesVersion)
+		architecture := architectures.Architecture(g.Architecture)
 
-		image := channel.FindImage(kops.CloudProviderAWS, kubernetesVersion)
+		image := channel.FindImage(kops.CloudProviderAWS, kubernetesVersion, architecture)
 		name := ""
 		if image != nil {
 			name = image.Name

--- a/tests/integration/channel/simple/channel.yaml
+++ b/tests/integration/channel/simple/channel.yaml
@@ -1,12 +1,41 @@
 spec:
   images:
-    # We put the "legacy" version first, for kops versions that don't support versions ( < 1.5.0 )
-    - name: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
-      providerID: aws
-      kubernetesVersion: ">=1.4.0 <1.5.0"
-    - name: kope.io/k8s-1.5-debian-jessie-amd64-hvm-ebs-2017-01-09
-      providerID: aws
-      kubernetesVersion: ">=1.5.0"
+  - name: kope.io/k8s-1.11-debian-stretch-amd64-hvm-ebs-2021-02-05
+    providerID: aws
+    architectureID: amd64
+    kubernetesVersion: "<1.12.0"
+  - name: kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2021-02-05
+    providerID: aws
+    architectureID: amd64
+    kubernetesVersion: ">=1.12.0 <1.13.0"
+  - name: kope.io/k8s-1.13-debian-stretch-amd64-hvm-ebs-2021-02-05
+    providerID: aws
+    architectureID: amd64
+    kubernetesVersion: ">=1.13.0 <1.14.0"
+  - name: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2021-02-05
+    providerID: aws
+    architectureID: amd64
+    kubernetesVersion: ">=1.14.0 <1.15.0"
+  - name: kope.io/k8s-1.15-debian-stretch-amd64-hvm-ebs-2021-02-05
+    providerID: aws
+    architectureID: amd64
+    kubernetesVersion: ">=1.15.0 <1.16.0"
+  - name: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2021-02-05
+    providerID: aws
+    architectureID: amd64
+    kubernetesVersion: ">=1.16.0 <1.17.0"
+  - name: kope.io/k8s-1.17-debian-stretch-amd64-hvm-ebs-2021-02-05
+    providerID: aws
+    architectureID: amd64
+    kubernetesVersion: ">=1.17.0 <1.18.0"
+  - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210119.1
+    providerID: aws
+    architectureID: amd64
+    kubernetesVersion: ">=1.18.0"
+  - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210119.1
+    providerID: aws
+    architectureID: arm64
+    kubernetesVersion: ">=1.18.0"
   cluster:
     kubernetesVersion: v1.4.7
     networking:


### PR DESCRIPTION
Cherry pick of #11046 on release-1.20.

#11046: Add channels entries for image architecture

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.