### PR TITLE
Fix arguments to csi-provisioner after bump to v2.2.0

### DIFF
--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -403,8 +403,7 @@ spec:
             - --csi-address=$(ADDRESS)
             - --v=5
             - --feature-gates=Topology=true
-            - --enable-leader-election
-            - --leader-election-type=leases
+            - --leader-election=true
             - --extra-create-metadata=true
           env:
             - name: ADDRESS

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -73,7 +73,7 @@ spec:
   - id: k8s-1.17
     kubernetesVersion: '>=1.17.0'
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0b66cd8dc9a3bd98e0138d424bc88d178f78e983
+    manifestHash: 89b6fd8933efc88c74a0931e465967a10f2dfde4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io


### PR DESCRIPTION
Parameters for leader elections have changed in v2.2.0, which causes the
csi-provisioner to not start anymore.