### PR TITLE
Kubetest2 - Ensure the bucket path is the final gsutil arg

### DIFF
--- a/tests/e2e/kubetest2-kops/gce/gcs.go
+++ b/tests/e2e/kubetest2-kops/gce/gcs.go
@@ -41,11 +41,12 @@ func GCSBucketName(projectID string) string {
 
 func EnsureGCSBucket(bucketPath, projectID string) error {
 	lsArgs := []string{
-		"gsutil", "ls", "-b", bucketPath,
+		"gsutil", "ls", "-b",
 	}
 	if projectID != "" {
 		lsArgs = append(lsArgs, "-p", projectID)
 	}
+	lsArgs = append(lsArgs, bucketPath)
 
 	klog.Info(strings.Join(lsArgs, " "))
 	cmd := exec.Command(lsArgs[0], lsArgs[1:]...)
@@ -59,11 +60,12 @@ func EnsureGCSBucket(bucketPath, projectID string) error {
 	}
 
 	mbArgs := []string{
-		"gsutil", "mb", bucketPath,
+		"gsutil", "mb",
 	}
 	if projectID != "" {
 		mbArgs = append(mbArgs, "-p", projectID)
 	}
+	mbArgs = append(mbArgs, bucketPath)
 
 	klog.Info(strings.Join(mbArgs, " "))
 	cmd = exec.Command(mbArgs[0], mbArgs[1:]...)


### PR DESCRIPTION
should fix this error: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-kubetest2/1381650445893636096#1:build-log.txt%3A122