### PR TITLE
Add tags to instance profile and OIDC provider terraform resources

### DIFF
--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -366,16 +366,31 @@ resource "aws_elb" "bastion-bastionuserdata-example-com" {
 resource "aws_iam_instance_profile" "bastions-bastionuserdata-example-com" {
   name = "bastions.bastionuserdata.example.com"
   role = aws_iam_role.bastions-bastionuserdata-example-com.name
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "bastions.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-bastionuserdata-example-com" {
   name = "masters.bastionuserdata.example.com"
   role = aws_iam_role.masters-bastionuserdata-example-com.name
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "masters.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-bastionuserdata-example-com" {
   name = "nodes.bastionuserdata.example.com"
   role = aws_iam_role.nodes-bastionuserdata-example-com.name
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "nodes.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-bastionuserdata-example-com" {
@@ -1008,7 +1023,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -269,11 +269,25 @@ resource "aws_ebs_volume" "a-etcd-main-complex-example-com" {
 resource "aws_iam_instance_profile" "masters-complex-example-com" {
   name = "masters.complex.example.com"
   role = aws_iam_role.masters-complex-example-com.name
+  tags = {
+    "KubernetesCluster"                         = "complex.example.com"
+    "Name"                                      = "masters.complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-complex-example-com" {
   name = "nodes.complex.example.com"
   role = aws_iam_role.nodes-complex-example-com.name
+  tags = {
+    "KubernetesCluster"                         = "complex.example.com"
+    "Name"                                      = "nodes.complex.example.com"
+    "Owner"                                     = "John Doe"
+    "foo/bar"                                   = "fib+baz"
+    "kubernetes.io/cluster/complex.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-complex-example-com" {
@@ -1004,7 +1018,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -226,11 +226,21 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-compress-example-com" {
 resource "aws_iam_instance_profile" "masters-compress-example-com" {
   name = "masters.compress.example.com"
   role = aws_iam_role.masters-compress-example-com.name
+  tags = {
+    "KubernetesCluster"                          = "compress.example.com"
+    "Name"                                       = "masters.compress.example.com"
+    "kubernetes.io/cluster/compress.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-compress-example-com" {
   name = "nodes.compress.example.com"
   role = aws_iam_role.nodes-compress-example-com.name
+  tags = {
+    "KubernetesCluster"                          = "compress.example.com"
+    "Name"                                       = "nodes.compress.example.com"
+    "kubernetes.io/cluster/compress.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-compress-example-com" {
@@ -616,7 +626,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -964,7 +964,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -455,11 +455,21 @@ resource "aws_elb" "api-existingsg-example-com" {
 resource "aws_iam_instance_profile" "masters-existingsg-example-com" {
   name = "masters.existingsg.example.com"
   role = aws_iam_role.masters-existingsg-example-com.name
+  tags = {
+    "KubernetesCluster"                            = "existingsg.example.com"
+    "Name"                                         = "masters.existingsg.example.com"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-existingsg-example-com" {
   name = "nodes.existingsg.example.com"
   role = aws_iam_role.nodes-existingsg-example-com.name
+  tags = {
+    "KubernetesCluster"                            = "existingsg.example.com"
+    "Name"                                         = "nodes.existingsg.example.com"
+    "kubernetes.io/cluster/existingsg.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-existingsg-example-com" {
@@ -1298,7 +1308,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -230,11 +230,21 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-externallb-example-com" {
 resource "aws_iam_instance_profile" "masters-externallb-example-com" {
   name = "masters.externallb.example.com"
   role = aws_iam_role.masters-externallb-example-com.name
+  tags = {
+    "KubernetesCluster"                            = "externallb.example.com"
+    "Name"                                         = "masters.externallb.example.com"
+    "kubernetes.io/cluster/externallb.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-externallb-example-com" {
   name = "nodes.externallb.example.com"
   role = aws_iam_role.nodes-externallb-example-com.name
+  tags = {
+    "KubernetesCluster"                            = "externallb.example.com"
+    "Name"                                         = "nodes.externallb.example.com"
+    "kubernetes.io/cluster/externallb.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-externallb-example-com" {
@@ -632,7 +642,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -280,11 +280,25 @@ resource "aws_elb" "api-externalpolicies-example-com" {
 resource "aws_iam_instance_profile" "masters-externalpolicies-example-com" {
   name = "masters.externalpolicies.example.com"
   role = aws_iam_role.masters-externalpolicies-example-com.name
+  tags = {
+    "KubernetesCluster"                                  = "externalpolicies.example.com"
+    "Name"                                               = "masters.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
+    "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-externalpolicies-example-com" {
   name = "nodes.externalpolicies.example.com"
   role = aws_iam_role.nodes-externalpolicies-example-com.name
+  tags = {
+    "KubernetesCluster"                                  = "externalpolicies.example.com"
+    "Name"                                               = "nodes.externalpolicies.example.com"
+    "Owner"                                              = "John Doe"
+    "foo/bar"                                            = "fib+baz"
+    "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "master-policyoverride-1242070525" {
@@ -814,7 +828,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -426,11 +426,21 @@ resource "aws_ebs_volume" "c-etcd-main-ha-example-com" {
 resource "aws_iam_instance_profile" "masters-ha-example-com" {
   name = "masters.ha.example.com"
   role = aws_iam_role.masters-ha-example-com.name
+  tags = {
+    "KubernetesCluster"                    = "ha.example.com"
+    "Name"                                 = "masters.ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-ha-example-com" {
   name = "nodes.ha.example.com"
   role = aws_iam_role.nodes-ha-example-com.name
+  tags = {
+    "KubernetesCluster"                    = "ha.example.com"
+    "Name"                                 = "nodes.ha.example.com"
+    "kubernetes.io/cluster/ha.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-ha-example-com" {
@@ -1026,7 +1036,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -172,7 +172,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -226,11 +226,21 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
 resource "aws_iam_instance_profile" "masters-minimal-example-com" {
   name = "masters.minimal.example.com"
   role = aws_iam_role.masters-minimal-example-com.name
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-example-com" {
   name = "nodes.minimal.example.com"
   role = aws_iam_role.nodes-minimal-example-com.name
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-minimal-example-com" {
@@ -624,7 +634,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -261,11 +261,21 @@
     "aws_iam_instance_profile": {
       "masters-minimal-json-example-com": {
         "name": "masters.minimal-json.example.com",
-        "role": "${aws_iam_role.masters-minimal-json-example-com.name}"
+        "role": "${aws_iam_role.masters-minimal-json-example-com.name}",
+        "tags": {
+          "KubernetesCluster": "minimal-json.example.com",
+          "Name": "masters.minimal-json.example.com",
+          "kubernetes.io/cluster/minimal-json.example.com": "owned"
+        }
       },
       "nodes-minimal-json-example-com": {
         "name": "nodes.minimal-json.example.com",
-        "role": "${aws_iam_role.nodes-minimal-json-example-com.name}"
+        "role": "${aws_iam_role.nodes-minimal-json-example-com.name}",
+        "tags": {
+          "KubernetesCluster": "minimal-json.example.com",
+          "Name": "nodes.minimal-json.example.com",
+          "kubernetes.io/cluster/minimal-json.example.com": "owned"
+        }
       }
     },
     "aws_iam_role": {

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -226,11 +226,21 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
 resource "aws_iam_instance_profile" "masters-minimal-example-com" {
   name = "masters.minimal.example.com"
   role = aws_iam_role.masters-minimal-example-com.name
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-example-com" {
   name = "nodes.minimal.example.com"
   role = aws_iam_role.nodes-minimal-example-com.name
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-minimal-example-com" {
@@ -628,7 +638,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -444,11 +444,21 @@ resource "aws_ebs_volume" "us-test-1c-etcd-main-mixedinstances-example-com" {
 resource "aws_iam_instance_profile" "masters-mixedinstances-example-com" {
   name = "masters.mixedinstances.example.com"
   role = aws_iam_role.masters-mixedinstances-example-com.name
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "masters.mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-mixedinstances-example-com" {
   name = "nodes.mixedinstances.example.com"
   role = aws_iam_role.nodes-mixedinstances-example-com.name
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "nodes.mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-mixedinstances-example-com" {
@@ -1044,7 +1054,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -444,11 +444,21 @@ resource "aws_ebs_volume" "us-test-1c-etcd-main-mixedinstances-example-com" {
 resource "aws_iam_instance_profile" "masters-mixedinstances-example-com" {
   name = "masters.mixedinstances.example.com"
   role = aws_iam_role.masters-mixedinstances-example-com.name
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "masters.mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-mixedinstances-example-com" {
   name = "nodes.mixedinstances.example.com"
   role = aws_iam_role.nodes-mixedinstances-example-com.name
+  tags = {
+    "KubernetesCluster"                                = "mixedinstances.example.com"
+    "Name"                                             = "nodes.mixedinstances.example.com"
+    "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-mixedinstances-example-com" {
@@ -1044,7 +1054,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -352,16 +352,31 @@ resource "aws_elb" "bastion-private-shared-ip-example-com" {
 resource "aws_iam_instance_profile" "bastions-private-shared-ip-example-com" {
   name = "bastions.private-shared-ip.example.com"
   role = aws_iam_role.bastions-private-shared-ip-example-com.name
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "bastions.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-private-shared-ip-example-com" {
   name = "masters.private-shared-ip.example.com"
   role = aws_iam_role.masters-private-shared-ip-example-com.name
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "masters.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-private-shared-ip-example-com" {
   name = "nodes.private-shared-ip.example.com"
   role = aws_iam_role.nodes-private-shared-ip-example-com.name
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "nodes.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-private-shared-ip-example-com" {
@@ -958,7 +973,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -347,16 +347,31 @@ resource "aws_elb" "bastion-private-shared-subnet-example-com" {
 resource "aws_iam_instance_profile" "bastions-private-shared-subnet-example-com" {
   name = "bastions.private-shared-subnet.example.com"
   role = aws_iam_role.bastions-private-shared-subnet-example-com.name
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "bastions.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-private-shared-subnet-example-com" {
   name = "masters.private-shared-subnet.example.com"
   role = aws_iam_role.masters-private-shared-subnet-example-com.name
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "masters.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-private-shared-subnet-example-com" {
   name = "nodes.private-shared-subnet.example.com"
   role = aws_iam_role.nodes-private-shared-subnet-example-com.name
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "nodes.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-private-shared-subnet-example-com" {
@@ -875,7 +890,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -366,16 +366,31 @@ resource "aws_elb" "bastion-privatecalico-example-com" {
 resource "aws_iam_instance_profile" "bastions-privatecalico-example-com" {
   name = "bastions.privatecalico.example.com"
   role = aws_iam_role.bastions-privatecalico-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "bastions.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privatecalico-example-com" {
   name = "masters.privatecalico.example.com"
   role = aws_iam_role.masters-privatecalico-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "masters.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecalico-example-com" {
   name = "nodes.privatecalico.example.com"
   role = aws_iam_role.nodes-privatecalico-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatecalico.example.com"
+    "Name"                                            = "nodes.privatecalico.example.com"
+    "kubernetes.io/cluster/privatecalico.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privatecalico-example-com" {
@@ -1016,7 +1031,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -366,16 +366,31 @@ resource "aws_elb" "bastion-privatecanal-example-com" {
 resource "aws_iam_instance_profile" "bastions-privatecanal-example-com" {
   name = "bastions.privatecanal.example.com"
   role = aws_iam_role.bastions-privatecanal-example-com.name
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "bastions.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privatecanal-example-com" {
   name = "masters.privatecanal.example.com"
   role = aws_iam_role.masters-privatecanal-example-com.name
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "masters.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecanal-example-com" {
   name = "nodes.privatecanal.example.com"
   role = aws_iam_role.nodes-privatecanal-example-com.name
+  tags = {
+    "KubernetesCluster"                              = "privatecanal.example.com"
+    "Name"                                           = "nodes.privatecanal.example.com"
+    "kubernetes.io/cluster/privatecanal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privatecanal-example-com" {
@@ -1007,7 +1022,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -366,16 +366,31 @@ resource "aws_elb" "bastion-privatecilium-example-com" {
 resource "aws_iam_instance_profile" "bastions-privatecilium-example-com" {
   name = "bastions.privatecilium.example.com"
   role = aws_iam_role.bastions-privatecilium-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "bastions.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privatecilium-example-com" {
   name = "masters.privatecilium.example.com"
   role = aws_iam_role.masters-privatecilium-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "masters.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecilium-example-com" {
   name = "nodes.privatecilium.example.com"
   role = aws_iam_role.nodes-privatecilium-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "nodes.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privatecilium-example-com" {
@@ -1007,7 +1022,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -366,16 +366,31 @@ resource "aws_elb" "bastion-privatecilium-example-com" {
 resource "aws_iam_instance_profile" "bastions-privatecilium-example-com" {
   name = "bastions.privatecilium.example.com"
   role = aws_iam_role.bastions-privatecilium-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "bastions.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privatecilium-example-com" {
   name = "masters.privatecilium.example.com"
   role = aws_iam_role.masters-privatecilium-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "masters.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privatecilium-example-com" {
   name = "nodes.privatecilium.example.com"
   role = aws_iam_role.nodes-privatecilium-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatecilium.example.com"
+    "Name"                                            = "nodes.privatecilium.example.com"
+    "kubernetes.io/cluster/privatecilium.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privatecilium-example-com" {
@@ -1007,7 +1022,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -382,16 +382,31 @@ resource "aws_elb" "bastion-privateciliumadvanced-example-com" {
 resource "aws_iam_instance_profile" "bastions-privateciliumadvanced-example-com" {
   name = "bastions.privateciliumadvanced.example.com"
   role = aws_iam_role.bastions-privateciliumadvanced-example-com.name
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "bastions.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privateciliumadvanced-example-com" {
   name = "masters.privateciliumadvanced.example.com"
   role = aws_iam_role.masters-privateciliumadvanced-example-com.name
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "masters.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privateciliumadvanced-example-com" {
   name = "nodes.privateciliumadvanced.example.com"
   role = aws_iam_role.nodes-privateciliumadvanced-example-com.name
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "nodes.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privateciliumadvanced-example-com" {
@@ -1023,7 +1038,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -406,16 +406,37 @@ resource "aws_elb" "bastion-privatedns1-example-com" {
 resource "aws_iam_instance_profile" "bastions-privatedns1-example-com" {
   name = "bastions.privatedns1.example.com"
   role = aws_iam_role.bastions-privatedns1-example-com.name
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "bastions.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privatedns1-example-com" {
   name = "masters.privatedns1.example.com"
   role = aws_iam_role.masters-privatedns1-example-com.name
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "masters.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privatedns1-example-com" {
   name = "nodes.privatedns1.example.com"
   role = aws_iam_role.nodes-privatedns1-example-com.name
+  tags = {
+    "KubernetesCluster"                             = "privatedns1.example.com"
+    "Name"                                          = "nodes.privatedns1.example.com"
+    "Owner"                                         = "John Doe"
+    "foo/bar"                                       = "fib+baz"
+    "kubernetes.io/cluster/privatedns1.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privatedns1-example-com" {
@@ -1104,7 +1125,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -361,16 +361,31 @@ resource "aws_elb" "bastion-privatedns2-example-com" {
 resource "aws_iam_instance_profile" "bastions-privatedns2-example-com" {
   name = "bastions.privatedns2.example.com"
   role = aws_iam_role.bastions-privatedns2-example-com.name
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "bastions.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privatedns2-example-com" {
   name = "masters.privatedns2.example.com"
   role = aws_iam_role.masters-privatedns2-example-com.name
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "masters.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privatedns2-example-com" {
   name = "nodes.privatedns2.example.com"
   role = aws_iam_role.nodes-privatedns2-example-com.name
+  tags = {
+    "KubernetesCluster"                             = "privatedns2.example.com"
+    "Name"                                          = "nodes.privatedns2.example.com"
+    "kubernetes.io/cluster/privatedns2.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privatedns2-example-com" {
@@ -967,7 +982,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -366,16 +366,31 @@ resource "aws_elb" "bastion-privateflannel-example-com" {
 resource "aws_iam_instance_profile" "bastions-privateflannel-example-com" {
   name = "bastions.privateflannel.example.com"
   role = aws_iam_role.bastions-privateflannel-example-com.name
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "bastions.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privateflannel-example-com" {
   name = "masters.privateflannel.example.com"
   role = aws_iam_role.masters-privateflannel-example-com.name
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "masters.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privateflannel-example-com" {
   name = "nodes.privateflannel.example.com"
   role = aws_iam_role.nodes-privateflannel-example-com.name
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "nodes.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privateflannel-example-com" {
@@ -1007,7 +1022,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -372,16 +372,31 @@ resource "aws_elb" "bastion-privatekopeio-example-com" {
 resource "aws_iam_instance_profile" "bastions-privatekopeio-example-com" {
   name = "bastions.privatekopeio.example.com"
   role = aws_iam_role.bastions-privatekopeio-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "bastions.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privatekopeio-example-com" {
   name = "masters.privatekopeio.example.com"
   role = aws_iam_role.masters-privatekopeio-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "masters.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privatekopeio-example-com" {
   name = "nodes.privatekopeio.example.com"
   role = aws_iam_role.nodes-privatekopeio-example-com.name
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "nodes.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privatekopeio-example-com" {
@@ -1055,7 +1070,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -366,16 +366,31 @@ resource "aws_elb" "bastion-privateweave-example-com" {
 resource "aws_iam_instance_profile" "bastions-privateweave-example-com" {
   name = "bastions.privateweave.example.com"
   role = aws_iam_role.bastions-privateweave-example-com.name
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "bastions.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-privateweave-example-com" {
   name = "masters.privateweave.example.com"
   role = aws_iam_role.masters-privateweave-example-com.name
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "masters.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-privateweave-example-com" {
   name = "nodes.privateweave.example.com"
   role = aws_iam_role.nodes-privateweave-example-com.name
+  tags = {
+    "KubernetesCluster"                              = "privateweave.example.com"
+    "Name"                                           = "nodes.privateweave.example.com"
+    "kubernetes.io/cluster/privateweave.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-privateweave-example-com" {
@@ -1007,7 +1022,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/public-jwks/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks/kubernetes.tf
@@ -236,15 +236,30 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
 resource "aws_iam_instance_profile" "masters-minimal-example-com" {
   name = "masters.minimal.example.com"
   role = aws_iam_role.masters-minimal-example-com.name
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-minimal-example-com" {
   name = "nodes.minimal.example.com"
   role = aws_iam_role.nodes-minimal-example-com.name
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_openid_connect_provider" "minimal-example-com" {
-  client_id_list  = ["amazonaws.com"]
+  client_id_list = ["amazonaws.com"]
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
   thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280", "a9d53002e97e00e043244f3d170d6f4c414104fd"]
   url             = "https://discovery.example.com/minimal.example.com/oidc"
 }
@@ -660,7 +675,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -221,11 +221,21 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-sharedsubnet-example-com" {
 resource "aws_iam_instance_profile" "masters-sharedsubnet-example-com" {
   name = "masters.sharedsubnet.example.com"
   role = aws_iam_role.masters-sharedsubnet-example-com.name
+  tags = {
+    "KubernetesCluster"                              = "sharedsubnet.example.com"
+    "Name"                                           = "masters.sharedsubnet.example.com"
+    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-sharedsubnet-example-com" {
   name = "nodes.sharedsubnet.example.com"
   role = aws_iam_role.nodes-sharedsubnet-example-com.name
+  tags = {
+    "KubernetesCluster"                              = "sharedsubnet.example.com"
+    "Name"                                           = "nodes.sharedsubnet.example.com"
+    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-sharedsubnet-example-com" {
@@ -554,7 +564,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -221,11 +221,21 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-sharedvpc-example-com" {
 resource "aws_iam_instance_profile" "masters-sharedvpc-example-com" {
   name = "masters.sharedvpc.example.com"
   role = aws_iam_role.masters-sharedvpc-example-com.name
+  tags = {
+    "KubernetesCluster"                           = "sharedvpc.example.com"
+    "Name"                                        = "masters.sharedvpc.example.com"
+    "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-sharedvpc-example-com" {
   name = "nodes.sharedvpc.example.com"
   role = aws_iam_role.nodes-sharedvpc-example-com.name
+  tags = {
+    "KubernetesCluster"                           = "sharedvpc.example.com"
+    "Name"                                        = "nodes.sharedvpc.example.com"
+    "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "masters-sharedvpc-example-com" {
@@ -588,7 +598,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -352,16 +352,31 @@ resource "aws_elb" "bastion-unmanaged-example-com" {
 resource "aws_iam_instance_profile" "bastions-unmanaged-example-com" {
   name = "bastions.unmanaged.example.com"
   role = aws_iam_role.bastions-unmanaged-example-com.name
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "bastions.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "masters-unmanaged-example-com" {
   name = "masters.unmanaged.example.com"
   role = aws_iam_role.masters-unmanaged-example-com.name
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "masters.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_instance_profile" "nodes-unmanaged-example-com" {
   name = "nodes.unmanaged.example.com"
   role = aws_iam_role.nodes-unmanaged-example-com.name
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "nodes.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
 }
 
 resource "aws_iam_role_policy" "bastions-unmanaged-example-com" {
@@ -932,7 +947,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -250,7 +250,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }
@@ -324,7 +324,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -106,21 +106,20 @@ func (_ *IAMInstanceProfileRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 			return fmt.Errorf("error creating IAMInstanceProfileRole: %v", err)
 		}
 	}
-
-	// TODO: Should we use path as our tag?
-	return nil // No tags in IAM
+	return nil
 }
 
 type terraformIAMInstanceProfile struct {
 	Name *string            `json:"name" cty:"name"`
 	Role *terraform.Literal `json:"role" cty:"role"`
-	// TODO(rifelpet): add tags field when terraform supports it
+	Tags map[string]string  `json:"tags,omitempty" cty:"tags"`
 }
 
 func (_ *IAMInstanceProfileRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMInstanceProfileRole) error {
 	tf := &terraformIAMInstanceProfile{
 		Name: e.InstanceProfile.Name,
 		Role: e.Role.TerraformLink(),
+		Tags: e.InstanceProfile.Tags,
 	}
 
 	return t.RenderResource("aws_iam_instance_profile", *e.InstanceProfile.Name, tf)
@@ -129,6 +128,7 @@ func (_ *IAMInstanceProfileRole) RenderTerraform(t *terraform.TerraformTarget, a
 type cloudformationIAMInstanceProfile struct {
 	InstanceProfileName *string                   `json:"InstanceProfileName"`
 	Roles               []*cloudformation.Literal `json:"Roles"`
+	// TODO: Add tags when Cloudformation supports them
 }
 
 func (_ *IAMInstanceProfileRole) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *IAMInstanceProfileRole) error {

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
@@ -187,6 +187,7 @@ type terraformIAMOIDCProvider struct {
 	ThumbprintList []*string `json:"thumbprint_list" cty:"thumbprint_list"`
 
 	AssumeRolePolicy *terraform.Literal `json:"assume_role_policy" cty:"assume_role_policy"`
+	Tags             map[string]string  `json:"tags,omitempty" cty:"tags"`
 }
 
 func (p *IAMOIDCProvider) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMOIDCProvider) error {
@@ -195,6 +196,7 @@ func (p *IAMOIDCProvider) RenderTerraform(t *terraform.TerraformTarget, a, e, ch
 		URL:            e.URL,
 		ClientIDList:   e.ClientIDs,
 		ThumbprintList: e.Thumbprints,
+		Tags:           e.Tags,
 	}
 
 	return t.RenderResource("aws_iam_openid_connect_provider", *e.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -247,9 +247,7 @@ func (_ *IAMRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRole) error
 			}
 		}
 	}
-
-	// TODO: Should we use path as our tag?
-	return nil // No tags in IAM
+	return nil
 }
 
 type terraformIAMRole struct {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -98,7 +98,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }
@@ -184,7 +184,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 2.46.0"
+      "version" = ">= 3.34.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -98,7 +98,7 @@ func (t *TerraformTarget) finishHCL2(taskMap map[string]fi.Task) error {
 	} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
 		writeMap(requiredProvidersBody, "aws", map[string]cty.Value{
 			"source":  cty.StringVal("hashicorp/aws"),
-			"version": cty.StringVal(">= 2.46.0"),
+			"version": cty.StringVal(">= 3.34.0"),
 		})
 		if featureflag.Spotinst.Enabled() {
 			writeMap(requiredProvidersBody, "spotinst", map[string]cty.Value{


### PR DESCRIPTION
This requires updating the minimum provider to the most recent version since [3.44.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3340-march-26-2021) is when the tagging support was added.

I reviewed the [3.X upgrade guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_security_group) and none of it was relevant to us.