### PR TITLE
[metrics-server] Bump manifest to latest stable

### DIFF
--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -1,4 +1,4 @@
-# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
+# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.3/components.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -79,7 +79,6 @@ subjects:
   name: metrics-server
   namespace: kube-system
 ---
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -94,8 +93,6 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
----
-
 ---
 apiVersion: v1
 kind: Service
@@ -133,6 +130,7 @@ spec:
       containers:
       - args:
           - --secure-port=4443
+          - --kubelet-use-node-status-port
 {{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
           - --tls-cert-file=/srv/tls.crt
           - --tls-private-key-file=/srv/tls.key
@@ -141,8 +139,8 @@ spec:
 {{ end }}
 {{ if not UseKopsControllerForNodeBootstrap }}
           - --kubelet-insecure-tls
-{{ end }} 
-        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.2" }}
+{{ end }}
+        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.3" }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -174,6 +172,10 @@ spec:
 {{ end }}
         - mountPath: /tmp
           name: tmp-dir
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
- Bump image to v0.4.3
- Set new default kubelet options based on upstream behavior
- Set default requested resources

As part of https://github.com/kubernetes/kops/issues/11251