### PR TITLE
Make it possible to detect field changes when mixedInstancePolicy is removed

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -437,7 +437,8 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			return req.MixedInstancesPolicy
 		}
 
-		if changes.LaunchTemplate != nil {
+		// We have to update LaunchTemplate to remove mixedInstancesPolicy when it is removed from spec.
+		if changes.LaunchTemplate != nil || a.UseMixedInstancesPolicy() && !e.UseMixedInstancesPolicy() {
 			spec := &autoscaling.LaunchTemplateSpecification{
 				LaunchTemplateId: e.LaunchTemplate.ID,
 				Version:          aws.String("$Latest"),

--- a/upup/pkg/fi/dryrun_target.go
+++ b/upup/pkg/fi/dryrun_target.go
@@ -302,11 +302,16 @@ func buildChangeList(a, e, changes Task) ([]change, error) {
 			}
 
 			fieldValC := valC.Field(i)
+			fieldValE := valE.Field(i)
+			fieldValA := valA.Field(i)
 
 			changed := true
 			switch fieldValC.Kind() {
 			case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map:
 				changed = !fieldValC.IsNil()
+				if fieldValC.IsNil() && !fieldValA.IsNil() && fieldValE.IsNil() {
+					changed = true
+				}
 
 			case reflect.String:
 				changed = fieldValC.Interface().(string) != ""
@@ -320,12 +325,9 @@ func buildChangeList(a, e, changes Task) ([]change, error) {
 				continue
 			}
 
-			fieldValE := valE.Field(i)
-
 			description := ""
 			ignored := false
 			if fieldValE.CanInterface() {
-				fieldValA := valA.Field(i)
 
 				switch fieldValE.Interface().(type) {
 				//case SimpleUnit:


### PR DESCRIPTION
Refs: #11253 

When I remove mixedInstancesPolicy using `kops edit`, there are difference actual and expected. But kops don't detect that changes. So, it was causing `internal consistency error`.
I changed `buildChangeList`, so kops can detect field changes when I remove mixedInstancePolicy.
