### PR TITLE
fix: create.go doesnt add --name flag to the prompt: kops update cluster

### DIFF
--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -226,7 +226,7 @@ func RunCreate(ctx context.Context, f *util.Factory, out io.Writer, c *CreateOpt
 		// so let's advise the user how to engage the cloud provider and deploy
 		if sb.String() != "" {
 			fmt.Fprintf(&sb, "\n")
-			fmt.Fprintf(&sb, "To deploy these resources, run: kops update cluster %s --yes\n", clusterName)
+			fmt.Fprintf(&sb, "To deploy these resources, run: kops update cluster --name %s --yes\n", clusterName)
 			fmt.Fprintf(&sb, "\n")
 		}
 		_, err := out.Write(sb.Bytes())


### PR DESCRIPTION
When you execute `kops create`, it will prompt:
`To deploy these resources, run: kops update cluster %s --yes`, and if you copy/paste this line it wont work.
The correct line is:
`To deploy these resources, run: kops update cluster --name %s --yes`