### PR TITLE
Set SAN for addon CAs

### DIFF
--- a/channels/pkg/channels/addon.go
+++ b/channels/pkg/channels/addon.go
@@ -237,6 +237,9 @@ func (a *Addon) installPKI(ctx context.Context, k8sClient kubernetes.Interface, 
 		Subject: pkix.Name{
 			CommonName: a.Name,
 		},
+		AlternateNames: []string{
+			a.Name,
+		},
 	}
 	cert, privateKey, _, err := pki.IssueCert(req, nil)
 	if err != nil {


### PR DESCRIPTION
We currently don't set alternative names on addon CAs, which results in failure for anything running go 1.16.