### PR TITLE
[addons/nth] Add capability to define resources

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3928,6 +3928,14 @@ spec:
                 description: NodeTerminationHandler determines the cluster autoscaler
                   configuration.
                 properties:
+                  cpuRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'CPURequest of NodeTerminationHandler container.
+                      Default: 50m'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   enableSQSTerminationDraining:
                     description: EnableSQSTerminationDraining enables queue-processor
                       mode which drains nodes when an SQS termination event is received.
@@ -3950,6 +3958,14 @@ spec:
                     description: ManagedASGTag is the tag used to determine which
                       nodes NTH can take action on
                     type: string
+                  memoryRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'MemoryRequest of NodeTerminationHandler container.
+                      Default: 64Mi'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   prometheusEnable:
                     description: EnablePrometheusMetrics enables the "/metrics" endpoint.
                     type: boolean

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -871,6 +871,13 @@ type NodeTerminationHandlerConfig struct {
 
 	// ManagedASGTag is the tag used to determine which nodes NTH can take action on
 	ManagedASGTag *string `json:"managedASGTag,omitempty"`
+
+	// MemoryRequest of NodeTerminationHandler container.
+	// Default: 64Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest of NodeTerminationHandler container.
+	// Default: 50m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 }
 
 // ClusterAutoscalerConfig determines the cluster autoscaler configuration.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -870,6 +870,13 @@ type NodeTerminationHandlerConfig struct {
 
 	// ManagedASGTag is the tag used to determine which nodes NTH can take action on
 	ManagedASGTag *string `json:"managedASGTag,omitempty"`
+
+	// MemoryRequest of NodeTerminationHandler container.
+	// Default: 64Mi
+	MemoryRequest *resource.Quantity `json:"memoryRequest,omitempty"`
+	// CPURequest of NodeTerminationHandler container.
+	// Default: 50m
+	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 }
 
 // ClusterAutoscalerConfig determines the cluster autoscaler configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5789,6 +5789,8 @@ func autoConvert_v1alpha2_NodeTerminationHandlerConfig_To_kops_NodeTerminationHa
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableSQSTerminationDraining = in.EnableSQSTerminationDraining
 	out.ManagedASGTag = in.ManagedASGTag
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
 	return nil
 }
 
@@ -5804,6 +5806,8 @@ func autoConvert_kops_NodeTerminationHandlerConfig_To_v1alpha2_NodeTerminationHa
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableSQSTerminationDraining = in.EnableSQSTerminationDraining
 	out.ManagedASGTag = in.ManagedASGTag
+	out.MemoryRequest = in.MemoryRequest
+	out.CPURequest = in.CPURequest
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3924,6 +3924,16 @@ func (in *NodeTerminationHandlerConfig) DeepCopyInto(out *NodeTerminationHandler
 		*out = new(string)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4122,6 +4122,16 @@ func (in *NodeTerminationHandlerConfig) DeepCopyInto(out *NodeTerminationHandler
 		*out = new(string)
 		**out = **in
 	}
+	if in.MemoryRequest != nil {
+		in, out := &in.MemoryRequest, &out.MemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.CPURequest != nil {
+		in, out := &in.CPURequest, &out.CPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/model/components/nodeterminationhandler.go
+++ b/pkg/model/components/nodeterminationhandler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package components
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
@@ -55,6 +56,16 @@ func (b *NodeTerminationHandlerOptionsBuilder) BuildOptions(o interface{}) error
 
 	if nth.ManagedASGTag == nil {
 		nth.ManagedASGTag = fi.String("aws-node-termination-handler/managed")
+	}
+
+	if nth.CPURequest == nil {
+		defaultCPURequest := resource.MustParse("50m")
+		nth.CPURequest = &defaultCPURequest
+	}
+
+	if nth.MemoryRequest == nil {
+		defaultMemoryRequest := resource.MustParse("64Mi")
+		nth.MemoryRequest = &defaultMemoryRequest
 	}
 
 	return nil

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -197,12 +197,9 @@ spec:
             - name: WORKERS
               value: "10"
           resources:
-            limits:
-              cpu: 100m
-              memory: 128Mi
             requests:
-              cpu: 50m
-              memory: 64Mi
+              cpu: {{ .CPURequest }}
+              memory: {{ .MemoryRequest }}
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
@@ -309,11 +306,9 @@ spec:
           - name: LOG_LEVEL
             value: "info"
           resources:
-            limits:
-              memory: 128Mi
             requests:
-              cpu: 50m
-              memory: 64Mi
+              cpu: {{ .CPURequest }}
+              memory: {{ .MemoryRequest }}
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:


### PR DESCRIPTION
Node termination handler as all daemonSets may play a critical role in
capacity planning, define resource policy for chosing instanceType etc.

In this commit, we enable users to define resources themselves to meet
their needs and also removed limits to convey with the chosen strategy
to avoid limits on such components.

Signed-off-by: dntosas <ntosas@gmail.com>