### PR TITLE
Automated cherry pick of #11312: Use the full operator instead of the generic one

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -32775,7 +32775,7 @@ spec:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
         command:
-        - cilium-operator-generic
+        - cilium-operator
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -32797,7 +32797,7 @@ spec:
           value: "{{ $.MasterInternalName }}"
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: "docker.io/cilium/operator-generic:{{ .Version }}"
+        image: "docker.io/cilium/operator:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -809,7 +809,7 @@ spec:
         - --config-dir=/tmp/cilium/config-map
         - --debug=$(CILIUM_DEBUG)
         command:
-        - cilium-operator-generic
+        - cilium-operator
         env:
         - name: K8S_NODE_NAME
           valueFrom:
@@ -831,7 +831,7 @@ spec:
           value: "{{ $.MasterInternalName }}"
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: "docker.io/cilium/operator-generic:{{ .Version }}"
+        image: "docker.io/cilium/operator:{{ .Version }}"
         imagePullPolicy: IfNotPresent
         name: cilium-operator
         {{ if .EnablePrometheusMetrics }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -70,7 +70,7 @@ spec:
     version: 1.17.0
   - id: k8s-1.12
     manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
-    manifestHash: 2831146cb6f181255c69a09d8e97cc406304a81a
+    manifestHash: a334e7c66061f19b6bd9b1ee95ce9a60c6e3f020
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #11312 on release-1.20.

#11312: Use the full operator instead of the generic one

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.