### PR TITLE
Automated cherry pick of #11276: If one tries to use eip with a public ip that doesn't exist,

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -135,7 +135,7 @@ func (e *ElasticIP) find(cloud awsup.AWSCloud) (*ElasticIP, error) {
 		}
 
 		if response == nil || len(response.Addresses) == 0 {
-			return nil, nil
+			return nil, fmt.Errorf("found no ElasticIPs for: %v", e)
 		}
 
 		if len(response.Addresses) != 1 {


### PR DESCRIPTION
Cherry pick of #11276 on release-1.20.

#11276: If one tries to use eip with a public ip that doesn't exist,

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.