### PR TITLE
Kubetest2 - detect errors creating GCS bucket

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -45,7 +45,9 @@ func (d *deployer) Up() error {
 	}
 
 	if d.CloudProvider == "gce" && d.createBucket {
-		gce.EnsureGCSBucket(d.stateStore(), d.GCPProject)
+		if err := gce.EnsureGCSBucket(d.stateStore(), d.GCPProject); err != nil {
+			return err
+		}
 	}
 
 	adminAccess := d.AdminAccess

--- a/tests/e2e/kubetest2-kops/gce/gcs.go
+++ b/tests/e2e/kubetest2-kops/gce/gcs.go
@@ -54,6 +54,7 @@ func EnsureGCSBucket(bucketPath, projectID string) error {
 	if err == nil {
 		return nil
 	} else if len(output) != 1 || !strings.Contains(output[0], "BucketNotFound") {
+		klog.Info(output)
 		return err
 	}
 


### PR DESCRIPTION
The job seems to be failing to check if the bucket exists or not. This should cause the job to fail sooner and hopefully log more info about why it failed.
See https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-kubetest2/1381529768943423488#1:build-log.txt%3A121
You see the `gsutil ls` command but not the `gsutil mb` command, 