### PR TITLE
Kubetest2 - Add flag to expose cluster validation wait time

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -20,6 +20,7 @@ package deployer
 import (
 	"flag"
 	"sync"
+	"time"
 
 	"github.com/octago/sflags/gen/gpflag"
 	"github.com/spf13/pflag"
@@ -54,6 +55,8 @@ type deployer struct {
 	CreateArgs     string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
 	KopsBinaryPath string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
 	StateStore     string   `flag:"-"`
+
+	ValidationWait time.Duration `flag:"validation-wait" desc:"time to wait for newly created cluster to pass validation"`
 
 	TemplatePath string `flag:"template-path" desc:"The path to the manifest template used for cluster creation"`
 


### PR DESCRIPTION
The flatcar jobs are failing because the OS performs package updates and a reboot after initial launch, even with the latest AMI.
This causes the cluster to timeout on its validation.

Exposing a flag will allow us to conditionally extend the validation for the flatcar tests

See https://testgrid.k8s.io/kops-distro-flatcar