### PR TITLE
Kubetest2 - Setup SSH keys for GCE

### DIFF
--- a/tests/e2e/kubetest2-kops/gce/ssh.go
+++ b/tests/e2e/kubetest2-kops/gce/ssh.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kubetest2/pkg/exec"
+)
+
+func SetupSSH(project string) (string, string, error) {
+	dir, err := os.MkdirTemp("kops", "ssh")
+	if err != nil {
+		return "", "", err
+	}
+
+	privateKey := filepath.Join(dir, "key")
+	configArgs := []string{
+		"gcloud",
+		"compute",
+		fmt.Sprintf("--project=%v", project),
+		"config-ssh",
+		fmt.Sprintf("--ssh-key-file=%v", privateKey),
+	}
+	klog.Info(strings.Join(configArgs, " "))
+	cmd := exec.Command(configArgs[0], configArgs[1:]...)
+
+	exec.InheritOutput(cmd)
+	err = cmd.Run()
+	if err != nil {
+		return "", "", err
+	}
+
+	return privateKey, fmt.Sprintf("%v.pub", privateKey), nil
+}


### PR DESCRIPTION
Originally I had thought we were relying on ssh keys mounted from a secret,
it turns out kubetest 1 generated the keys indirectly through gcloud.

This runs the [same command as kubetest 1](https://github.com/kubernetes/test-infra/blob/de07aa4b89f1161778856dc0fed310bd816aad72/kubetest/main.go#L808), creating and uploading the SSH keys.

I'm hoping to get [this failing job](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-kubetest2/1373617563581288448) to get ssh access and dump the node logs as artifacts so we can fix the job.