### PR TITLE
Automated cherry pick of #11352: Mount /run inside etcd-manager pods for systemd mounts

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -184,6 +184,8 @@ spec:
     # TODO: Would be nice to scope this more tightly, but needed for volume mounting
     - mountPath: /rootfs
       name: rootfs
+    - mountPath: /run
+      name: run
     - mountPath: /etc/kubernetes/pki/etcd-manager
       name: pki
   hostNetwork: true
@@ -193,6 +195,10 @@ spec:
       path: /
       type: Directory
     name: rootfs
+  - hostPath:
+      path: /run
+      type: DirectoryOrCreate
+    name: run
   - hostPath:
       path: /etc/kubernetes/pki/etcd-manager
       type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -85,6 +85,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -100,6 +102,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -142,6 +148,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -157,6 +165,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -85,6 +85,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /etc/hosts
@@ -102,6 +104,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -148,6 +154,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /etc/hosts
@@ -165,6 +173,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -88,6 +88,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -103,6 +105,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -148,6 +154,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -163,6 +171,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
@@ -85,6 +85,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -100,6 +102,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -142,6 +148,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /var/log/etcd.log
@@ -157,6 +165,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -94,6 +94,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /etc/hosts
@@ -111,6 +113,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-events
         type: DirectoryOrCreate
@@ -166,6 +172,8 @@ Contents: |
       volumeMounts:
       - mountPath: /rootfs
         name: rootfs
+      - mountPath: /run
+        name: run
       - mountPath: /etc/kubernetes/pki/etcd-manager
         name: pki
       - mountPath: /etc/hosts
@@ -183,6 +191,10 @@ Contents: |
         path: /
         type: Directory
       name: rootfs
+    - hostPath:
+        path: /run
+        type: DirectoryOrCreate
+      name: run
     - hostPath:
         path: /etc/kubernetes/pki/etcd-manager-main
         type: DirectoryOrCreate


### PR DESCRIPTION
Cherry pick of #11352 on release-1.20.

#11352: Mount /run inside etcd-manager pods for systemd mounts

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.