### PR TITLE
Automated cherry pick of #11286: feat(spot/addon): bump ocean-controller to 1.0.74

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -43383,7 +43383,7 @@ rules:
   # ----------------------------------------------------------------------------
 - apiGroups: ["certificates.k8s.io"]
   resources: ["certificatesigningrequests"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "create", "delete"]
 - apiGroups: ["certificates.k8s.io"]
   resources: ["certificatesigningrequests/approval"]
   verbs: ["patch", "update"]
@@ -43494,7 +43494,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.73
+        image: spotinst/kubernetes-cluster-controller:1.0.74
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -94,7 +94,7 @@ rules:
   # ----------------------------------------------------------------------------
 - apiGroups: ["certificates.k8s.io"]
   resources: ["certificatesigningrequests"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "create", "delete"]
 - apiGroups: ["certificates.k8s.io"]
   resources: ["certificatesigningrequests/approval"]
   verbs: ["patch", "update"]
@@ -205,7 +205,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: spotinst/kubernetes-cluster-controller:1.0.73
+        image: spotinst/kubernetes-cluster-controller:1.0.74
         livenessProbe:
           httpGet:
             path: /healthcheck

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -667,7 +667,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		{
 			id := "v1.14.0"
 			location := key + "/" + id + ".yaml"
-			version := "1.0.73"
+			version := "1.0.74"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
 				Name:              fi.String(key),


### PR DESCRIPTION
Cherry pick of #11286 on release-1.20.

#11286: feat(spot/addon): bump ocean-controller to 1.0.74

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.