### PR TITLE
fix(docs): cpuCFSQuotaPeriod needs a feature gate

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -600,6 +600,8 @@ spec:
     cpuCFSQuotaPeriod: "100ms"
 ```
 
+This change requires `CustomCPUCFSQuotaPeriod` [feature gate](#feature-gates).
+
 ### Enable Custom metrics support
 To use custom metrics in kubernetes as per [custom metrics doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics)
 we have to set the flag `--enable-custom-metrics` to `true` on all the kubelets. We can specify that in the `kubelet` spec in our cluster.yml.


### PR DESCRIPTION
[`CustomCPUCFSQuotaPeriod`](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features) feature gate is [required](https://github.com/kubernetes/kubernetes/pull/94687/files#diff-22e050d3cefdd68e1601d3aab0f1a7d42f1c2563bd04ae9b3dae5f43af80a205R56-R58) to set custom `cpuCFSQuotaPeriod`.