### PR TITLE
Fix kops-controller's GCE ListManagedInstances filter

### DIFF
--- a/pkg/nodeidentity/gce/identify.go
+++ b/pkg/nodeidentity/gce/identify.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
@@ -180,7 +179,7 @@ func (i *nodeIdentifier) getMIG(zone string, migName string) (*compute.InstanceG
 
 // getMIGMember queries GCE for the instance from the MIG
 func (i *nodeIdentifier) getManagedInstance(mig *compute.InstanceGroupManager, instanceID uint64) (*compute.ManagedInstance, error) {
-	filter := "id=" + strconv.FormatUint(instanceID, 10)
+	filter := fmt.Sprintf("id=\"%d\"", instanceID)
 	zone := lastComponent(mig.Zone)
 	instances, err := i.computeService.InstanceGroupManagers.ListManagedInstances(i.project, zone, mig.Name).Filter(filter).Do()
 	if err != nil {


### PR DESCRIPTION
We are seeing [logs](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/10847/pull-kops-e2e-k8s-gce/1385969563077709824/artifacts/cluster-info/kube-system/kops-controller-pbmbh/logs.txt) of "found instances with mismatched id" indicating the filter is not working correctly (see Line 194 of identify.go).

The [documentation](https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroupManagers/listManagedInstances#response-body) mentions that the ID field is actually a string, so this quotes the value of the id filter to match [other filter examples](https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroupManagers/listManagedInstances#query-parameters) using string fields.