### PR TITLE
Fix kubetest2 panic inheriting env vars

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -123,8 +123,11 @@ func (d *deployer) initialize() error {
 		for _, envvar := range d.env() {
 			// Set all of the env vars we use for kops in the current process
 			// so that the tester inherits them when shelling out to kops
-			i := strings.Index(envvar, "=")
-			os.Setenv(envvar[0:i], envvar[i+1:])
+			if i := strings.Index(envvar, "="); i != -1 {
+				os.Setenv(envvar[0:i], envvar[i+1:])
+			} else {
+				os.Setenv(envvar, "")
+			}
 		}
 	}
 	return nil
@@ -137,7 +140,7 @@ func (d *deployer) verifyKopsFlags() error {
 		if err != nil {
 			return err
 		}
-		klog.Info("Using cluster name ", d.ClusterName)
+		klog.Infof("Using cluster name: %v", d.ClusterName)
 		d.ClusterName = name
 	}
 


### PR DESCRIPTION
Fixes `panic: runtime error: slice bounds out of range [:-1]` found here: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-grid-scenario-aws-cloud-controller-manager/1387534126441041920

Also fixes a logging statement to include the cluster name (empty cluster name is seen in those same logs)