### PR TITLE
Update k8s versions with March 2021 releases

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -84,13 +84,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.20.0"
-    recommendedVersion: 1.20.4
+    recommendedVersion: 1.20.5
     requiredVersion: 1.20.0
   - range: ">=1.19.0"
-    recommendedVersion: 1.19.8
+    recommendedVersion: 1.19.9
     requiredVersion: 1.19.0
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.16
+    recommendedVersion: 1.18.17
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
     recommendedVersion: 1.17.17
@@ -120,15 +120,15 @@ spec:
   - range: ">=1.20.0-alpha.1"
     #recommendedVersion: "1.19.0-beta.3"
     #requiredVersion: 1.20.0
-    kubernetesVersion: 1.20.4
+    kubernetesVersion: 1.20.5
   - range: ">=1.19.0-beta.3"
     #recommendedVersion: "1.19.0-beta.3"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.8
+    kubernetesVersion: 1.19.9
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.16
+    kubernetesVersion: 1.18.17
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.18.2"
     #requiredVersion: 1.17.0


### PR DESCRIPTION
Update alpha channel with recent k8s releases:
* https://github.com/kubernetes/kubernetes/releases/tag/v1.20.5
* https://github.com/kubernetes/kubernetes/releases/tag/v1.19.9
* https://github.com/kubernetes/kubernetes/releases/tag/v1.18.17