### PR TITLE
Automated cherry pick of #11271: Add Azure image to alpha/stable channel

### DIFF
--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -335,5 +335,6 @@ func (c *Channel) HasUpstreamImagePrefix(image string) bool {
 	return strings.HasPrefix(image, "kope.io/k8s-") ||
 		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-") ||
 		strings.HasPrefix(image, "cos-cloud/cos-stable-") ||
-		strings.HasPrefix(image, "ubuntu-os-cloud/ubuntu-")
+		strings.HasPrefix(image, "ubuntu-os-cloud/ubuntu-") ||
+		strings.HasPrefix(image, "Canonical:UbuntuServer:")
 }

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -48,9 +48,8 @@ const (
 	defaultMasterMachineTypeALI   = "ecs.n2.medium"
 	defaultMasterMachineTypeAzure = "Standard_B2ms"
 
-	defaultDONodeImage    = "ubuntu-20-04-x64"
-	defaultALINodeImage   = "centos_7_04_64_20G_alibase_201701015.vhd"
-	defaultAzureNodeImage = "Canonical:UbuntuServer:20.04-LTS:latest"
+	defaultDONodeImage  = "ubuntu-20-04-x64"
+	defaultALINodeImage = "centos_7_04_64_20G_alibase_201701015.vhd"
 )
 
 // TODO: this hardcoded list can be replaced with DescribeInstanceTypes' DedicatedHostsSupported field
@@ -254,8 +253,6 @@ func defaultImage(cluster *kops.Cluster, channel *kops.Channel, architecture arc
 		return defaultDONodeImage
 	case kops.CloudProviderALI:
 		return defaultALINodeImage
-	case kops.CloudProviderAzure:
-		return defaultAzureNodeImage
 	}
 	klog.Infof("Cannot set default Image for CloudProvider=%q", cluster.Spec.CloudProvider)
 	return ""


### PR DESCRIPTION
Cherry pick of #11271 on release-1.20.

#11271: Add Azure image to alpha/stable channel

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.