### PR TITLE
Use "tag on create" for EIPs, NLBs, and TargetGroups

### DIFF
--- a/cloudmock/aws/mockec2/address.go
+++ b/cloudmock/aws/mockec2/address.go
@@ -50,10 +50,12 @@ func (m *MockEC2) AllocateAddressWithId(request *ec2.AllocateAddressInput, id st
 		binary.BigEndian.PutUint32(publicIP, v)
 	}
 
+	tags := tagSpecificationsToTags(request.TagSpecifications, ec2.ResourceTypeElasticIp)
 	address := &ec2.Address{
 		AllocationId: s(id),
 		Domain:       s("vpc"),
 		PublicIp:     s(publicIP.String()),
+		Tags:         tags,
 	}
 	if request.Address != nil {
 		address.PublicIp = request.Address
@@ -63,6 +65,8 @@ func (m *MockEC2) AllocateAddressWithId(request *ec2.AllocateAddressInput, id st
 		m.Addresses = make(map[string]*ec2.Address)
 	}
 	m.Addresses[id] = address
+	m.addTags(id, tags...)
+
 	response := &ec2.AllocateAddressOutput{
 		AllocationId: address.AllocationId,
 		Domain:       address.Domain,

--- a/cloudmock/aws/mockelbv2/loadbalancers.go
+++ b/cloudmock/aws/mockelbv2/loadbalancers.go
@@ -122,9 +122,16 @@ func (m *MockELBV2) CreateLoadBalancer(request *elbv2.CreateLoadBalancerInput) (
 	if m.LBAttributes == nil {
 		m.LBAttributes = make(map[string][]*elbv2.LoadBalancerAttribute)
 	}
+	if m.Tags == nil {
+		m.Tags = make(map[string]*elbv2.TagDescription)
+	}
 
 	m.LoadBalancers[arn] = &loadBalancer{description: lb}
 	m.LBAttributes[arn] = make([]*elbv2.LoadBalancerAttribute, 0)
+	m.Tags[arn] = &elbv2.TagDescription{
+		ResourceArn: aws.String(arn),
+		Tags:        request.Tags,
+	}
 
 	return &elbv2.CreateLoadBalancerOutput{LoadBalancers: []*elbv2.LoadBalancer{&lb}}, nil
 }

--- a/cloudmock/aws/mockelbv2/targetgroups.go
+++ b/cloudmock/aws/mockelbv2/targetgroups.go
@@ -109,8 +109,15 @@ func (m *MockELBV2) CreateTargetGroup(request *elbv2.CreateTargetGroupInput) (*e
 	if m.TargetGroups == nil {
 		m.TargetGroups = make(map[string]*targetGroup)
 	}
+	if m.Tags == nil {
+		m.Tags = make(map[string]*elbv2.TagDescription)
+	}
 
 	m.TargetGroups[arn] = &targetGroup{description: tg}
+	m.Tags[arn] = &elbv2.TagDescription{
+		ResourceArn: aws.String(arn),
+		Tags:        request.Tags,
+	}
 	return &elbv2.CreateTargetGroupOutput{TargetGroups: []*elbv2.TargetGroup{&tg}}, nil
 }
 

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -227,7 +227,9 @@ func (_ *ElasticIP) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *ElasticIP) e
 	if a == nil {
 		klog.V(2).Infof("Creating ElasticIP for VPC")
 
-		request := &ec2.AllocateAddressInput{}
+		request := &ec2.AllocateAddressInput{
+			TagSpecifications: awsup.EC2TagSpecification(ec2.ResourceTypeElasticIp, e.Tags),
+		}
 		request.Domain = aws.String(ec2.DomainTypeVpc)
 
 		response, err := t.Cloud.EC2().AllocateAddress(request)
@@ -242,10 +244,9 @@ func (_ *ElasticIP) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *ElasticIP) e
 	} else {
 		publicIp = a.PublicIP
 		eipId = a.ID
-	}
-
-	if err := t.AddAWSTags(*e.ID, e.Tags); err != nil {
-		return err
+		if err := t.AddAWSTags(*e.ID, e.Tags); err != nil {
+			return err
+		}
 	}
 
 	// Tag the associated subnet

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
@@ -58,6 +58,7 @@ func TestElasticIPCreate(t *testing.T) {
 		eip1 := &ElasticIP{
 			Name:        s("eip1"),
 			TagOnSubnet: subnet1,
+			Tags:        map[string]string{"Name": "eip1"},
 		}
 
 		return map[string]fi.Task{
@@ -97,6 +98,12 @@ func TestElasticIPCreate(t *testing.T) {
 			AllocationId: eip1.ID,
 			Domain:       s("vpc"),
 			PublicIp:     s("192.0.2.1"),
+			Tags: []*ec2.Tag{
+				{
+					Key:   s("Name"),
+					Value: s("eip1"),
+				},
+			},
 		}
 		actual := c.Addresses[*eip1.ID]
 		if !reflect.DeepEqual(actual, expected) {

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -581,6 +581,7 @@ func (_ *NetworkLoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Ne
 		request.Name = e.LoadBalancerName
 		request.Scheme = e.Scheme
 		request.Type = e.Type
+		request.Tags = awsup.ELBv2Tags(e.Tags)
 
 		for _, subnetMapping := range e.SubnetMappings {
 			request.SubnetMappings = append(request.SubnetMappings, &elbv2.SubnetMapping{
@@ -708,14 +709,13 @@ func (_ *NetworkLoadBalancer) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Ne
 				}
 			}
 		}
-	}
+		if err := t.AddELBV2Tags(loadBalancerArn, e.Tags); err != nil {
+			return err
+		}
 
-	if err := t.AddELBV2Tags(loadBalancerArn, e.Tags); err != nil {
-		return err
-	}
-
-	if err := t.RemoveELBV2Tags(loadBalancerArn, e.Tags); err != nil {
-		return err
+		if err := t.RemoveELBV2Tags(loadBalancerArn, e.Tags); err != nil {
+			return err
+		}
 	}
 
 	if err := e.modifyLoadBalancerAttributes(t, a, e, changes, loadBalancerArn); err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -176,6 +176,7 @@ func (_ *TargetGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *TargetGrou
 			VpcId:                   e.VPC.ID,
 			HealthyThresholdCount:   e.HealthyThreshold,
 			UnhealthyThresholdCount: e.UnhealthyThreshold,
+			Tags:                    awsup.ELBv2Tags(e.Tags),
 		}
 
 		klog.V(2).Infof("Creating Target Group for NLB")
@@ -186,9 +187,11 @@ func (_ *TargetGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *TargetGrou
 
 		targetGroupArn := *response.TargetGroups[0].TargetGroupArn
 		e.ARN = fi.String(targetGroupArn)
-
-		if err := t.AddELBV2Tags(targetGroupArn, e.Tags); err != nil {
-			return err
+	} else {
+		if a.ARN != nil {
+			if err := t.AddELBV2Tags(fi.StringValue(a.ARN), e.Tags); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -202,6 +202,22 @@ func EC2TagSpecification(resourceType string, tags map[string]string) []*ec2.Tag
 	return []*ec2.TagSpecification{specification}
 }
 
+// ELBv2Tags converts a map of tags to ELBv2 Tags
+func ELBv2Tags(tags map[string]string) []*elbv2.Tag {
+	if len(tags) == 0 {
+		return nil
+	}
+	elbv2Tags := make([]*elbv2.Tag, 0)
+	for k, v := range tags {
+		elbv2Tags = append(elbv2Tags, &elbv2.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+
+	return elbv2Tags
+}
+
 // GetResourceName32 will attempt to calculate a meaningful name for a resource given a prefix
 // Will never return a string longer than 32 chars
 func GetResourceName32(cluster string, prefix string) string {


### PR DESCRIPTION
These are the remaining resources that support "tag on create" of which we werent taking advantage.

This allows more fine-grained IAM permissions for the kops cli.

ref: https://github.com/kubernetes/kops/issues/9640