### PR TITLE
Update AWS zones used by e2e tests

### DIFF
--- a/tests/e2e/kubetest2-kops/aws/zones.go
+++ b/tests/e2e/kubetest2-kops/aws/zones.go
@@ -27,43 +27,58 @@ var allZones = []string{
 	"ap-northeast-1c",
 	"ap-northeast-1d",
 	"ap-northeast-2a",
-	//"ap-northeast-2b" - AZ does not exist, so we"re breaking the 3 AZs per region target here
+	//"ap-northeast-2b" - AZ does not exist, so we're breaking the 3 AZs per region target here
 	"ap-northeast-2c",
+	"ap-northeast-2d",
+	"ap-northeast-3a",
+	"ap-northeast-3b",
+	"ap-northeast-3c",
 	"ap-south-1a",
 	"ap-south-1b",
+	"ap-south-1c",
 	"ap-southeast-1a",
 	"ap-southeast-1b",
 	"ap-southeast-1c",
 	"ap-southeast-2a",
 	"ap-southeast-2b",
 	"ap-southeast-2c",
+	"ca-central-1a",
+	"ca-central-1b",
+	"ca-central-1d",
 	"eu-central-1a",
 	"eu-central-1b",
 	"eu-central-1c",
+	"eu-north-1a",
+	"eu-north-1b",
+	"eu-north-1c",
 	"eu-west-1a",
 	"eu-west-1b",
 	"eu-west-1c",
 	"eu-west-2a",
 	"eu-west-2b",
 	"eu-west-2c",
-	//"eu-west-3a", documented to not support c4 family
-	//"eu-west-3b", documented to not support c4 family
-	//"eu-west-3c", documented to not support c4 family
-	//"us-east-1a", // temporarily removing due to lack of quota test-infra#10043
-	//"us-east-1b", // temporarily removing due to lack of quota test-infra#10043
-	//"us-east-1c", // temporarily removing due to lack of quota test-infra#10043
-	//"us-east-1d", // limiting to 3 zones to not overallocate
-	//"us-east-1e", // limiting to 3 zones to not overallocate
-	//"us-east-1f", // limiting to 3 zones to not overallocate
-	//"us-east-2a", InsufficientInstanceCapacity for c4.large 2018-05-30
-	//"us-east-2b", InsufficientInstanceCapacity for c4.large 2018-05-30
-	//"us-east-2c", InsufficientInstanceCapacity for c4.large 2018-05-30
+	"eu-west-3a",
+	"eu-west-3b",
+	"eu-west-3c",
+	"sa-east-1a",
+	"sa-east-1b",
+	"sa-east-1c",
+	"us-east-1a",
+	"us-east-1b",
+	"us-east-1c",
+	"us-east-1d",
+	"us-east-1e",
+	"us-east-1f",
+	"us-east-2a",
+	"us-east-2b",
+	"us-east-2c",
 	"us-west-1a",
 	"us-west-1b",
-	//"us-west-1c", AZ does not exist, so we"re breaking the 3 AZs per region target here
-	//"us-west-2a", // temporarily removing due to lack of quota test-infra#10043
-	//"us-west-2b", // temporarily removing due to lack of quota test-infra#10043
-	//"us-west-2c", // temporarily removing due to lack of quota test-infra#10043
+	//"us-west-1c", AZ does not exist, so we're breaking the 3 AZs per region target here
+	"us-west-2a",
+	"us-west-2b",
+	"us-west-2c",
+	"us-west-2d",
 }
 
 // ErrNoEligibleRegion indicates the requested number of zones is not available in any region


### PR DESCRIPTION
This adds zones that have been released since this list was updated.
This also reenables some that were disabled due to capacity for c4 instance types - we use c5 now so hopefully they'll have sufficient coverage.
We can disable them if we continue to run into availability issues.

Long term I could see us using the ec2.DescribeAvailabilityZones and ec2.DescribeInstanceTypeOfferings APIs to pick random zone(s) in a random region and guarantee that it has the needed instance types.


I'm doing this to try to avoid Route53 API throttling mentioned in https://github.com/kubernetes/kops/pull/11099#issuecomment-803666505