### PR TITLE
Logging cleanup

### DIFF
--- a/protokube/pkg/protokube/channels.go
+++ b/protokube/pkg/protokube/channels.go
@@ -36,8 +36,8 @@ func applyChannel(channel string) error {
 }
 
 func execChannels(args ...string) (string, error) {
-	kubectlPath := "/opt/kops/bin/channels"
-	cmd := exec.Command(kubectlPath, args...)
+	channelsPath := "/opt/kops/bin/channels"
+	cmd := exec.Command(channelsPath, args...)
 	env := os.Environ()
 	cmd.Env = env
 

--- a/upup/pkg/fi/executor.go
+++ b/upup/pkg/fi/executor.go
@@ -134,7 +134,7 @@ func (e *executor) RunTasks(taskMap map[string]Task) error {
 
 				remaining := time.Second * time.Duration(int(time.Until(ts.deadline).Seconds()))
 				if _, ok := err.(*TryAgainLaterError); ok {
-					klog.Infof("Task %q not ready: %v", ts.key, err)
+					klog.V(2).Infof("Task %q not ready: %v", ts.key, err)
 				} else {
 					klog.Warningf("error running task %q (%v remaining to succeed): %v", ts.key, remaining, err)
 				}

--- a/upup/pkg/fi/task.go
+++ b/upup/pkg/fi/task.go
@@ -98,18 +98,18 @@ func (c *ModelBuilderContext) setLifecycleOverride(task Task) Task {
 	// TODO(@chrislovecnm) - wonder if we should update the nodeup tasks to have lifecycle
 	// TODO - so that we can return an error here, rather than just returning.
 	// certain tasks have not implemented HasLifecycle interface
-	hl, ok := task.(HasLifecycle)
-	if !ok {
-		klog.V(8).Infof("task %T does not implement HasLifecycle", task)
-		return task
-	}
-
 	typeName := TypeNameForTask(task)
 	klog.V(8).Infof("testing task %q", typeName)
 
 	// typeName can be values like "InternetGateway"
 	value, ok := c.LifecycleOverrides[typeName]
 	if ok {
+		hl, okHL := task.(HasLifecycle)
+		if !okHL {
+			klog.Warningf("task %T does not implement HasLifecycle", task)
+			return task
+		}
+
 		klog.Warningf("overriding task %s, lifecycle %s", task, value)
 		hl.SetLifecycle(value)
 	}


### PR DESCRIPTION
After staring at prow job outputs and nodeup logs for a long time, i'm removing some of the unnecessary logging statements.

The first will remove these in the kops cli:

```
 I0318 08:50:47.113867    2772 executor.go:111] Tasks: 80 done / 82 total; 2 can run
I0318 08:50:48.918239    2772 executor.go:137] Task "AutoscalingGroup/master-ap-northeast-1a.masters.e2e-e6110d5e7d-a98da.test-cncf-aws.k8s.io" not ready: waiting for the IAM Instance Profile to be propagated
I0318 08:50:48.918286    2772 executor.go:137] Task "AutoscalingGroup/nodes-ap-northeast-1a.e2e-e6110d5e7d-a98da.test-cncf-aws.k8s.io" not ready: waiting for the IAM Instance Profile to be propagated
I0318 08:50:48.918297    2772 executor.go:155] No progress made, sleeping before retrying 2 task(s) 
```

The second will remove these from the [nodeup logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-distro-imagerhel8/1372953273908072448/artifacts/ip-172-20-37-77.ap-southeast-1.compute.internal/journal.log):

```
Mar 19 16:52:10.691883 ip-172-20-37-77.ap-southeast-1.compute.internal cloud-init[2044]: I0319 16:52:10.684448    4573 task.go:103] task *nodetasks.Service does not implement HasLifecycle
```