### PR TITLE
Update kubetest2 dependency and fix install method for upgrade scenario

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -12,7 +12,7 @@ require (
 	k8s.io/klog/v2 v2.8.0
 	k8s.io/kops v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc
-	sigs.k8s.io/kubetest2 v0.0.0-20210309183806-9230b4e73d8d
+	sigs.k8s.io/kubetest2 v0.0.0-20210423234514-1c731a5d2283
 )
 
 replace k8s.io/kops => ../../.

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -2211,8 +2211,8 @@ sigs.k8s.io/controller-runtime v0.5.4/go.mod h1:JZUwSMVbxDupo0lTJSSFP5pimEyxGynR
 sigs.k8s.io/controller-runtime v0.6.2/go.mod h1:vhcq/rlnENJ09SIRp3EveTaZ0yqH526hjf9iJdbUJ/E=
 sigs.k8s.io/controller-runtime v0.9.0-alpha.1/go.mod h1:BARxVvgj+8Ihw9modUvYh7/OJmjxuBtLK8P36jdf7rY=
 sigs.k8s.io/controller-tools v0.2.9-0.20200414181213-645d44dca7c0/go.mod h1:YKE/iHvcKITCljdnlqHYe+kAt7ZldvtAwUzQff0k1T0=
-sigs.k8s.io/kubetest2 v0.0.0-20210309183806-9230b4e73d8d h1:dhWiqYfVQS+jhaoGsdbw7rZJjtuN4gzgcoHPgXptttI=
-sigs.k8s.io/kubetest2 v0.0.0-20210309183806-9230b4e73d8d/go.mod h1:miwZW11FA2Bvclxo4WqIVY+gHTR5B927inXdfxJYoAA=
+sigs.k8s.io/kubetest2 v0.0.0-20210423234514-1c731a5d2283 h1:8w3J6N9j8lUP3lb3B/2PGsJ5A6rtFF9wUpPPEk9/ctI=
+sigs.k8s.io/kubetest2 v0.0.0-20210423234514-1c731a5d2283/go.mod h1:miwZW11FA2Bvclxo4WqIVY+gHTR5B927inXdfxJYoAA=
 sigs.k8s.io/kustomize/api v0.8.5/go.mod h1:M377apnKT5ZHJS++6H4rQoCHmWtt6qTpp3mbe7p6OLY=
 sigs.k8s.io/kustomize/cmd/config v0.9.7/go.mod h1:MvXCpHs77cfyxRmCNUQjIqCmZyYsbn5PyQpWiq44nW0=
 sigs.k8s.io/kustomize/kustomize/v4 v4.0.5/go.mod h1:C7rYla7sI8EnxHE/xEhRBSHMNfcL91fx0uKmUlUhrBk=

--- a/tests/e2e/scenarios/upgrade/run-test
+++ b/tests/e2e/scenarios/upgrade/run-test
@@ -28,7 +28,7 @@ KUBETEST2_COMMON_ARGS="-v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${
 KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --admin-access=${ADMIN_ACCESS:-}"
 
 export GO111MODULE=on
-go get sigs.k8s.io/kubetest2@latest
+go install sigs.k8s.io/kubetest2
 
 cd ${REPO_ROOT}/tests/e2e
 go install ./kubetest2-kops


### PR DESCRIPTION
This should fix the upgrade jobs: https://testgrid.k8s.io/kops-misc#kops-aws-upgrade