### PR TITLE
Automated cherry pick of #11091: Put awslbcontroller on the control-plane

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1748,10 +1748,14 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       securityContext:
         fsGroup: 1337
       serviceAccountName: aws-load-balancer-controller
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
       volumes:
         - name: cert
           secret:

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
@@ -513,10 +513,14 @@ spec:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
               readOnly: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       securityContext:
         fsGroup: 1337
       serviceAccountName: aws-load-balancer-controller
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
       volumes:
         - name: cert
           secret:


### PR DESCRIPTION
Cherry pick of #11091 on release-1.20.

#11091: Put awslbcontroller on the control-plane

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.