### PR TITLE
Kubetest2 - Create project-specific state store buckets in GCP

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -54,7 +54,7 @@ type deployer struct {
 	Env            []string `flag:"env" desc:"Additional env vars to set for kops commands in NAME=VALUE format"`
 	CreateArgs     string   `flag:"create-args" desc:"Extra space-separated arguments passed to 'kops create cluster'"`
 	KopsBinaryPath string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
-	StateStore     string   `flag:"-"`
+	createBucket   bool     `flag:"-"`
 
 	ValidationWait time.Duration `flag:"validation-wait" desc:"time to wait for newly created cluster to pass validation"`
 

--- a/tests/e2e/kubetest2-kops/deployer/down.go
+++ b/tests/e2e/kubetest2-kops/deployer/down.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/klog/v2"
+	"k8s.io/kops/tests/e2e/kubetest2-kops/gce"
 	"sigs.k8s.io/kubetest2/pkg/boskos"
 	"sigs.k8s.io/kubetest2/pkg/exec"
 )
@@ -51,6 +52,10 @@ func (d *deployer) Down() error {
 	exec.InheritOutput(cmd)
 	if err := cmd.Run(); err != nil {
 		return err
+	}
+
+	if d.CloudProvider == "gce" && d.createBucket {
+		gce.DeleteGCSBucket(d.stateStore(), d.GCPProject)
 	}
 
 	if d.boskos != nil {

--- a/tests/e2e/kubetest2-kops/deployer/template.go
+++ b/tests/e2e/kubetest2-kops/deployer/template.go
@@ -76,7 +76,7 @@ func (d *deployer) templateValues(zones []string, publicIP string) (map[string]i
 		"clusterName":       d.ClusterName,
 		"kubernetesVersion": d.KubernetesVersion,
 		"publicIP":          publicIP,
-		"stateStore":        d.StateStore,
+		"stateStore":        d.stateStore(),
 		"zones":             zones,
 		"sshPublicKey":      string(publicKey),
 	}, nil

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -44,6 +44,10 @@ func (d *deployer) Up() error {
 		return err
 	}
 
+	if d.CloudProvider == "gce" && d.createBucket {
+		gce.EnsureGCSBucket(d.stateStore(), d.GCPProject)
+	}
+
 	adminAccess := d.AdminAccess
 	if adminAccess == "" {
 		adminAccess = publicIP

--- a/tests/e2e/kubetest2-kops/gce/gcs.go
+++ b/tests/e2e/kubetest2-kops/gce/gcs.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"os"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kubetest2/pkg/exec"
+)
+
+func GCSBucketName(projectID string) string {
+	var s string
+	if jobID := os.Getenv("PROW_JOB_ID"); len(jobID) >= 2 {
+		s = jobID[:2]
+	} else {
+		b := make([]byte, 2)
+		rand.Read(b)
+		s = hex.EncodeToString(b)
+	}
+	bucket := strings.Join([]string{projectID, "state", s}, "-")
+	return bucket
+}
+
+func EnsureGCSBucket(bucketPath, projectID string) error {
+	lsArgs := []string{
+		"gsutil", "ls", "-b", bucketPath,
+	}
+	if projectID != "" {
+		lsArgs = append(lsArgs, "-p", projectID)
+	}
+
+	klog.Info(strings.Join(lsArgs, " "))
+	cmd := exec.Command(lsArgs[0], lsArgs[1:]...)
+
+	output, err := exec.CombinedOutputLines(cmd)
+	if err == nil {
+		return nil
+	} else if len(output) != 1 || !strings.Contains(output[0], "BucketNotFound") {
+		return err
+	}
+
+	mbArgs := []string{
+		"gsutil", "mb", bucketPath,
+	}
+	if projectID != "" {
+		mbArgs = append(mbArgs, "-p", projectID)
+	}
+
+	klog.Info(strings.Join(mbArgs, " "))
+	cmd = exec.Command(mbArgs[0], mbArgs[1:]...)
+
+	exec.InheritOutput(cmd)
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func DeleteGCSBucket(bucketPath, projectID string) error {
+	rmArgs := []string{
+		"gsutil", "rm", "-r", bucketPath,
+	}
+	if projectID != "" {
+		rmArgs = append(rmArgs, "-p", projectID)
+	}
+
+	klog.Info(strings.Join(rmArgs, " "))
+	cmd := exec.Command(rmArgs[0], rmArgs[1:]...)
+
+	exec.InheritOutput(cmd)
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Since we use boskos to get a random GCP project, we need to create a bucket per project so that permissions will be setup properly.
This matches the existing kubetest1 behavior. It turns out kubetest1 never actually used `gs://k8s-kops-gce`.

Ref: https://github.com/kubernetes/test-infra/blob/726b9ea2a24eaaa152ab6c63f443f45941d45116/kubetest/kops.go#L880-L903

This should fix the gce kubetest2 job: https://testgrid.k8s.io/kops-gce#kops-gce-kubetest2

specifically the permission errors in etcd manager: https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-gce-kubetest2/1380986173320597504/artifacts/34.105.15.245/etcd.log