### PR TITLE
Don't start kubelet if instance is entering the warm pool

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -42,8 +42,13 @@ import (
 	"github.com/blang/semver/v4"
 )
 
+const (
+	ConfigurationModeWarming string = "Warming"
+)
+
 // NodeupModelContext is the context supplied the nodeup tasks
 type NodeupModelContext struct {
+	Cloud         fi.Cloud
 	Architecture  architectures.Architecture
 	Assets        *fi.AssetStore
 	Cluster       *kops.Cluster
@@ -62,6 +67,10 @@ type NodeupModelContext struct {
 
 	kubernetesVersion semver.Version
 	bootstrapCerts    map[string]*nodetasks.BootstrapCert
+
+	// ConfigurationMode determines if we are prewarming an instance or running it live
+	ConfigurationMode string
+	InstanceID        string
 }
 
 // Init completes initialization of the object, for example pre-parsing the kubernetes version

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -293,6 +293,11 @@ func (b *KubeletBuilder) buildSystemdService() *nodetasks.Service {
 
 	service.InitDefaults()
 
+	if b.ConfigurationMode == "Warming" {
+
+		service.Running = fi.Bool(false)
+	}
+
 	return service
 }
 
@@ -443,14 +448,7 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 			instanceTypeName = *b.NodeupConfig.DefaultMachineType
 		}
 
