### PR TITLE
kubetest2 - Specify GCE network name 

### DIFF
--- a/tests/e2e/kubetest2-kops/aws/zones.go
+++ b/tests/e2e/kubetest2-kops/aws/zones.go
@@ -30,9 +30,9 @@ var allZones = []string{
 	//"ap-northeast-2b" - AZ does not exist, so we're breaking the 3 AZs per region target here
 	"ap-northeast-2c",
 	"ap-northeast-2d",
-	"ap-northeast-3a",
-	"ap-northeast-3b",
-	"ap-northeast-3c",
+	//"ap-northeast-3a", - Disabled until etcd-manager supports the region and the AMIs used in testing are present
+	//"ap-northeast-3b",
+	//"ap-northeast-3c",
 	"ap-south-1a",
 	"ap-south-1b",
 	"ap-south-1c",

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -118,6 +118,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string) error {
 		if d.GCPProject != "" {
 			args = appendIfUnset(args, "--project", d.GCPProject)
 		}
+		args = appendIfUnset(args, "--vpc", strings.Split(d.ClusterName, ".")[0])
 	case "digitalocean":
 		args = appendIfUnset(args, "--master-size", "s-8vcpu-16gb")
 	}


### PR DESCRIPTION
Kops defaults to a network named "default" and has issues with network modes.
Apparently there is a "default" network within the projects that boskos issues,
causing `kops create cluster` to fail some cloudup validation.

By specifying a cluster-specific network, kops will create this new network with the non-deprecated settings.

Hoping to fix this error: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-kubetest2/1374704711222956032

and here is the line number in question, notice that `a` is not nil at this point, indicating that `Find` was able to find an existing Network:

https://github.com/kubernetes/kops/blob/42fbb1c1c5b1f46405294ded37395906743c5b16/upup/pkg/fi/cloudup/gcetasks/network.go#L141-L143


Also disabling ap-northeast-3 zones for now