### PR TITLE
Automated cherry pick of #11333: Add support for configuring Cilium

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2468,6 +2468,9 @@ spec:
                       enableEncryption:
                         description: 'EnableEncryption enables Cilium Encryption. Default: false'
                         type: boolean
+                      enableHostReachableServices:
+                        description: 'EnableHostReachableServices configures Cilium to enable services to be reached from the host namespace in addition to pod namespaces. https://docs.cilium.io/en/v1.9/gettingstarted/host-services/ Default: false'
+                        type: boolean
                       enableNodePort:
                         description: 'EnableNodePort replaces kube-proxy with Cilium''s BPF implementation. Requires spec.kubeProxy.enabled be set to false. Default: false'
                         type: boolean

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -466,6 +466,11 @@ type CiliumNetworkingSpec struct {
 	// AutoDirectNodeRoutes adds automatic L2 routing between nodes.
 	// Default: false
 	AutoDirectNodeRoutes bool `json:"autoDirectNodeRoutes,omitempty"`
+	// EnableHostReachableServices configures Cilium to enable services to be
+	// reached from the host namespace in addition to pod namespaces.
+	// https://docs.cilium.io/en/v1.9/gettingstarted/host-services/
+	// Default: false
+	EnableHostReachableServices bool `json:"enableHostReachableServices,omitempty"`
 	// EnableNodePort replaces kube-proxy with Cilium's BPF implementation.
 	// Requires spec.kubeProxy.enabled be set to false.
 	// Default: false

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -464,6 +464,11 @@ type CiliumNetworkingSpec struct {
 	// AutoDirectNodeRoutes adds automatic L2 routing between nodes.
 	// Default: false
 	AutoDirectNodeRoutes bool `json:"autoDirectNodeRoutes,omitempty"`
+	// EnableHostReachableServices configures Cilium to enable services to be
+	// reached from the host namespace in addition to pod namespaces.
+	// https://docs.cilium.io/en/v1.9/gettingstarted/host-services/
+	// Default: false
+	EnableHostReachableServices bool `json:"enableHostReachableServices,omitempty"`
 	// EnableNodePort replaces kube-proxy with Cilium's BPF implementation.
 	// Requires spec.kubeProxy.enabled be set to false.
 	// Default: false

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1529,6 +1529,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.Ipam = in.Ipam
 	out.IPTablesRulesNoinstall = in.IPTablesRulesNoinstall
 	out.AutoDirectNodeRoutes = in.AutoDirectNodeRoutes
+	out.EnableHostReachableServices = in.EnableHostReachableServices
 	out.EnableNodePort = in.EnableNodePort
 	out.EtcdManaged = in.EtcdManaged
 	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity
@@ -1621,6 +1622,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.Ipam = in.Ipam
 	out.IPTablesRulesNoinstall = in.IPTablesRulesNoinstall
 	out.AutoDirectNodeRoutes = in.AutoDirectNodeRoutes
+	out.EnableHostReachableServices = in.EnableHostReachableServices
 	out.EnableNodePort = in.EnableNodePort
 	out.EtcdManaged = in.EtcdManaged
 	out.EnableRemoteNodeIdentity = in.EnableRemoteNodeIdentity

--- a/pkg/commands/set_cluster_test.go
+++ b/pkg/commands/set_cluster_test.go
@@ -240,6 +240,21 @@ func TestSetClusterFields(t *testing.T) {
 		},
 		{
 			Fields: []string{
+				"cluster.spec.networking.cilium.enableHostReachableServices=true",
+			},
+			Input: kops.Cluster{},
+			Output: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					Networking: &kops.NetworkingSpec{
+						Cilium: &kops.CiliumNetworkingSpec{
+							EnableHostReachableServices: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			Fields: []string{
 				"cluster.spec.networking.cilium.enableNodePort=true",
 			},
 			Input: kops.Cluster{},

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -4770,6 +4770,9 @@ data:
   masquerade: "{{- if .DisableMasquerade -}}false{{- else -}}true{{- end -}}"
   install-iptables-rules: "{{- if .IPTablesRulesNoinstall -}}false{{- else -}}true{{- end -}}"
   auto-direct-node-routes: "{{ .AutoDirectNodeRoutes }}"
+  {{ if .EnableHostReachableServices }}
+  enable-host-reachable-services: "{{ .EnableHostReachableServices }}"
+  {{ end }}
   enable-node-port: "{{ .EnableNodePort }}"
   kube-proxy-replacement: "{{- if .EnableNodePort -}}strict{{- else -}}partial{{- end -}}"
   enable-remote-node-identity: "{{ .EnableRemoteNodeIdentity -}}"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -154,6 +154,9 @@ data:
   masquerade: "{{- if .DisableMasquerade -}}false{{- else -}}true{{- end -}}"
   install-iptables-rules: "{{- if .IPTablesRulesNoinstall -}}false{{- else -}}true{{- end -}}"
   auto-direct-node-routes: "{{ .AutoDirectNodeRoutes }}"
+  {{ if .EnableHostReachableServices }}
+  enable-host-reachable-services: "{{ .EnableHostReachableServices }}"
+  {{ end }}
   enable-node-port: "{{ .EnableNodePort }}"
   kube-proxy-replacement: "{{- if .EnableNodePort -}}strict{{- else -}}partial{{- end -}}"
   enable-remote-node-identity: "{{ .EnableRemoteNodeIdentity -}}"


### PR DESCRIPTION
Cherry pick of #11333 on release-1.19.

#11333: Add support for configuring Cilium

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.