-		region, err := awsup.FindRegion(b.Cluster)
-		if err != nil {
-			return nil, err
-		}
-		awsCloud, err := awsup.NewAWSCloud(region, nil)
-		if err != nil {
-			return nil, err
-		}
+		awsCloud := b.Cloud.(awsup.AWSCloud)
 		// Get the instance type's detailed information.
 		instanceType, err := awsup.GetMachineTypeInfo(awsCloud, instanceTypeName)
 		if err != nil {

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -157,8 +157,34 @@ func Test_RunKubeletBuilder(t *testing.T) {
 		t.Fatalf("error loading model %q: %v", basedir, err)
 		return
 	}
+	runKubeletBuilder(t, context, nodeUpModelContext)
 
-	builder := KubeletBuilder{NodeupModelContext: nodeUpModelContext}
+	testutils.ValidateTasks(t, filepath.Join(basedir, "tasks.yaml"), context)
+
+}
+
+func Test_RunKubeletBuilderWarmPool(t *testing.T) {
+	basedir := "tests/kubelet/warmpool"
+
+	context := &fi.ModelBuilderContext{
+		Tasks: make(map[string]fi.Task),
+	}
+	nodeUpModelContext, err := BuildNodeupModelContext(basedir)
+	if err != nil {
+		t.Fatalf("error loading model %q: %v", basedir, err)
+		return
+	}
+
+	nodeUpModelContext.ConfigurationMode = "Warming"
+
+	runKubeletBuilder(t, context, nodeUpModelContext)
+
+	testutils.ValidateTasks(t, filepath.Join(basedir, "tasks.yaml"), context)
+
+}
+
+func runKubeletBuilder(t *testing.T, context *fi.ModelBuilderContext, nodeupModelContext *NodeupModelContext) {
+	builder := KubeletBuilder{NodeupModelContext: nodeupModelContext}
 
 	kubeletConfig, err := builder.buildKubeletConfig()
 	if err != nil {
@@ -191,7 +217,6 @@ func Test_RunKubeletBuilder(t *testing.T) {
 		context.AddTask(task)
 	}
 
-	testutils.ValidateTasks(t, filepath.Join(basedir, "tasks.yaml"), context)
 }
 
 func BuildNodeupModelContext(basedir string) (*NodeupModelContext, error) {

--- a/nodeup/pkg/model/tests/kubelet/warmpool/cluster.yaml
+++ b/nodeup/pkg/model/tests/kubelet/warmpool/cluster.yaml
@@ -1,0 +1,60 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  containerRuntime: docker
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    name: events
+  iam: {}
+  kubelet:
+    podManifestPath: "/etc/kubernetes/manifests"
+  kubernetesVersion: v1.20.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2016-12-10T22:42:28Z"
+  name: nodes
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  role: Node
+  subnets:
+  - us-test-1a

--- a/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
@@ -1,0 +1,31 @@
+mode: "0755"
+path: /etc/kubernetes/manifests
+type: directory
+---
+contents: |
+  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --client-ca-file=/srv/kubernetes/ca.crt --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/ --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key"
+  HOME="/root"
+path: /etc/sysconfig/kubelet
+type: file
+---
+Name: kubelet.service
+definition: |
+  [Unit]
+  Description=Kubernetes Kubelet Server
+  Documentation=https://github.com/kubernetes/kubernetes
+  After=docker.service
+
+  [Service]
+  EnvironmentFile=/etc/sysconfig/kubelet
+  ExecStart=/usr/local/bin/kubelet "$DAEMON_ARGS"
+  Restart=always
+  RestartSec=2s
+  StartLimitInterval=0
+  KillMode=process
+  User=root
+  CPUAccounting=true
+  MemoryAccounting=true
+enabled: true
+manageState: true
+running: false
+smartRestart: true

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/pkg/model/iam/tests/iam_builder_node_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_node_legacy.json
@@ -11,6 +11,13 @@
       ]
     },
     {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
       "Action": [
         "s3:*"
       ],

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -11,6 +11,13 @@
       ]
     },
     {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
       "Action": [
         "s3:Get*"
       ],

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -11,6 +11,13 @@
       ]
     },
     {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
       "Action": [
         "s3:Get*"
       ],

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json
@@ -1161,6 +1161,13 @@
               ]
             },
             {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
               "Action": [
                 "iam:ListServerCertificates",
                 "iam:GetServerCertificate"
@@ -1254,6 +1261,21 @@
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup",
                 "autoscaling:UpdateAutoScalingGroup"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "minimal.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
               ],
               "Condition": {
                 "StringEquals": {
@@ -1372,6 +1394,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "bastionuserdata.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -1649,6 +1649,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "complex.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1754,6 +1769,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "complex.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "compress.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json
@@ -976,6 +976,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "containerd.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1081,6 +1096,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/containerd/cloudformation.json
+++ b/tests/integration/update_cluster/containerd/cloudformation.json
@@ -976,6 +976,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "containerd.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1081,6 +1096,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json
@@ -976,6 +976,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "docker.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1081,6 +1096,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "existingsg.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -992,6 +992,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "externallb.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1097,6 +1112,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "externallb.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "externalpolicies.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "ha.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -976,6 +976,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "minimal.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1081,6 +1096,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json
@@ -972,6 +972,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "minimal.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1077,6 +1092,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/minimal-json/data/aws_iam_role_policy_masters.minimal-json.example.com_policy
+++ b/tests/integration/update_cluster/minimal-json/data/aws_iam_role_policy_masters.minimal-json.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "minimal-json.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/minimal-json/data/aws_iam_role_policy_nodes.minimal-json.example.com_policy
+++ b/tests/integration/update_cluster/minimal-json/data/aws_iam_role_policy_nodes.minimal-json.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -1679,6 +1679,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1784,6 +1799,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -1680,6 +1680,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1785,6 +1800,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -1471,6 +1471,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "private-shared-ip.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1576,6 +1591,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "private-shared-ip.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "private-shared-subnet.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -1616,6 +1616,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "privatecalico.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1721,6 +1736,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privatecalico.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privatecanal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_nodes.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_nodes.privatecanal.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -1602,6 +1602,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "privatecilium.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1707,6 +1722,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privatecilium.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -1602,6 +1602,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "privatecilium.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1707,6 +1722,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privatecilium.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -1635,6 +1635,21 @@
             },
             {
               "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeAutoScalingInstances"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "autoscaling:ResourceTag/KubernetesCluster": "privateciliumadvanced.example.com"
+                }
+              },
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": [
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
@@ -1760,6 +1775,13 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
               ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingInstances",
               "Effect": "Allow",
               "Resource": [
                 "*"

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privateciliumadvanced.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privatedns1.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privatedns2.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privateflannel.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privatekopeio.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "privateweave.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_nodes.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_nodes.privateweave.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "minimal.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "sharedsubnet.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "sharedvpc.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -81,6 +81,21 @@
     },
     {
       "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/KubernetesCluster": "unmanaged.example.com"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
         "elasticloadbalancing:AddTags",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
@@ -9,6 +9,13 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Action": "autoscaling:DescribeAutoScalingInstances",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
     }
   ],
   "Version": "2012-10-17"

--- a/upup/pkg/fi/nodeup/BUILD.bazel
+++ b/upup/pkg/fi/nodeup/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//util/pkg/vfs:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/autoscaling:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],


### PR DESCRIPTION
AWS just launched a feature where one can create free cold standbys. These nodes run for an arbitrary amount of second as if they were normal instances, then stop. When an ASG needs to scale up, they boot up again as normal instances. 

This PR prevents kubelet from starting if the instance is entering the warm pool. That prevents the instance from joining the cluster. quickly ending up in NotReady nodes that don't go away because the instances still exists.

I have all the code already for supporting other aspects of this new feature (rolling cluster for example), but splitting across multiple PRs to make review easier.

To test this PR, you can create a new cluster, then manually click the "create warm pool" button in the console.