### PR TITLE
skip detached nodes from readiness and system-*-critical checks

### DIFF
--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -299,8 +299,11 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 		}
 
 		for _, member := range allMembers {
-			node := member.Node
+			if member.Status == cloudinstances.CloudInstanceStatusDetached {
+				continue
+			}
 
+			node := member.Node
 			if node == nil {
 				nodeExpectedToJoin := true
 				if cloudGroup.InstanceGroup.Spec.Role == kops.InstanceGroupRoleBastion {
@@ -308,10 +311,6 @@ func (v *ValidationCluster) validateNodes(cloudGroups map[string]*cloudinstances
 					nodeExpectedToJoin = false
 				}
 				if member.State == cloudinstances.WarmPool {
-					nodeExpectedToJoin = false
-				}
-
-				if member.Status == cloudinstances.CloudInstanceStatusDetached {
 					nodeExpectedToJoin = false
 				}
 

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -324,6 +324,66 @@ func Test_ValidateNodeNotReady(t *testing.T) {
 	}
 }
 
+func Test_ValidateNodeDetachedAndNotReady(t *testing.T) {
+	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
+	groups["node-1"] = &cloudinstances.CloudInstanceGroup{
+		InstanceGroup: &kopsapi.InstanceGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-1",
+			},
+			Spec: kopsapi.InstanceGroupSpec{
+				Role: kopsapi.InstanceGroupRoleNode,
+			},
+		},
+		MinSize:    2,
+		TargetSize: 2,
+		Ready: []*cloudinstances.CloudInstance{
+			{
+				ID: "i-00001",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1a"},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: "Ready", Status: v1.ConditionTrue},
+						},
+					},
+				},
+			},
+			{
+				ID: "i-00002",
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1b"},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: "Ready", Status: v1.ConditionTrue},
+						},
+					},
+				},
+			},
+		},
+		NeedUpdate: []*cloudinstances.CloudInstance{
+			{
+				ID:     "i-00003",
+				Status: cloudinstances.CloudInstanceStatusDetached,
+				Node: &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1c"},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: "Ready", Status: v1.ConditionFalse},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v, err := testValidate(t, groups, nil)
+	require.NoError(t, err)
+	if !assert.Empty(t, v.Failures) {
+		printDebug(t, v)
+	}
+}
+
 func Test_ValidateMastersNotEnough(t *testing.T) {
 	groups := make(map[string]*cloudinstances.CloudInstanceGroup)
 	groups["node-1"] = &cloudinstances.CloudInstanceGroup{


### PR DESCRIPTION
in continuation to PR: https://github.com/kubernetes/kops/pull/11349 and comment: https://github.com/kubernetes/kops/pull/11349#issuecomment-828658240, ignoring detached nodes from ready and system-*-critical checks as well.