### PR TITLE
fix permissions required for NTH Queue Processor

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -143,20 +143,27 @@ The kOps CLI requires additional IAM permissions to manage the requisite EventBr
 
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "events:PutEvents",
-                "events:PutTargets",
-                "sqs:CreateQueue",
-                "sqs:ListQueues",
-                "sqs:DeleteQueue",
-            ],
-            "Resource": "*"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "events:DeleteRule",
+        "events:ListRules",
+        "events:ListTargetsByRule",
+        "events:ListTagsForResource",
+        "events:PutEvents",
+        "events:PutTargets",
+        "events:RemoveTargets",
+        "sqs:CreateQueue",
+        "sqs:DeleteQueue",
+        "sqs:GetQueueAttributes",
+        "sqs:ListQueues",
+        "sqs:ListQueueTags"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 ```
 

--- a/docs/releases/1.21-NOTES.md
+++ b/docs/releases/1.21-NOTES.md
@@ -21,7 +21,7 @@ In 1.21, this feature is behind a feature flag as node role name, labels, taints
 
 # Required Actions
 
-* To support [Node Termination Handler's Queue Process mode](/addons/#node-termination-handler), AWS cluster deletion now requires the kops CLI have `sqs:ListQueues` permission regardless of whether or not the addon is used.
+* To support [Node Termination Handler's Queue Process mode](/addons/#node-termination-handler), AWS cluster deletion now requires the kops CLI have `sqs:ListQueues` and `events:ListRules` permissions regardless of whether or not the addon is used.
 
 # Deprecations
 

--- a/pkg/resources/aws/eventbridge.go
+++ b/pkg/resources/aws/eventbridge.go
@@ -48,19 +48,19 @@ func DeleteEventBridgeRule(cloud fi.Cloud, r *resources.Resource) error {
 	if err != nil {
 		return fmt.Errorf("error listing targets for EventBridge rule %q: %v", r.Name, err)
 	}
-
-	var ids []*string
-	for _, target := range targets.Targets {
-		ids = append(ids, target.Id)
-	}
-
-	klog.V(2).Infof("Removing EventBridge Targets for rule %q", r.Name)
-	_, err = c.EventBridge().RemoveTargets(&eventbridge.RemoveTargetsInput{
-		Ids:  ids,
-		Rule: aws.String(r.Name),
-	})
-	if err != nil {
-		return fmt.Errorf("error removing targets for EventBridge rule %q: %v", r.Name, err)
+	if len(targets.Targets) > 0 {
+		var ids []*string
+		for _, target := range targets.Targets {
+			ids = append(ids, target.Id)
+		}
+		klog.V(2).Infof("Removing EventBridge Targets for rule %q", r.Name)
+		_, err = c.EventBridge().RemoveTargets(&eventbridge.RemoveTargetsInput{
+			Ids:  ids,
+			Rule: aws.String(r.Name),
+		})
+		if err != nil {
+			return fmt.Errorf("error removing targets for EventBridge rule %q: %v", r.Name, err)
+		}
 	}
 
 	klog.V(2).Infof("Deleting EventBridge rule %q", r.Name)


### PR DESCRIPTION
There were more missing permissions for NTH Queue Processor for deleting/updating the resources. Perhaps at this point it would be reasonable to grant full access to sqs and eventbridge, similar to how the other kops user permissions are configured? 

Additionally I noticed a small error when deleting EventBridge rules that had already had their targets removed, so that check is included in here. I can split it into a different pr if that's the preference