### PR TITLE
Automated cherry pick of #11048: remove instance-selector label

### DIFF
--- a/cmd/kops/toolbox_instance_selector.go
+++ b/cmd/kops/toolbox_instance_selector.go
@@ -500,12 +500,6 @@ func decorateWithMixedInstancesPolicy(instanceGroup *kops.InstanceGroup, usageCl
 		return nil, fmt.Errorf("error node usage class not supported")
 	}
 
-	generatedWithLabelKey := "kops.k8s.io/instance-selector"
-	if ig.Spec.CloudLabels == nil {
-		ig.Spec.CloudLabels = make(map[string]string)
-	}
-	ig.Spec.CloudLabels[generatedWithLabelKey] = "1"
-
 	return ig, nil
 }
 


### PR DESCRIPTION
Cherry pick of #11048 on release-1.19.

#11048: remove instance-selector label

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.