### PR TITLE
Automated cherry pick of #11328: Set SAN for addon CAs

### DIFF
--- a/channels/pkg/channels/addon.go
+++ b/channels/pkg/channels/addon.go
@@ -235,6 +235,9 @@ func (a *Addon) installPKI(ctx context.Context, k8sClient kubernetes.Interface, 
 		Subject: pkix.Name{
 			CommonName: a.Name,
 		},
+		AlternateNames: []string{
+			a.Name,
+		},
 	}
 	cert, privateKey, _, err := pki.IssueCert(req, nil)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #11328 on release-1.20.

#11328: Set SAN for addon CAs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.