### PR TITLE
Automated cherry pick of #11179: fix(spot/ocean): configure root volume size using bdm

### DIFF
--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -401,7 +401,6 @@ func (_ *LaunchSpec) create(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) err
 				return err
 			}
 
-			spec.SetRootVolumeSize(nil) // mutually exclusive
 			spec.SetBlockDeviceMappings([]*aws.BlockDeviceMapping{
 				e.convertBlockDeviceMapping(rootDevice),
 			})


### PR DESCRIPTION
Cherry pick of #11179 on release-1.20.

#11179: fix(spot/ocean): configure root volume size using bdm

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.