### PR TITLE
Filter kOps NatGateways from route table

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
@@ -81,6 +81,7 @@ go_library(
         "//pkg/diff:go_default_library",
         "//pkg/featureflag:go_default_library",
         "//pkg/pki:go_default_library",
+        "//pkg/resources/aws:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/cloudformation:go_default_library",


### PR DESCRIPTION
current solution is not filtering multiple natgateways from route table. We do have use-case where we have multiple natgateways. So when I add filtering to this function, it will only manage kops natgateways and not others.