### PR TITLE
Docs: Remove 'prerelease' warning from 1.20

### DIFF
--- a/docs/releases/1.19-NOTES.md
+++ b/docs/releases/1.19-NOTES.md
@@ -144,7 +144,7 @@ has been updated by a newer version of kOps unless it is given the `--allow-kops
 
 * The [manifest based cluster autoscaler addon](https://github.com/kubernetes/kops/tree/master/addons/cluster-autoscaler) has been deprecated in favour of a configurable addon.
 
-* The experimental node authorizor is now ignored if you are using kubernetes 1.19. The feature will be removed in 1.20. Worker nodes will instead be authorized using kops-controller.
+* The experimental node authorizer is now ignored if you are using kubernetes 1.19. The feature will be removed in 1.20. Worker nodes will instead be authorized using kops-controller.
 
 * Support for AWS LaunchConfiguration has been deprecated and will be removed in kOps 1.21.
 

--- a/docs/releases/1.20-NOTES.md
+++ b/docs/releases/1.20-NOTES.md
@@ -1,9 +1,5 @@
 ## Release notes for kOps 1.20 series
 
-**&#9888; kOps 1.20 has not been released yet! &#9888;**
-
-This is a document to gather the release notes prior to the release.
-
 # Significant changes
 
 * Default container runtime is now set to `containerd` for new clusters running Kubernetes 1.20.0+.


### PR DESCRIPTION
Also fix a small typo I noticed in the 1.19 notes.