### PR TITLE
Remove unused RoleLabelName16

### DIFF
--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	RoleLabelName15           = "kubernetes.io/role"
-	RoleLabelName16           = "kubernetes.io/role"
 	RoleMasterLabelValue15    = "master"
 	RoleAPIServerLabelValue15 = "api-server"
 	RoleNodeLabelValue15      = "node"


### PR DESCRIPTION
The constant was unused, confusing and deprecated.  I shouldn't have
introduced it!