### PR TITLE
Fix GCE channels version constraints

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -73,11 +73,11 @@ spec:
     - name: "cos-cloud/cos-stable-77-12371-114-0"
       providerID: gce
       architectureID: amd64
-      kubernetesVersion: ">=1.16.0-alpha.1"
+      kubernetesVersion: ">=1.16.0 <1.18.0"
     - name: "ubuntu-os-cloud/ubuntu-2004-focal-v20210119a"
       providerID: gce
       architectureID: amd64
-      kubernetesVersion: ">=1.17.0"
+      kubernetesVersion: ">=1.18.0"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/channels/stable
+++ b/channels/stable
@@ -73,11 +73,11 @@ spec:
     - name: "cos-cloud/cos-stable-77-12371-114-0"
       providerID: gce
       architectureID: amd64
-      kubernetesVersion: ">=1.16.0-alpha.1"
+      kubernetesVersion: ">=1.16.0 <1.18.0"
     - name: "ubuntu-os-cloud/ubuntu-2004-focal-v20210119a"
       providerID: gce
       architectureID: amd64
-      kubernetesVersion: ">=1.17.0"
+      kubernetesVersion: ">=1.18.0"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/docs/releases/1.20-NOTES.md
+++ b/docs/releases/1.20-NOTES.md
@@ -20,7 +20,7 @@
 
 * Following kubeadm, control plane nodes are now labelled with `node-role.kubernetes.io/control-plane=""`
 
-* Default node image for GCE changed from COS to Ubuntu for K8s versions >= 1.17.0. This is to more closely align with the AWS implementation (the most mature support) and because COS limits the ability to modify files on its disk.
+* Default node image for GCE changed from COS to Ubuntu for K8s versions >= 1.18.0. This is to more closely align with the AWS implementation (the most mature support) and because COS limits the ability to modify files on its disk.
 
 # Breaking changes
 

--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -62,7 +62,7 @@ metadata:
     kops.k8s.io/cluster: gce.example.com
   name: master-us-test1-a
 spec:
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
@@ -85,7 +85,7 @@ metadata:
     kops.k8s.io/cluster: gce.example.com
   name: nodes-us-test1-a
 spec:
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-2
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -70,7 +70,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: master-us-test1-a
 spec:
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
@@ -93,7 +93,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: master-us-test1-b
 spec:
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
@@ -116,7 +116,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: master-us-test1-c
 spec:
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
@@ -139,7 +139,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes-us-test1-a
 spec:
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-2
   maxSize: 1
   minSize: 1
@@ -162,7 +162,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes-us-test1-b
 spec:
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-2
   maxSize: 1
   minSize: 1
@@ -185,7 +185,7 @@ metadata:
     kops.k8s.io/cluster: ha-gce.example.com
   name: nodes-us-test1-c
 spec:
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-2
   maxSize: 1
   minSize: 1

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -72,7 +72,7 @@ metadata:
     kops.k8s.io/cluster: private.example.com
   name: bastions
 spec:
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: f1-micro
   maxSize: 1
   minSize: 1
@@ -98,7 +98,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid3
   - sg-exampleid4
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-1
   maxSize: 1
   minSize: 1
@@ -124,7 +124,7 @@ spec:
   additionalSecurityGroups:
   - sg-exampleid
   - sg-exampleid2
-  image: cos-cloud/cos-stable-77-12371-114-0
+  image: ubuntu-os-cloud/ubuntu-2004-focal-v20210119a
   machineType: n1-standard-2
   maxSize: 1
   minSize: 1


### PR DESCRIPTION
Previously k8s 1.18+ would always match with COS rather than Ubuntu 20.04 because of the unbound version range.

This should fix the failure to download logs via SSH here: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-kubetest2/1373013584195358720
The instance groups confirm the use of COS rather than u2004: https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-gce-kubetest2/1373013584195358720/artifacts/instancegroups.yaml

we may need to cherrypick the test updates to release-1.20
