### PR TITLE
Exclude nodes from load balancers upon cordoning

### DIFF
--- a/pkg/instancegroups/rollingupdate_test.go
+++ b/pkg/instancegroups/rollingupdate_test.go
@@ -45,8 +45,9 @@ import (
 )
 
 const (
-	cordonPatch = "{\"spec\":{\"unschedulable\":true}}"
-	taintPatch  = "{\"spec\":{\"taints\":[{\"effect\":\"PreferNoSchedule\",\"key\":\"kops.k8s.io/scheduled-for-update\"}]}}"
+	cordonPatch    = "{\"spec\":{\"unschedulable\":true}}"
+	excludeLBPatch = "{\"metadata\":{\"labels\":{\"node.kubernetes.io/exclude-from-external-load-balancers\":\"\"}}}"
+	taintPatch     = "{\"spec\":{\"taints\":[{\"effect\":\"PreferNoSchedule\",\"key\":\"kops.k8s.io/scheduled-for-update\"}]}}"
 )
 
 func getTestSetup() (*RollingUpdateCluster, *awsup.MockAWSCloud) {
@@ -213,6 +214,7 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 	assert.NoError(t, err, "rolling update")
 
 	cordoned := ""
+	excluded := ""
 	tainted := map[string]bool{}
 	deleted := map[string]bool{}
 	for _, action := range c.K8sClient.(*fake.Clientset).Actions() {
@@ -223,6 +225,11 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 				assert.Equal(t, "", cordoned, "at most one node cordoned at a time")
 				assert.True(t, tainted[a.GetName()], "node", a.GetName(), "tainted")
 				cordoned = a.GetName()
+			} else if string(a.GetPatch()) == excludeLBPatch {
+				assertExclude(t, a)
+				assert.Equal(t, "", excluded, "at most one node excluded at a time")
+				assert.True(t, tainted[a.GetName()], "node", a.GetName(), "tainted")
+				excluded = a.GetName()
 			} else {
 				assertTaint(t, a)
 				assert.Equal(t, "", cordoned, "not tainting while node cordoned")
@@ -232,6 +239,7 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 		case testingclient.DeleteAction:
 			assert.Equal(t, "nodes", a.GetResource().Resource)
 			assert.Equal(t, cordoned, a.GetName(), "node was cordoned before delete")
+			assert.Equal(t, excluded, a.GetName(), "node was excluded before delete")
 			assert.False(t, deleted[a.GetName()], "node", a.GetName(), "already deleted")
 			if !strings.HasPrefix(a.GetName(), "master-") {
 				assert.True(t, deleted["master-1a.local"], "master-1a was deleted before node", a.GetName())
@@ -239,6 +247,7 @@ func TestRollingUpdateAllNeedUpdate(t *testing.T) {
 			}
 			deleted[a.GetName()] = true
 			cordoned = ""
+			excluded = ""
 		case testingclient.ListAction:
 			// Don't care
 		default:
@@ -813,6 +822,7 @@ func TestRollingUpdateTaintAllButOneNeedUpdate(t *testing.T) {
 	assert.NoError(t, err, "rolling update")
 
 	cordoned := ""
+	excluded := ""
 	tainted := map[string]bool{}
 	deleted := map[string]bool{}
 	for _, action := range c.K8sClient.(*fake.Clientset).Actions() {
@@ -822,6 +832,10 @@ func TestRollingUpdateTaintAllButOneNeedUpdate(t *testing.T) {
 				assertCordon(t, a)
 				assert.Equal(t, "", cordoned, "at most one node cordoned at a time")
 				cordoned = a.GetName()
+			} else if string(a.GetPatch()) == excludeLBPatch {
+				assertExclude(t, a)
+				assert.Equal(t, "", excluded, "at most one node excluded at a time")
+				excluded = a.GetName()
 			} else {
 				assertTaint(t, a)
 				assert.False(t, tainted[a.GetName()], "node", a.GetName(), "already tainted")
@@ -830,10 +844,12 @@ func TestRollingUpdateTaintAllButOneNeedUpdate(t *testing.T) {
 		case testingclient.DeleteAction:
 			assert.Equal(t, "nodes", a.GetResource().Resource)
 			assert.Equal(t, cordoned, a.GetName(), "node was cordoned before delete")
+			assert.Equal(t, excluded, a.GetName(), "node was excluded before delete")
 			assert.Len(t, tainted, 2, "all nodes tainted before any delete")
 			assert.False(t, deleted[a.GetName()], "node", a.GetName(), "already deleted")
 			deleted[a.GetName()] = true
 			cordoned = ""
+			excluded = ""
 		case testingclient.ListAction:
 			// Don't care
 		default:
@@ -859,6 +875,7 @@ func TestRollingUpdateMaxSurgeIgnoredForMaster(t *testing.T) {
 	assert.NoError(t, err, "rolling update")
 
 	cordoned := ""
+	excluded := ""
 	tainted := map[string]bool{}
 	deleted := map[string]bool{}
 	for _, action := range c.K8sClient.(*fake.Clientset).Actions() {
@@ -869,6 +886,11 @@ func TestRollingUpdateMaxSurgeIgnoredForMaster(t *testing.T) {
 				assert.Equal(t, "", cordoned, "at most one node cordoned at a time")
 				assert.True(t, tainted[a.GetName()], "node", a.GetName(), "tainted")
 				cordoned = a.GetName()
+			} else if string(a.GetPatch()) == excludeLBPatch {
+				assertExclude(t, a)
+				assert.Equal(t, "", excluded, "at most one node excluded at a time")
+				assert.True(t, tainted[a.GetName()], "node", a.GetName(), "tainted")
+				excluded = a.GetName()
 			} else {
 				assertTaint(t, a)
 				assert.Equal(t, "", cordoned, "not tainting while node cordoned")
@@ -878,9 +900,11 @@ func TestRollingUpdateMaxSurgeIgnoredForMaster(t *testing.T) {
 		case testingclient.DeleteAction:
 			assert.Equal(t, "nodes", a.GetResource().Resource)
 			assert.Equal(t, cordoned, a.GetName(), "node was cordoned before delete")
+			assert.Equal(t, excluded, a.GetName(), "node was excluded before delete")
 			assert.False(t, deleted[a.GetName()], "node", a.GetName(), "already deleted")
 			deleted[a.GetName()] = true
 			cordoned = ""
+			excluded = ""
 		case testingclient.ListAction:
 			// Don't care
 		default:
@@ -1482,6 +1506,11 @@ func TestRollingUpdateMaxSurgeAllNeedUpdateMaxAlreadyDetached(t *testing.T) {
 func assertCordon(t *testing.T, action testingclient.PatchAction) {
 	assert.Equal(t, "nodes", action.GetResource().Resource)
 	assert.Equal(t, cordonPatch, string(action.GetPatch()))
+}
+
+func assertExclude(t *testing.T, action testingclient.PatchAction) {
+	assert.Equal(t, "nodes", action.GetResource().Resource)
+	assert.Equal(t, excludeLBPatch, string(action.GetPatch()))
 }
 
 func assertTaint(t *testing.T, action testingclient.PatchAction) {


### PR DESCRIPTION
Per kubernetes/kubernetes#90823 (k8s 1.19), nodes that are unschedulable are no longer removed from load balancers. Rolling update needs to add the appropriate label to preserve this functionality.

/area rolling-update
/kind bug