### PR TITLE
Deeper validation in dns controller tests

### DIFF
--- a/dns-controller/README.md
+++ b/dns-controller/README.md
@@ -47,7 +47,7 @@ If _either_ of the two annotations are set on a `LoadBalancer` service, it will 
 dns-controller can optionally watch `Ingress` resources. To enable this, you need to add the following to the cluster spec:
 ```
 spec:
-  external-dns:
+  externalDns:
     watchIngress: true
 ```
 

--- a/dns-controller/pkg/watchers/BUILD.bazel
+++ b/dns-controller/pkg/watchers/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//dns-controller/pkg/dns:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",


### PR DESCRIPTION
Follow up to #11069; use cmp.Diff to compare got vs want.