### PR TITLE
Kubetest2 - fix temp directory created for GCE SSH keys

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/publish.go
+++ b/tests/e2e/kubetest2-kops/deployer/publish.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -43,7 +43,7 @@ func (d *deployer) PostTest(testErr error) error {
 	if err := util.HTTPGETWithHeaders(d.KopsVersionMarker, nil, &b); err != nil {
 		return err
 	}
-	tempSrc, err := ioutil.TempFile("", "kops-version-marker")
+	tempSrc, err := os.CreateTemp("", "kops-version-marker")
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/kubetest2-kops/deployer/template.go
+++ b/tests/e2e/kubetest2-kops/deployer/template.go
@@ -17,7 +17,7 @@ limitations under the License.
 package deployer
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -29,7 +29,7 @@ import (
 // renderTemplate will render the manifest template with the provided values,
 // setting the deployer's manifestPath
 func (d *deployer) renderTemplate(values map[string]interface{}) error {
-	dir, err := ioutil.TempDir("", "kops-template")
+	dir, err := os.MkdirTemp("", "kops-template")
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,10 @@ func (d *deployer) renderTemplate(values map[string]interface{}) error {
 		return err
 	}
 	valuesPath := path.Join(dir, "values.yaml")
-	ioutil.WriteFile(valuesPath, valuesBytes, 0644)
+	err = os.WriteFile(valuesPath, valuesBytes, 0644)
+	if err != nil {
+		return err
+	}
 
 	manifestPath := path.Join(dir, "manifest.yaml")
 	d.manifestPath = manifestPath
@@ -64,7 +67,7 @@ func (d *deployer) renderTemplate(values map[string]interface{}) error {
 }
 
 func (d *deployer) templateValues(zones []string, publicIP string) (map[string]interface{}, error) {
-	publicKey, err := ioutil.ReadFile(d.SSHPublicKeyPath)
+	publicKey, err := os.ReadFile(d.SSHPublicKeyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/kubetest2-kops/gce/ssh.go
+++ b/tests/e2e/kubetest2-kops/gce/ssh.go
@@ -27,7 +27,7 @@ import (
 )
 
 func SetupSSH(project string) (string, string, error) {
-	dir, err := os.MkdirTemp("kops", "ssh")
+	dir, err := os.MkdirTemp("", "kops-ssh")
 	if err != nil {
 		return "", "", err
 	}

--- a/tests/e2e/pkg/kops/download.go
+++ b/tests/e2e/pkg/kops/download.go
@@ -19,7 +19,6 @@ package kops
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -39,7 +38,7 @@ func DownloadKops(markerURL, downloadPath string) (string, string, error) {
 
 	var kopsFile *os.File
 	if downloadPath == "" {
-		tmp, err := ioutil.TempFile("", "kops")
+		tmp, err := os.CreateTemp("", "kops")
 		if err != nil {
 			return "", "", err
 		}

--- a/tests/e2e/pkg/target/terraform.go
+++ b/tests/e2e/pkg/target/terraform.go
@@ -19,7 +19,7 @@ package target
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -48,7 +48,7 @@ func NewTerraform(version string) (*Terraform, error) {
 	if err != nil {
 		return nil, err
 	}
-	tfDir, err := ioutil.TempDir("", "kops-terraform")
+	tfDir, err := os.MkdirTemp("", "kops-terraform")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/pkg/tester/kubectl.go
+++ b/tests/e2e/pkg/tester/kubectl.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -84,7 +83,7 @@ func (t *Tester) extractBinaries(downloadPath string) (string, error) {
 	}
 	tarReader := tar.NewReader(gzf)
 
-	kubectlDir, err := ioutil.TempDir("", "kubectl")
+	kubectlDir, err := os.MkdirTemp("", "kubectl")
 	if err != nil {
 		return "", err
 	}

--- a/tests/e2e/pkg/util/zip.go
+++ b/tests/e2e/pkg/util/zip.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,7 +32,7 @@ func UnzipToTempDir(data []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Also update all ioutil references to their go 1.16 replacements

Should fix this error: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-kubetest2/1374583912889585664#1:build-log.txt%3A105