### PR TITLE
Pass ctx to drain helper

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -571,6 +571,7 @@ func (c *RollingUpdateCluster) drainNode(u *cloudinstances.CloudInstance) error 
 	}
 
 	helper := &drain.Helper{
+		Ctx:                 c.Ctx,
 		Client:              c.K8sClient,
 		Force:               true,
 		GracePeriodSeconds:  -1,


### PR DESCRIPTION
In some rare cases, we hit an NPR because the k8s code tries to use the
ctx we are not passing.