### PR TITLE
[kubelet] Remove deprecated flag allowPrivileged

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2233,10 +2233,6 @@ spec:
               kubelet:
                 description: KubeletConfigSpec defines the kubelet configuration
                 properties:
-                  allowPrivileged:
-                    description: AllowPrivileged enables containers to request privileged
-                      mode (defaults to false)
-                    type: boolean
                   allowedUnsafeSysctls:
                     description: AllowedUnsafeSysctls are passed to the kubelet config
                       to whitelist allowable sysctls
@@ -2639,10 +2635,6 @@ spec:
               masterKubelet:
                 description: KubeletConfigSpec defines the kubelet configuration
                 properties:
-                  allowPrivileged:
-                    description: AllowPrivileged enables containers to request privileged
-                      mode (defaults to false)
-                    type: boolean
                   allowedUnsafeSysctls:
                     description: AllowedUnsafeSysctls are passed to the kubelet config
                       to whitelist allowable sysctls

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -257,10 +257,6 @@ spec:
               kubelet:
                 description: Kubelet overrides kubelet config from the ClusterSpec
                 properties:
-                  allowPrivileged:
-                    description: AllowPrivileged enables containers to request privileged
-                      mode (defaults to false)
-                    type: boolean
                   allowedUnsafeSysctls:
                     description: AllowedUnsafeSysctls are passed to the kubelet config
                       to whitelist allowable sysctls

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -55,8 +55,6 @@ type KubeletConfigSpec struct {
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
 	// SeccompProfileRoot is the directory path for seccomp profiles.
 	SeccompProfileRoot *string `json:"seccompProfileRoot,omitempty" flag:"seccomp-profile-root"`
-	// AllowPrivileged enables containers to request privileged mode (defaults to false)
-	AllowPrivileged *bool `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
 	// EnableDebuggingHandlers enables server endpoints for log collection and local running of containers and commands
 	EnableDebuggingHandlers *bool `json:"enableDebuggingHandlers,omitempty" flag:"enable-debugging-handlers"`
 	// RegisterNode enables automatic registration with the apiserver.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -55,8 +55,6 @@ type KubeletConfigSpec struct {
 	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
 	// SeccompProfileRoot is the directory path for seccomp profiles.
 	SeccompProfileRoot *string `json:"seccompProfileRoot,omitempty" flag:"seccomp-profile-root"`
-	// AllowPrivileged enables containers to request privileged mode (defaults to false)
-	AllowPrivileged *bool `json:"allowPrivileged,omitempty" flag:"allow-privileged"`
 	// EnableDebuggingHandlers enables server endpoints for log collection and local running of containers and commands
 	EnableDebuggingHandlers *bool `json:"enableDebuggingHandlers,omitempty" flag:"enable-debugging-handlers"`
 	// RegisterNode enables automatic registration with the apiserver.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4871,7 +4871,6 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
 	out.SeccompProfileRoot = in.SeccompProfileRoot
-	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers
 	out.RegisterNode = in.RegisterNode
 	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
@@ -4965,7 +4964,6 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.HostnameOverride = in.HostnameOverride
 	out.PodInfraContainerImage = in.PodInfraContainerImage
 	out.SeccompProfileRoot = in.SeccompProfileRoot
-	out.AllowPrivileged = in.AllowPrivileged
 	out.EnableDebuggingHandlers = in.EnableDebuggingHandlers
 	out.RegisterNode = in.RegisterNode
 	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3117,11 +3117,6 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.AllowPrivileged != nil {
-		in, out := &in.AllowPrivileged, &out.AllowPrivileged
-		*out = new(bool)
-		**out = **in
-	}
 	if in.EnableDebuggingHandlers != nil {
 		in, out := &in.EnableDebuggingHandlers, &out.EnableDebuggingHandlers
 		*out = new(bool)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3299,11 +3299,6 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.AllowPrivileged != nil {
-		in, out := &in.AllowPrivileged, &out.AllowPrivileged
-		*out = new(bool)
-		**out = **in
-	}
 	if in.EnableDebuggingHandlers != nil {
 		in, out := &in.EnableDebuggingHandlers, &out.EnableDebuggingHandlers
 		*out = new(bool)

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -59,18 +59,6 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	clusterSpec.Kubelet.ClusterDomain = clusterSpec.ClusterDNSDomain
 	clusterSpec.Kubelet.NonMasqueradeCIDR = clusterSpec.NonMasqueradeCIDR
 
-	// AllowPrivileged is deprecated and removed in v1.14.
-	// See https://github.com/kubernetes/kubernetes/pull/71835
-	if clusterSpec.Kubelet.AllowPrivileged != nil {
-		// If it is explicitly set to false, return an error, because this
-		// behavior is no longer supported in v1.14 (the default was true, prior).
-		if !*clusterSpec.Kubelet.AllowPrivileged {
-			klog.Warningf("Kubelet's --allow-privileged flag is no longer supported in v1.14.")
-		}
-		// Explicitly set it to nil, so it won't be passed on the command line.
-		clusterSpec.Kubelet.AllowPrivileged = nil
-	}
-
 	if clusterSpec.Kubelet.ClusterDNS == "" {
 		if clusterSpec.KubeDNS != nil && clusterSpec.KubeDNS.NodeLocalDNS != nil && fi.BoolValue(clusterSpec.KubeDNS.NodeLocalDNS.Enabled) {
 			clusterSpec.Kubelet.ClusterDNS = clusterSpec.KubeDNS.NodeLocalDNS.LocalIP


### PR DESCRIPTION
Kubelet has removed the support of allowPrivileged flag since version
1.15 of Kubernetes. As a result, utilizing this flag will make both
master and regular nodes unable to join the cluster as they will stale
on Kubelet starting.

In this commit, we completely remove this flag to prevent users from
using it and introduce disturbance on their clusters.

Signed-off-by: dntosas <ntosas@gmail.com>