### PR TITLE
replace hard coded aws region checks with aws sdk calls

### DIFF
--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//util/pkg/architectures:go_default_library",
         "//util/pkg/mirrors:go_default_library",
         "//util/pkg/vfs:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/endpoints:go_default_library",
         "//vendor/github.com/blang/semver/v4:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
@@ -68,6 +69,7 @@ go_test(
     srcs = [
         "bootstrapscript_test.go",
         "firewall_test.go",
+        "iam_test.go",
     ],
     data = glob(["tests/**"]),  #keep
     embed = [":go_default_library"],

--- a/pkg/model/iam.go
+++ b/pkg/model/iam.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/dns"
@@ -319,16 +320,16 @@ func (b *IAMModelBuilder) buildIAMTasks(role iam.Subject, iamName string, c *fi.
 }
 
 // IAMServiceEC2 returns the name of the IAM service for EC2 in the current region.
-// It is ec2.amazonaws.com everywhere but in cn-north / cn-northwest, where it is ec2.amazonaws.com.cn
+// It is ec2.amazonaws.com in the default aws partition, but different in other isolated/custom partitions
 func IAMServiceEC2(region string) string {
-	switch region {
-	case "cn-north-1":
-		return "ec2.amazonaws.com.cn"
-	case "cn-northwest-1":
-		return "ec2.amazonaws.com.cn"
-	default:
-		return "ec2.amazonaws.com"
+	partitions := endpoints.DefaultPartitions()
+	for _, p := range partitions {
+		if _, ok := p.Regions()[region]; ok {
+			ep := "ec2." + p.DNSSuffix()
+			return ep
+		}
 	}
+	return "ec2.amazonaws.com"
 }
 
 // buildAWSIAMRolePolicy produces the AWS IAM role policy for the given role.

--- a/pkg/model/iam/BUILD.bazel
+++ b/pkg/model/iam/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//util/pkg/vfs:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/endpoints:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -33,6 +33,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
@@ -398,20 +399,16 @@ func (r *NodeRoleBastion) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 }
 
 // IAMPrefix returns the prefix for AWS ARNs in the current region, for use with IAM
-// it is arn:aws everywhere but in cn-north and us-gov-west-1
+// it is arn:aws in the default aws partition but different in other isolated or non-standard partitions
 func (b *PolicyBuilder) IAMPrefix() string {
-	switch b.Region {
-	case "cn-north-1":
-		return "arn:aws-cn"
-	case "cn-northwest-1":
-		return "arn:aws-cn"
-	case "us-gov-east-1":
-		return "arn:aws-us-gov"
-	case "us-gov-west-1":
-		return "arn:aws-us-gov"
-	default:
-		return "arn:aws"
+	partitions := endpoints.DefaultPartitions()
+	for _, p := range partitions {
+		if _, ok := p.Regions()[b.Region]; ok {
+			arn := "arn:" + p.ID()
+			return arn
+		}
 	}
+	return "arn:aws"
 }
 
 // AddS3Permissions builds an IAM Policy, with statements granting tailored

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -27,6 +27,25 @@ import (
 	"k8s.io/kops/pkg/util/stringorslice"
 )
 
+func TestIAMPrefix(t *testing.T) {
+	var expectations = map[string]string{
+		"us-east-1":      "arn:aws",
+		"us-iso-east-1":  "arn:aws-iso",
+		"us-isob-east-1": "arn:aws-iso-b",
+		"us-gov-east-1":  "arn:aws-us-gov",
+		"randomunknown":  "arn:aws",
+		"cn-north-1":     "arn:aws-cn",
+		"cn-northwest-1": "arn:aws-cn",
+	}
+
+	for region, expect := range expectations {
+		arn := (&PolicyBuilder{Region: region}).IAMPrefix()
+		if arn != expect {
+			t.Errorf("expected %s for %s, received %s", expect, region, arn)
+		}
+	}
+}
+
 func TestRoundTrip(t *testing.T) {
 	grid := []struct {
 		IAM  *Statement

--- a/pkg/model/iam_test.go
+++ b/pkg/model/iam_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+)
+
+func TestIAMServiceEC2(t *testing.T) {
+	var expectations = map[string]string{
+		"us-east-1":      "ec2.amazonaws.com",
+		"randomunknown":  "ec2.amazonaws.com",
+		"us-gov-east-1":  "ec2.amazonaws.com",
+		"cn-north-1":     "ec2.amazonaws.com.cn",
+		"cn-northwest-1": "ec2.amazonaws.com.cn",
+	}
+
+	for region, expect := range expectations {
+		principal := IAMServiceEC2(region)
+		if principal != expect {
+			t.Errorf("expected %s for %s, but received %s", expect, region, principal)
+		}
+	}
+}


### PR DESCRIPTION
future proof AWS endpoint and IAM Prefix generation to handle new AWS Partitions and future new ones. Offload to AWS SDK