### PR TITLE
[DigitalOcean] Fix DO Tag issue

### DIFF
--- a/pkg/model/domodel/droplets.go
+++ b/pkg/model/domodel/droplets.go
@@ -71,7 +71,9 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		if ig.IsMaster() {
 			masterIndexCount++
-			clusterTagIndex := do.TagKubernetesClusterIndex + ":" + strconv.Itoa(masterIndexCount)
+			// create tag based on etcd name. etcd name is now prefixed with etcd-
+			// Ref: https://github.com/kubernetes/kops/commit/31f8cbd571964f19d3c31024ddba918998d29929
+			clusterTagIndex := do.TagKubernetesClusterIndex + ":" + "etcd-" + strconv.Itoa(masterIndexCount)
 			droplet.Tags = append(droplet.Tags, clusterTagIndex)
 			droplet.Tags = append(droplet.Tags, clusterMasterTag)
 			droplet.Tags = append(droplet.Tags, digitalocean.TagKubernetesInstanceGroup+":"+ig.Name)


### PR DESCRIPTION
We add tags to the droplets in order to match the correct volume that needs to be attached. The volumes for etcd-main and etcd-events are also tagged and the etcd-manager does this mapping.

Due to this [change](https://github.com/kubernetes/kops/commit/31f8cbd571964f19d3c31024ddba918998d29929), this was breaking DO droplets to volume matching logic and the new clusters wasn't coming up.

FYI - @rifelpet @timoreimann 

I can work on a better logic going further, but would need this change to go in so I can continue to test the e2e tests.

Please let me know your thoughts, thanks !