### PR TITLE
[WIP] Adding IPV6 support for aws vpc and subnet

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -425,6 +425,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 			group.Spec.MachineType = c.NodeSize
 		}
 	}
+
 	if c.Image != "" {
 		for _, group := range instanceGroups {
 			group.Spec.Image = c.Image
@@ -435,7 +436,6 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 			group.Spec.Image = c.MasterImage
 		}
 	}
-
 	if c.NodeImage != "" {
 		for _, group := range nodes {
 			group.Spec.Image = c.NodeImage

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -425,7 +425,6 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 			group.Spec.MachineType = c.NodeSize
 		}
 	}
-
 	if c.Image != "" {
 		for _, group := range instanceGroups {
 			group.Spec.Image = c.Image
@@ -436,6 +435,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 			group.Spec.Image = c.MasterImage
 		}
 	}
+
 	if c.NodeImage != "" {
 		for _, group := range nodes {
 			group.Spec.Image = c.NodeImage

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -69,11 +69,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              amazonProvidedIpv6CidrBlock:
-                description: IPv6NetworkCIDR is the IPv6 CIDR used for the AWS VPC
-                  This is a real CIDR, not the internal k8s network On AWS, it maps
-                  to the VPC CIDR.  It is not required on GCE.
-                type: boolean
               api:
                 description: API field controls how the API is exposed outside the
                   cluster

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -69,6 +69,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              amazonProvidedIpv6CidrBlock:
+                description: IPv6NetworkCIDR is the IPv6 CIDR used for the AWS VPC This is a real CIDR, not the internal k8s network On AWS, it maps to the VPC CIDR.  It is not required on GCE.
+                type: boolean
               api:
                 description: API field controls how the API is exposed outside the
                   cluster
@@ -4102,6 +4105,9 @@ spec:
                 description: Configuration of subnets we are targeting
                 items:
                   properties:
+                    awsIpv6SubnetNum:
+                      description: define aws subnet number in decimanl
+                      type: integer
                     cidr:
                       type: string
                     egress:

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -70,7 +70,9 @@ spec:
                   type: object
                 type: array
               amazonProvidedIpv6CidrBlock:
-                description: IPv6NetworkCIDR is the IPv6 CIDR used for the AWS VPC This is a real CIDR, not the internal k8s network On AWS, it maps to the VPC CIDR.  It is not required on GCE.
+                description: IPv6NetworkCIDR is the IPv6 CIDR used for the AWS VPC
+                  This is a real CIDR, not the internal k8s network On AWS, it maps
+                  to the VPC CIDR.  It is not required on GCE.
                 type: boolean
               api:
                 description: API field controls how the API is exposed outside the

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -639,6 +639,8 @@ type ClusterSubnetSpec struct {
 	Type SubnetType `json:"type,omitempty"`
 	// PublicIP to attach to NatGateway
 	PublicIP string `json:"publicIP,omitempty"`
+	// define aws subnet number in decimanl
+	AwsIpv6SubnetNum int `json:"awsIpv6SubnetNum,omitempty"`
 }
 
 type EgressProxySpec struct {

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -77,6 +77,10 @@ type ClusterSpec struct {
 	// This is a real CIDR, not the internal k8s network
 	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
 	NetworkCIDR string `json:"networkCIDR,omitempty"`
+	// IPv6NetworkCIDR is the IPv6 CIDR used for the AWS VPC
+	// This is a real CIDR, not the internal k8s network
+	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
+	AmazonProvidedIpv6CidrBlock bool `json:"amazonProvidedIpv6CidrBlock,omitempty"`
 	// AdditionalNetworkCIDRs is a list of additional CIDR used for the AWS VPC
 	// or otherwise allocated to k8s. This is a real CIDR, not the internal k8s network
 	// On AWS, it maps to any additional CIDRs added to a VPC.

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -77,10 +77,6 @@ type ClusterSpec struct {
 	// This is a real CIDR, not the internal k8s network
 	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
 	NetworkCIDR string `json:"networkCIDR,omitempty"`
-	// IPv6NetworkCIDR is the IPv6 CIDR used for the AWS VPC
-	// This is a real CIDR, not the internal k8s network
-	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
-	AmazonProvidedIpv6CidrBlock bool `json:"amazonProvidedIpv6CidrBlock,omitempty"`
 	// AdditionalNetworkCIDRs is a list of additional CIDR used for the AWS VPC
 	// or otherwise allocated to k8s. This is a real CIDR, not the internal k8s network
 	// On AWS, it maps to any additional CIDRs added to a VPC.

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -640,7 +640,7 @@ type ClusterSubnetSpec struct {
 	// PublicIP to attach to NatGateway
 	PublicIP string `json:"publicIP,omitempty"`
 	// define aws subnet number in decimanl
-	AwsIpv6SubnetNum int `json:"awsIpv6SubnetNum,omitempty"`
+	AwsIpv6SubnetNum *int `json:"awsIpv6SubnetNum,omitempty"`
 }
 
 type EgressProxySpec struct {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -73,10 +73,6 @@ type ClusterSpec struct {
 	// This is a real CIDR, not the internal k8s network
 	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
 	NetworkCIDR string `json:"networkCIDR,omitempty"`
-	// IPv6NetworkCIDR is the IPv6 CIDR used for the AWS VPC
-	// This is a real CIDR, not the internal k8s network
-	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
-	AmazonProvidedIpv6CidrBlock bool `json:"amazonProvidedIpv6CidrBlock,omitempty"`
 	// AdditionalNetworkCIDRs is a list of additional CIDR used for the AWS VPC
 	// or otherwise allocated to k8s. This is a real CIDR, not the internal k8s network
 	// On AWS, it maps to any additional CIDRs added to a VPC.

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -621,6 +621,8 @@ type ClusterSubnetSpec struct {
 	Type SubnetType `json:"type,omitempty"`
 	// PublicIP to attach to NatGateway
 	PublicIP string `json:"publicIP,omitempty"`
+	// define aws subnet number in decimanl
+	AwsIpv6SubnetNum int `json:"awsIpv6SubnetNum,omitempty"`
 }
 
 type EgressProxySpec struct {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -622,7 +622,7 @@ type ClusterSubnetSpec struct {
 	// PublicIP to attach to NatGateway
 	PublicIP string `json:"publicIP,omitempty"`
 	// define aws subnet number in decimanl
-	AwsIpv6SubnetNum int `json:"awsIpv6SubnetNum,omitempty"`
+	AwsIpv6SubnetNum *int `json:"awsIpv6SubnetNum,omitempty"`
 }
 
 type EgressProxySpec struct {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -73,6 +73,10 @@ type ClusterSpec struct {
 	// This is a real CIDR, not the internal k8s network
 	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
 	NetworkCIDR string `json:"networkCIDR,omitempty"`
+	// IPv6NetworkCIDR is the IPv6 CIDR used for the AWS VPC
+	// This is a real CIDR, not the internal k8s network
+	// On AWS, it maps to the VPC CIDR.  It is not required on GCE.
+	AmazonProvidedIpv6CidrBlock bool `json:"amazonProvidedIpv6CidrBlock,omitempty"`
 	// AdditionalNetworkCIDRs is a list of additional CIDR used for the AWS VPC
 	// or otherwise allocated to k8s. This is a real CIDR, not the internal k8s network
 	// On AWS, it maps to any additional CIDRs added to a VPC.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2231,6 +2231,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	out.MasterPublicName = in.MasterPublicName
 	out.MasterInternalName = in.MasterInternalName
 	out.NetworkCIDR = in.NetworkCIDR
+	out.AmazonProvidedIpv6CidrBlock = in.AmazonProvidedIpv6CidrBlock
 	out.AdditionalNetworkCIDRs = in.AdditionalNetworkCIDRs
 	out.NetworkID = in.NetworkID
 	if in.Topology != nil {
@@ -2625,6 +2626,7 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	out.MasterPublicName = in.MasterPublicName
 	out.MasterInternalName = in.MasterInternalName
 	out.NetworkCIDR = in.NetworkCIDR
+	out.AmazonProvidedIpv6CidrBlock = in.AmazonProvidedIpv6CidrBlock
 	out.AdditionalNetworkCIDRs = in.AdditionalNetworkCIDRs
 	out.NetworkID = in.NetworkID
 	if in.Topology != nil {
@@ -2987,6 +2989,7 @@ func autoConvert_v1alpha2_ClusterSubnetSpec_To_kops_ClusterSubnetSpec(in *Cluste
 	out.Egress = in.Egress
 	out.Type = kops.SubnetType(in.Type)
 	out.PublicIP = in.PublicIP
+	out.AwsIpv6SubnetNum = in.AwsIpv6SubnetNum
 	return nil
 }
 
@@ -3004,6 +3007,7 @@ func autoConvert_kops_ClusterSubnetSpec_To_v1alpha2_ClusterSubnetSpec(in *kops.C
 	out.Egress = in.Egress
 	out.Type = SubnetType(in.Type)
 	out.PublicIP = in.PublicIP
+	out.AwsIpv6SubnetNum = in.AwsIpv6SubnetNum
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2231,7 +2231,6 @@ func autoConvert_v1alpha2_ClusterSpec_To_kops_ClusterSpec(in *ClusterSpec, out *
 	out.MasterPublicName = in.MasterPublicName
 	out.MasterInternalName = in.MasterInternalName
 	out.NetworkCIDR = in.NetworkCIDR
-	out.AmazonProvidedIpv6CidrBlock = in.AmazonProvidedIpv6CidrBlock
 	out.AdditionalNetworkCIDRs = in.AdditionalNetworkCIDRs
 	out.NetworkID = in.NetworkID
 	if in.Topology != nil {
@@ -2626,7 +2625,6 @@ func autoConvert_kops_ClusterSpec_To_v1alpha2_ClusterSpec(in *kops.ClusterSpec, 
 	out.MasterPublicName = in.MasterPublicName
 	out.MasterInternalName = in.MasterInternalName
 	out.NetworkCIDR = in.NetworkCIDR
-	out.AmazonProvidedIpv6CidrBlock = in.AmazonProvidedIpv6CidrBlock
 	out.AdditionalNetworkCIDRs = in.AdditionalNetworkCIDRs
 	out.NetworkID = in.NetworkID
 	if in.Topology != nil {

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -84,6 +84,11 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			t.CIDR = fi.String(b.Cluster.Spec.NetworkCIDR)
 		}
 
+		if b.Cluster.Spec.AmazonProvidedIpv6CidrBlock {
+			fmt.Println("enableing ipv6")
+			t.AmazonProvidedIpv6CidrBlock = fi.Bool(true)
+		}
+
 		c.AddTask(t)
 	}
 

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -193,7 +193,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				c.AddTask(&awstasks.Route{
 					Name:            fi.String("ipv6-0.0.0.0/0"),
 					Lifecycle:       b.Lifecycle,
-					IPv6CIDR:        fi.String("::/0"),
+					CIDR:            fi.String("::/0"),
 					RouteTable:      publicRouteTable,
 					InternetGateway: igw,
 				})
@@ -238,10 +238,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			CIDR:             fi.String(subnetSpec.CIDR),
 			Shared:           fi.Bool(sharedSubnet),
 			Tags:             tags,
-		}
-
-		if ipv6Enabled {
-			subnet.AwsIpv6SubnetNum = fi.Int(subnetSpec.AwsIpv6SubnetNum)
+			AwsIpv6SubnetNum: subnetSpec.AwsIpv6SubnetNum,
 		}
 
 		if subnetSpec.ProviderID != "" {

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -191,9 +191,9 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			})
 			if ipv6Enabled {
 				c.AddTask(&awstasks.Route{
-					Name:            s("ipv6-0.0.0.0/0"),
+					Name:            fi.String("ipv6-0.0.0.0/0"),
 					Lifecycle:       b.Lifecycle,
-					IPv6CIDR:        s("::/0"),
+					IPv6CIDR:        fi.String("::/0"),
 					RouteTable:      publicRouteTable,
 					InternetGateway: igw,
 				})

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json
@@ -706,6 +706,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableminimalexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayminimalexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersminimalexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                                       = "minimal.example.com"
+  ipv6_vpc_cidr_block                                = aws_vpc.minimal-example-com.ipv6_cidr_block
   kube-system-aws-load-balancer-controller_role_arn  = aws_iam_role.aws-load-balancer-controller-kube-system-sa-minimal-example-com.arn
   kube-system-aws-load-balancer-controller_role_name = aws_iam_role.aws-load-balancer-controller-kube-system-sa-minimal-example-com.name
   kube-system-dns-controller_role_arn                = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.arn
@@ -22,6 +23,10 @@ locals {
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.minimal-example-com.ipv6_cidr_block
 }
 
 output "kube-system-aws-load-balancer-controller_role_arn" {
@@ -512,6 +517,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.minimal-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.minimal-example-com.id
+  route_table_id              = aws_route_table.minimal-example-com.id
+}
+
 resource "aws_route_table" "minimal-example-com" {
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
@@ -671,9 +682,10 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
 }
 
 resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "minimal.example.com"

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-bastionuserdata-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-bastionuserdata-example-com.name
   cluster_name                      = "bastionuserdata.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.bastionuserdata-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-bastionuserdata-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-bastionuserdata-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-bastionuserdata-example-com.arn
@@ -40,6 +41,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "bastionuserdata.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.bastionuserdata-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -693,6 +698,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.bastionuserdata-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.bastionuserdata-example-com.id
+  route_table_id              = aws_route_table.bastionuserdata-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-bastionuserdata-example-com.id
@@ -993,9 +1004,10 @@ resource "aws_subnet" "utility-us-test-1a-bastionuserdata-example-com" {
 }
 
 resource "aws_vpc" "bastionuserdata-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                                 = "bastionuserdata.example.com"
     "Name"                                              = "bastionuserdata.example.com"

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -646,6 +646,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTablecomplexexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewaycomplexexamplecom"
+        }
+      }
+    },
     "AWSEC2Routeprivateustest1a00000": {
       "Type": "AWS::EC2::Route",
       "Properties": {

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                      = "complex.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.complex-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-complex-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-complex-example-com.id, "sg-exampleid5", "sg-exampleid6"]
   masters_role_arn                  = aws_iam_role.masters-complex-example-com.arn
@@ -21,6 +22,10 @@ locals {
 
 output "cluster_name" {
   value = "complex.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.complex-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -599,6 +604,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.complex-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.complex-example-com.id
+  route_table_id              = aws_route_table.complex-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   route_table_id         = aws_route_table.private-us-test-1a-complex-example-com.id
@@ -974,9 +985,10 @@ resource "aws_subnet" "us-test-1a-complex-example-com" {
 }
 
 resource "aws_vpc" "complex-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "complex.example.com"

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "compress.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.compress-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-compress-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-compress-example-com.id]
   masters_role_arn             = aws_iam_role.masters-compress-example-com.arn
@@ -18,6 +19,10 @@ locals {
 
 output "cluster_name" {
   value = "compress.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.compress-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -437,6 +442,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.compress-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.compress-example-com.id
+  route_table_id              = aws_route_table.compress-example-com.id
+}
+
 resource "aws_route_table" "compress-example-com" {
   tags = {
     "KubernetesCluster"                          = "compress.example.com"
@@ -596,9 +607,10 @@ resource "aws_subnet" "us-test-1a-compress-example-com" {
 }
 
 resource "aws_vpc" "compress-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                          = "compress.example.com"
     "Name"                                       = "compress.example.com"

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json
@@ -503,6 +503,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTablecontainerdexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewaycontainerdexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommasterscontainerdexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/containerd/cloudformation.json
+++ b/tests/integration/update_cluster/containerd/cloudformation.json
@@ -503,6 +503,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTablecontainerdexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewaycontainerdexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommasterscontainerdexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json
@@ -503,6 +503,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTabledockerexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewaydockerexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersdockerexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "existing-iam.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.existing-iam-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-existing-iam-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-existing-iam-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-existing-iam-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-existing-iam-example-com.id]
   node_autoscaling_group_ids   = [aws_autoscaling_group.nodes-existing-iam-example-com.id]
@@ -16,6 +17,10 @@ locals {
 
 output "cluster_name" {
   value = "existing-iam.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.existing-iam-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -739,6 +744,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.existing-iam-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.existing-iam-example-com.id
+  route_table_id              = aws_route_table.existing-iam-example-com.id
+}
+
 resource "aws_route_table" "existing-iam-example-com" {
   tags = {
     "KubernetesCluster"                              = "existing-iam.example.com"
@@ -934,9 +945,10 @@ resource "aws_subnet" "us-test-1c-existing-iam-example-com" {
 }
 
 resource "aws_vpc" "existing-iam-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                              = "existing-iam.example.com"
     "Name"                                           = "existing-iam.example.com"

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
@@ -499,6 +499,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableminimalexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayminimalexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersminimalexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "existingsg.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.existingsg-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-existingsg-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-existingsg-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-existingsg-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-existingsg-example-com.id, "sg-master-1a", "sg-master-1b"]
   masters_role_arn             = aws_iam_role.masters-existingsg-example-com.arn
@@ -20,6 +21,10 @@ locals {
 
 output "cluster_name" {
   value = "existingsg.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.existingsg-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -840,6 +845,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.existingsg-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.existingsg-example-com.id
+  route_table_id              = aws_route_table.existingsg-example-com.id
+}
+
 resource "aws_route53_record" "api-existingsg-example-com" {
   alias {
     evaluate_target_health = false
@@ -1278,9 +1289,10 @@ resource "aws_subnet" "us-test-1c-existingsg-example-com" {
 }
 
 resource "aws_vpc" "existingsg-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                            = "existingsg.example.com"
     "Name"                                         = "existingsg.example.com"

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -519,6 +519,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableexternallbexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayexternallbexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersexternallbexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "externallb.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.externallb-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-externallb-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-externallb-example-com.id]
   masters_role_arn             = aws_iam_role.masters-externallb-example-com.arn
@@ -18,6 +19,10 @@ locals {
 
 output "cluster_name" {
   value = "externallb.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.externallb-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -453,6 +458,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.externallb-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.externallb-example-com.id
+  route_table_id              = aws_route_table.externallb-example-com.id
+}
+
 resource "aws_route_table" "externallb-example-com" {
   tags = {
     "KubernetesCluster"                            = "externallb.example.com"
@@ -612,9 +623,10 @@ resource "aws_subnet" "us-test-1a-externallb-example-com" {
 }
 
 resource "aws_vpc" "externallb-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                            = "externallb.example.com"
     "Name"                                         = "externallb.example.com"

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "externalpolicies.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.externalpolicies-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-externalpolicies-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-externalpolicies-example-com.id]
   masters_role_arn             = aws_iam_role.masters-externalpolicies-example-com.arn
@@ -18,6 +19,10 @@ locals {
 
 output "cluster_name" {
   value = "externalpolicies.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.externalpolicies-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -540,6 +545,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.externalpolicies-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.externalpolicies-example-com.id
+  route_table_id              = aws_route_table.externalpolicies-example-com.id
+}
+
 resource "aws_route53_record" "api-externalpolicies-example-com" {
   alias {
     evaluate_target_health = false
@@ -794,9 +805,10 @@ resource "aws_subnet" "us-test-1a-externalpolicies-example-com" {
 }
 
 resource "aws_vpc" "externalpolicies-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                                  = "externalpolicies.example.com"
     "Name"                                               = "externalpolicies.example.com"

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "ha.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.ha-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-ha-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-ha-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-ha-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-ha-example-com.id]
   masters_role_arn             = aws_iam_role.masters-ha-example-com.arn
@@ -20,6 +21,10 @@ locals {
 
 output "cluster_name" {
   value = "ha.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.ha-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -811,6 +816,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.ha-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.ha-example-com.id
+  route_table_id              = aws_route_table.ha-example-com.id
+}
+
 resource "aws_route_table" "ha-example-com" {
   tags = {
     "KubernetesCluster"                    = "ha.example.com"
@@ -1006,9 +1017,10 @@ resource "aws_subnet" "us-test-1c-ha-example-com" {
 }
 
 resource "aws_vpc" "ha-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                    = "ha.example.com"
     "Name"                                 = "ha.example.com"

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -2,6 +2,7 @@ locals {
   cluster_name                          = "minimal.example.com"
   default-myserviceaccount_role_arn     = aws_iam_role.myserviceaccount-default-sa-minimal-example-com.arn
   default-myserviceaccount_role_name    = aws_iam_role.myserviceaccount-default-sa-minimal-example-com.name
+  ipv6_vpc_cidr_block                   = aws_vpc.minimal-example-com.ipv6_cidr_block
   master_autoscaling_group_ids          = [aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id]
   master_security_group_ids             = [aws_security_group.masters-minimal-example-com.id]
   masters_role_arn                      = aws_iam_role.masters-minimal-example-com.arn
@@ -30,6 +31,10 @@ output "default-myserviceaccount_role_arn" {
 
 output "default-myserviceaccount_role_name" {
   value = aws_iam_role.myserviceaccount-default-sa-minimal-example-com.name
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.minimal-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -511,6 +516,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.minimal-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.minimal-example-com.id
+  route_table_id              = aws_route_table.minimal-example-com.id
+}
+
 resource "aws_route_table" "minimal-example-com" {
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
@@ -670,9 +681,10 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
 }
 
 resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "minimal.example.com"

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                      = "lifecyclephases.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.lifecyclephases-example-com.ipv6_cidr_block
   region                            = "us-test-1"
   route_table_private-us-test-1a_id = aws_route_table.private-us-test-1a-lifecyclephases-example-com.id
   route_table_public_id             = aws_route_table.lifecyclephases-example-com.id
@@ -11,6 +12,10 @@ locals {
 
 output "cluster_name" {
   value = "lifecyclephases.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.lifecyclephases-example-com.ipv6_cidr_block
 }
 
 output "region" {
@@ -79,6 +84,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.lifecyclephases-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.lifecyclephases-example-com.id
+  route_table_id              = aws_route_table.lifecyclephases-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-lifecyclephases-example-com.id
@@ -142,9 +153,10 @@ resource "aws_subnet" "utility-us-test-1a-lifecyclephases-example-com" {
 }
 
 resource "aws_vpc" "lifecyclephases-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                                 = "lifecyclephases.example.com"
     "Name"                                              = "lifecyclephases.example.com"

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -503,6 +503,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableminimalexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayminimalexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersminimalexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/minimal-etcd/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-etcd/cloudformation.json
@@ -503,6 +503,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableminimaletcdexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayminimaletcdexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersminimaletcdexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json
@@ -499,6 +499,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableminimalexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayminimalexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersminimalexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "minimal.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.minimal-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-minimal-example-com.id]
   masters_role_arn             = aws_iam_role.masters-minimal-example-com.arn
@@ -18,6 +19,10 @@ locals {
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.minimal-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -445,6 +450,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.minimal-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.minimal-example-com.id
+  route_table_id              = aws_route_table.minimal-example-com.id
+}
+
 resource "aws_route_table" "minimal-example-com" {
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
@@ -604,9 +615,10 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
 }
 
 resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "minimal.example.com"

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -1,6 +1,7 @@
 {
   "locals": {
     "cluster_name": "minimal-json.example.com",
+    "ipv6_vpc_cidr_block": "${aws_vpc.minimal-json-example-com.ipv6_cidr_block}",
     "master_autoscaling_group_ids": [
       "${aws_autoscaling_group.master-us-test-1a-masters-minimal-json-example-com.id}"
     ],
@@ -29,6 +30,9 @@
   "output": {
     "cluster_name": {
       "value": "minimal-json.example.com"
+    },
+    "ipv6_vpc_cidr_block": {
+      "value": "${aws_vpc.minimal-json-example-com.ipv6_cidr_block}"
     },
     "master_autoscaling_group_ids": {
       "value": [
@@ -509,6 +513,11 @@
         "route_table_id": "${aws_route_table.minimal-json-example-com.id}",
         "destination_cidr_block": "0.0.0.0/0",
         "gateway_id": "${aws_internet_gateway.minimal-json-example-com.id}"
+      },
+      "route-ipv6-default": {
+        "route_table_id": "${aws_route_table.minimal-json-example-com.id}",
+        "destination_ipv6_cidr_block": "::/0",
+        "gateway_id": "${aws_internet_gateway.minimal-json-example-com.id}"
       }
     },
     "aws_route_table": {
@@ -681,7 +690,8 @@
           "KubernetesCluster": "minimal-json.example.com",
           "Name": "minimal-json.example.com",
           "kubernetes.io/cluster/minimal-json.example.com": "owned"
-        }
+        },
+        "assign_generated_ipv6_cidr_block": true
       }
     },
     "aws_vpc_dhcp_options": {

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "minimal.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.minimal-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-minimal-example-com.id]
   masters_role_arn             = aws_iam_role.masters-minimal-example-com.arn
@@ -18,6 +19,10 @@ locals {
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.minimal-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -449,6 +454,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.minimal-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.minimal-example-com.id
+  route_table_id              = aws_route_table.minimal-example-com.id
+}
+
 resource "aws_route_table" "minimal-example-com" {
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
@@ -608,9 +619,10 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
 }
 
 resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "minimal.example.com"

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -988,6 +988,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTablemixedinstancesexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewaymixedinstancesexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersmixedinstancesexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "mixedinstances.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.mixedinstances-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-mixedinstances-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-mixedinstances-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-mixedinstances-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-mixedinstances-example-com.id]
   masters_role_arn             = aws_iam_role.masters-mixedinstances-example-com.arn
@@ -20,6 +21,10 @@ locals {
 
 output "cluster_name" {
   value = "mixedinstances.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.mixedinstances-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -829,6 +834,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.mixedinstances-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.mixedinstances-example-com.id
+  route_table_id              = aws_route_table.mixedinstances-example-com.id
+}
+
 resource "aws_route_table" "mixedinstances-example-com" {
   tags = {
     "KubernetesCluster"                                = "mixedinstances.example.com"
@@ -1024,9 +1035,10 @@ resource "aws_subnet" "us-test-1c-mixedinstances-example-com" {
 }
 
 resource "aws_vpc" "mixedinstances-example-com" {
-  cidr_block           = "10.0.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "10.0.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                                = "mixedinstances.example.com"
     "Name"                                             = "mixedinstances.example.com"

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -989,6 +989,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTablemixedinstancesexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewaymixedinstancesexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersmixedinstancesexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "mixedinstances.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.mixedinstances-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-mixedinstances-example-com.id, aws_autoscaling_group.master-us-test-1b-masters-mixedinstances-example-com.id, aws_autoscaling_group.master-us-test-1c-masters-mixedinstances-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-mixedinstances-example-com.id]
   masters_role_arn             = aws_iam_role.masters-mixedinstances-example-com.arn
@@ -20,6 +21,10 @@ locals {
 
 output "cluster_name" {
   value = "mixedinstances.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.mixedinstances-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -829,6 +834,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.mixedinstances-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.mixedinstances-example-com.id
+  route_table_id              = aws_route_table.mixedinstances-example-com.id
+}
+
 resource "aws_route_table" "mixedinstances-example-com" {
   tags = {
     "KubernetesCluster"                                = "mixedinstances.example.com"
@@ -1024,9 +1035,10 @@ resource "aws_subnet" "us-test-1c-mixedinstances-example-com" {
 }
 
 resource "aws_vpc" "mixedinstances-example-com" {
-  cidr_block           = "10.0.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "10.0.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                                = "mixedinstances.example.com"
     "Name"                                             = "mixedinstances.example.com"

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
@@ -553,6 +553,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTablenthsqsresourcesexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewaynthsqsresourcesexamplecom"
+        }
+      }
+    },
     "AWSEC2SecurityGroupEgressfrommastersnthsqsresourcesexamplecomegressall0to000000": {
       "Type": "AWS::EC2::SecurityGroupEgress",
       "Properties": {

--- a/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
+++ b/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "nthsqsresources.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.nthsqsresources-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-nthsqsresources-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-nthsqsresources-example-com.id]
   masters_role_arn             = aws_iam_role.masters-nthsqsresources-example-com.arn
@@ -18,6 +19,10 @@ locals {
 
 output "cluster_name" {
   value = "nthsqsresources.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.nthsqsresources-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -526,6 +531,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.nthsqsresources-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.nthsqsresources-example-com.id
+  route_table_id              = aws_route_table.nthsqsresources-example-com.id
+}
+
 resource "aws_route_table" "nthsqsresources-example-com" {
   tags = {
     "KubernetesCluster"                                 = "nthsqsresources.example.com"
@@ -696,9 +707,10 @@ resource "aws_subnet" "us-test-1a-nthsqsresources-example-com" {
 }
 
 resource "aws_vpc" "nthsqsresources-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                                 = "nthsqsresources.example.com"
     "Name"                                              = "nthsqsresources.example.com"

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -704,6 +704,16 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableprivatesharedipexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": "igw-1"
+      }
+    },
     "AWSEC2Routeprivateustest1a00000": {
       "Type": "AWS::EC2::Route",
       "Properties": {

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -669,6 +669,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.private-shared-ip-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = "igw-1"
+  route_table_id              = aws_route_table.private-shared-ip-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-private-shared-ip-example-com.id

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -777,6 +777,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableprivatecalicoexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayprivatecalicoexamplecom"
+        }
+      }
+    },
     "AWSEC2Routeprivateustest1a00000": {
       "Type": "AWS::EC2::Route",
       "Properties": {

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-privatecalico-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-privatecalico-example-com.name
   cluster_name                      = "privatecalico.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.privatecalico-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-privatecalico-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-privatecalico-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-privatecalico-example-com.arn
@@ -40,6 +41,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "privatecalico.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.privatecalico-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -692,6 +697,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privatecalico-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.privatecalico-example-com.id
+  route_table_id              = aws_route_table.privatecalico-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-privatecalico-example-com.id
@@ -1001,9 +1012,10 @@ resource "aws_subnet" "utility-us-test-1a-privatecalico-example-com" {
 }
 
 resource "aws_vpc" "privatecalico-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                               = "privatecalico.example.com"
     "Name"                                            = "privatecalico.example.com"

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-privatecanal-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-privatecanal-example-com.name
   cluster_name                      = "privatecanal.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.privatecanal-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-privatecanal-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-privatecanal-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-privatecanal-example-com.arn
@@ -40,6 +41,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "privatecanal.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.privatecanal-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -692,6 +697,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privatecanal-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.privatecanal-example-com.id
+  route_table_id              = aws_route_table.privatecanal-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-privatecanal-example-com.id
@@ -992,9 +1003,10 @@ resource "aws_subnet" "utility-us-test-1a-privatecanal-example-com" {
 }
 
 resource "aws_vpc" "privatecanal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                              = "privatecanal.example.com"
     "Name"                                           = "privatecanal.example.com"

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -777,6 +777,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableprivateciliumexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayprivateciliumexamplecom"
+        }
+      }
+    },
     "AWSEC2Routeprivateustest1a00000": {
       "Type": "AWS::EC2::Route",
       "Properties": {

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-privatecilium-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-privatecilium-example-com.name
   cluster_name                      = "privatecilium.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.privatecilium-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-privatecilium-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-privatecilium-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-privatecilium-example-com.arn
@@ -40,6 +41,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "privatecilium.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.privatecilium-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -692,6 +697,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privatecilium-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.privatecilium-example-com.id
+  route_table_id              = aws_route_table.privatecilium-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-privatecilium-example-com.id
@@ -992,9 +1003,10 @@ resource "aws_subnet" "utility-us-test-1a-privatecilium-example-com" {
 }
 
 resource "aws_vpc" "privatecilium-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "privatecilium.example.com"

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -777,6 +777,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableprivateciliumexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayprivateciliumexamplecom"
+        }
+      }
+    },
     "AWSEC2Routeprivateustest1a00000": {
       "Type": "AWS::EC2::Route",
       "Properties": {

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-privatecilium-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-privatecilium-example-com.name
   cluster_name                      = "privatecilium.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.privatecilium-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-privatecilium-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-privatecilium-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-privatecilium-example-com.arn
@@ -40,6 +41,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "privatecilium.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.privatecilium-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -692,6 +697,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privatecilium-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.privatecilium-example-com.id
+  route_table_id              = aws_route_table.privatecilium-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-privatecilium-example-com.id
@@ -992,9 +1003,10 @@ resource "aws_subnet" "utility-us-test-1a-privatecilium-example-com" {
 }
 
 resource "aws_vpc" "privatecilium-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                               = "privatecilium.example.com"
     "Name"                                            = "privatecilium.example.com"

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -777,6 +777,18 @@
         ]
       }
     },
+    "AWSEC2Routeipv6default": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "AWSEC2RouteTableprivateciliumadvancedexamplecom"
+        },
+        "DestinationCidrBlock": "::/0",
+        "GatewayId": {
+          "Ref": "AWSEC2InternetGatewayprivateciliumadvancedexamplecom"
+        }
+      }
+    },
     "AWSEC2Routeprivateustest1a00000": {
       "Type": "AWS::EC2::Route",
       "Properties": {

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-privateciliumadvanced-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-privateciliumadvanced-example-com.name
   cluster_name                      = "privateciliumadvanced.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.privateciliumadvanced-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-privateciliumadvanced-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-privateciliumadvanced-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-privateciliumadvanced-example-com.arn
@@ -40,6 +41,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "privateciliumadvanced.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.privateciliumadvanced-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -708,6 +713,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privateciliumadvanced-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.privateciliumadvanced-example-com.id
+  route_table_id              = aws_route_table.privateciliumadvanced-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-privateciliumadvanced-example-com.id
@@ -1008,9 +1019,10 @@ resource "aws_subnet" "utility-us-test-1a-privateciliumadvanced-example-com" {
 }
 
 resource "aws_vpc" "privateciliumadvanced-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
     "Name"                                                    = "privateciliumadvanced.example.com"

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-privatedns1-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-privatedns1-example-com.name
   cluster_name                      = "privatedns1.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.privatedns1-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-privatedns1-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-privatedns1-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-privatedns1-example-com.arn
@@ -40,6 +41,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "privatedns1.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.privatedns1-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -768,6 +773,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privatedns1-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.privatedns1-example-com.id
+  route_table_id              = aws_route_table.privatedns1-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-privatedns1-example-com.id
@@ -1091,9 +1102,10 @@ resource "aws_subnet" "utility-us-test-1a-privatedns1-example-com" {
 }
 
 resource "aws_vpc" "privatedns1-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                             = "privatedns1.example.com"
     "Name"                                          = "privatedns1.example.com"

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -678,6 +678,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privatedns2-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = "igw-1"
+  route_table_id              = aws_route_table.privatedns2-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-privatedns2-example-com.id

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-privateflannel-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-privateflannel-example-com.name
   cluster_name                      = "privateflannel.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.privateflannel-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-privateflannel-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-privateflannel-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-privateflannel-example-com.arn
@@ -40,6 +41,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "privateflannel.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.privateflannel-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -692,6 +697,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privateflannel-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.privateflannel-example-com.id
+  route_table_id              = aws_route_table.privateflannel-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-privateflannel-example-com.id
@@ -992,9 +1003,10 @@ resource "aws_subnet" "utility-us-test-1a-privateflannel-example-com" {
 }
 
 resource "aws_vpc" "privateflannel-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                                = "privateflannel.example.com"
     "Name"                                             = "privateflannel.example.com"

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-privatekopeio-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-privatekopeio-example-com.name
   cluster_name                      = "privatekopeio.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.privatekopeio-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-privatekopeio-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-privatekopeio-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-privatekopeio-example-com.arn
@@ -43,6 +44,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "privatekopeio.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.privatekopeio-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -688,6 +693,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privatekopeio-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.privatekopeio-example-com.id
+  route_table_id              = aws_route_table.privatekopeio-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "nat-a2345678"
@@ -1040,9 +1051,10 @@ resource "aws_subnet" "utility-us-test-1b-privatekopeio-example-com" {
 }
 
 resource "aws_vpc" "privatekopeio-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                               = "privatekopeio.example.com"
     "Name"                                            = "privatekopeio.example.com"

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -4,6 +4,7 @@ locals {
   bastions_role_arn                 = aws_iam_role.bastions-privateweave-example-com.arn
   bastions_role_name                = aws_iam_role.bastions-privateweave-example-com.name
   cluster_name                      = "privateweave.example.com"
+  ipv6_vpc_cidr_block               = aws_vpc.privateweave-example-com.ipv6_cidr_block
   master_autoscaling_group_ids      = [aws_autoscaling_group.master-us-test-1a-masters-privateweave-example-com.id]
   master_security_group_ids         = [aws_security_group.masters-privateweave-example-com.id]
   masters_role_arn                  = aws_iam_role.masters-privateweave-example-com.arn
@@ -40,6 +41,10 @@ output "bastions_role_name" {
 
 output "cluster_name" {
   value = "privateweave.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.privateweave-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -692,6 +697,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.privateweave-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.privateweave-example-com.id
+  route_table_id              = aws_route_table.privateweave-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1a-privateweave-example-com.id
@@ -992,9 +1003,10 @@ resource "aws_subnet" "utility-us-test-1a-privateweave-example-com" {
 }
 
 resource "aws_vpc" "privateweave-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                              = "privateweave.example.com"
     "Name"                                           = "privateweave.example.com"

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                         = "minimal.example.com"
+  ipv6_vpc_cidr_block                  = aws_vpc.minimal-example-com.ipv6_cidr_block
   kube-system-dns-controller_role_arn  = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.arn
   kube-system-dns-controller_role_name = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.name
   master_autoscaling_group_ids         = [aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id]
@@ -20,6 +21,10 @@ locals {
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.minimal-example-com.ipv6_cidr_block
 }
 
 output "kube-system-dns-controller_role_arn" {
@@ -486,6 +491,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.minimal-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.minimal-example-com.id
+  route_table_id              = aws_route_table.minimal-example-com.id
+}
+
 resource "aws_route_table" "minimal-example-com" {
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
@@ -645,9 +656,10 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
 }
 
 resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "minimal.example.com"

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -435,6 +435,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.sharedvpc-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = "igw-1"
+  route_table_id              = aws_route_table.sharedvpc-example-com.id
+}
+
 resource "aws_route_table" "sharedvpc-example-com" {
   tags = {
     "KubernetesCluster"                           = "sharedvpc.example.com"

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -1,5 +1,6 @@
 locals {
   cluster_name                 = "minimal.example.com"
+  ipv6_vpc_cidr_block          = aws_vpc.minimal-example-com.ipv6_cidr_block
   master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id]
   master_security_group_ids    = [aws_security_group.masters-minimal-example-com.id]
   masters_role_arn             = aws_iam_role.masters-minimal-example-com.arn
@@ -18,6 +19,10 @@ locals {
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "ipv6_vpc_cidr_block" {
+  value = aws_vpc.minimal-example-com.ipv6_cidr_block
 }
 
 output "master_autoscaling_group_ids" {
@@ -460,6 +465,12 @@ resource "aws_route" "route-0-0-0-0--0" {
   route_table_id         = aws_route_table.minimal-example-com.id
 }
 
+resource "aws_route" "route-ipv6-default" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.minimal-example-com.id
+  route_table_id              = aws_route_table.minimal-example-com.id
+}
+
 resource "aws_route_table" "minimal-example-com" {
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
@@ -619,9 +630,10 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
 }
 
 resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "172.20.0.0/16"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "minimal.example.com"

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -238,13 +238,13 @@ func checkNotNil(s *string) *string {
 }
 
 type terraformRoute struct {
-	RouteTableID      *terraform.Literal `json:"route_table_id" cty:"route_table_id"`
-	CIDR              *string            `json:"destination_cidr_block,omitempty" cty:"destination_cidr_block"`
-	IPv6CIDR          *string            `json:"destination_ipv6_cidr_block,omitempty" cty:"destination_ipv6_cidr_block"`
-	InternetGatewayID *terraform.Literal `json:"gateway_id,omitempty" cty:"gateway_id"`
-	NATGatewayID      *terraform.Literal `json:"nat_gateway_id,omitempty" cty:"nat_gateway_id"`
-	TransitGatewayID  *string            `json:"transit_gateway_id,omitempty" cty:"transit_gateway_id"`
-	InstanceID        *terraform.Literal `json:"instance_id,omitempty" cty:"instance_id"`
+	RouteTableID      *terraformWriter.Literal `json:"route_table_id" cty:"route_table_id"`
+	CIDR              *string                  `json:"destination_cidr_block,omitempty" cty:"destination_cidr_block"`
+	IPv6CIDR          *string                  `json:"destination_ipv6_cidr_block,omitempty" cty:"destination_ipv6_cidr_block"`
+	InternetGatewayID *terraformWriter.Literal `json:"gateway_id,omitempty" cty:"gateway_id"`
+	NATGatewayID      *terraformWriter.Literal `json:"nat_gateway_id,omitempty" cty:"nat_gateway_id"`
+	TransitGatewayID  *string                  `json:"transit_gateway_id,omitempty" cty:"transit_gateway_id"`
+	InstanceID        *terraformWriter.Literal `json:"instance_id,omitempty" cty:"instance_id"`
 }
 
 func (_ *Route) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Route) error {

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -19,6 +19,8 @@ package awstasks
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
@@ -37,7 +39,6 @@ type Route struct {
 	RouteTable *RouteTable
 	Instance   *Instance
 	CIDR       *string
-	IPv6CIDR   *string
 
 	// Exactly one of the below fields
 	// MUST be provided.
@@ -124,7 +125,7 @@ func (s *Route) CheckChanges(a, e, changes *Route) error {
 		if e.RouteTable == nil {
 			return fi.RequiredField("RouteTable")
 		}
-		if e.CIDR == nil && e.IPv6CIDR == nil {
+		if e.CIDR == nil {
 			return fi.RequiredField("CIDR")
 		}
 		targetCount := 0
@@ -252,10 +253,10 @@ func (_ *Route) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Rou
 		RouteTableID: e.RouteTable.TerraformLink(),
 	}
 
-	if e.CIDR != nil {
+	if strings.Contains(*e.CIDR, ".") {
 		tf.CIDR = e.CIDR
 	} else {
-		tf.IPv6CIDR = e.IPv6CIDR
+		tf.IPv6CIDR = e.CIDR
 	}
 
 	if e.InternetGateway == nil && e.NatGateway == nil && e.TransitGatewayID == nil {

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -221,7 +221,7 @@ type terraformSubnet struct {
 	CIDR             *string            `json:"cidr_block" cty:"cidr_block"`
 	AvailabilityZone *string            `json:"availability_zone" cty:"availability_zone"`
 	Tags             map[string]string  `json:"tags,omitempty" cty:"tags"`
-	Ipv6_CIDR        *terraform.Literal `json:"ipv6_cidr_block:omitempty" cty:"ipv6_cidr_block"`
+	Ipv6_CIDR        *terraform.Literal `json:"ipv6_cidr_block,omitempty" cty:"ipv6_cidr_block"`
 }
 
 func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Subnet) error {

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -217,11 +217,11 @@ func subnetSlicesEqualIgnoreOrder(l, r []*Subnet) bool {
 }
 
 type terraformSubnet struct {
-	VPCID            *terraform.Literal `json:"vpc_id" cty:"vpc_id"`
-	CIDR             *string            `json:"cidr_block" cty:"cidr_block"`
-	AvailabilityZone *string            `json:"availability_zone" cty:"availability_zone"`
-	Tags             map[string]string  `json:"tags,omitempty" cty:"tags"`
-	Ipv6_CIDR        *terraform.Literal `json:"ipv6_cidr_block,omitempty" cty:"ipv6_cidr_block"`
+	VPCID            *terraformWriter.Literal `json:"vpc_id" cty:"vpc_id"`
+	CIDR             *string                  `json:"cidr_block" cty:"cidr_block"`
+	AvailabilityZone *string                  `json:"availability_zone" cty:"availability_zone"`
+	Tags             map[string]string        `json:"tags,omitempty" cty:"tags"`
+	Ipv6_CIDR        *terraformWriter.Literal `json:"ipv6_cidr_block,omitempty" cty:"ipv6_cidr_block"`
 }
 
 func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Subnet) error {
@@ -249,9 +249,10 @@ func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Su
 		AvailabilityZone: e.AvailabilityZone,
 		Tags:             e.Tags,
 	}
-	netnum := fi.IntValue(e.AwsIpv6SubnetNum)
-	if netnum > 0 {
-		tf.Ipv6_CIDR = terraform.LiteralCidrsubnetExpression(e.VPC.TerraformIpv6CidrLink(), 8, netnum)
+	netnum := e.AwsIpv6SubnetNum
+	if netnum != nil {
+		// newbits will always be 8 for aws subnet
+		tf.Ipv6_CIDR = terraformWriter.LiteralCidrsubnetExpression(e.VPC.TerraformIpv6CidrLink(), fi.Int(8), netnum)
 	}
 
 	return t.RenderResource("aws_subnet", *e.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -221,7 +221,7 @@ type terraformSubnet struct {
 	CIDR             *string                  `json:"cidr_block" cty:"cidr_block"`
 	AvailabilityZone *string                  `json:"availability_zone" cty:"availability_zone"`
 	Tags             map[string]string        `json:"tags,omitempty" cty:"tags"`
-	Ipv6_CIDR        *terraformWriter.Literal `json:"ipv6_cidr_block,omitempty" cty:"ipv6_cidr_block"`
+	IPv6CIDR         *terraformWriter.Literal `json:"ipv6_cidr_block,omitempty" cty:"ipv6_cidr_block"`
 }
 
 func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Subnet) error {
@@ -252,7 +252,7 @@ func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Su
 	netnum := e.AwsIpv6SubnetNum
 	if netnum != nil {
 		// newbits will always be 8 for aws subnet
-		tf.Ipv6_CIDR = terraformWriter.LiteralCidrsubnetExpression(e.VPC.TerraformIpv6CidrLink(), fi.Int(8), netnum)
+		tf.IPv6CIDR = terraformWriter.LiteralCidrsubnetExpression(e.VPC.TerraformIpv6CidrLink(), fi.Int(8), netnum)
 	}
 
 	return t.RenderResource("aws_subnet", *e.Name, tf)

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -277,10 +277,11 @@ func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) 
 	}
 
 	tf := &terraformVPC{
-		CIDR:               e.CIDR,
-		Tags:               e.Tags,
-		EnableDNSHostnames: e.EnableDNSHostnames,
-		EnableDNSSupport:   e.EnableDNSSupport,
+		CIDR:                        e.CIDR,
+		Tags:                        e.Tags,
+		EnableDNSHostnames:          e.EnableDNSHostnames,
+		EnableDNSSupport:            e.EnableDNSSupport,
+		AmazonProvidedIpv6CidrBlock: e.AmazonProvidedIpv6CidrBlock,
 	}
 
 	return t.RenderResource("aws_vpc", *e.Name, tf)
@@ -298,6 +299,14 @@ func (e *VPC) TerraformLink() *terraformWriter.Literal {
 	}
 
 	return terraformWriter.LiteralProperty("aws_vpc", *e.Name, "id")
+}
+
+func (e *VPC) TerraformIpv6CidrLink() *terraform.Literal {
+	shared := fi.BoolValue(e.Shared)
+	if shared {
+		klog.Fatalf("only kops managed VPC is supported: %s", e)
+	}
+	return terraform.LiteralProperty("aws_vpc", *e.Name, "ipv6_cidr_block")
 }
 
 type cloudformationVPC struct {

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -263,6 +263,11 @@ func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) 
 	if err := t.AddOutputVariable("vpc_id", e.TerraformLink()); err != nil {
 		return err
 	}
+	if fi.BoolValue(e.AmazonProvidedIpv6CidrBlock) {
+		if err := t.AddOutputVariable("ipv6_vpc_cidr_block", e.TerraformIpv6CidrLink()); err != nil {
+			return err
+		}
+	}
 
 	shared := fi.BoolValue(e.Shared)
 	if shared {

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -306,12 +306,12 @@ func (e *VPC) TerraformLink() *terraformWriter.Literal {
 	return terraformWriter.LiteralProperty("aws_vpc", *e.Name, "id")
 }
 
-func (e *VPC) TerraformIpv6CidrLink() *terraform.Literal {
+func (e *VPC) TerraformIpv6CidrLink() *terraformWriter.Literal {
 	shared := fi.BoolValue(e.Shared)
 	if shared {
 		klog.Fatalf("only kops managed VPC is supported: %s", e)
 	}
-	return terraform.LiteralProperty("aws_vpc", *e.Name, "ipv6_cidr_block")
+	return terraformWriter.LiteralProperty("aws_vpc", *e.Name, "ipv6_cidr_block")
 }
 
 type cloudformationVPC struct {

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -36,10 +36,11 @@ type VPC struct {
 	Name      *string
 	Lifecycle *fi.Lifecycle
 
-	ID                 *string
-	CIDR               *string
-	EnableDNSHostnames *bool
-	EnableDNSSupport   *bool
+	ID                          *string
+	CIDR                        *string
+	EnableDNSHostnames          *bool
+	EnableDNSSupport            *bool
+	AmazonProvidedIpv6CidrBlock *bool
 
 	// Shared is set if this is a shared VPC
 	Shared *bool
@@ -163,8 +164,9 @@ func (_ *VPC) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPC) error {
 		klog.V(2).Infof("Creating VPC with CIDR: %q", *e.CIDR)
 
 		request := &ec2.CreateVpcInput{
-			CidrBlock:         e.CIDR,
-			TagSpecifications: awsup.EC2TagSpecification(ec2.ResourceTypeVpc, e.Tags),
+			CidrBlock:                   e.CIDR,
+			TagSpecifications:           awsup.EC2TagSpecification(ec2.ResourceTypeVpc, e.Tags),
+			AmazonProvidedIpv6CidrBlock: e.AmazonProvidedIpv6CidrBlock,
 		}
 
 		response, err := t.Cloud.EC2().CreateVpc(request)
@@ -250,10 +252,11 @@ func (e *VPC) FindDeletions(c *fi.Context) ([]fi.Deletion, error) {
 }
 
 type terraformVPC struct {
-	CIDR               *string           `json:"cidr_block,omitempty" cty:"cidr_block"`
-	EnableDNSHostnames *bool             `json:"enable_dns_hostnames,omitempty" cty:"enable_dns_hostnames"`
-	EnableDNSSupport   *bool             `json:"enable_dns_support,omitempty" cty:"enable_dns_support"`
-	Tags               map[string]string `json:"tags,omitempty" cty:"tags"`
+	CIDR                        *string           `json:"cidr_block,omitempty" cty:"cidr_block"`
+	EnableDNSHostnames          *bool             `json:"enable_dns_hostnames,omitempty" cty:"enable_dns_hostnames"`
+	EnableDNSSupport            *bool             `json:"enable_dns_support,omitempty" cty:"enable_dns_support"`
+	Tags                        map[string]string `json:"tags,omitempty" cty:"tags"`
+	AmazonProvidedIpv6CidrBlock *bool             `json:"assign_generated_ipv6_cidr_block,omitempty" cty:"assign_generated_ipv6_cidr_block"`
 }
 
 func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) error {

--- a/upup/pkg/fi/cloudup/terraform/hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl2.go
@@ -111,6 +111,14 @@ func writeLiteral(body *hclwrite.Body, key string, literal *terraformWriter.Lite
 			},
 		}
 		body.SetAttributeRaw(key, tokens)
+	} else if literal.Netnum > 0 {
+		tokens := hclwrite.Tokens{
+			{
+				Type:  hclsyntax.TokenIdent,
+				Bytes: []byte(fmt.Sprintf("%v(%s,%d,%d)", literal.CidrSubnetFn, literal.CidrLink, literal.SubnetBits, literal.Netnum)),
+			},
+		}
+		body.SetAttributeRaw(key, tokens)
 	} else if literal.ResourceType == "" || literal.ResourceName == "" || literal.ResourceProp == "" {
 		body.SetAttributeValue(key, cty.StringVal(literal.Value))
 	} else {

--- a/upup/pkg/fi/cloudup/terraform/hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl2.go
@@ -111,11 +111,11 @@ func writeLiteral(body *hclwrite.Body, key string, literal *terraformWriter.Lite
 			},
 		}
 		body.SetAttributeRaw(key, tokens)
-	} else if literal.Netnum > 0 {
+	} else if literal.Netnum != nil {
 		tokens := hclwrite.Tokens{
 			{
 				Type:  hclsyntax.TokenIdent,
-				Bytes: []byte(fmt.Sprintf("%v(%s,%d,%d)", literal.CidrSubnetFn, literal.CidrLink, literal.SubnetBits, literal.Netnum)),
+				Bytes: []byte(fmt.Sprintf("%v(%s,%d,%d)", literal.CIDRSubnetFn, literal.CIDRLink, *literal.SubnetBits, *literal.Netnum)),
 			},
 		}
 		body.SetAttributeRaw(key, tokens)

--- a/upup/pkg/fi/cloudup/terraform/hcl2_test.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl2_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
 	"k8s.io/kops/pkg/diff"
+	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
@@ -135,6 +136,11 @@ func TestWriteLiteral(t *testing.T) {
 			name:     "file",
 			literal:  terraformWriter.LiteralFileExpression("${path.module}/foo", false),
 			expected: `foo = file("${path.module}/foo")`,
+		},
+		{
+			name:     "cidrsubnet",
+			literal:  terraformWriter.LiteralCidrsubnetExpression(terraformWriter.LiteralProperty("aws_vpc", "test", "ipv6_cidr_block"), fi.Int(8), fi.Int(1)),
+			expected: `foo = cidrsubnet(aws_vpc.test.ipv6_cidr_block,8,1)`,
 		},
 	}
 	for _, tc := range cases {

--- a/upup/pkg/fi/cloudup/terraformWriter/literal.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/literal.go
@@ -50,13 +50,13 @@ type Literal struct {
 	// FileFn represents the function used to reference the file
 	FileFn fileFn `cty:"file_fn"`
 	// CidrSubnetFn represents the function used calculate the subnetMask for ipv6 aws vpc
-	CidrSubnetFn string `cty:"cidrsubnet_fn"`
+	CIDRSubnetFn string `cty:"cidrsubnet_fn"`
 	// terraform link for vpc ipv6 cidr block
-	CidrLink string `cty:"vpc_ipv6_cidr_link"`
+	CIDRLink string `cty:"vpc_ipv6_cidr_link"`
 	// subnet bits. for ipv6 this value mostly will be 8 i.e /64 ipv6 subnet
-	SubnetBits int `cty:"subnet_bits"`
+	SubnetBits *int `cty:"subnet_bits"`
 	// decimal representation of subnet number
-	Netnum int `cty:"netnum"`
+	Netnum *int `cty:"netnum"`
 }
 
 var _ json.Marshaler = &Literal{}
@@ -65,13 +65,13 @@ func (l *Literal) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&l.Value)
 }
 
-func LiteralCidrsubnetExpression(vpcCidrProp *Literal, subnetBits, netnum int) *Literal {
+func LiteralCidrsubnetExpression(vpcCidrProp *Literal, subnetBits, netnum *int) *Literal {
 	cidrLink := vpcCidrProp.ResourceType + "." + vpcCidrProp.ResourceName + "." + vpcCidrProp.ResourceProp
 	return &Literal{
 		// value used for Terraform 0.11
 		Value:        fmt.Sprintf("${cidrsubnet(%s,%d,%d)}", cidrLink, subnetBits, netnum),
-		CidrLink:     cidrLink,
-		CidrSubnetFn: cidrSubnetFn,
+		CIDRLink:     cidrLink,
+		CIDRSubnetFn: cidrSubnetFn,
 		SubnetBits:   subnetBits,
 		Netnum:       netnum,
 	}

--- a/upup/pkg/fi/cloudup/terraformWriter/literal.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/literal.go
@@ -51,9 +51,12 @@ type Literal struct {
 	FileFn fileFn `cty:"file_fn"`
 	// CidrSubnetFn represents the function used calculate the subnetMask for ipv6 aws vpc
 	CidrSubnetFn string `cty:"cidrsubnet_fn"`
-	CidrLink     string `cty:"vpc_ipv6_cidr_link"`
-	SubnetBits   int    `cty:"subnet_bits"`
-	Netnum       int    `cty:"netnum"`
+	// terraform link for vpc ipv6 cidr block
+	CidrLink string `cty:"vpc_ipv6_cidr_link"`
+	// subnet bits. for ipv6 this value mostly will be 8 i.e /64 ipv6 subnet
+	SubnetBits int `cty:"subnet_bits"`
+	// decimal representation of subnet number
+	Netnum int `cty:"netnum"`
 }
 
 var _ json.Marshaler = &Literal{}
@@ -65,8 +68,7 @@ func (l *Literal) MarshalJSON() ([]byte, error) {
 func LiteralCidrsubnetExpression(vpcCidrProp *Literal, subnetBits, netnum int) *Literal {
 	cidrLink := vpcCidrProp.ResourceType + "." + vpcCidrProp.ResourceName + "." + vpcCidrProp.ResourceProp
 	return &Literal{
-		// file() is hardcoded here because this field is
-		// used for Terraform 0.11 which does not have filebase64()
+		// value used for Terraform 0.11
 		Value:        fmt.Sprintf("${cidrsubnet(%s,%d,%d)}", cidrLink, subnetBits, netnum),
 		CidrLink:     cidrLink,
 		CidrSubnetFn: cidrSubnetFn,


### PR DESCRIPTION
Reference: https://github.com/kubernetes/kops/issues/8432
with AWS VPC and subnet having ipv6 CIDR block we can enable external elb/alb to a dual-stack.

logic:
- AWS terraform have only option to enable ipv6 for vpc is `assign_generated_ipv6_cidr_block`
- from it, AWS will assign an autogenerated ipv6 address to VPC of `/56 range`
- so we cannot decide subnet for a new cluster directly but in aws its mandatory to create a `subnet of /64`
- so we can ask user subnet mask directly as they will always have 8 fix digit to play
- I am taking that value in awsIpv6SubnetNum which is [netnum](https://www.terraform.io/docs/language/functions/cidrsubnet.html), we have similar function in cloudformation as well and other SDKs to.

I have run and tested it with terraform and it seems to work fine with the below cluster.yaml

```
  subnets:
  - cidr: 10.8.16.0/20
    name: ap-south-1a
    type: Private
    zone: ap-south-1a
  - cidr: 10.8.32.0/20
    name: ap-south-1b
    type: Private
    zone: ap-south-1b
  - cidr: 10.8.0.0/23
    name: utility-ap-south-1a
    type: Utility
    zone: ap-south-1a
    awsIpv6SubnetNum: 1
  - cidr: 10.8.2.0/23
    name: utility-ap-south-1b
    type: Utility
    zone: ap-south-1b
    awsIpv6SubnetNum: 2
...
...    
    amazonProvidedIpv6CidrBlock: true
    networkCIDR: 10.8.0.0/17
```

terraform diff
```
+resource "aws_route" "route-ipv6-0-0-0-0--0" {
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.spike-np-tech-in.id
+  route_table_id              = aws_route_table.spike-np-tech-in.id
+}
+
 resource "aws_route" "route-private-ap-south-1a-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.ap-south-1a-spike-np-tech-in.id
@@ -2073,6 +2079,7 @@ resource "aws_subnet" "ap-south-1b-spike-np-tech-in" {
 resource "aws_subnet" "utility-ap-south-1a-spike-np-tech-in" {
   availability_zone = "ap-south-1a"
   cidr_block        = "10.8.0.0/23"
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.spike-np-tech-in.ipv6_cidr_block, 8, 1)
   tags = {
     "Environment"                                 = "dev"
     "KubernetesCluster"                           = "spike.np.tech-in"
@@ -2091,6 +2098,7 @@ resource "aws_subnet" "utility-ap-south-1a-spike-np-tech-in" {
 resource "aws_subnet" "utility-ap-south-1b-spike-np-tech-in" {
   availability_zone = "ap-south-1b"
   cidr_block        = "10.8.2.0/23"
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.spike-np-tech-in.ipv6_cidr_block, 8, 2)
   tags = {
     "Environment"                                 = "dev"
     "KubernetesCluster"                           = "spike.np.tech-in"
@@ -2127,9 +2135,10 @@ resource "aws_vpc_dhcp_options" "spike-np-tech-in" {
 }

 resource "aws_vpc" "spike-np-tech-in" {
-  cidr_block           = "10.8.0.0/17"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  assign_generated_ipv6_cidr_block = true
+  cidr_block                       = "10.8.0.0/17"
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
```


**I will add tests and other things but before that, I wanted to discuss if this approach is right**