### PR TITLE
Clarify release notes around exporting kubeconfig

### DIFF
--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -8,7 +8,7 @@
 
 ## Changes to kubernetes config export
 
-kOps will no longer automatically export the kubernetes config on `kops update cluster`. In order to export the config on cluster update, you need to either add the `--user <user>` to reference an existing user, or `--admin` to export the cluster admin user. If neither flag is passed, the kubernetes config will not be modified. This makes it easier to reuse user definitions across clusters should you, for example, use OIDC for authentication.
+kOps will no longer automatically export user credentials on `kops update cluster`. In order to export user credentials on cluster update, you need to either add the `--user <user>` to reference an existing user block in kubeconfig, or `--admin` to export the cluster admin user. If neither flag is passed, the kubernetes user config will not be modified. This makes it easier to reuse user definitions across clusters should you, for example, use OIDC for authentication.
 
 Similarly, `kops export kubecfg` will also require passing either the `--admin` or `--user` flag if the context does not already exist.
 


### PR DESCRIPTION
Make a clearer distinction between exporting kubeconfig (including
server endpoints / certificates) vs exporting credentials.

Issue #11021