### PR TITLE
Ignore detached nodes when doing validate cluster

### DIFF
--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -311,6 +311,10 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 					nodeExpectedToJoin = false
 				}
 
+				if member.Status == cloudinstances.CloudInstanceStatusDetached {
+					nodeExpectedToJoin = false
+				}
+
 				if nodeExpectedToJoin {
 					v.addError(&ValidationError{
 						Kind:          "Machine",


### PR DESCRIPTION
Ran into this issue while doing rolling-update on our cluster today. The rolling updated was cancelled (for unrelated reasons) before it could complete.