### PR TITLE
Automated cherry pick of #11314: Expose hubble agent when hubble is enabled

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -736,8 +736,11 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 		}
 
 		if v.Hubble != nil && fi.BoolValue(v.Hubble.Enabled) {
+			if !components.IsCertManagerEnabled(cluster) {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("hubble", "enabled"), "Hubble requires that cert manager is enabled"))
+			}
 			if version.Minor < 8 {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Root().Child("hubble", "enabled"), "Hubble requires Cilium 1.8 or newer"))
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("hubble", "enabled"), "Hubble requires Cilium 1.8 or newer"))
 			}
 		}
 	}

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -843,6 +843,20 @@ func Test_Validate_Cilium(t *testing.T) {
 					Enabled: fi.Bool(true),
 				},
 			},
+			ExpectedErrors: []string{"Forbidden::cilium.hubble.enabled"},
+		},
+		{
+			Cilium: kops.CiliumNetworkingSpec{
+				Version: "v1.8.0",
+				Hubble: &kops.HubbleSpec{
+					Enabled: fi.Bool(true),
+				},
+			},
+			Spec: kops.ClusterSpec{
+				CertManager: &kops.CertManagerConfig{
+					Enabled: fi.Bool(true),
+				},
+			},
 		},
 	}
 	for _, g := range grid {

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -32170,6 +32170,12 @@ data:
   enable-hubble: "true"
   # UNIX domain socket for Hubble server to listen to.
   hubble-socket-path:  "/var/run/cilium/hubble.sock"
+  # An additional address for Hubble server to listen to (e.g. ":4244").
+  hubble-listen-address: ":4244"
+  hubble-disable-tls: "false"
+  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/tls.crt
+  hubble-tls-key-file: /var/lib/cilium/tls/hubble/tls.key
+  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/ca.crt
   {{ if .Hubble.Metrics }}
   hubble-metrics-server: ":9091"
   hubble-metrics:
@@ -32191,8 +32197,13 @@ data:
   config.yaml: |
     peer-service: unix:///var/run/cilium/hubble.sock
     listen-address: :4245
-    disable-client-tls: true
+
     disable-server-tls: true
+
+    tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
+    tls-client-key-file: /var/lib/hubble-relay/tls/client.key
+    tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
+
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -32635,6 +32646,9 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /var/lib/cilium/tls/hubble
+          name: hubble-tls
+          readOnly: true
 {{ if CiliumSecret }}
         - mountPath: /etc/ipsec
           name: cilium-ipsec-secrets
@@ -32749,6 +32763,10 @@ spec:
         secret:
           secretName: cilium-ipsec-keys
 {{ end }}
+      - name: hubble-tls
+        secret:
+          secretName: hubble-server-certs
+          optional: true
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -32882,7 +32900,7 @@ spec:
   strategy:
     rollingUpdate:
       maxUnavailable: 1
-      type: RollingUpdate    
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -32908,6 +32926,10 @@ spec:
             - "serve"
             - "--peer-service=unix:///var/run/cilium/hubble.sock"
             - "--listen-address=:4245"
+          env:
+            # unfortunately, the addon CAs use only CN
+            - name: GODEBUG
+              value: x509ignoreCN=0
           ports:
             - name: grpc
               containerPort: 4245
@@ -32923,6 +32945,9 @@ spec:
             readOnly: true
           - mountPath: /etc/hubble-relay
             name: config
+            readOnly: true
+          - mountPath: /var/lib/hubble-relay/tls
+            name: tls
             readOnly: true
       restartPolicy: Always
       serviceAccount: hubble-relay
@@ -32941,6 +32966,50 @@ spec:
           - key: config.yaml
             path: config.yaml
         name: config
+      - projected:
+          sources:
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+                - key: ca.crt
+                  path: hubble-server-ca.crt
+        name: tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    k8s-app: cilium
+  name: hubble-server-certs
+  namespace: kube-system
+spec:
+  dnsNames:
+  - "*.default.hubble-grpc.cilium.io"
+  issuerRef:
+    kind: Issuer
+    name: networking.cilium.io
+  secretName: hubble-server-certs
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    k8s-app: cilium
+  name: hubble-relay-client-certs
+  namespace: kube-system
+spec:
+  dnsNames:
+  - "hubble-relay-client"
+  issuerRef:
+    kind: Issuer
+    name: networking.cilium.io
+  usages:
+  - client auth
+  secretName: hubble-relay-client-certs
 {{ end }}
 {{ end }}`)
 

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -201,6 +201,12 @@ data:
   enable-hubble: "true"
   # UNIX domain socket for Hubble server to listen to.
   hubble-socket-path:  "/var/run/cilium/hubble.sock"
+  # An additional address for Hubble server to listen to (e.g. ":4244").
+  hubble-listen-address: ":4244"
+  hubble-disable-tls: "false"
+  hubble-tls-cert-file: /var/lib/cilium/tls/hubble/tls.crt
+  hubble-tls-key-file: /var/lib/cilium/tls/hubble/tls.key
+  hubble-tls-client-ca-files: /var/lib/cilium/tls/hubble/ca.crt
   {{ if .Hubble.Metrics }}
   hubble-metrics-server: ":9091"
   hubble-metrics:
@@ -222,8 +228,13 @@ data:
   config.yaml: |
     peer-service: unix:///var/run/cilium/hubble.sock
     listen-address: :4245
-    disable-client-tls: true
+
     disable-server-tls: true
+
+    tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
+    tls-client-key-file: /var/lib/hubble-relay/tls/client.key
+    tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
+
 {{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -666,6 +677,9 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /var/lib/cilium/tls/hubble
+          name: hubble-tls
+          readOnly: true
 {{ if CiliumSecret }}
         - mountPath: /etc/ipsec
           name: cilium-ipsec-secrets
@@ -780,6 +794,10 @@ spec:
         secret:
           secretName: cilium-ipsec-keys
 {{ end }}
+      - name: hubble-tls
+        secret:
+          secretName: hubble-server-certs
+          optional: true
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -913,7 +931,7 @@ spec:
   strategy:
     rollingUpdate:
       maxUnavailable: 1
-      type: RollingUpdate    
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -939,6 +957,10 @@ spec:
             - "serve"
             - "--peer-service=unix:///var/run/cilium/hubble.sock"
             - "--listen-address=:4245"
+          env:
+            # unfortunately, the addon CAs use only CN
+            - name: GODEBUG
+              value: x509ignoreCN=0
           ports:
             - name: grpc
               containerPort: 4245
@@ -954,6 +976,9 @@ spec:
             readOnly: true
           - mountPath: /etc/hubble-relay
             name: config
+            readOnly: true
+          - mountPath: /var/lib/hubble-relay/tls
+            name: tls
             readOnly: true
       restartPolicy: Always
       serviceAccount: hubble-relay
@@ -972,5 +997,49 @@ spec:
           - key: config.yaml
             path: config.yaml
         name: config
+      - projected:
+          sources:
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+                - key: ca.crt
+                  path: hubble-server-ca.crt
+        name: tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    k8s-app: cilium
+  name: hubble-server-certs
+  namespace: kube-system
+spec:
+  dnsNames:
+  - "*.default.hubble-grpc.cilium.io"
+  issuerRef:
+    kind: Issuer
+    name: networking.cilium.io
+  secretName: hubble-server-certs
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    k8s-app: cilium
+  name: hubble-relay-client-certs
+  namespace: kube-system
+spec:
+  dnsNames:
+  - "hubble-relay-client"
+  issuerRef:
+    kind: Issuer
+    name: networking.cilium.io
+  usages:
+  - client auth
+  secretName: hubble-relay-client-certs
 {{ end }}
 {{ end }}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/cilium.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/cilium.go
@@ -65,19 +65,23 @@ func addCiliumAddon(b *BootstrapChannelBuilder, addons *api.Addons) error {
 				})
 			}
 		} else if ver.Minor == 9 {
-			version := "1.9.0-kops.1"
+			version := "1.9.4-kops.1"
 			{
 				id := "k8s-1.12"
 				location := key + "/" + id + "-v1.9.yaml"
 
-				addons.Spec.Addons = append(addons.Spec.Addons, &api.AddonSpec{
+				addon := &api.AddonSpec{
 					Name:               fi.String(key),
 					Version:            fi.String(version),
 					Selector:           networkingSelector(),
 					Manifest:           fi.String(location),
 					Id:                 id,
 					NeedsRollingUpdate: "all",
-				})
+				}
+				if cilium.Hubble != nil && fi.BoolValue(cilium.Hubble.Enabled) {
+					addon.NeedsPKI = true
+				}
+				addons.Spec.Addons = append(addons.Spec.Addons, addon)
 			}
 		} else {
 			return fmt.Errorf("unknown cilium version: %q", cilium.Version)

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -70,9 +70,9 @@ spec:
     version: 1.17.0
   - id: k8s-1.12
     manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
-    manifestHash: a334e7c66061f19b6bd9b1ee95ce9a60c6e3f020
+    manifestHash: 03a778ce52061724f429fef87cedee0eba11bcaf
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:
       role.kubernetes.io/networking: "1"
-    version: 1.9.0-kops.1
+    version: 1.9.4-kops.1


### PR DESCRIPTION
Cherry pick of #11314 on release-1.20.

#11314: Expose hubble agent when hubble is enabled

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.