### PR TITLE
Automated cherry pick of #11140: Add scaleDownDelayAfterAdd to clusterAutoscaler spec

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -33,8 +33,14 @@ Cluster autoscaler can be enabled to automatically adjust the size of the kubern
 spec:
   clusterAutoscaler:
     enabled: true
+    expander: least-waste
+    balanceSimilarNodeGroups: false
+    scaleDownUtilizationThreshold: 0.5
     skipNodesWithLocalStorage: true
     skipNodesWithSystemPods: true
+    newPodScaleUpDelay: 0s
+    scaleDownDelayAfterAdd: 10m0s
+    image: <the latest supported image for the specified kubernetes version>
     cpuRequest: "100m"
     memoryRequest: "300Mi"
 ```

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -555,6 +555,10 @@ spec:
                       ignore unschedulable pods until they are a certain "age", regardless
                       of the scan-interval Default: 0s'
                     type: string
+                  scaleDownDelayAfterAdd:
+                    description: 'ScaleDownDelayAfterAdd determines the time after
+                      scale up that scale down evaluation resumes Default: 10m0s'
+                    type: string
                   scaleDownUtilizationThreshold:
                     description: 'ScaleDownUtilizationThreshold determines the utilization
                       threshold for node scale-down. Default: 0.5'

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -880,6 +880,9 @@ type ClusterAutoscalerConfig struct {
 	// NewPodScaleUpDelay causes cluster autoscaler to ignore unschedulable pods until they are a certain "age", regardless of the scan-interval
 	// Default: 0s
 	NewPodScaleUpDelay *string `json:"newPodScaleUpDelay,omitempty"`
+	// ScaleDownDelayAfterAdd determines the time after scale up that scale down evaluation resumes
+	// Default: 10m0s
+	ScaleDownDelayAfterAdd *string `json:"scaleDownDelayAfterAdd,omitempty"`
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -879,6 +879,9 @@ type ClusterAutoscalerConfig struct {
 	// NewPodScaleUpDelay causes cluster autoscaler to ignore unschedulable pods until they are a certain "age", regardless of the scan-interval
 	// Default: 0s
 	NewPodScaleUpDelay *string `json:"newPodScaleUpDelay,omitempty"`
+	// ScaleDownDelayAfterAdd determines the time after scale up that scale down evaluation resumes
+	// Default: 10m0s
+	ScaleDownDelayAfterAdd *string `json:"scaleDownDelayAfterAdd,omitempty"`
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2030,6 +2030,7 @@ func autoConvert_v1alpha2_ClusterAutoscalerConfig_To_kops_ClusterAutoscalerConfi
 	out.SkipNodesWithSystemPods = in.SkipNodesWithSystemPods
 	out.SkipNodesWithLocalStorage = in.SkipNodesWithLocalStorage
 	out.NewPodScaleUpDelay = in.NewPodScaleUpDelay
+	out.ScaleDownDelayAfterAdd = in.ScaleDownDelayAfterAdd
 	out.Image = in.Image
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
@@ -2049,6 +2050,7 @@ func autoConvert_kops_ClusterAutoscalerConfig_To_v1alpha2_ClusterAutoscalerConfi
 	out.SkipNodesWithSystemPods = in.SkipNodesWithSystemPods
 	out.SkipNodesWithLocalStorage = in.SkipNodesWithLocalStorage
 	out.NewPodScaleUpDelay = in.NewPodScaleUpDelay
+	out.ScaleDownDelayAfterAdd = in.ScaleDownDelayAfterAdd
 	out.Image = in.Image
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -721,6 +721,11 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ScaleDownDelayAfterAdd != nil {
+		in, out := &in.ScaleDownDelayAfterAdd, &out.ScaleDownDelayAfterAdd
+		*out = new(string)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -821,6 +821,11 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ScaleDownDelayAfterAdd != nil {
+		in, out := &in.ScaleDownDelayAfterAdd, &out.ScaleDownDelayAfterAdd
+		*out = new(string)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -85,6 +85,9 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 	if cas.NewPodScaleUpDelay == nil {
 		cas.NewPodScaleUpDelay = fi.String("0s")
 	}
+	if cas.ScaleDownDelayAfterAdd == nil {
+		cas.ScaleDownDelayAfterAdd = fi.String("10m0s")
+	}
 
 	return nil
 }

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -28454,6 +28454,7 @@ spec:
             - --scale-down-utilization-threshold={{ .ScaleDownUtilizationThreshold }}
             - --skip-nodes-with-local-storage={{ .SkipNodesWithLocalStorage }}
             - --skip-nodes-with-system-pods={{ .SkipNodesWithSystemPods }}
+            - --scale-down-delay-after-add={{ .ScaleDownDelayAfterAdd }}
             - --new-pod-scale-up-delay={{ .NewPodScaleUpDelay }}
             - --stderrthreshold=info
             - --v=2

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -164,6 +164,7 @@ spec:
             - --scale-down-utilization-threshold={{ .ScaleDownUtilizationThreshold }}
             - --skip-nodes-with-local-storage={{ .SkipNodesWithLocalStorage }}
             - --skip-nodes-with-system-pods={{ .SkipNodesWithSystemPods }}
+            - --scale-down-delay-after-add={{ .ScaleDownDelayAfterAdd }}
             - --new-pod-scale-up-delay={{ .NewPodScaleUpDelay }}
             - --stderrthreshold=info
             - --v=2


### PR DESCRIPTION
Cherry pick of #11140 on release-1.20.

#11140: Add scaleDownDelayAfterAdd to clusterAutoscaler spec

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.