### PR TITLE
Spotinst: Configure headroom resources only at the VNG level

### DIFF
--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -487,6 +487,7 @@ func (b *SpotInstanceGroupModelBuilder) buildOcean(c *fi.ModelBuilderContext, ig
 	if ocean.AutoScalerOpts != nil { // remove unsupported options
 		ocean.AutoScalerOpts.Labels = nil
 		ocean.AutoScalerOpts.Taints = nil
+		ocean.AutoScalerOpts.Headroom = nil
 	}
 
 	// Create a Launch Spec for each instance group.
@@ -925,12 +926,6 @@ func (b *SpotInstanceGroupModelBuilder) buildAutoScalerOpts(clusterID string, ig
 				opts.ResourceLimits.MaxMemory = fi.Int(int(fi.Int64Value(v)))
 			}
 		}
-	}
-
-	// Toggle automatic configuration off if headroom resources are explicitly defined.
-	if fi.BoolValue(opts.AutoConfig) && opts.Headroom != nil {
-		opts.AutoConfig = fi.Bool(false)
-		opts.AutoHeadroomPercentage = nil
 	}
 
 	// Configure Elastigroup defaults to avoid state drifts.

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -294,16 +294,6 @@ func (o *Ocean) Find(c *fi.Context) (*Ocean, error) {
 			actual.AutoScalerOpts.AutoHeadroomPercentage = ocean.AutoScaler.AutoHeadroomPercentage
 			actual.AutoScalerOpts.Cooldown = ocean.AutoScaler.Cooldown
 
-			// Headroom.
-			if headroom := ocean.AutoScaler.Headroom; headroom != nil {
-				actual.AutoScalerOpts.Headroom = &AutoScalerHeadroomOpts{
-					CPUPerUnit: headroom.CPUPerUnit,
-					GPUPerUnit: headroom.GPUPerUnit,
-					MemPerUnit: headroom.MemoryPerUnit,
-					NumOfUnits: headroom.NumOfUnits,
-				}
-			}
-
 			// Scale down.
 			if down := ocean.AutoScaler.Down; down != nil {
 				actual.AutoScalerOpts.Down = &AutoScalerDownOpts{
@@ -522,17 +512,6 @@ func (_ *Ocean) create(cloud awsup.AWSCloud, a, e, changes *Ocean) error {
 				autoScaler.IsAutoConfig = opts.AutoConfig
 				autoScaler.AutoHeadroomPercentage = opts.AutoHeadroomPercentage
 				autoScaler.Cooldown = opts.Cooldown
-
-				// Headroom.
-				if headroom := opts.Headroom; headroom != nil {
-					autoScaler.IsAutoConfig = fi.Bool(false)
-					autoScaler.Headroom = &aws.AutoScalerHeadroom{
-						CPUPerUnit:    headroom.CPUPerUnit,
-						GPUPerUnit:    headroom.GPUPerUnit,
-						MemoryPerUnit: headroom.MemPerUnit,
-						NumOfUnits:    headroom.NumOfUnits,
-					}
-				}
 
 				// Scale down.
 				if down := opts.Down; down != nil {
@@ -943,20 +922,6 @@ func (_ *Ocean) update(cloud awsup.AWSCloud, a, e, changes *Ocean) error {
 				autoScaler.AutoHeadroomPercentage = e.AutoScalerOpts.AutoHeadroomPercentage
 				autoScaler.Cooldown = e.AutoScalerOpts.Cooldown
 
-				// Headroom.
-				if headroom := opts.Headroom; headroom != nil {
-					autoScaler.IsAutoConfig = fi.Bool(false)
-					autoScaler.Headroom = &aws.AutoScalerHeadroom{
-						CPUPerUnit:    e.AutoScalerOpts.Headroom.CPUPerUnit,
-						GPUPerUnit:    e.AutoScalerOpts.Headroom.GPUPerUnit,
-						MemoryPerUnit: e.AutoScalerOpts.Headroom.MemPerUnit,
-						NumOfUnits:    e.AutoScalerOpts.Headroom.NumOfUnits,
-					}
-				} else if a.AutoScalerOpts != nil && a.AutoScalerOpts.Headroom != nil {
-					autoScaler.IsAutoConfig = fi.Bool(true)
-					autoScaler.SetHeadroom(nil)
-				}
-
 				// Scale down.
 				if down := opts.Down; down != nil {
 					autoScaler.Down = &aws.AutoScalerDown{
@@ -1170,17 +1135,6 @@ func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Oce
 					AutoConfig:             opts.AutoConfig,
 					AutoHeadroomPercentage: opts.AutoHeadroomPercentage,
 					Cooldown:               opts.Cooldown,
-				}
-
-				// Headroom.
-				if headroom := opts.Headroom; headroom != nil {
-					tf.AutoScaler.AutoConfig = fi.Bool(false)
-					tf.AutoScaler.Headroom = &terraformAutoScalerHeadroom{
-						CPUPerUnit: headroom.CPUPerUnit,
-						GPUPerUnit: headroom.GPUPerUnit,
-						MemPerUnit: headroom.MemPerUnit,
-						NumOfUnits: headroom.NumOfUnits,
-					}
 				}
 
 				// Scale down.


### PR DESCRIPTION
The PR removes the headroom configuration from the cluster level. Custom headroom should now be applied only at the VNG level, while the cluster should use automatic headroom.