### PR TITLE
Automated cherry pick of #11127: Validate that kube-apiserver has the necessary authz modes

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -440,12 +440,33 @@ func validateKubeAPIServer(v *kops.KubeAPIServerConfig, c *kops.Cluster, fldPath
 		}
 	}
 
-	if v.AuthorizationMode != nil && strings.Contains(*v.AuthorizationMode, "Webhook") {
-		if v.AuthorizationWebhookConfigFile == nil {
-			allErrs = append(allErrs, field.Required(fldPath.Child("authorizationWebhookConfigFile"), "Authorization mode Webhook requires authorizationWebhookConfigFile to be specified"))
+	if v.AuthorizationMode != nil {
+		if strings.Contains(*v.AuthorizationMode, "Webhook") {
+			if v.AuthorizationWebhookConfigFile == nil {
+				allErrs = append(allErrs, field.Required(fldPath.Child("authorizationWebhookConfigFile"), "Authorization mode Webhook requires authorizationWebhookConfigFile to be specified"))
+			}
+		}
+
+		if c.Spec.Authorization != nil && c.Spec.Authorization.RBAC != nil {
+
+			var hasNode, hasRBAC bool
+			for _, mode := range strings.Split(*v.AuthorizationMode, ",") {
+				switch mode {
+				case "Node":
+					hasNode = true
+				case "RBAC":
+					hasRBAC = true
+				default:
+					allErrs = append(allErrs, IsValidValue(fldPath.Child("authorizationMode"), &mode, []string{"ABAC", "Webhook", "Node", "RBAC", "AlwaysAllow", "AlwaysDeny"})...)
+				}
+			}
+			if kops.CloudProviderID(c.Spec.CloudProvider) == kops.CloudProviderAWS && c.IsKubernetesGTE("1.19") {
+				if !hasNode || !hasRBAC {
+					allErrs = append(allErrs, field.Required(fldPath.Child("authorizationMode"), "As of kubernetes 1.19 on AWS, authorizationMode must include RBAC and Node"))
+				}
+			}
 		}
 	}
-
 	return allErrs
 }
 


### PR DESCRIPTION
Cherry pick of #11127 on release-1.19.

#11127: Validate that kube-apiserver has the necessary authz modes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.