### PR TITLE
Update kops_create_secret_dockerconfig.md

### DIFF
--- a/cmd/kops/create_secret_dockerconfig.go
+++ b/cmd/kops/create_secret_dockerconfig.go
@@ -35,7 +35,12 @@ var (
 	createSecretDockerconfigLong = templates.LongDesc(i18n.T(`
 	Create a new docker config, and store it in the state store.
 	Used to configure docker on each master or node (i.e. for auth)
-	Use update to modify it, this command will only create a new entry.`))
+	Use update to modify it, this command will only create a new entry.
+	
+	After creating a dockerconfig secret, a .docker/config.json file will 
+	be added to all newly created nodes without running kops update.
+	This file should also apply auth to containerd, which is the default
+	container runtime in kops 1.20 and above.`))
 
 	createSecretDockerconfigExample = templates.Examples(i18n.T(`
 	# Create a new docker config.

--- a/cmd/kops/create_secret_dockerconfig.go
+++ b/cmd/kops/create_secret_dockerconfig.go
@@ -37,10 +37,10 @@ var (
 	Used to configure docker on each master or node (i.e. for auth)
 	Use update to modify it, this command will only create a new entry.
 	
-	After creating a dockerconfig secret, a .docker/config.json file will 
-	be added to all newly created nodes without running kops update.
-	This file should also apply auth to containerd, which is the default
-	container runtime in kops 1.20 and above.`))
+	After creating a dockerconfig secret, a /root/.docker/config.json file
+    will be added to newly created nodes. This file will be used by Kubernetes
+    to authenticate to container registries and will also work when using
+	containerd as container runtime.`))
 
 	createSecretDockerconfigExample = templates.Examples(i18n.T(`
 	# Create a new docker config.

--- a/docs/cli/kops_create_secret_dockerconfig.md
+++ b/docs/cli/kops_create_secret_dockerconfig.md
@@ -9,6 +9,8 @@ Create a docker config.
 
 Create a new docker config, and store it in the state store. Used to configure docker on each master or node (i.e. for auth) Use update to modify it, this command will only create a new entry.
 
+ After creating a dockerconfig secret, a .docker/config.json file will be added to all newly created nodes without running kops update. This file should also apply auth to containerd, which is the default container runtime in kops 1.20 and above.
+
 ```
 kops create secret dockerconfig [flags]
 ```

--- a/docs/cli/kops_create_secret_dockerconfig.md
+++ b/docs/cli/kops_create_secret_dockerconfig.md
@@ -9,7 +9,7 @@ Create a docker config.
 
 Create a new docker config, and store it in the state store. Used to configure docker on each master or node (i.e. for auth) Use update to modify it, this command will only create a new entry.
 
- After creating a dockerconfig secret, a .docker/config.json file will be added to all newly created nodes without running kops update. This file should also apply auth to containerd, which is the default container runtime in kops 1.20 and above.
+ After creating a dockerconfig secret, a /root/.docker/config.json file will be added to newly created nodes. This file will be used by Kubernetes to authenticate to container registries and will also work when using containerd as container runtime.
 
 ```
 kops create secret dockerconfig [flags]


### PR DESCRIPTION
Today we were implementing an authenticated docker user, but it was unclear how exactly to do that.  We learned that simply making this secret within kops was all that was needed for the docker config to start appearing on newly built nodes.  It would be nice if the documentation here reflected that.  It would have saved us some time.