### PR TITLE
Skip warmpool deletion when creating clusters

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -104,7 +104,7 @@ func (*WarmPool) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *WarmPool) error
 				}
 				return fmt.Errorf("error modifying warm pool: %w", err)
 			}
-		} else {
+		} else if a != nil {
 			_, err := svc.DeleteWarmPool(&autoscaling.DeleteWarmPoolInput{
 				AutoScalingGroupName: e.Name,
 				// We don't need to do any cleanup so, the faster the better


### PR DESCRIPTION
Fixes: #11282 

At the moment, kOps calls `DeleteWarmPool` method when creating cluster. So it says error. 
I changed to skip this logic when create new clusters.