### PR TITLE
Mount /run inside etcd-manager pods for systemd mounts

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -185,6 +185,8 @@ spec:
     # TODO: Would be nice to scope this more tightly, but needed for volume mounting
     - mountPath: /rootfs
       name: rootfs
+    - mountPath: /run
+      name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
   hostNetwork: true
@@ -194,6 +196,10 @@ spec:
       path: /
       type: Directory
     name: rootfs
+  - hostPath:
+      path: /run
+      type: DirectoryOrCreate
+    name: run
   - hostPath:
       path: /etc/kubernetes/pki/etcd-manager
       type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -94,6 +94,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -109,6 +111,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -159,6 +165,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -174,6 +182,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -94,6 +94,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /etc/hosts
@@ -111,6 +113,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -165,6 +171,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /etc/hosts
@@ -182,6 +190,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -97,6 +97,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -112,6 +114,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -165,6 +171,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -180,6 +188,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
@@ -94,6 +94,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -109,6 +111,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -159,6 +165,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -174,6 +182,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -103,6 +103,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /etc/hosts
@@ -120,6 +122,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -183,6 +189,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /etc/hosts
@@ -200,6 +208,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate


### PR DESCRIPTION
xRef: https://github.com/kubernetes-sigs/etcdadm/pull/213

This will have no effect without the necessary binaries in the `etcd-manager` image.
`/run` is already available in `/rootfs/run` so there are no new security concerns.

/cc @olemarkus 