### PR TITLE
Automated cherry pick of #11365: Mark control-plane node for update when etcd volume size

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -309,16 +309,19 @@ func (b *BootstrapScript) Run(c *fi.Context) error {
 
 				for _, etcdCluster := range cs.EtcdClusters {
 					c := kops.EtcdClusterSpec{
-						Image:   etcdCluster.Image,
-						Version: etcdCluster.Version,
+						Image:         etcdCluster.Image,
+						Version:       etcdCluster.Version,
+						CPURequest:    etcdCluster.CPURequest,
+						MemoryRequest: etcdCluster.MemoryRequest,
 					}
-					// if the user has not specified memory or cpu allotments for etcd, do not
-					// apply one.  Described in PR #6313.
-					if etcdCluster.CPURequest != nil {
-						c.CPURequest = etcdCluster.CPURequest
-					}
-					if etcdCluster.MemoryRequest != nil {
-						c.MemoryRequest = etcdCluster.MemoryRequest
+					for _, etcdMember := range etcdCluster.Members {
+						if fi.StringValue(etcdMember.InstanceGroup) == b.ig.Name && etcdMember.VolumeSize != nil {
+							m := kops.EtcdMemberSpec{
+								Name:       etcdMember.Name,
+								VolumeSize: etcdMember.VolumeSize,
+							}
+							c.Members = append(c.Members, m)
+						}
 					}
 					spec["etcdClusters"].(map[string]kops.EtcdClusterSpec)[etcdCluster.Name] = c
 				}

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json
@@ -803,7 +803,7 @@
       "Type": "AWS::EC2::Volume",
       "Properties": {
         "AvailabilityZone": "us-test-1a",
-        "Size": 20,
+        "Size": 50,
         "VolumeType": "gp3",
         "Iops": 5000,
         "Throughput": 125,

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json.extracted.yaml
@@ -164,8 +164,14 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
   encryptionConfig: null
   etcdClusters:
     events:
+      etcdMembers:
+      - name: us-test-1a
+        volumeSize: 20
       version: 3.4.13
     main:
+      etcdMembers:
+      - name: us-test-1a
+        volumeSize: 50
       version: 3.4.13
   kubeAPIServer:
     allowPrivileged: true

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -163,8 +163,14 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
+    etcdMembers:
+    - name: us-test-1a
+      volumeSize: 20
     version: 3.4.13
   main:
+    etcdMembers:
+    - name: us-test-1a
+      volumeSize: 50
     version: 3.4.13
 kubeAPIServer:
   allowPrivileged: true

--- a/tests/integration/update_cluster/minimal-gp3/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal-gp3/in-v1alpha2.yaml
@@ -14,12 +14,14 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
       volumeIops: 5000
+      volumeSize: 50
       volumeThroughput: 125
       volumeType: gp3
     name: main
   - etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
+      volumeSize: 20
       volumeType: gp3
     name: events
   iam: {}

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -201,7 +201,7 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-minimal-example-com" {
   availability_zone = "us-test-1a"
   encrypted         = false
   iops              = 5000
-  size              = 20
+  size              = 50
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "us-test-1a.etcd-main.minimal.example.com"


### PR DESCRIPTION
Cherry pick of #11365 on release-1.20.

#11365: Mark control-plane node for update when etcd volume size

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.