### PR TITLE
Spotinst: Use BDM to configure the root volume size at VNG level

### DIFF
--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -401,7 +401,6 @@ func (_ *LaunchSpec) create(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) err
 				return err
 			}
 
-			spec.SetRootVolumeSize(nil) // mutually exclusive
 			spec.SetBlockDeviceMappings([]*aws.BlockDeviceMapping{
 				e.convertBlockDeviceMapping(rootDevice),
 			})


### PR DESCRIPTION
This PR removes the setting of the obsolete `rootVolumeSize` field in order to resolve a validation error returned from the Spot backend:

```
{
  "request": {
    "id": "dedd14d9-7f56-4bee-951b-redacted",
    "url": "/ocean/aws/k8s/launchSpec",
    "method": "POST",
    "timestamp": "2021-04-06T19:33:53.885Z"
  },
  "response": {
    "status": {
      "code": 400,
      "message": "Bad Request"
    },
    "errors": [
      {
        "code": "ValidationError",
        "message": "\"rootVolumeSize\" must not exist simultaneously with [blockDeviceMappings]",
        "field": "body:launchSpec"
      }
    ]
  }
}
```