### PR TITLE
Remove validations for EBS from cluster validation

### DIFF
--- a/pkg/apis/kops/validation/cluster.go
+++ b/pkg/apis/kops/validation/cluster.go
@@ -110,18 +110,6 @@ func validateEtcdMemberUpdate(fp *field.Path, obj kops.EtcdMemberSpec, status *k
 		allErrs = append(allErrs, field.Forbidden(fp.Child("instanceGroup"), "instanceGroup cannot be changed"))
 	}
 
-	if fi.Int32Value(obj.VolumeSize) != fi.Int32Value(old.VolumeSize) {
-		allErrs = append(allErrs, field.Forbidden(fp.Child("volumeSize"), "volumeSize cannot be changed"))
-	}
-
-	if fi.StringValue(obj.KmsKeyId) != fi.StringValue(old.KmsKeyId) {
-		allErrs = append(allErrs, field.Forbidden(fp.Child("kmsKeyId"), "kmsKeyId cannot be changed"))
-	}
-
-	if fi.BoolValue(obj.EncryptedVolume) != fi.BoolValue(old.EncryptedVolume) {
-		allErrs = append(allErrs, field.Forbidden(fp.Child("encryptedVolume"), "encryptedVolume cannot be changed"))
-	}
-
 	return allErrs
 }
 


### PR DESCRIPTION
Refs: https://github.com/kubernetes/kops/issues/11062

We can create clusters without specifying `encryptedVolume`, but default encryption is determined by [this setting in AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default). And default value of `encryptedVolume` in kops spec is `false`. As a result,  there is a difference between the kops spec and the AWS entity. 
To resolve this difference, we have to update `encryptedVolume` in our kops spec. But at the moment kops rejects changes to `encryptedVolume`.

Therefore, I removed a validation for `encryptedVolume` in `kops edit`.
Even if I remove the validation in `kops edit`, there is a validation for `encryptedVolume` in `kops update` so it is no problem.