### PR TITLE
Revert "Update kube-router to v1.2.0"

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -34232,7 +34232,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v1.2.0
+        image: docker.io/cloudnativelabs/kube-router:v1.1.1
         args:
         - --run-router=true
         - --run-firewall=true
@@ -34273,7 +34273,7 @@ spec:
           readOnly: false
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v1.2.0
+        image: docker.io/cloudnativelabs/kube-router:v1.1.1
         command:
         - /bin/sh
         - -c

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: docker.io/cloudnativelabs/kube-router:v1.2.0
+        image: docker.io/cloudnativelabs/kube-router:v1.1.1
         args:
         - --run-router=true
         - --run-firewall=true
@@ -97,7 +97,7 @@ spec:
           readOnly: false
       initContainers:
       - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router:v1.2.0
+        image: docker.io/cloudnativelabs/kube-router:v1.1.1
         command:
         - /bin/sh
         - -c

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -845,7 +845,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	if b.Cluster.Spec.Networking.Kuberouter != nil {
 		key := "networking.kuberouter"
 		versions := map[string]string{
-			"k8s-1.12": "1.2.0-kops.1",
+			"k8s-1.12": "1.1.1-kops.1",
 		}
 
 		{


### PR DESCRIPTION
This reverts commit b32689ba.
Seems that this is not just an easy version bump and should not block the release.