### PR TITLE
Automated cherry pick of #11185: Use secure kubelet auth

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -403,11 +403,6 @@ func (c *NodeupModelContext) UseBootstrapTokens() bool {
 	return c.Cluster.Spec.Kubelet != nil && c.Cluster.Spec.Kubelet.BootstrapKubeconfig != ""
 }
 
-// UseSecureKubelet checks if the kubelet api should be protected by a client certificate.
-func (c *NodeupModelContext) UseSecureKubelet() bool {
-	return c.NodeupConfig.KubeletConfig.AnonymousAuth != nil && !*c.NodeupConfig.KubeletConfig.AnonymousAuth
-}
-
 // KubectlPath returns distro based path for kubectl
 func (c *NodeupModelContext) KubectlPath() string {
 	kubeletCommand := "/usr/local/bin"

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -111,19 +111,16 @@ func (b *KubeAPIServerBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 	}
 
-	// @check if we are using secure client certificates for kubelet and grab the certificates
-	if b.UseSecureKubelet() {
-		issueCert := &nodetasks.IssueCert{
-			Name:    "kubelet-api",
-			Signer:  fi.CertificateIDCA,
-			Type:    "client",
-			Subject: nodetasks.PKIXName{CommonName: "kubelet-api"},
-		}
-		c.AddTask(issueCert)
-		err := issueCert.AddFileTasks(c, b.PathSrvKubernetes(), "kubelet-api", "", nil)
-		if err != nil {
-			return err
-		}
+	issueCert := &nodetasks.IssueCert{
+		Name:    "kubelet-api",
+		Signer:  fi.CertificateIDCA,
+		Type:    "client",
+		Subject: nodetasks.PKIXName{CommonName: "kubelet-api"},
+	}
+	c.AddTask(issueCert)
+	err := issueCert.AddFileTasks(c, b.PathSrvKubernetes(), "kubelet-api", "", nil)
+	if err != nil {
+		return err
 	}
 
 	c.AddTask(&nodetasks.File{
@@ -333,12 +330,9 @@ func (b *KubeAPIServerBuilder) buildPod() (*v1.Pod, error) {
 		kubeAPIServer.EtcdServersOverrides = []string{"/events#https://127.0.0.1:4002"}
 	}
 
-	// @check if we are using secure kubelet client certificates
-	if b.UseSecureKubelet() {
-		// @note we are making assumption were using the ones created by the pki model, not custom defined ones
-		kubeAPIServer.KubeletClientCertificate = filepath.Join(b.PathSrvKubernetes(), "kubelet-api.crt")
-		kubeAPIServer.KubeletClientKey = filepath.Join(b.PathSrvKubernetes(), "kubelet-api.key")
-	}
+	// @note we are making assumption were using the ones created by the pki model, not custom defined ones
+	kubeAPIServer.KubeletClientCertificate = filepath.Join(b.PathSrvKubernetes(), "kubelet-api.crt")
+	kubeAPIServer.KubeletClientKey = filepath.Join(b.PathSrvKubernetes(), "kubelet-api.key")
 
 	{
 		certPath := filepath.Join(b.PathSrvKubernetes(), "apiserver-aggregator.crt")

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -425,10 +425,7 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 	// Merge KubeletConfig for NodeLabels
 	c := b.NodeupConfig.KubeletConfig
 
-	// check if we are using secure kubelet <-> api settings
-	if b.UseSecureKubelet() {
-		c.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
-	}
+	c.ClientCAFile = filepath.Join(b.PathSrvKubernetes(), "ca.crt")
 
 	if isMaster {
 		c.BootstrapKubeconfig = ""

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/"
+  DAEMON_ARGS="--client-ca-file=/srv/kubernetes/ca.crt --feature-gates=AllowExtTrafficLocalEndpoints=false,ExperimentalCriticalPodAnnotation=true --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node= --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cni-bin-dir=/opt/cni/bin/ --cni-conf-dir=/etc/cni/net.d/"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file


### PR DESCRIPTION
Cherry pick of #11185 on release-1.19.

#11185: Use secure kubelet auth

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.