### PR TITLE
WIP: Use CertificateSigningRequests when requesting kops-controller certificates

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -21,8 +21,6 @@ import (
 	"path"
 	"path/filepath"
 
-	"k8s.io/kops/pkg/model/components"
-
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 
@@ -30,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/flagbuilder"
+	"k8s.io/kops/pkg/model/components"
 	"k8s.io/kops/pkg/nodelabels"
 	"k8s.io/kops/pkg/rbac"
 	"k8s.io/kops/pkg/systemd"

--- a/pkg/apis/nodeup/bootstrap.go
+++ b/pkg/apis/nodeup/bootstrap.go
@@ -23,11 +23,19 @@ type BootstrapRequest struct {
 	// APIVersion defines the versioned schema of this representation of a request.
 	APIVersion string `json:"apiVersion"`
 	// Certs are the requested certificates and their respective public keys.
+	// @deprecated:ShouldIssueWithCSRs - use CertificateSigningRequests which is more extensible and secure
 	Certs map[string]string `json:"certs"`
+
+	// CertificateSigningRequests are requests for private keys to be signed.
+	CertificateSigningRequests map[string]*CertificateSigningRequest `json:"csrs"`
 
 	// IncludeNodeConfig controls whether the cluster & instance group configuration should be returned.
 	// This allows for nodes without access to the kops state store.
 	IncludeNodeConfig bool `json:"includeNodeConfig"`
+}
+
+type CertificateSigningRequest struct {
+	PEMData string `json:"pemData"`
 }
 
 // BootstrapResponse is a response to a BootstrapRequest.

--- a/pkg/deprecations/kops.go
+++ b/pkg/deprecations/kops.go
@@ -1,0 +1,21 @@
+package deprecations
+
+import "k8s.io/klog"
+
+type Deprecation struct {
+	Key              string
+	DeprecatedInKops string
+}
+
+// ShouldIssueWithCSRs is the deprecation to use CertificateSigningRequests instead of Certs in BootstrapRequest.
+// CSRs demonstrate ownership of the public key.
+var ShouldIssueWithCSRs = Deprecation{Key: "ShouldIssueWithCSRs", DeprecatedInKops: "1.21"}
+
+func (d *Deprecation) Use() {
+	klog.Warningf("using deprecated functionality %q", d.Key)
+}
+
+func (d *Deprecation) IsEnabled() bool {
+	klog.Infof("continuing to use deprecated codepath for %q", d.Key)
+	return true
+}


### PR DESCRIPTION
This is slightly more secure, because we prove that we control the private key.

Also introduce a structured deprecation tracker.