### PR TITLE
Automated cherry pick of #11101: Have nodeup retry kops-controller bootstrapping sooner if DNS

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
+++ b/upup/pkg/fi/nodeup/nodetasks/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/pki:go_default_library",
         "//pkg/wellknownports:go_default_library",
         "//upup/pkg/fi:go_default_library",
+        "//upup/pkg/fi/cloudup:go_default_library",
         "//upup/pkg/fi/nodeup/cloudinit:go_default_library",
         "//upup/pkg/fi/nodeup/local:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",


### PR DESCRIPTION
Cherry pick of #11101 on release-1.20.

#11101: Have nodeup retry kops-controller bootstrapping sooner if DNS

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.