### PR TITLE
Add ability to set a default Issuer in certManager addon

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -66,6 +66,7 @@ Cert-manager handles x509 certificates for your cluster.
 spec:
   certManager:
     enabled: true
+    defaultIssuer: yourDefaultIssuer
 ```
 
 **Warning: cert-manager only supports one installation per cluster. If you are already running cert-manager, you need to remove this installation prior to enabling this addon. As long as you are using v1 versions of the cert-manager resources, it is safe to remove existing installs and replace it with this addon**

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -237,6 +237,10 @@ spec:
               certManager:
                 description: CertManager determines the metrics server configuration.
                 properties:
+                  defaultIssuer:
+                    description: 'defaultIssuer sets a default clusterIssuer Default:
+                      none'
+                    type: string
                   enabled:
                     description: 'Enabled enables the cert manager. Default: false'
                     type: boolean

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -916,6 +916,10 @@ type CertManagerConfig struct {
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`
+
+	// defaultIssuer sets a default clusterIssuer
+	// Default: none
+	DefaultIssuer *string `json:"defaultIssuer,omitempty"`
 }
 
 // AWSLoadBalancerControllerConfig determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -915,6 +915,10 @@ type CertManagerConfig struct {
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`
+
+	// defaultIssuer sets a default clusterIssuer
+	// Default: none
+	DefaultIssuer *string `json:"defaultIssuer,omitempty"`
 }
 
 // AWSLoadBalancerControllerConfig determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1635,6 +1635,7 @@ func Convert_kops_CanalNetworkingSpec_To_v1alpha2_CanalNetworkingSpec(in *kops.C
 func autoConvert_v1alpha2_CertManagerConfig_To_kops_CertManagerConfig(in *CertManagerConfig, out *kops.CertManagerConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.Image = in.Image
+	out.DefaultIssuer = in.DefaultIssuer
 	return nil
 }
 
@@ -1646,6 +1647,7 @@ func Convert_v1alpha2_CertManagerConfig_To_kops_CertManagerConfig(in *CertManage
 func autoConvert_kops_CertManagerConfig_To_v1alpha2_CertManagerConfig(in *kops.CertManagerConfig, out *CertManagerConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
 	out.Image = in.Image
+	out.DefaultIssuer = in.DefaultIssuer
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -415,6 +415,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DefaultIssuer != nil {
+		in, out := &in.DefaultIssuer, &out.DefaultIssuer
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -431,6 +431,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DefaultIssuer != nil {
+		in, out := &in.DefaultIssuer, &out.DefaultIssuer
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -26279,6 +26279,11 @@ spec:
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=kube-system
         - --enable-certificate-owner-ref=true
+        {{ if .CertManager.DefaultIssuer }}
+        - --default-issuer-name={{ .CertManager.DefaultIssuer }}
+        - --default-issuer-kind=ClusterIssuer
+        - --default-issuer-group=cert-manager.io
+        {{ end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -26297,7 +26302,7 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
-        
+
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR allows to set a default clusterIssuer in cert-manager

We're using this heavily to enable automated certs in many ingresses only with the acme annotation