### PR TITLE
Set IMDSv2 on by default for nodes and apiservers

### DIFF
--- a/docs/releases/1.22-NOTES.md
+++ b/docs/releases/1.22-NOTES.md
@@ -6,6 +6,20 @@ This is a document to gather the release notes prior to the release.
 
 # Significant changes
 
+## Instance metadata service version 2
+
+ On AWS, kOps will enable [Instance Metadata Service Version 2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) by default with a max-hop-limit of 1 on new clusters that use Kubernetes 1.22. This means that any container running in the cluster will be unable to connect to the instance metadata _unless_ the container is running with `hostNetworking: true`. This will increase security by default, but may break some types of workloads. In order to revert to old behavior, add the following to the InstanceGroup:
+
+```
+spec:
+  instanceMetadata:
+    httpTokens: optional
+```
+
+This change only affects dedicated API server nodes and worker nodes. It does not affect control plane nodes.
+
+## Other significant changes
+
 * New clusters running Kubernetes 1.22 will have AWS EBS CSI driver enabled by default.
 
 # Breaking changes

--- a/tests/integration/create_cluster/minimal-1.22/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.22/expected-v1alpha2.yaml
@@ -66,6 +66,9 @@ metadata:
   name: master-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210415
+  instanceMetadata:
+    httpPutResponseHopLimit: 3
+    httpTokens: required
   machineType: m3.medium
   maxSize: 1
   minSize: 1
@@ -86,6 +89,9 @@ metadata:
   name: nodes-us-test-1a
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210415
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
   machineType: t2.medium
   maxSize: 1
   minSize: 1

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -693,6 +693,13 @@ func setupMasters(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap 
 				g.Spec.Zones = []string{zone}
 			}
 
+			if cluster.IsKubernetesGTE("1.22") {
+				g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{
+					HTTPPutResponseHopLimit: fi.Int64(3),
+					HTTPTokens:              fi.String("required"),
+				}
+			}
+
 			masters = append(masters, g)
 		}
 	}
@@ -807,6 +814,13 @@ func setupNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetMap ma
 			g.Spec.Zones = []string{zone}
 		}
 
+		if cluster.IsKubernetesGTE("1.22") {
+			g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{
+				HTTPPutResponseHopLimit: fi.Int64(1),
+				HTTPTokens:              fi.String("required"),
+			}
+		}
+
 		nodes = append(nodes, g)
 	}
 
@@ -846,6 +860,13 @@ func setupAPIServers(opt *NewClusterOptions, cluster *api.Cluster, zoneToSubnetM
 		g.Spec.Subnets = []string{subnet.Name}
 		if cp := api.CloudProviderID(cluster.Spec.CloudProvider); cp == api.CloudProviderGCE || cp == api.CloudProviderAzure {
 			g.Spec.Zones = []string{zone}
+		}
+
+		if cluster.IsKubernetesGTE("1.22") {
+			g.Spec.InstanceMetadata = &api.InstanceMetadataOptions{
+				HTTPPutResponseHopLimit: fi.Int64(1),
+				HTTPTokens:              fi.String("required"),
+			}
 		}
 
 		nodes = append(nodes, g)
@@ -998,6 +1019,14 @@ func setupTopology(opt *NewClusterOptions, cluster *api.Cluster, allZones sets.S
 			if api.CloudProviderID(cluster.Spec.CloudProvider) == api.CloudProviderGCE {
 				bastionGroup.Spec.Zones = allZones.List()
 			}
+
+			if cluster.IsKubernetesGTE("1.22") {
+				bastionGroup.Spec.InstanceMetadata = &api.InstanceMetadataOptions{
+					HTTPPutResponseHopLimit: fi.Int64(1),
+					HTTPTokens:              fi.String("required"),
+				}
+			}
+
 		}
 
 	default:


### PR DESCRIPTION
This should mitigate security concerns around things like e.g enabling lifecycle hooks by default