### PR TITLE
Apiserver fixes

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -228,7 +228,7 @@ func (c *NodeupModelContext) BuildIssuedKubeconfig(name string, subject nodetask
 		Key:  keyResource,
 		CA:   caResource,
 	}
-	if c.IsMaster {
+	if c.HasAPIServer {
 		// @note: use https even for local connections, so we can turn off the insecure port
 		kubeConfig.ServerURL = "https://127.0.0.1"
 	} else {
@@ -267,7 +267,7 @@ func (c *NodeupModelContext) BuildBootstrapKubeconfig(name string, ctx *fi.Model
 			Key:  key,
 			CA:   fi.NewBytesResource(ca),
 		}
-		if c.IsMaster {
+		if c.HasAPIServer {
 			// @note: use https even for local connections, so we can turn off the insecure port
 			kubeConfig.ServerURL = "https://127.0.0.1"
 		} else {
@@ -302,7 +302,7 @@ func (c *NodeupModelContext) BuildBootstrapKubeconfig(name string, ctx *fi.Model
 			Key:  fi.NewBytesResource(key),
 			CA:   fi.NewBytesResource(ca),
 		}
-		if c.IsMaster {
+		if c.HasAPIServer {
 			// @note: use https even for local connections, so we can turn off the insecure port
 			// This code path is used for the kubelet cert in Kubernetes 1.18 and earlier.
 			kubeConfig.ServerURL = "https://127.0.0.1"
@@ -399,7 +399,7 @@ func (c *NodeupModelContext) UsesSecondaryIP() bool {
 
 // UseBootstrapTokens checks if we are using bootstrap tokens
 func (c *NodeupModelContext) UseBootstrapTokens() bool {
-	if c.IsMaster {
+	if c.HasAPIServer {
 		return fi.BoolValue(c.Cluster.Spec.KubeAPIServer.EnableBootstrapAuthToken)
 	}
 

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -85,7 +85,7 @@ func (b *KubeProxyBuilder) Build(c *fi.ModelBuilderContext) error {
 		var kubeconfig fi.Resource
 		var err error
 
-		if b.IsMaster {
+		if b.HasAPIServer {
 			kubeconfig = b.BuildIssuedKubeconfig("kube-proxy", nodetasks.PKIXName{CommonName: rbac.KubeProxy}, c)
 		} else {
 			kubeconfig, err = b.BuildBootstrapKubeconfig("kube-proxy", c)

--- a/nodeup/pkg/model/kubectl.go
+++ b/nodeup/pkg/model/kubectl.go
@@ -35,7 +35,7 @@ var _ fi.ModelBuilder = &KubectlBuilder{}
 
 // Build is responsible for managing the kubectl on the nodes
 func (b *KubectlBuilder) Build(c *fi.ModelBuilderContext) error {
-	if !b.IsMaster {
+	if !b.HasAPIServer {
 		return nil
 	}
 

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -115,9 +115,9 @@ func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
 			Mode: s("0755"),
 		})
 
-		if b.IsMaster || !b.UseBootstrapTokens() {
+		if b.HasAPIServer || !b.UseBootstrapTokens() {
 			var kubeconfig fi.Resource
-			if b.IsMaster && (b.IsKubernetesGTE("1.19") || b.UseBootstrapTokens()) {
+			if b.HasAPIServer && (b.IsKubernetesGTE("1.19") || b.UseBootstrapTokens()) {
 				kubeconfig, err = b.buildMasterKubeletKubeconfig(c)
 			} else {
 				kubeconfig, err = b.BuildBootstrapKubeconfig("kubelet", c)
@@ -565,7 +565,7 @@ func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.ModelBuilderContex
 			return err
 		}
 
-		if !b.IsMaster {
+		if !b.HasAPIServer {
 			cert, key := b.GetBootstrapCert(name)
 
 			c.AddTask(&nodetasks.File{

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -64,8 +64,10 @@ spec:
 {{ range $arg := KopsControllerArgv }}
         - "{{ $arg }}"
 {{ end }}
-{{- if KopsSystemEnv }}
         env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+{{- if KopsSystemEnv }}
 {{ range $var := KopsSystemEnv }}
         - name: {{ $var.Name }}
           value: {{ $var.Value }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0a42bd40e2057fe077b41f0ddf20b1f4ce6a852e
+    manifestHash: a9b3e339b0da476af01be54bcfd68064cb3219e0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0a42bd40e2057fe077b41f0ddf20b1f4ce6a852e
+    manifestHash: a9b3e339b0da476af01be54bcfd68064cb3219e0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d393cb5a91ee4b47c4666d60f0f88a959aaa7b1c
+    manifestHash: 13c4c6fca314d4349070ed8f9f1f58f284bfebfe
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d393cb5a91ee4b47c4666d60f0f88a959aaa7b1c
+    manifestHash: 13c4c6fca314d4349070ed8f9f1f58f284bfebfe
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -44,6 +44,9 @@ spec:
         - /kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config/config.yaml
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: k8s.gcr.io/kops/kops-controller:1.21.0-alpha.3
         name: kops-controller
         resources:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0a42bd40e2057fe077b41f0ddf20b1f4ce6a852e
+    manifestHash: a9b3e339b0da476af01be54bcfd68064cb3219e0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -44,6 +44,9 @@ spec:
         - /kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config/config.yaml
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: k8s.gcr.io/kops/kops-controller:1.21.0-alpha.3
         name: kops-controller
         resources:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/public-jwks/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0a42bd40e2057fe077b41f0ddf20b1f4ce6a852e
+    manifestHash: a9b3e339b0da476af01be54bcfd68064cb3219e0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -46,6 +46,9 @@ spec:
         - /kops-controller
         - --v=2
         - --conf=/etc/kubernetes/kops-controller/config/config.yaml
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: k8s.gcr.io/kops/kops-controller:1.21.0-alpha.3
         name: kops-controller
         resources:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d393cb5a91ee4b47c4666d60f0f88a959aaa7b1c
+    manifestHash: 13c4c6fca314d4349070ed8f9f1f58f284bfebfe
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,7 +7,7 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d393cb5a91ee4b47c4666d60f0f88a959aaa7b1c
+    manifestHash: 13c4c6fca314d4349070ed8f9f1f58f284bfebfe
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:


### PR DESCRIPTION
This PR includes two fixes for issues I ran into when stress testing the API. Both are technically around kops-controller going into crashloop, preventing more api servers to join the cluster. See the individual commits for details.

* Make kops-controller use the local apiserver
* Make APIServer role less dependent on kops-controller