### PR TITLE
Kubetest2 - Set KOPS_BASE_URL to --build's stage location

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -58,6 +58,9 @@ func (d *deployer) verifyBuildFlags() error {
 		}
 		d.StageLocation = fmt.Sprintf(defaultGCSPath, jobName)
 	}
+	if d.KopsBaseURL == "" {
+		d.KopsBaseURL = strings.Replace(d.StageLocation, "gs://", "https://storage.googleapis.com/", 1)
+	}
 	fi, err := os.Stat(d.KopsRoot)
 	if err != nil {
 		return err

--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -22,11 +22,13 @@ import (
 	"os"
 	"path"
 	"strings"
+
+	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
 const (
 	defaultJobName = "pull-kops-e2e-kubernetes-aws"
-	defaultGCSPath = "gs://kops-ci/pulls/%v"
+	defaultGCSPath = "gs://kops-ci/pulls/%v/pull-%v"
 )
 
 func (d *deployer) Build() error {
@@ -52,11 +54,11 @@ func (d *deployer) verifyBuildFlags() error {
 			return errors.New("stage-location must be a gs:// path")
 		}
 	} else {
-		jobName := os.Getenv("JOB_NAME")
-		if jobName == "" {
-			jobName = defaultJobName
+		stageLocation, err := defaultStageLocation(d.KopsRoot)
+		if err != nil {
+			return err
 		}
-		d.StageLocation = fmt.Sprintf(defaultGCSPath, jobName)
+		d.StageLocation = stageLocation
 	}
 	if d.KopsBaseURL == "" {
 		d.KopsBaseURL = strings.Replace(d.StageLocation, "gs://", "https://storage.googleapis.com/", 1)
@@ -75,4 +77,22 @@ func (d *deployer) verifyBuildFlags() error {
 	d.BuildOptions.KopsRoot = d.KopsRoot
 	d.BuildOptions.StageLocation = d.StageLocation
 	return nil
+}
+
+func defaultStageLocation(kopsRoot string) (string, error) {
+	jobName := os.Getenv("JOB_NAME")
+	if jobName == "" {
+		jobName = defaultJobName
+	}
+
+	cmd := exec.Command("git", "describe", "--always")
+	cmd.SetDir(kopsRoot)
+	output, err := exec.CombinedOutputLines(cmd)
+	if err != nil {
+		return "", err
+	} else if len(output) != 1 {
+		return "", fmt.Errorf("unexpected output from git describe: %v", output)
+	}
+	sha := strings.TrimSpace(output[0])
+	return fmt.Sprintf(defaultGCSPath, jobName, sha), nil
 }


### PR DESCRIPTION
Previously we would upload the custom kops build to the stage location but the kops commands would not have their KOPS_BASE_URL overridden.
This ensures that all kops commands have KOPS_BASE_URL correctly set.

We only support gs:// paths for --stage-location, as verified earlier in this function.

[Here](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-kops-e2e-kubernetes-aws/1377343455298064384#1:build-log.txt%3A635) is a kubetest1 presubmit demonstrating that KOPS_BASE_URL was overridden (line 635). [Kubetest2](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-kops-e2e-kubernetes-aws/1381294979149729792#1:build-log.txt%3A438) does not have that logging statement, confirming that it wasn't being overridden.

This also updates the default --stage-location used for presubmit jobs to match the [kubetest1 format](https://github.com/kubernetes/test-infra/blob/675a42cb78d8eb6239cf4117e39a78f21c4e6891/scenarios/kubernetes_e2e.py#L259-L267) so that they are PR-specific.

Fixes #11209