### PR TITLE
kubetest2 - Pass GOPATH when building kops

### DIFF
--- a/tests/e2e/kubetest2-kops/builder/build.go
+++ b/tests/e2e/kubetest2-kops/builder/build.go
@@ -35,6 +35,7 @@ func (b *BuildOptions) Build() error {
 		fmt.Sprintf("HOME=%v", os.Getenv("HOME")),
 		fmt.Sprintf("PATH=%v", os.Getenv("PATH")),
 		fmt.Sprintf("GCS_LOCATION=%v", b.StageLocation),
+		fmt.Sprintf("GOPATH=%v", os.Getenv("GOPATH")),
 	)
 	cmd.SetDir(b.KopsRoot)
 	exec.InheritOutput(cmd)


### PR DESCRIPTION
this fix is needed for the network plugin presubmits to pass in https://github.com/kubernetes/kops/pull/11166. they were recently migrated to kubetest2 in https://github.com/kubernetes/test-infra/pull/21609