### PR TITLE
Kubetest2 - Cleanup leaked resources from previous clusters

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -39,6 +39,13 @@ func (d *deployer) Up() error {
 		return err
 	}
 
+	if d.terraform == nil {
+		klog.Info("Cleaning up any leaked resources from previous cluster")
+		// Intentionally ignore errors:
+		// Either the cluster didn't exist or something failed that the next cluster creation will catch
+		_ = d.Down()
+	}
+
 	publicIP, err := util.ExternalIPRange()
 	if err != nil {
 		return err


### PR DESCRIPTION
If --up is specified then we always delete any previous cluster with the same name since it would conflict otherwise and ensures leaked resources are cleaned up.

We don't do this if --terraform is specified because Down() will run `terraform destroy` but each kubetest2 invocation uses a random temp directory for its terraform state, so it wouldn't know of any resources to destroy