### PR TITLE
Automated cherry pick of #11052: Cleanup some nodeup & protokube logging

### DIFF
--- a/channels/pkg/channels/apply.go
+++ b/channels/pkg/channels/apply.go
@@ -69,7 +69,7 @@ func execKubectl(args ...string) (string, error) {
 	if err != nil {
 		klog.Infof("error running %s", human)
 		klog.Info(string(output))
-		return string(output), fmt.Errorf("error running kubectl")
+		return string(output), fmt.Errorf("error running kubectl: %v", err)
 	}
 
 	return string(output), err

--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -135,10 +135,6 @@ func (k *KubeBoot) syncOnce(ctx context.Context) error {
 				}
 			}
 		}
-	} else if k.ManageEtcd {
-		klog.V(4).Infof("Not in role master; won't scan for volumes")
-	} else {
-		klog.V(4).Infof("protokube management of etcd not enabled; won't scan for volumes")
 	}
 
 	if k.Master {

--- a/util/pkg/proxy/proxy.go
+++ b/util/pkg/proxy/proxy.go
@@ -27,7 +27,6 @@ import (
 
 func GetProxyEnvVars(proxies *kops.EgressProxySpec) []v1.EnvVar {
 	if proxies == nil {
-		klog.V(8).Info("proxies is == nil, returning empty list")
 		return []v1.EnvVar{}
 	}
 


### PR DESCRIPTION
Cherry pick of #11052 on release-1.20.

#11052: Cleanup some nodeup & protokube logging

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.