### PR TITLE
Don't add control-plane DNS permissions with UseServiceAccountIAM

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -257,10 +257,12 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		addKMSIAMPolicies(p, stringorslice.Slice(b.KMSKeys), b.Cluster.Spec.IAM.Legacy)
 	}
 
-	if b.Cluster.Spec.IAM.Legacy {
-		addLegacyDNSControllerPermissions(b, p)
+	if !b.UseServiceAccountIAM {
+		if b.Cluster.Spec.IAM.Legacy {
+			addLegacyDNSControllerPermissions(b, p)
+		}
+		AddDNSControllerPermissions(b, p)
 	}
-	AddDNSControllerPermissions(b, p)
 
 	if b.Cluster.Spec.IAM.Legacy || b.Cluster.Spec.IAM.AllowContainerRegistry {
 		addECRPermissions(p)


### PR DESCRIPTION
Should not be needed; dns-controller should run on the control-plane
node so there should not be a bootstrapping problem with the nodes.

Reverts #10529