### PR TITLE
Always secure api -> kubelet communication

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -397,11 +397,6 @@ func (c *NodeupModelContext) UseBootstrapTokens() bool {
 	return c.Cluster.Spec.Kubelet != nil && c.Cluster.Spec.Kubelet.BootstrapKubeconfig != ""
 }
 
-// UseSecureKubelet checks if the kubelet api should be protected by a client certificate.
-func (c *NodeupModelContext) UseSecureKubelet() bool {
-	return c.NodeupConfig.KubeletConfig.AnonymousAuth != nil && !*c.NodeupConfig.KubeletConfig.AnonymousAuth
-}
-
 // KubectlPath returns distro based path for kubectl
 func (c *NodeupModelContext) KubectlPath() string {
 	kubeletCommand := "/usr/local/bin"

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -107,19 +107,16 @@ func (b *KubeAPIServerBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 	}
 
-	// @check if we are using secure client certificates for kubelet and grab the certificates
-	if b.UseSecureKubelet() {
-		issueCert := &nodetasks.IssueCert{
-			Name:    "kubelet-api",
-			Signer:  fi.CertificateIDCA,
-			Type:    "client",
-			Subject: nodetasks.PKIXName{CommonName: "kubelet-api"},
-		}
-		c.AddTask(issueCert)
-		err := issueCert.AddFileTasks(c, b.PathSrvKubernetes(), "kubelet-api", "", nil)
-		if err != nil {
-			return err
-		}
+	issueCert := &nodetasks.IssueCert{
+		Name:    "kubelet-api",
+		Signer:  fi.CertificateIDCA,
+		Type:    "client",
+		Subject: nodetasks.PKIXName{CommonName: "kubelet-api"},
+	}
+	c.AddTask(issueCert)
+	err := issueCert.AddFileTasks(c, b.PathSrvKubernetes(), "kubelet-api", "", nil)
+	if err != nil {
+		return err
 	}
 
 	c.AddTask(&nodetasks.File{
@@ -341,12 +338,9 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 		kubeAPIServer.EtcdServersOverrides = []string{"/events#" + eventsEtcdCluster}
 	}
 
-	// @check if we are using secure kubelet client certificates
-	if b.UseSecureKubelet() {
-		// @note we are making assumption were using the ones created by the pki model, not custom defined ones
-		kubeAPIServer.KubeletClientCertificate = filepath.Join(b.PathSrvKubernetes(), "kubelet-api.crt")
-		kubeAPIServer.KubeletClientKey = filepath.Join(b.PathSrvKubernetes(), "kubelet-api.key")
-	}
+	// @note we are making assumption were using the ones created by the pki model, not custom defined ones
+	kubeAPIServer.KubeletClientCertificate = filepath.Join(b.PathSrvKubernetes(), "kubelet-api.crt")
+	kubeAPIServer.KubeletClientKey = filepath.Join(b.PathSrvKubernetes(), "kubelet-api.key")
 
 	{
 		certPath := filepath.Join(b.PathSrvKubernetes(), "apiserver-aggregator.crt")

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -426,10 +426,7 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 	// Merge KubeletConfig for NodeLabels
 	c := b.NodeupConfig.KubeletConfig
 
-	// check if we are using secure kubelet <-> api settings
-	if b.UseSecureKubelet() {
-		c.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
-	}
+	c.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
 
 	if isMaster {
 		c.BootstrapKubeconfig = ""

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/"
+  DAEMON_ARGS="--client-ca-file=/srv/kubernetes/ca.crt --feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file


### PR DESCRIPTION
Without secure node auth enabled, commands like `kubectl logs` may fail with certain configurations.

As of kubernetes 1.11, we explicitly disable anonymousauth on kubelet for new clusters. We also always disable AlwaysAllow auth mode for kubelet as of 1.19. This combination works for new clusters and those who have already disabled anonymousAuth for kubelet, which accounts for most users, it seems.

But old clusters upgrading from pre 1.11 face issues with commands like `kubectl logs` because for these clusters, apiserver is anonymous and anonymous users are not allowed to talk to kubelet per our RBAC rules.

The logic for this is 
```
// UseSecureKubelet checks if the kubelet api should be protected by a client certificate.
func (c *NodeupModelContext) UseSecureKubelet() bool {
	return c.NodeupConfig.KubeletConfig.AnonymousAuth != nil && !*c.NodeupConfig.KubeletConfig.AnonymousAuth
}
```
anonymousAuth and secure kubelet comms are two different things as far as I can tell. So not sure why we made the check this way. Checking for `AuthorizationMode="" or AlwaysAllow` would make more sense.

This PR enables secure comms unconditionally