### PR TITLE
Refactor terraform writing

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -274,30 +274,6 @@ resource "aws_iam_openid_connect_provider" "minimal-example-com" {
   url             = "https://discovery.example.com/minimal.example.com/oidc"
 }
 
-resource "aws_iam_role_policy" "aws-load-balancer-controller-kube-system-sa-minimal-example-com" {
-  name   = "aws-load-balancer-controller.kube-system.sa.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy")
-  role   = aws_iam_role.aws-load-balancer-controller-kube-system-sa-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "dns-controller-kube-system-sa-minimal-example-com" {
-  name   = "dns-controller.kube-system.sa.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy")
-  role   = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-minimal-example-com" {
-  name   = "masters.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
-  role   = aws_iam_role.masters-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-minimal-example-com" {
-  name   = "nodes.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
-  role   = aws_iam_role.nodes-minimal-example-com.name
-}
-
 resource "aws_iam_role" "aws-load-balancer-controller-kube-system-sa-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy")
   name               = "aws-load-balancer-controller.kube-system.sa.minimal.example.com"
@@ -336,6 +312,30 @@ resource "aws_iam_role" "nodes-minimal-example-com" {
     "Name"                                      = "nodes.minimal.example.com"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "aws-load-balancer-controller-kube-system-sa-minimal-example-com" {
+  name   = "aws-load-balancer-controller.kube-system.sa.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy")
+  role   = aws_iam_role.aws-load-balancer-controller-kube-system-sa-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy" "dns-controller-kube-system-sa-minimal-example-com" {
+  name   = "dns-controller.kube-system.sa.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy")
+  role   = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy" "masters-minimal-example-com" {
+  name   = "masters.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
+  role   = aws_iam_role.masters-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-minimal-example-com" {
+  name   = "nodes.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
+  role   = aws_iam_role.nodes-minimal-example-com.name
 }
 
 resource "aws_internet_gateway" "minimal-example-com" {
@@ -506,9 +506,10 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
 }
 
-resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
-  route_table_id = aws_route_table.minimal-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.minimal-example-com.id
+  route_table_id         = aws_route_table.minimal-example-com.id
 }
 
 resource "aws_route_table" "minimal-example-com" {
@@ -521,10 +522,31 @@ resource "aws_route_table" "minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.minimal-example-com.id
-  route_table_id         = aws_route_table.minimal-example-com.id
+resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
+  route_table_id = aws_route_table.minimal-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+}
+
+resource "aws_security_group" "masters-minimal-example-com" {
+  description = "Security group for masters"
+  name        = "masters.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
+}
+
+resource "aws_security_group" "nodes-minimal-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-minimal-example-com" {
@@ -635,28 +657,6 @@ resource "aws_security_group_rule" "from-nodes-minimal-example-com-ingress-udp-1
   type                     = "ingress"
 }
 
-resource "aws_security_group" "masters-minimal-example-com" {
-  description = "Security group for masters"
-  name        = "masters.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "masters.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
-resource "aws_security_group" "nodes-minimal-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "nodes.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-minimal-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -670,9 +670,15 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
-  vpc_id          = aws_vpc.minimal-example-com.id
+resource "aws_vpc" "minimal-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "minimal-example-com" {
@@ -685,15 +691,9 @@ resource "aws_vpc_dhcp_options" "minimal-example-com" {
   }
 }
 
-resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
+  vpc_id          = aws_vpc.minimal-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -393,24 +393,6 @@ resource "aws_iam_instance_profile" "nodes-bastionuserdata-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "bastions-bastionuserdata-example-com" {
-  name   = "bastions.bastionuserdata.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_bastions.bastionuserdata.example.com_policy")
-  role   = aws_iam_role.bastions-bastionuserdata-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-bastionuserdata-example-com" {
-  name   = "masters.bastionuserdata.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy")
-  role   = aws_iam_role.masters-bastionuserdata-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-bastionuserdata-example-com" {
-  name   = "nodes.bastionuserdata.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy")
-  role   = aws_iam_role.nodes-bastionuserdata-example-com.name
-}
-
 resource "aws_iam_role" "bastions-bastionuserdata-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.bastionuserdata.example.com_policy")
   name               = "bastions.bastionuserdata.example.com"
@@ -439,6 +421,24 @@ resource "aws_iam_role" "nodes-bastionuserdata-example-com" {
     "Name"                                              = "nodes.bastionuserdata.example.com"
     "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "bastions-bastionuserdata-example-com" {
+  name   = "bastions.bastionuserdata.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_bastions.bastionuserdata.example.com_policy")
+  role   = aws_iam_role.bastions-bastionuserdata-example-com.name
+}
+
+resource "aws_iam_role_policy" "masters-bastionuserdata-example-com" {
+  name   = "masters.bastionuserdata.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy")
+  role   = aws_iam_role.masters-bastionuserdata-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-bastionuserdata-example-com" {
+  name   = "nodes.bastionuserdata.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy")
+  role   = aws_iam_role.nodes-bastionuserdata-example-com.name
 }
 
 resource "aws_internet_gateway" "bastionuserdata-example-com" {
@@ -687,6 +687,18 @@ resource "aws_nat_gateway" "us-test-1a-bastionuserdata-example-com" {
   }
 }
 
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.bastionuserdata-example-com.id
+  route_table_id         = aws_route_table.bastionuserdata-example-com.id
+}
+
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.us-test-1a-bastionuserdata-example-com.id
+  route_table_id         = aws_route_table.private-us-test-1a-bastionuserdata-example-com.id
+}
+
 resource "aws_route53_record" "api-bastionuserdata-example-com" {
   alias {
     evaluate_target_health = false
@@ -696,16 +708,6 @@ resource "aws_route53_record" "api-bastionuserdata-example-com" {
   name    = "api.bastionuserdata.example.com"
   type    = "A"
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
-}
-
-resource "aws_route_table_association" "private-us-test-1a-bastionuserdata-example-com" {
-  route_table_id = aws_route_table.private-us-test-1a-bastionuserdata-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-bastionuserdata-example-com.id
-}
-
-resource "aws_route_table_association" "utility-us-test-1a-bastionuserdata-example-com" {
-  route_table_id = aws_route_table.bastionuserdata-example-com.id
-  subnet_id      = aws_subnet.utility-us-test-1a-bastionuserdata-example-com.id
 }
 
 resource "aws_route_table" "bastionuserdata-example-com" {
@@ -728,16 +730,69 @@ resource "aws_route_table" "private-us-test-1a-bastionuserdata-example-com" {
   vpc_id = aws_vpc.bastionuserdata-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.bastionuserdata-example-com.id
-  route_table_id         = aws_route_table.bastionuserdata-example-com.id
+resource "aws_route_table_association" "private-us-test-1a-bastionuserdata-example-com" {
+  route_table_id = aws_route_table.private-us-test-1a-bastionuserdata-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-bastionuserdata-example-com.id
 }
 
-resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.us-test-1a-bastionuserdata-example-com.id
-  route_table_id         = aws_route_table.private-us-test-1a-bastionuserdata-example-com.id
+resource "aws_route_table_association" "utility-us-test-1a-bastionuserdata-example-com" {
+  route_table_id = aws_route_table.bastionuserdata-example-com.id
+  subnet_id      = aws_subnet.utility-us-test-1a-bastionuserdata-example-com.id
+}
+
+resource "aws_security_group" "api-elb-bastionuserdata-example-com" {
+  description = "Security group for api ELB"
+  name        = "api-elb.bastionuserdata.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "api-elb.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.bastionuserdata-example-com.id
+}
+
+resource "aws_security_group" "bastion-bastionuserdata-example-com" {
+  description = "Security group for bastion"
+  name        = "bastion.bastionuserdata.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "bastion.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.bastionuserdata-example-com.id
+}
+
+resource "aws_security_group" "bastion-elb-bastionuserdata-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.bastionuserdata.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "bastion-elb.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.bastionuserdata-example-com.id
+}
+
+resource "aws_security_group" "masters-bastionuserdata-example-com" {
+  description = "Security group for masters"
+  name        = "masters.bastionuserdata.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "masters.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.bastionuserdata-example-com.id
+}
+
+resource "aws_security_group" "nodes-bastionuserdata-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.bastionuserdata.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "nodes.bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.bastionuserdata-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-bastionuserdata-example-com" {
@@ -767,24 +822,6 @@ resource "aws_security_group_rule" "from-api-elb-bastionuserdata-example-com-egr
   type              = "egress"
 }
 
-resource "aws_security_group_rule" "from-bastion-elb-bastionuserdata-example-com-egress-all-0to0-0-0-0-0--0" {
-  cidr_blocks       = ["0.0.0.0/0"]
-  from_port         = 0
-  protocol          = "-1"
-  security_group_id = aws_security_group.bastion-elb-bastionuserdata-example-com.id
-  to_port           = 0
-  type              = "egress"
-}
-
-resource "aws_security_group_rule" "from-bastion-elb-bastionuserdata-example-com-ingress-tcp-22to22-bastion-bastionuserdata-example-com" {
-  from_port                = 22
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.bastion-bastionuserdata-example-com.id
-  source_security_group_id = aws_security_group.bastion-elb-bastionuserdata-example-com.id
-  to_port                  = 22
-  type                     = "ingress"
-}
-
 resource "aws_security_group_rule" "from-bastion-bastionuserdata-example-com-egress-all-0to0-0-0-0-0--0" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 0
@@ -808,6 +845,24 @@ resource "aws_security_group_rule" "from-bastion-bastionuserdata-example-com-ing
   protocol                 = "tcp"
   security_group_id        = aws_security_group.nodes-bastionuserdata-example-com.id
   source_security_group_id = aws_security_group.bastion-bastionuserdata-example-com.id
+  to_port                  = 22
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-bastionuserdata-example-com-egress-all-0to0-0-0-0-0--0" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.bastion-elb-bastionuserdata-example-com.id
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "from-bastion-elb-bastionuserdata-example-com-ingress-tcp-22to22-bastion-bastionuserdata-example-com" {
+  from_port                = 22
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.bastion-bastionuserdata-example-com.id
+  source_security_group_id = aws_security_group.bastion-elb-bastionuserdata-example-com.id
   to_port                  = 22
   type                     = "ingress"
 }
@@ -911,61 +966,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
-resource "aws_security_group" "api-elb-bastionuserdata-example-com" {
-  description = "Security group for api ELB"
-  name        = "api-elb.bastionuserdata.example.com"
-  tags = {
-    "KubernetesCluster"                                 = "bastionuserdata.example.com"
-    "Name"                                              = "api-elb.bastionuserdata.example.com"
-    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.bastionuserdata-example-com.id
-}
-
-resource "aws_security_group" "bastion-elb-bastionuserdata-example-com" {
-  description = "Security group for bastion ELB"
-  name        = "bastion-elb.bastionuserdata.example.com"
-  tags = {
-    "KubernetesCluster"                                 = "bastionuserdata.example.com"
-    "Name"                                              = "bastion-elb.bastionuserdata.example.com"
-    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.bastionuserdata-example-com.id
-}
-
-resource "aws_security_group" "bastion-bastionuserdata-example-com" {
-  description = "Security group for bastion"
-  name        = "bastion.bastionuserdata.example.com"
-  tags = {
-    "KubernetesCluster"                                 = "bastionuserdata.example.com"
-    "Name"                                              = "bastion.bastionuserdata.example.com"
-    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.bastionuserdata-example-com.id
-}
-
-resource "aws_security_group" "masters-bastionuserdata-example-com" {
-  description = "Security group for masters"
-  name        = "masters.bastionuserdata.example.com"
-  tags = {
-    "KubernetesCluster"                                 = "bastionuserdata.example.com"
-    "Name"                                              = "masters.bastionuserdata.example.com"
-    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.bastionuserdata-example-com.id
-}
-
-resource "aws_security_group" "nodes-bastionuserdata-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.bastionuserdata.example.com"
-  tags = {
-    "KubernetesCluster"                                 = "bastionuserdata.example.com"
-    "Name"                                              = "nodes.bastionuserdata.example.com"
-    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.bastionuserdata-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-bastionuserdata-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -992,9 +992,15 @@ resource "aws_subnet" "utility-us-test-1a-bastionuserdata-example-com" {
   vpc_id = aws_vpc.bastionuserdata-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "bastionuserdata-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.bastionuserdata-example-com.id
-  vpc_id          = aws_vpc.bastionuserdata-example-com.id
+resource "aws_vpc" "bastionuserdata-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                                 = "bastionuserdata.example.com"
+    "Name"                                              = "bastionuserdata.example.com"
+    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "bastionuserdata-example-com" {
@@ -1007,15 +1013,9 @@ resource "aws_vpc_dhcp_options" "bastionuserdata-example-com" {
   }
 }
 
-resource "aws_vpc" "bastionuserdata-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                                 = "bastionuserdata.example.com"
-    "Name"                                              = "bastionuserdata.example.com"
-    "kubernetes.io/cluster/bastionuserdata.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "bastionuserdata-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.bastionuserdata-example-com.id
+  vpc_id          = aws_vpc.bastionuserdata-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -733,6 +733,22 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.existing-iam.example.com_user_data")
 }
 
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.existing-iam-example-com.id
+  route_table_id         = aws_route_table.existing-iam-example-com.id
+}
+
+resource "aws_route_table" "existing-iam-example-com" {
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "existing-iam.example.com"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+    "kubernetes.io/kops/role"                        = "public"
+  }
+  vpc_id = aws_vpc.existing-iam-example-com.id
+}
+
 resource "aws_route_table_association" "us-test-1a-existing-iam-example-com" {
   route_table_id = aws_route_table.existing-iam-example-com.id
   subnet_id      = aws_subnet.us-test-1a-existing-iam-example-com.id
@@ -748,20 +764,26 @@ resource "aws_route_table_association" "us-test-1c-existing-iam-example-com" {
   subnet_id      = aws_subnet.us-test-1c-existing-iam-example-com.id
 }
 
-resource "aws_route_table" "existing-iam-example-com" {
+resource "aws_security_group" "masters-existing-iam-example-com" {
+  description = "Security group for masters"
+  name        = "masters.existing-iam.example.com"
   tags = {
     "KubernetesCluster"                              = "existing-iam.example.com"
-    "Name"                                           = "existing-iam.example.com"
+    "Name"                                           = "masters.existing-iam.example.com"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
-    "kubernetes.io/kops/role"                        = "public"
   }
   vpc_id = aws_vpc.existing-iam-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.existing-iam-example-com.id
-  route_table_id         = aws_route_table.existing-iam-example-com.id
+resource "aws_security_group" "nodes-existing-iam-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.existing-iam.example.com"
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "nodes.existing-iam.example.com"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.existing-iam-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-existing-iam-example-com" {
@@ -872,28 +894,6 @@ resource "aws_security_group_rule" "from-nodes-existing-iam-example-com-ingress-
   type                     = "ingress"
 }
 
-resource "aws_security_group" "masters-existing-iam-example-com" {
-  description = "Security group for masters"
-  name        = "masters.existing-iam.example.com"
-  tags = {
-    "KubernetesCluster"                              = "existing-iam.example.com"
-    "Name"                                           = "masters.existing-iam.example.com"
-    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.existing-iam-example-com.id
-}
-
-resource "aws_security_group" "nodes-existing-iam-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.existing-iam.example.com"
-  tags = {
-    "KubernetesCluster"                              = "existing-iam.example.com"
-    "Name"                                           = "nodes.existing-iam.example.com"
-    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.existing-iam-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-existing-iam-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -933,9 +933,15 @@ resource "aws_subnet" "us-test-1c-existing-iam-example-com" {
   vpc_id = aws_vpc.existing-iam-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "existing-iam-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.existing-iam-example-com.id
-  vpc_id          = aws_vpc.existing-iam-example-com.id
+resource "aws_vpc" "existing-iam-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                              = "existing-iam.example.com"
+    "Name"                                           = "existing-iam.example.com"
+    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "existing-iam-example-com" {
@@ -948,15 +954,9 @@ resource "aws_vpc_dhcp_options" "existing-iam-example-com" {
   }
 }
 
-resource "aws_vpc" "existing-iam-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                              = "existing-iam.example.com"
-    "Name"                                           = "existing-iam.example.com"
-    "kubernetes.io/cluster/existing-iam.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "existing-iam-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.existing-iam-example-com.id
+  vpc_id          = aws_vpc.existing-iam-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -274,29 +274,6 @@ resource "aws_iam_openid_connect_provider" "minimal-example-com" {
   url             = "https://discovery.example.com/minimal.example.com/oidc"
 }
 
-resource "aws_iam_role_policy_attachment" "external-myserviceaccount-default-sa-minimal-example-com-3186075376" {
-  policy_arn = "arn:aws:iam::123456789012:policy/UsersManageOwnCredentials"
-  role       = aws_iam_role.myserviceaccount-default-sa-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-minimal-example-com" {
-  name   = "masters.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
-  role   = aws_iam_role.masters-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "myotherserviceaccount-myapp-sa-minimal-example-com" {
-  name   = "myotherserviceaccount.myapp.sa.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_myotherserviceaccount.myapp.sa.minimal.example.com_policy")
-  role   = aws_iam_role.myotherserviceaccount-myapp-sa-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-minimal-example-com" {
-  name   = "nodes.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
-  role   = aws_iam_role.nodes-minimal-example-com.name
-}
-
 resource "aws_iam_role" "masters-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.minimal.example.com_policy")
   name               = "masters.minimal.example.com"
@@ -335,6 +312,29 @@ resource "aws_iam_role" "nodes-minimal-example-com" {
     "Name"                                      = "nodes.minimal.example.com"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "masters-minimal-example-com" {
+  name   = "masters.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
+  role   = aws_iam_role.masters-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy" "myotherserviceaccount-myapp-sa-minimal-example-com" {
+  name   = "myotherserviceaccount.myapp.sa.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_myotherserviceaccount.myapp.sa.minimal.example.com_policy")
+  role   = aws_iam_role.myotherserviceaccount-myapp-sa-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-minimal-example-com" {
+  name   = "nodes.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
+  role   = aws_iam_role.nodes-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy_attachment" "external-myserviceaccount-default-sa-minimal-example-com-3186075376" {
+  policy_arn = "arn:aws:iam::123456789012:policy/UsersManageOwnCredentials"
+  role       = aws_iam_role.myserviceaccount-default-sa-minimal-example-com.name
 }
 
 resource "aws_internet_gateway" "minimal-example-com" {
@@ -505,9 +505,10 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
 }
 
-resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
-  route_table_id = aws_route_table.minimal-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.minimal-example-com.id
+  route_table_id         = aws_route_table.minimal-example-com.id
 }
 
 resource "aws_route_table" "minimal-example-com" {
@@ -520,10 +521,31 @@ resource "aws_route_table" "minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.minimal-example-com.id
-  route_table_id         = aws_route_table.minimal-example-com.id
+resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
+  route_table_id = aws_route_table.minimal-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+}
+
+resource "aws_security_group" "masters-minimal-example-com" {
+  description = "Security group for masters"
+  name        = "masters.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
+}
+
+resource "aws_security_group" "nodes-minimal-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-minimal-example-com" {
@@ -634,28 +656,6 @@ resource "aws_security_group_rule" "from-nodes-minimal-example-com-ingress-udp-1
   type                     = "ingress"
 }
 
-resource "aws_security_group" "masters-minimal-example-com" {
-  description = "Security group for masters"
-  name        = "masters.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "masters.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
-resource "aws_security_group" "nodes-minimal-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "nodes.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-minimal-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -669,9 +669,15 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
-  vpc_id          = aws_vpc.minimal-example-com.id
+resource "aws_vpc" "minimal-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "minimal-example-com" {
@@ -684,15 +690,9 @@ resource "aws_vpc_dhcp_options" "minimal-example-com" {
   }
 }
 
-resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
+  vpc_id          = aws_vpc.minimal-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -73,14 +73,16 @@ resource "aws_nat_gateway" "us-test-1a-lifecyclephases-example-com" {
   }
 }
 
-resource "aws_route_table_association" "private-us-test-1a-lifecyclephases-example-com" {
-  route_table_id = aws_route_table.private-us-test-1a-lifecyclephases-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-lifecyclephases-example-com.id
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.lifecyclephases-example-com.id
+  route_table_id         = aws_route_table.lifecyclephases-example-com.id
 }
 
-resource "aws_route_table_association" "utility-us-test-1a-lifecyclephases-example-com" {
-  route_table_id = aws_route_table.lifecyclephases-example-com.id
-  subnet_id      = aws_subnet.utility-us-test-1a-lifecyclephases-example-com.id
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.us-test-1a-lifecyclephases-example-com.id
+  route_table_id         = aws_route_table.private-us-test-1a-lifecyclephases-example-com.id
 }
 
 resource "aws_route_table" "lifecyclephases-example-com" {
@@ -103,16 +105,14 @@ resource "aws_route_table" "private-us-test-1a-lifecyclephases-example-com" {
   vpc_id = aws_vpc.lifecyclephases-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.lifecyclephases-example-com.id
-  route_table_id         = aws_route_table.lifecyclephases-example-com.id
+resource "aws_route_table_association" "private-us-test-1a-lifecyclephases-example-com" {
+  route_table_id = aws_route_table.private-us-test-1a-lifecyclephases-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-lifecyclephases-example-com.id
 }
 
-resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.us-test-1a-lifecyclephases-example-com.id
-  route_table_id         = aws_route_table.private-us-test-1a-lifecyclephases-example-com.id
+resource "aws_route_table_association" "utility-us-test-1a-lifecyclephases-example-com" {
+  route_table_id = aws_route_table.lifecyclephases-example-com.id
+  subnet_id      = aws_subnet.utility-us-test-1a-lifecyclephases-example-com.id
 }
 
 resource "aws_subnet" "us-test-1a-lifecyclephases-example-com" {
@@ -141,9 +141,15 @@ resource "aws_subnet" "utility-us-test-1a-lifecyclephases-example-com" {
   vpc_id = aws_vpc.lifecyclephases-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "lifecyclephases-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.lifecyclephases-example-com.id
-  vpc_id          = aws_vpc.lifecyclephases-example-com.id
+resource "aws_vpc" "lifecyclephases-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                                 = "lifecyclephases.example.com"
+    "Name"                                              = "lifecyclephases.example.com"
+    "kubernetes.io/cluster/lifecyclephases.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "lifecyclephases-example-com" {
@@ -156,15 +162,9 @@ resource "aws_vpc_dhcp_options" "lifecyclephases-example-com" {
   }
 }
 
-resource "aws_vpc" "lifecyclephases-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                                 = "lifecyclephases.example.com"
-    "Name"                                              = "lifecyclephases.example.com"
-    "kubernetes.io/cluster/lifecyclephases.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "lifecyclephases-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.lifecyclephases-example-com.id
+  vpc_id          = aws_vpc.lifecyclephases-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -243,18 +243,6 @@ resource "aws_iam_instance_profile" "nodes-minimal-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "masters-minimal-example-com" {
-  name   = "masters.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
-  role   = aws_iam_role.masters-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-minimal-example-com" {
-  name   = "nodes.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
-  role   = aws_iam_role.nodes-minimal-example-com.name
-}
-
 resource "aws_iam_role" "masters-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.minimal.example.com_policy")
   name               = "masters.minimal.example.com"
@@ -273,6 +261,18 @@ resource "aws_iam_role" "nodes-minimal-example-com" {
     "Name"                                      = "nodes.minimal.example.com"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "masters-minimal-example-com" {
+  name   = "masters.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
+  role   = aws_iam_role.masters-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-minimal-example-com" {
+  name   = "nodes.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
+  role   = aws_iam_role.nodes-minimal-example-com.name
 }
 
 resource "aws_internet_gateway" "minimal-example-com" {
@@ -439,9 +439,10 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
 }
 
-resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
-  route_table_id = aws_route_table.minimal-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.minimal-example-com.id
+  route_table_id         = aws_route_table.minimal-example-com.id
 }
 
 resource "aws_route_table" "minimal-example-com" {
@@ -454,10 +455,31 @@ resource "aws_route_table" "minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.minimal-example-com.id
-  route_table_id         = aws_route_table.minimal-example-com.id
+resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
+  route_table_id = aws_route_table.minimal-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+}
+
+resource "aws_security_group" "masters-minimal-example-com" {
+  description = "Security group for masters"
+  name        = "masters.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
+}
+
+resource "aws_security_group" "nodes-minimal-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-minimal-example-com" {
@@ -568,28 +590,6 @@ resource "aws_security_group_rule" "from-nodes-minimal-example-com-ingress-udp-1
   type                     = "ingress"
 }
 
-resource "aws_security_group" "masters-minimal-example-com" {
-  description = "Security group for masters"
-  name        = "masters.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "masters.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
-resource "aws_security_group" "nodes-minimal-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "nodes.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-minimal-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -603,9 +603,15 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
-  vpc_id          = aws_vpc.minimal-example-com.id
+resource "aws_vpc" "minimal-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "minimal-example-com" {
@@ -618,15 +624,9 @@ resource "aws_vpc_dhcp_options" "minimal-example-com" {
   }
 }
 
-resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
+  vpc_id          = aws_vpc.minimal-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -323,17 +323,17 @@ resource "google_compute_network" "default" {
   name                    = "default"
 }
 
+resource "google_compute_router" "nat-minimal-gce-private-example-com" {
+  name    = "nat-minimal-gce-private-example-com"
+  network = "https://www.googleapis.com/compute/v1/projects/testproject/global/networks/default"
+}
+
 resource "google_compute_router_nat" "nat-minimal-gce-private-example-com" {
   name                               = "nat-minimal-gce-private-example-com"
   nat_ip_allocate_option             = "AUTO_ONLY"
   region                             = "us-test1"
   router                             = "nat-minimal-gce-private-example-com"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-}
-
-resource "google_compute_router" "nat-minimal-gce-private-example-com" {
-  name    = "nat-minimal-gce-private-example-com"
-  network = "https://www.googleapis.com/compute/v1/projects/testproject/global/networks/default"
 }
 
 terraform {

--- a/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
+++ b/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
@@ -314,18 +314,6 @@ resource "aws_iam_instance_profile" "nodes-nthsqsresources-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "masters-nthsqsresources-example-com" {
-  name   = "masters.nthsqsresources.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.nthsqsresources.example.com_policy")
-  role   = aws_iam_role.masters-nthsqsresources-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-nthsqsresources-example-com" {
-  name   = "nodes.nthsqsresources.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.nthsqsresources.example.com_policy")
-  role   = aws_iam_role.nodes-nthsqsresources-example-com.name
-}
-
 resource "aws_iam_role" "masters-nthsqsresources-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.nthsqsresources.example.com_policy")
   name               = "masters.nthsqsresources.example.com"
@@ -344,6 +332,18 @@ resource "aws_iam_role" "nodes-nthsqsresources-example-com" {
     "Name"                                              = "nodes.nthsqsresources.example.com"
     "kubernetes.io/cluster/nthsqsresources.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "masters-nthsqsresources-example-com" {
+  name   = "masters.nthsqsresources.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.nthsqsresources.example.com_policy")
+  role   = aws_iam_role.masters-nthsqsresources-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-nthsqsresources-example-com" {
+  name   = "nodes.nthsqsresources.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.nthsqsresources.example.com_policy")
+  role   = aws_iam_role.nodes-nthsqsresources-example-com.name
 }
 
 resource "aws_internet_gateway" "nthsqsresources-example-com" {
@@ -520,9 +520,10 @@ resource "aws_launch_template" "nodes-nthsqsresources-example-com" {
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.nthsqsresources.example.com_user_data")
 }
 
-resource "aws_route_table_association" "us-test-1a-nthsqsresources-example-com" {
-  route_table_id = aws_route_table.nthsqsresources-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-nthsqsresources-example-com.id
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.nthsqsresources-example-com.id
+  route_table_id         = aws_route_table.nthsqsresources-example-com.id
 }
 
 resource "aws_route_table" "nthsqsresources-example-com" {
@@ -535,10 +536,31 @@ resource "aws_route_table" "nthsqsresources-example-com" {
   vpc_id = aws_vpc.nthsqsresources-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.nthsqsresources-example-com.id
-  route_table_id         = aws_route_table.nthsqsresources-example-com.id
+resource "aws_route_table_association" "us-test-1a-nthsqsresources-example-com" {
+  route_table_id = aws_route_table.nthsqsresources-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-nthsqsresources-example-com.id
+}
+
+resource "aws_security_group" "masters-nthsqsresources-example-com" {
+  description = "Security group for masters"
+  name        = "masters.nthsqsresources.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "nthsqsresources.example.com"
+    "Name"                                              = "masters.nthsqsresources.example.com"
+    "kubernetes.io/cluster/nthsqsresources.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.nthsqsresources-example-com.id
+}
+
+resource "aws_security_group" "nodes-nthsqsresources-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.nthsqsresources.example.com"
+  tags = {
+    "KubernetesCluster"                                 = "nthsqsresources.example.com"
+    "Name"                                              = "nodes.nthsqsresources.example.com"
+    "kubernetes.io/cluster/nthsqsresources.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.nthsqsresources-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-nthsqsresources-example-com" {
@@ -649,28 +671,6 @@ resource "aws_security_group_rule" "from-nodes-nthsqsresources-example-com-ingre
   type                     = "ingress"
 }
 
-resource "aws_security_group" "masters-nthsqsresources-example-com" {
-  description = "Security group for masters"
-  name        = "masters.nthsqsresources.example.com"
-  tags = {
-    "KubernetesCluster"                                 = "nthsqsresources.example.com"
-    "Name"                                              = "masters.nthsqsresources.example.com"
-    "kubernetes.io/cluster/nthsqsresources.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.nthsqsresources-example-com.id
-}
-
-resource "aws_security_group" "nodes-nthsqsresources-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.nthsqsresources.example.com"
-  tags = {
-    "KubernetesCluster"                                 = "nthsqsresources.example.com"
-    "Name"                                              = "nodes.nthsqsresources.example.com"
-    "kubernetes.io/cluster/nthsqsresources.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.nthsqsresources-example-com.id
-}
-
 resource "aws_sqs_queue" "nthsqsresources-example-com-nth" {
   message_retention_seconds = 300
   name                      = "nthsqsresources-example-com-nth"
@@ -695,9 +695,15 @@ resource "aws_subnet" "us-test-1a-nthsqsresources-example-com" {
   vpc_id = aws_vpc.nthsqsresources-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "nthsqsresources-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.nthsqsresources-example-com.id
-  vpc_id          = aws_vpc.nthsqsresources-example-com.id
+resource "aws_vpc" "nthsqsresources-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                                 = "nthsqsresources.example.com"
+    "Name"                                              = "nthsqsresources.example.com"
+    "kubernetes.io/cluster/nthsqsresources.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "nthsqsresources-example-com" {
@@ -710,15 +716,9 @@ resource "aws_vpc_dhcp_options" "nthsqsresources-example-com" {
   }
 }
 
-resource "aws_vpc" "nthsqsresources-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                                 = "nthsqsresources.example.com"
-    "Name"                                              = "nthsqsresources.example.com"
-    "kubernetes.io/cluster/nthsqsresources.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "nthsqsresources-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.nthsqsresources-example-com.id
+  vpc_id          = aws_vpc.nthsqsresources-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -379,24 +379,6 @@ resource "aws_iam_instance_profile" "nodes-private-shared-ip-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "bastions-private-shared-ip-example-com" {
-  name   = "bastions.private-shared-ip.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_bastions.private-shared-ip.example.com_policy")
-  role   = aws_iam_role.bastions-private-shared-ip-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-private-shared-ip-example-com" {
-  name   = "masters.private-shared-ip.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy")
-  role   = aws_iam_role.masters-private-shared-ip-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-private-shared-ip-example-com" {
-  name   = "nodes.private-shared-ip.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy")
-  role   = aws_iam_role.nodes-private-shared-ip-example-com.name
-}
-
 resource "aws_iam_role" "bastions-private-shared-ip-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.private-shared-ip.example.com_policy")
   name               = "bastions.private-shared-ip.example.com"
@@ -425,6 +407,24 @@ resource "aws_iam_role" "nodes-private-shared-ip-example-com" {
     "Name"                                                = "nodes.private-shared-ip.example.com"
     "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "bastions-private-shared-ip-example-com" {
+  name   = "bastions.private-shared-ip.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_bastions.private-shared-ip.example.com_policy")
+  role   = aws_iam_role.bastions-private-shared-ip-example-com.name
+}
+
+resource "aws_iam_role_policy" "masters-private-shared-ip-example-com" {
+  name   = "masters.private-shared-ip.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy")
+  role   = aws_iam_role.masters-private-shared-ip-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-private-shared-ip-example-com" {
+  name   = "nodes.private-shared-ip.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy")
+  role   = aws_iam_role.nodes-private-shared-ip-example-com.name
 }
 
 resource "aws_key_pair" "kubernetes-private-shared-ip-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
@@ -663,6 +663,18 @@ resource "aws_nat_gateway" "us-test-1a-private-shared-ip-example-com" {
   }
 }
 
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "igw-1"
+  route_table_id         = aws_route_table.private-shared-ip-example-com.id
+}
+
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.us-test-1a-private-shared-ip-example-com.id
+  route_table_id         = aws_route_table.private-us-test-1a-private-shared-ip-example-com.id
+}
+
 resource "aws_route53_record" "api-private-shared-ip-example-com" {
   alias {
     evaluate_target_health = false
@@ -672,16 +684,6 @@ resource "aws_route53_record" "api-private-shared-ip-example-com" {
   name    = "api.private-shared-ip.example.com"
   type    = "A"
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
-}
-
-resource "aws_route_table_association" "private-us-test-1a-private-shared-ip-example-com" {
-  route_table_id = aws_route_table.private-us-test-1a-private-shared-ip-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-private-shared-ip-example-com.id
-}
-
-resource "aws_route_table_association" "utility-us-test-1a-private-shared-ip-example-com" {
-  route_table_id = aws_route_table.private-shared-ip-example-com.id
-  subnet_id      = aws_subnet.utility-us-test-1a-private-shared-ip-example-com.id
 }
 
 resource "aws_route_table" "private-shared-ip-example-com" {
@@ -704,16 +706,69 @@ resource "aws_route_table" "private-us-test-1a-private-shared-ip-example-com" {
   vpc_id = "vpc-12345678"
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "igw-1"
-  route_table_id         = aws_route_table.private-shared-ip-example-com.id
+resource "aws_route_table_association" "private-us-test-1a-private-shared-ip-example-com" {
+  route_table_id = aws_route_table.private-us-test-1a-private-shared-ip-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-private-shared-ip-example-com.id
 }
 
-resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.us-test-1a-private-shared-ip-example-com.id
-  route_table_id         = aws_route_table.private-us-test-1a-private-shared-ip-example-com.id
+resource "aws_route_table_association" "utility-us-test-1a-private-shared-ip-example-com" {
+  route_table_id = aws_route_table.private-shared-ip-example-com.id
+  subnet_id      = aws_subnet.utility-us-test-1a-private-shared-ip-example-com.id
+}
+
+resource "aws_security_group" "api-elb-private-shared-ip-example-com" {
+  description = "Security group for api ELB"
+  name        = "api-elb.private-shared-ip.example.com"
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "api-elb.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "bastion-elb-private-shared-ip-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.private-shared-ip.example.com"
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "bastion-elb.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "bastion-private-shared-ip-example-com" {
+  description = "Security group for bastion"
+  name        = "bastion.private-shared-ip.example.com"
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "bastion.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "masters-private-shared-ip-example-com" {
+  description = "Security group for masters"
+  name        = "masters.private-shared-ip.example.com"
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "masters.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "nodes-private-shared-ip-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.private-shared-ip.example.com"
+  tags = {
+    "KubernetesCluster"                                   = "private-shared-ip.example.com"
+    "Name"                                                = "nodes.private-shared-ip.example.com"
+    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-private-shared-ip-example-com" {
@@ -885,61 +940,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   security_group_id = aws_security_group.api-elb-private-shared-ip-example-com.id
   to_port           = 4
   type              = "ingress"
-}
-
-resource "aws_security_group" "api-elb-private-shared-ip-example-com" {
-  description = "Security group for api ELB"
-  name        = "api-elb.private-shared-ip.example.com"
-  tags = {
-    "KubernetesCluster"                                   = "private-shared-ip.example.com"
-    "Name"                                                = "api-elb.private-shared-ip.example.com"
-    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "bastion-elb-private-shared-ip-example-com" {
-  description = "Security group for bastion ELB"
-  name        = "bastion-elb.private-shared-ip.example.com"
-  tags = {
-    "KubernetesCluster"                                   = "private-shared-ip.example.com"
-    "Name"                                                = "bastion-elb.private-shared-ip.example.com"
-    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "bastion-private-shared-ip-example-com" {
-  description = "Security group for bastion"
-  name        = "bastion.private-shared-ip.example.com"
-  tags = {
-    "KubernetesCluster"                                   = "private-shared-ip.example.com"
-    "Name"                                                = "bastion.private-shared-ip.example.com"
-    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "masters-private-shared-ip-example-com" {
-  description = "Security group for masters"
-  name        = "masters.private-shared-ip.example.com"
-  tags = {
-    "KubernetesCluster"                                   = "private-shared-ip.example.com"
-    "Name"                                                = "masters.private-shared-ip.example.com"
-    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "nodes-private-shared-ip-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.private-shared-ip.example.com"
-  tags = {
-    "KubernetesCluster"                                   = "private-shared-ip.example.com"
-    "Name"                                                = "nodes.private-shared-ip.example.com"
-    "kubernetes.io/cluster/private-shared-ip.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
 }
 
 resource "aws_subnet" "us-test-1a-private-shared-ip-example-com" {

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -374,24 +374,6 @@ resource "aws_iam_instance_profile" "nodes-private-shared-subnet-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "bastions-private-shared-subnet-example-com" {
-  name   = "bastions.private-shared-subnet.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_bastions.private-shared-subnet.example.com_policy")
-  role   = aws_iam_role.bastions-private-shared-subnet-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-private-shared-subnet-example-com" {
-  name   = "masters.private-shared-subnet.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy")
-  role   = aws_iam_role.masters-private-shared-subnet-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-private-shared-subnet-example-com" {
-  name   = "nodes.private-shared-subnet.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy")
-  role   = aws_iam_role.nodes-private-shared-subnet-example-com.name
-}
-
 resource "aws_iam_role" "bastions-private-shared-subnet-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.private-shared-subnet.example.com_policy")
   name               = "bastions.private-shared-subnet.example.com"
@@ -420,6 +402,24 @@ resource "aws_iam_role" "nodes-private-shared-subnet-example-com" {
     "Name"                                                    = "nodes.private-shared-subnet.example.com"
     "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "bastions-private-shared-subnet-example-com" {
+  name   = "bastions.private-shared-subnet.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_bastions.private-shared-subnet.example.com_policy")
+  role   = aws_iam_role.bastions-private-shared-subnet-example-com.name
+}
+
+resource "aws_iam_role_policy" "masters-private-shared-subnet-example-com" {
+  name   = "masters.private-shared-subnet.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy")
+  role   = aws_iam_role.masters-private-shared-subnet-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-private-shared-subnet-example-com" {
+  name   = "nodes.private-shared-subnet.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy")
+  role   = aws_iam_role.nodes-private-shared-subnet-example-com.name
 }
 
 resource "aws_key_pair" "kubernetes-private-shared-subnet-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
@@ -659,6 +659,61 @@ resource "aws_route53_record" "api-private-shared-subnet-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_security_group" "api-elb-private-shared-subnet-example-com" {
+  description = "Security group for api ELB"
+  name        = "api-elb.private-shared-subnet.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "api-elb.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "bastion-elb-private-shared-subnet-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.private-shared-subnet.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "bastion-elb.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "bastion-private-shared-subnet-example-com" {
+  description = "Security group for bastion"
+  name        = "bastion.private-shared-subnet.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "bastion.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "masters-private-shared-subnet-example-com" {
+  description = "Security group for masters"
+  name        = "masters.private-shared-subnet.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "masters.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "nodes-private-shared-subnet-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.private-shared-subnet.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
+    "Name"                                                    = "nodes.private-shared-subnet.example.com"
+    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-private-shared-subnet-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -828,61 +883,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   security_group_id = aws_security_group.api-elb-private-shared-subnet-example-com.id
   to_port           = 4
   type              = "ingress"
-}
-
-resource "aws_security_group" "api-elb-private-shared-subnet-example-com" {
-  description = "Security group for api ELB"
-  name        = "api-elb.private-shared-subnet.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-    "Name"                                                    = "api-elb.private-shared-subnet.example.com"
-    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "bastion-elb-private-shared-subnet-example-com" {
-  description = "Security group for bastion ELB"
-  name        = "bastion-elb.private-shared-subnet.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-    "Name"                                                    = "bastion-elb.private-shared-subnet.example.com"
-    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "bastion-private-shared-subnet-example-com" {
-  description = "Security group for bastion"
-  name        = "bastion.private-shared-subnet.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-    "Name"                                                    = "bastion.private-shared-subnet.example.com"
-    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "masters-private-shared-subnet-example-com" {
-  description = "Security group for masters"
-  name        = "masters.private-shared-subnet.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-    "Name"                                                    = "masters.private-shared-subnet.example.com"
-    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "nodes-private-shared-subnet-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.private-shared-subnet.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "private-shared-subnet.example.com"
-    "Name"                                                    = "nodes.private-shared-subnet.example.com"
-    "kubernetes.io/cluster/private-shared-subnet.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
 }
 
 terraform {

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -409,24 +409,6 @@ resource "aws_iam_instance_profile" "nodes-privateciliumadvanced-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "bastions-privateciliumadvanced-example-com" {
-  name   = "bastions.privateciliumadvanced.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_bastions.privateciliumadvanced.example.com_policy")
-  role   = aws_iam_role.bastions-privateciliumadvanced-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-privateciliumadvanced-example-com" {
-  name   = "masters.privateciliumadvanced.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy")
-  role   = aws_iam_role.masters-privateciliumadvanced-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-privateciliumadvanced-example-com" {
-  name   = "nodes.privateciliumadvanced.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy")
-  role   = aws_iam_role.nodes-privateciliumadvanced-example-com.name
-}
-
 resource "aws_iam_role" "bastions-privateciliumadvanced-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privateciliumadvanced.example.com_policy")
   name               = "bastions.privateciliumadvanced.example.com"
@@ -455,6 +437,24 @@ resource "aws_iam_role" "nodes-privateciliumadvanced-example-com" {
     "Name"                                                    = "nodes.privateciliumadvanced.example.com"
     "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "bastions-privateciliumadvanced-example-com" {
+  name   = "bastions.privateciliumadvanced.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_bastions.privateciliumadvanced.example.com_policy")
+  role   = aws_iam_role.bastions-privateciliumadvanced-example-com.name
+}
+
+resource "aws_iam_role_policy" "masters-privateciliumadvanced-example-com" {
+  name   = "masters.privateciliumadvanced.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy")
+  role   = aws_iam_role.masters-privateciliumadvanced-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-privateciliumadvanced-example-com" {
+  name   = "nodes.privateciliumadvanced.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy")
+  role   = aws_iam_role.nodes-privateciliumadvanced-example-com.name
 }
 
 resource "aws_internet_gateway" "privateciliumadvanced-example-com" {
@@ -702,6 +702,18 @@ resource "aws_nat_gateway" "us-test-1a-privateciliumadvanced-example-com" {
   }
 }
 
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.privateciliumadvanced-example-com.id
+  route_table_id         = aws_route_table.privateciliumadvanced-example-com.id
+}
+
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.us-test-1a-privateciliumadvanced-example-com.id
+  route_table_id         = aws_route_table.private-us-test-1a-privateciliumadvanced-example-com.id
+}
+
 resource "aws_route53_record" "api-privateciliumadvanced-example-com" {
   alias {
     evaluate_target_health = false
@@ -711,16 +723,6 @@ resource "aws_route53_record" "api-privateciliumadvanced-example-com" {
   name    = "api.privateciliumadvanced.example.com"
   type    = "A"
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
-}
-
-resource "aws_route_table_association" "private-us-test-1a-privateciliumadvanced-example-com" {
-  route_table_id = aws_route_table.private-us-test-1a-privateciliumadvanced-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-privateciliumadvanced-example-com.id
-}
-
-resource "aws_route_table_association" "utility-us-test-1a-privateciliumadvanced-example-com" {
-  route_table_id = aws_route_table.privateciliumadvanced-example-com.id
-  subnet_id      = aws_subnet.utility-us-test-1a-privateciliumadvanced-example-com.id
 }
 
 resource "aws_route_table" "private-us-test-1a-privateciliumadvanced-example-com" {
@@ -743,16 +745,69 @@ resource "aws_route_table" "privateciliumadvanced-example-com" {
   vpc_id = aws_vpc.privateciliumadvanced-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.privateciliumadvanced-example-com.id
-  route_table_id         = aws_route_table.privateciliumadvanced-example-com.id
+resource "aws_route_table_association" "private-us-test-1a-privateciliumadvanced-example-com" {
+  route_table_id = aws_route_table.private-us-test-1a-privateciliumadvanced-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-privateciliumadvanced-example-com.id
 }
 
-resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.us-test-1a-privateciliumadvanced-example-com.id
-  route_table_id         = aws_route_table.private-us-test-1a-privateciliumadvanced-example-com.id
+resource "aws_route_table_association" "utility-us-test-1a-privateciliumadvanced-example-com" {
+  route_table_id = aws_route_table.privateciliumadvanced-example-com.id
+  subnet_id      = aws_subnet.utility-us-test-1a-privateciliumadvanced-example-com.id
+}
+
+resource "aws_security_group" "api-elb-privateciliumadvanced-example-com" {
+  description = "Security group for api ELB"
+  name        = "api-elb.privateciliumadvanced.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "api-elb.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
+}
+
+resource "aws_security_group" "bastion-elb-privateciliumadvanced-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.privateciliumadvanced.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "bastion-elb.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
+}
+
+resource "aws_security_group" "bastion-privateciliumadvanced-example-com" {
+  description = "Security group for bastion"
+  name        = "bastion.privateciliumadvanced.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "bastion.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
+}
+
+resource "aws_security_group" "masters-privateciliumadvanced-example-com" {
+  description = "Security group for masters"
+  name        = "masters.privateciliumadvanced.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "masters.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
+}
+
+resource "aws_security_group" "nodes-privateciliumadvanced-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.privateciliumadvanced.example.com"
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "nodes.privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privateciliumadvanced-example-com" {
@@ -926,61 +981,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
-resource "aws_security_group" "api-elb-privateciliumadvanced-example-com" {
-  description = "Security group for api ELB"
-  name        = "api-elb.privateciliumadvanced.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-    "Name"                                                    = "api-elb.privateciliumadvanced.example.com"
-    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
-}
-
-resource "aws_security_group" "bastion-elb-privateciliumadvanced-example-com" {
-  description = "Security group for bastion ELB"
-  name        = "bastion-elb.privateciliumadvanced.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-    "Name"                                                    = "bastion-elb.privateciliumadvanced.example.com"
-    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
-}
-
-resource "aws_security_group" "bastion-privateciliumadvanced-example-com" {
-  description = "Security group for bastion"
-  name        = "bastion.privateciliumadvanced.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-    "Name"                                                    = "bastion.privateciliumadvanced.example.com"
-    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
-}
-
-resource "aws_security_group" "masters-privateciliumadvanced-example-com" {
-  description = "Security group for masters"
-  name        = "masters.privateciliumadvanced.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-    "Name"                                                    = "masters.privateciliumadvanced.example.com"
-    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
-}
-
-resource "aws_security_group" "nodes-privateciliumadvanced-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.privateciliumadvanced.example.com"
-  tags = {
-    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-    "Name"                                                    = "nodes.privateciliumadvanced.example.com"
-    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateciliumadvanced-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-privateciliumadvanced-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -1007,9 +1007,15 @@ resource "aws_subnet" "utility-us-test-1a-privateciliumadvanced-example-com" {
   vpc_id = aws_vpc.privateciliumadvanced-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "privateciliumadvanced-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.privateciliumadvanced-example-com.id
-  vpc_id          = aws_vpc.privateciliumadvanced-example-com.id
+resource "aws_vpc" "privateciliumadvanced-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
+    "Name"                                                    = "privateciliumadvanced.example.com"
+    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "privateciliumadvanced-example-com" {
@@ -1022,15 +1028,9 @@ resource "aws_vpc_dhcp_options" "privateciliumadvanced-example-com" {
   }
 }
 
-resource "aws_vpc" "privateciliumadvanced-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                                       = "privateciliumadvanced.example.com"
-    "Name"                                                    = "privateciliumadvanced.example.com"
-    "kubernetes.io/cluster/privateciliumadvanced.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "privateciliumadvanced-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.privateciliumadvanced-example-com.id
+  vpc_id          = aws_vpc.privateciliumadvanced-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -393,24 +393,6 @@ resource "aws_iam_instance_profile" "nodes-privateflannel-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "bastions-privateflannel-example-com" {
-  name   = "bastions.privateflannel.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_bastions.privateflannel.example.com_policy")
-  role   = aws_iam_role.bastions-privateflannel-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-privateflannel-example-com" {
-  name   = "masters.privateflannel.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.privateflannel.example.com_policy")
-  role   = aws_iam_role.masters-privateflannel-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-privateflannel-example-com" {
-  name   = "nodes.privateflannel.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy")
-  role   = aws_iam_role.nodes-privateflannel-example-com.name
-}
-
 resource "aws_iam_role" "bastions-privateflannel-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privateflannel.example.com_policy")
   name               = "bastions.privateflannel.example.com"
@@ -439,6 +421,24 @@ resource "aws_iam_role" "nodes-privateflannel-example-com" {
     "Name"                                             = "nodes.privateflannel.example.com"
     "kubernetes.io/cluster/privateflannel.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "bastions-privateflannel-example-com" {
+  name   = "bastions.privateflannel.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_bastions.privateflannel.example.com_policy")
+  role   = aws_iam_role.bastions-privateflannel-example-com.name
+}
+
+resource "aws_iam_role_policy" "masters-privateflannel-example-com" {
+  name   = "masters.privateflannel.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.privateflannel.example.com_policy")
+  role   = aws_iam_role.masters-privateflannel-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-privateflannel-example-com" {
+  name   = "nodes.privateflannel.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy")
+  role   = aws_iam_role.nodes-privateflannel-example-com.name
 }
 
 resource "aws_internet_gateway" "privateflannel-example-com" {
@@ -686,6 +686,18 @@ resource "aws_nat_gateway" "us-test-1a-privateflannel-example-com" {
   }
 }
 
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.privateflannel-example-com.id
+  route_table_id         = aws_route_table.privateflannel-example-com.id
+}
+
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.us-test-1a-privateflannel-example-com.id
+  route_table_id         = aws_route_table.private-us-test-1a-privateflannel-example-com.id
+}
+
 resource "aws_route53_record" "api-privateflannel-example-com" {
   alias {
     evaluate_target_health = false
@@ -695,16 +707,6 @@ resource "aws_route53_record" "api-privateflannel-example-com" {
   name    = "api.privateflannel.example.com"
   type    = "A"
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
-}
-
-resource "aws_route_table_association" "private-us-test-1a-privateflannel-example-com" {
-  route_table_id = aws_route_table.private-us-test-1a-privateflannel-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-privateflannel-example-com.id
-}
-
-resource "aws_route_table_association" "utility-us-test-1a-privateflannel-example-com" {
-  route_table_id = aws_route_table.privateflannel-example-com.id
-  subnet_id      = aws_subnet.utility-us-test-1a-privateflannel-example-com.id
 }
 
 resource "aws_route_table" "private-us-test-1a-privateflannel-example-com" {
@@ -727,16 +729,69 @@ resource "aws_route_table" "privateflannel-example-com" {
   vpc_id = aws_vpc.privateflannel-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.privateflannel-example-com.id
-  route_table_id         = aws_route_table.privateflannel-example-com.id
+resource "aws_route_table_association" "private-us-test-1a-privateflannel-example-com" {
+  route_table_id = aws_route_table.private-us-test-1a-privateflannel-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-privateflannel-example-com.id
 }
 
-resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.us-test-1a-privateflannel-example-com.id
-  route_table_id         = aws_route_table.private-us-test-1a-privateflannel-example-com.id
+resource "aws_route_table_association" "utility-us-test-1a-privateflannel-example-com" {
+  route_table_id = aws_route_table.privateflannel-example-com.id
+  subnet_id      = aws_subnet.utility-us-test-1a-privateflannel-example-com.id
+}
+
+resource "aws_security_group" "api-elb-privateflannel-example-com" {
+  description = "Security group for api ELB"
+  name        = "api-elb.privateflannel.example.com"
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "api-elb.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateflannel-example-com.id
+}
+
+resource "aws_security_group" "bastion-elb-privateflannel-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.privateflannel.example.com"
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "bastion-elb.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateflannel-example-com.id
+}
+
+resource "aws_security_group" "bastion-privateflannel-example-com" {
+  description = "Security group for bastion"
+  name        = "bastion.privateflannel.example.com"
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "bastion.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateflannel-example-com.id
+}
+
+resource "aws_security_group" "masters-privateflannel-example-com" {
+  description = "Security group for masters"
+  name        = "masters.privateflannel.example.com"
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "masters.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateflannel-example-com.id
+}
+
+resource "aws_security_group" "nodes-privateflannel-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.privateflannel.example.com"
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "nodes.privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privateflannel-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privateflannel-example-com" {
@@ -910,61 +965,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
-resource "aws_security_group" "api-elb-privateflannel-example-com" {
-  description = "Security group for api ELB"
-  name        = "api-elb.privateflannel.example.com"
-  tags = {
-    "KubernetesCluster"                                = "privateflannel.example.com"
-    "Name"                                             = "api-elb.privateflannel.example.com"
-    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateflannel-example-com.id
-}
-
-resource "aws_security_group" "bastion-elb-privateflannel-example-com" {
-  description = "Security group for bastion ELB"
-  name        = "bastion-elb.privateflannel.example.com"
-  tags = {
-    "KubernetesCluster"                                = "privateflannel.example.com"
-    "Name"                                             = "bastion-elb.privateflannel.example.com"
-    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateflannel-example-com.id
-}
-
-resource "aws_security_group" "bastion-privateflannel-example-com" {
-  description = "Security group for bastion"
-  name        = "bastion.privateflannel.example.com"
-  tags = {
-    "KubernetesCluster"                                = "privateflannel.example.com"
-    "Name"                                             = "bastion.privateflannel.example.com"
-    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateflannel-example-com.id
-}
-
-resource "aws_security_group" "masters-privateflannel-example-com" {
-  description = "Security group for masters"
-  name        = "masters.privateflannel.example.com"
-  tags = {
-    "KubernetesCluster"                                = "privateflannel.example.com"
-    "Name"                                             = "masters.privateflannel.example.com"
-    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateflannel-example-com.id
-}
-
-resource "aws_security_group" "nodes-privateflannel-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.privateflannel.example.com"
-  tags = {
-    "KubernetesCluster"                                = "privateflannel.example.com"
-    "Name"                                             = "nodes.privateflannel.example.com"
-    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privateflannel-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-privateflannel-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -991,9 +991,15 @@ resource "aws_subnet" "utility-us-test-1a-privateflannel-example-com" {
   vpc_id = aws_vpc.privateflannel-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "privateflannel-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.privateflannel-example-com.id
-  vpc_id          = aws_vpc.privateflannel-example-com.id
+resource "aws_vpc" "privateflannel-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                                = "privateflannel.example.com"
+    "Name"                                             = "privateflannel.example.com"
+    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "privateflannel-example-com" {
@@ -1006,15 +1012,9 @@ resource "aws_vpc_dhcp_options" "privateflannel-example-com" {
   }
 }
 
-resource "aws_vpc" "privateflannel-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                                = "privateflannel.example.com"
-    "Name"                                             = "privateflannel.example.com"
-    "kubernetes.io/cluster/privateflannel.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "privateflannel-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.privateflannel-example-com.id
+  vpc_id          = aws_vpc.privateflannel-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -399,24 +399,6 @@ resource "aws_iam_instance_profile" "nodes-privatekopeio-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "bastions-privatekopeio-example-com" {
-  name   = "bastions.privatekopeio.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_bastions.privatekopeio.example.com_policy")
-  role   = aws_iam_role.bastions-privatekopeio-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-privatekopeio-example-com" {
-  name   = "masters.privatekopeio.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy")
-  role   = aws_iam_role.masters-privatekopeio-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-privatekopeio-example-com" {
-  name   = "nodes.privatekopeio.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy")
-  role   = aws_iam_role.nodes-privatekopeio-example-com.name
-}
-
 resource "aws_iam_role" "bastions-privatekopeio-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.privatekopeio.example.com_policy")
   name               = "bastions.privatekopeio.example.com"
@@ -445,6 +427,24 @@ resource "aws_iam_role" "nodes-privatekopeio-example-com" {
     "Name"                                            = "nodes.privatekopeio.example.com"
     "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "bastions-privatekopeio-example-com" {
+  name   = "bastions.privatekopeio.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_bastions.privatekopeio.example.com_policy")
+  role   = aws_iam_role.bastions-privatekopeio-example-com.name
+}
+
+resource "aws_iam_role_policy" "masters-privatekopeio-example-com" {
+  name   = "masters.privatekopeio.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy")
+  role   = aws_iam_role.masters-privatekopeio-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-privatekopeio-example-com" {
+  name   = "nodes.privatekopeio.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy")
+  role   = aws_iam_role.nodes-privatekopeio-example-com.name
 }
 
 resource "aws_internet_gateway" "privatekopeio-example-com" {
@@ -682,6 +682,24 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.privatekopeio.example.com_user_data")
 }
 
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.privatekopeio-example-com.id
+  route_table_id         = aws_route_table.privatekopeio-example-com.id
+}
+
+resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = "nat-a2345678"
+  route_table_id         = aws_route_table.private-us-test-1a-privatekopeio-example-com.id
+}
+
+resource "aws_route" "route-private-us-test-1b-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = "nat-b2345678"
+  route_table_id         = aws_route_table.private-us-test-1b-privatekopeio-example-com.id
+}
+
 resource "aws_route53_record" "api-privatekopeio-example-com" {
   alias {
     evaluate_target_health = false
@@ -691,26 +709,6 @@ resource "aws_route53_record" "api-privatekopeio-example-com" {
   name    = "api.privatekopeio.example.com"
   type    = "A"
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
-}
-
-resource "aws_route_table_association" "private-us-test-1a-privatekopeio-example-com" {
-  route_table_id = aws_route_table.private-us-test-1a-privatekopeio-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-privatekopeio-example-com.id
-}
-
-resource "aws_route_table_association" "private-us-test-1b-privatekopeio-example-com" {
-  route_table_id = aws_route_table.private-us-test-1b-privatekopeio-example-com.id
-  subnet_id      = aws_subnet.us-test-1b-privatekopeio-example-com.id
-}
-
-resource "aws_route_table_association" "utility-us-test-1a-privatekopeio-example-com" {
-  route_table_id = aws_route_table.privatekopeio-example-com.id
-  subnet_id      = aws_subnet.utility-us-test-1a-privatekopeio-example-com.id
-}
-
-resource "aws_route_table_association" "utility-us-test-1b-privatekopeio-example-com" {
-  route_table_id = aws_route_table.privatekopeio-example-com.id
-  subnet_id      = aws_subnet.utility-us-test-1b-privatekopeio-example-com.id
 }
 
 resource "aws_route_table" "private-us-test-1a-privatekopeio-example-com" {
@@ -743,22 +741,79 @@ resource "aws_route_table" "privatekopeio-example-com" {
   vpc_id = aws_vpc.privatekopeio-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.privatekopeio-example-com.id
-  route_table_id         = aws_route_table.privatekopeio-example-com.id
+resource "aws_route_table_association" "private-us-test-1a-privatekopeio-example-com" {
+  route_table_id = aws_route_table.private-us-test-1a-privatekopeio-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-privatekopeio-example-com.id
 }
 
-resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "nat-a2345678"
-  route_table_id         = aws_route_table.private-us-test-1a-privatekopeio-example-com.id
+resource "aws_route_table_association" "private-us-test-1b-privatekopeio-example-com" {
+  route_table_id = aws_route_table.private-us-test-1b-privatekopeio-example-com.id
+  subnet_id      = aws_subnet.us-test-1b-privatekopeio-example-com.id
 }
 
-resource "aws_route" "route-private-us-test-1b-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "nat-b2345678"
-  route_table_id         = aws_route_table.private-us-test-1b-privatekopeio-example-com.id
+resource "aws_route_table_association" "utility-us-test-1a-privatekopeio-example-com" {
+  route_table_id = aws_route_table.privatekopeio-example-com.id
+  subnet_id      = aws_subnet.utility-us-test-1a-privatekopeio-example-com.id
+}
+
+resource "aws_route_table_association" "utility-us-test-1b-privatekopeio-example-com" {
+  route_table_id = aws_route_table.privatekopeio-example-com.id
+  subnet_id      = aws_subnet.utility-us-test-1b-privatekopeio-example-com.id
+}
+
+resource "aws_security_group" "api-elb-privatekopeio-example-com" {
+  description = "Security group for api ELB"
+  name        = "api-elb.privatekopeio.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "api-elb.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privatekopeio-example-com.id
+}
+
+resource "aws_security_group" "bastion-elb-privatekopeio-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.privatekopeio.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "bastion-elb.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privatekopeio-example-com.id
+}
+
+resource "aws_security_group" "bastion-privatekopeio-example-com" {
+  description = "Security group for bastion"
+  name        = "bastion.privatekopeio.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "bastion.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privatekopeio-example-com.id
+}
+
+resource "aws_security_group" "masters-privatekopeio-example-com" {
+  description = "Security group for masters"
+  name        = "masters.privatekopeio.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "masters.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privatekopeio-example-com.id
+}
+
+resource "aws_security_group" "nodes-privatekopeio-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.privatekopeio.example.com"
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "nodes.privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.privatekopeio-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-privatekopeio-example-com" {
@@ -932,61 +987,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   type              = "ingress"
 }
 
-resource "aws_security_group" "api-elb-privatekopeio-example-com" {
-  description = "Security group for api ELB"
-  name        = "api-elb.privatekopeio.example.com"
-  tags = {
-    "KubernetesCluster"                               = "privatekopeio.example.com"
-    "Name"                                            = "api-elb.privatekopeio.example.com"
-    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privatekopeio-example-com.id
-}
-
-resource "aws_security_group" "bastion-elb-privatekopeio-example-com" {
-  description = "Security group for bastion ELB"
-  name        = "bastion-elb.privatekopeio.example.com"
-  tags = {
-    "KubernetesCluster"                               = "privatekopeio.example.com"
-    "Name"                                            = "bastion-elb.privatekopeio.example.com"
-    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privatekopeio-example-com.id
-}
-
-resource "aws_security_group" "bastion-privatekopeio-example-com" {
-  description = "Security group for bastion"
-  name        = "bastion.privatekopeio.example.com"
-  tags = {
-    "KubernetesCluster"                               = "privatekopeio.example.com"
-    "Name"                                            = "bastion.privatekopeio.example.com"
-    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privatekopeio-example-com.id
-}
-
-resource "aws_security_group" "masters-privatekopeio-example-com" {
-  description = "Security group for masters"
-  name        = "masters.privatekopeio.example.com"
-  tags = {
-    "KubernetesCluster"                               = "privatekopeio.example.com"
-    "Name"                                            = "masters.privatekopeio.example.com"
-    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privatekopeio-example-com.id
-}
-
-resource "aws_security_group" "nodes-privatekopeio-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.privatekopeio.example.com"
-  tags = {
-    "KubernetesCluster"                               = "privatekopeio.example.com"
-    "Name"                                            = "nodes.privatekopeio.example.com"
-    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.privatekopeio-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-privatekopeio-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -1039,9 +1039,15 @@ resource "aws_subnet" "utility-us-test-1b-privatekopeio-example-com" {
   vpc_id = aws_vpc.privatekopeio-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "privatekopeio-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.privatekopeio-example-com.id
-  vpc_id          = aws_vpc.privatekopeio-example-com.id
+resource "aws_vpc" "privatekopeio-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                               = "privatekopeio.example.com"
+    "Name"                                            = "privatekopeio.example.com"
+    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "privatekopeio-example-com" {
@@ -1054,15 +1060,9 @@ resource "aws_vpc_dhcp_options" "privatekopeio-example-com" {
   }
 }
 
-resource "aws_vpc" "privatekopeio-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                               = "privatekopeio.example.com"
-    "Name"                                            = "privatekopeio.example.com"
-    "kubernetes.io/cluster/privatekopeio.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "privatekopeio-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.privatekopeio-example-com.id
+  vpc_id          = aws_vpc.privatekopeio-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -264,24 +264,6 @@ resource "aws_iam_openid_connect_provider" "minimal-example-com" {
   url             = "https://discovery.example.com/minimal.example.com/oidc"
 }
 
-resource "aws_iam_role_policy" "dns-controller-kube-system-sa-minimal-example-com" {
-  name   = "dns-controller.kube-system.sa.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy")
-  role   = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-minimal-example-com" {
-  name   = "masters.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
-  role   = aws_iam_role.masters-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-minimal-example-com" {
-  name   = "nodes.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
-  role   = aws_iam_role.nodes-minimal-example-com.name
-}
-
 resource "aws_iam_role" "dns-controller-kube-system-sa-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy")
   name               = "dns-controller.kube-system.sa.minimal.example.com"
@@ -310,6 +292,24 @@ resource "aws_iam_role" "nodes-minimal-example-com" {
     "Name"                                      = "nodes.minimal.example.com"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "dns-controller-kube-system-sa-minimal-example-com" {
+  name   = "dns-controller.kube-system.sa.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy")
+  role   = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy" "masters-minimal-example-com" {
+  name   = "masters.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
+  role   = aws_iam_role.masters-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-minimal-example-com" {
+  name   = "nodes.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
+  role   = aws_iam_role.nodes-minimal-example-com.name
 }
 
 resource "aws_internet_gateway" "minimal-example-com" {
@@ -480,9 +480,10 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
 }
 
-resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
-  route_table_id = aws_route_table.minimal-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.minimal-example-com.id
+  route_table_id         = aws_route_table.minimal-example-com.id
 }
 
 resource "aws_route_table" "minimal-example-com" {
@@ -495,10 +496,31 @@ resource "aws_route_table" "minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.minimal-example-com.id
-  route_table_id         = aws_route_table.minimal-example-com.id
+resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
+  route_table_id = aws_route_table.minimal-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+}
+
+resource "aws_security_group" "masters-minimal-example-com" {
+  description = "Security group for masters"
+  name        = "masters.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
+}
+
+resource "aws_security_group" "nodes-minimal-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-minimal-example-com" {
@@ -609,28 +631,6 @@ resource "aws_security_group_rule" "from-nodes-minimal-example-com-ingress-udp-1
   type                     = "ingress"
 }
 
-resource "aws_security_group" "masters-minimal-example-com" {
-  description = "Security group for masters"
-  name        = "masters.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "masters.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
-resource "aws_security_group" "nodes-minimal-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "nodes.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-minimal-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -644,9 +644,15 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
-  vpc_id          = aws_vpc.minimal-example-com.id
+resource "aws_vpc" "minimal-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "minimal-example-com" {
@@ -659,15 +665,9 @@ resource "aws_vpc_dhcp_options" "minimal-example-com" {
   }
 }
 
-resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
+  vpc_id          = aws_vpc.minimal-example-com.id
 }
 
 terraform {

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -238,18 +238,6 @@ resource "aws_iam_instance_profile" "nodes-sharedsubnet-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "masters-sharedsubnet-example-com" {
-  name   = "masters.sharedsubnet.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy")
-  role   = aws_iam_role.masters-sharedsubnet-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-sharedsubnet-example-com" {
-  name   = "nodes.sharedsubnet.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy")
-  role   = aws_iam_role.nodes-sharedsubnet-example-com.name
-}
-
 resource "aws_iam_role" "masters-sharedsubnet-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.sharedsubnet.example.com_policy")
   name               = "masters.sharedsubnet.example.com"
@@ -268,6 +256,18 @@ resource "aws_iam_role" "nodes-sharedsubnet-example-com" {
     "Name"                                           = "nodes.sharedsubnet.example.com"
     "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "masters-sharedsubnet-example-com" {
+  name   = "masters.sharedsubnet.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy")
+  role   = aws_iam_role.masters-sharedsubnet-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-sharedsubnet-example-com" {
+  name   = "nodes.sharedsubnet.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy")
+  role   = aws_iam_role.nodes-sharedsubnet-example-com.name
 }
 
 resource "aws_key_pair" "kubernetes-sharedsubnet-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
@@ -429,6 +429,28 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data")
 }
 
+resource "aws_security_group" "masters-sharedsubnet-example-com" {
+  description = "Security group for masters"
+  name        = "masters.sharedsubnet.example.com"
+  tags = {
+    "KubernetesCluster"                              = "sharedsubnet.example.com"
+    "Name"                                           = "masters.sharedsubnet.example.com"
+    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "nodes-sharedsubnet-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.sharedsubnet.example.com"
+  tags = {
+    "KubernetesCluster"                              = "sharedsubnet.example.com"
+    "Name"                                           = "nodes.sharedsubnet.example.com"
+    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-sharedsubnet-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -535,28 +557,6 @@ resource "aws_security_group_rule" "from-nodes-sharedsubnet-example-com-ingress-
   source_security_group_id = aws_security_group.nodes-sharedsubnet-example-com.id
   to_port                  = 65535
   type                     = "ingress"
-}
-
-resource "aws_security_group" "masters-sharedsubnet-example-com" {
-  description = "Security group for masters"
-  name        = "masters.sharedsubnet.example.com"
-  tags = {
-    "KubernetesCluster"                              = "sharedsubnet.example.com"
-    "Name"                                           = "masters.sharedsubnet.example.com"
-    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "nodes-sharedsubnet-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.sharedsubnet.example.com"
-  tags = {
-    "KubernetesCluster"                              = "sharedsubnet.example.com"
-    "Name"                                           = "nodes.sharedsubnet.example.com"
-    "kubernetes.io/cluster/sharedsubnet.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
 }
 
 terraform {

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -379,24 +379,6 @@ resource "aws_iam_instance_profile" "nodes-unmanaged-example-com" {
   }
 }
 
-resource "aws_iam_role_policy" "bastions-unmanaged-example-com" {
-  name   = "bastions.unmanaged.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_bastions.unmanaged.example.com_policy")
-  role   = aws_iam_role.bastions-unmanaged-example-com.name
-}
-
-resource "aws_iam_role_policy" "masters-unmanaged-example-com" {
-  name   = "masters.unmanaged.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.unmanaged.example.com_policy")
-  role   = aws_iam_role.masters-unmanaged-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-unmanaged-example-com" {
-  name   = "nodes.unmanaged.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy")
-  role   = aws_iam_role.nodes-unmanaged-example-com.name
-}
-
 resource "aws_iam_role" "bastions-unmanaged-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_bastions.unmanaged.example.com_policy")
   name               = "bastions.unmanaged.example.com"
@@ -425,6 +407,24 @@ resource "aws_iam_role" "nodes-unmanaged-example-com" {
     "Name"                                        = "nodes.unmanaged.example.com"
     "kubernetes.io/cluster/unmanaged.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "bastions-unmanaged-example-com" {
+  name   = "bastions.unmanaged.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_bastions.unmanaged.example.com_policy")
+  role   = aws_iam_role.bastions-unmanaged-example-com.name
+}
+
+resource "aws_iam_role_policy" "masters-unmanaged-example-com" {
+  name   = "masters.unmanaged.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.unmanaged.example.com_policy")
+  role   = aws_iam_role.masters-unmanaged-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-unmanaged-example-com" {
+  name   = "nodes.unmanaged.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy")
+  role   = aws_iam_role.nodes-unmanaged-example-com.name
 }
 
 resource "aws_key_pair" "kubernetes-unmanaged-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157" {
@@ -664,6 +664,61 @@ resource "aws_route53_record" "api-unmanaged-example-com" {
   zone_id = "/hostedzone/Z1AFAKE1ZON3YO"
 }
 
+resource "aws_security_group" "api-elb-unmanaged-example-com" {
+  description = "Security group for api ELB"
+  name        = "api-elb.unmanaged.example.com"
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "api-elb.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "bastion-elb-unmanaged-example-com" {
+  description = "Security group for bastion ELB"
+  name        = "bastion-elb.unmanaged.example.com"
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "bastion-elb.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "bastion-unmanaged-example-com" {
+  description = "Security group for bastion"
+  name        = "bastion.unmanaged.example.com"
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "bastion.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "masters-unmanaged-example-com" {
+  description = "Security group for masters"
+  name        = "masters.unmanaged.example.com"
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "masters.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
+resource "aws_security_group" "nodes-unmanaged-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.unmanaged.example.com"
+  tags = {
+    "KubernetesCluster"                           = "unmanaged.example.com"
+    "Name"                                        = "nodes.unmanaged.example.com"
+    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
+  }
+  vpc_id = "vpc-12345678"
+}
+
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-bastion-elb-unmanaged-example-com" {
   cidr_blocks       = ["0.0.0.0/0"]
   from_port         = 22
@@ -833,61 +888,6 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
   security_group_id = aws_security_group.api-elb-unmanaged-example-com.id
   to_port           = 4
   type              = "ingress"
-}
-
-resource "aws_security_group" "api-elb-unmanaged-example-com" {
-  description = "Security group for api ELB"
-  name        = "api-elb.unmanaged.example.com"
-  tags = {
-    "KubernetesCluster"                           = "unmanaged.example.com"
-    "Name"                                        = "api-elb.unmanaged.example.com"
-    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "bastion-elb-unmanaged-example-com" {
-  description = "Security group for bastion ELB"
-  name        = "bastion-elb.unmanaged.example.com"
-  tags = {
-    "KubernetesCluster"                           = "unmanaged.example.com"
-    "Name"                                        = "bastion-elb.unmanaged.example.com"
-    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "bastion-unmanaged-example-com" {
-  description = "Security group for bastion"
-  name        = "bastion.unmanaged.example.com"
-  tags = {
-    "KubernetesCluster"                           = "unmanaged.example.com"
-    "Name"                                        = "bastion.unmanaged.example.com"
-    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "masters-unmanaged-example-com" {
-  description = "Security group for masters"
-  name        = "masters.unmanaged.example.com"
-  tags = {
-    "KubernetesCluster"                           = "unmanaged.example.com"
-    "Name"                                        = "masters.unmanaged.example.com"
-    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
-}
-
-resource "aws_security_group" "nodes-unmanaged-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.unmanaged.example.com"
-  tags = {
-    "KubernetesCluster"                           = "unmanaged.example.com"
-    "Name"                                        = "nodes.unmanaged.example.com"
-    "kubernetes.io/cluster/unmanaged.example.com" = "owned"
-  }
-  vpc_id = "vpc-12345678"
 }
 
 resource "aws_subnet" "us-test-1a-unmanaged-example-com" {

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -254,18 +254,6 @@ resource "aws_iam_openid_connect_provider" "minimal-example-com" {
   url             = "https://discovery.example.com/minimal.example.com/oidc"
 }
 
-resource "aws_iam_role_policy" "masters-minimal-example-com" {
-  name   = "masters.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
-  role   = aws_iam_role.masters-minimal-example-com.name
-}
-
-resource "aws_iam_role_policy" "nodes-minimal-example-com" {
-  name   = "nodes.minimal.example.com"
-  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
-  role   = aws_iam_role.nodes-minimal-example-com.name
-}
-
 resource "aws_iam_role" "masters-minimal-example-com" {
   assume_role_policy = file("${path.module}/data/aws_iam_role_masters.minimal.example.com_policy")
   name               = "masters.minimal.example.com"
@@ -284,6 +272,18 @@ resource "aws_iam_role" "nodes-minimal-example-com" {
     "Name"                                      = "nodes.minimal.example.com"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
   }
+}
+
+resource "aws_iam_role_policy" "masters-minimal-example-com" {
+  name   = "masters.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_masters.minimal.example.com_policy")
+  role   = aws_iam_role.masters-minimal-example-com.name
+}
+
+resource "aws_iam_role_policy" "nodes-minimal-example-com" {
+  name   = "nodes.minimal.example.com"
+  policy = file("${path.module}/data/aws_iam_role_policy_nodes.minimal.example.com_policy")
+  role   = aws_iam_role.nodes-minimal-example-com.name
 }
 
 resource "aws_internet_gateway" "minimal-example-com" {
@@ -454,9 +454,10 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   user_data = filebase64("${path.module}/data/aws_launch_template_nodes.minimal.example.com_user_data")
 }
 
-resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
-  route_table_id = aws_route_table.minimal-example-com.id
-  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+resource "aws_route" "route-0-0-0-0--0" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.minimal-example-com.id
+  route_table_id         = aws_route_table.minimal-example-com.id
 }
 
 resource "aws_route_table" "minimal-example-com" {
@@ -469,10 +470,31 @@ resource "aws_route_table" "minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_route" "route-0-0-0-0--0" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = aws_internet_gateway.minimal-example-com.id
-  route_table_id         = aws_route_table.minimal-example-com.id
+resource "aws_route_table_association" "us-test-1a-minimal-example-com" {
+  route_table_id = aws_route_table.minimal-example-com.id
+  subnet_id      = aws_subnet.us-test-1a-minimal-example-com.id
+}
+
+resource "aws_security_group" "masters-minimal-example-com" {
+  description = "Security group for masters"
+  name        = "masters.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "masters.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
+}
+
+resource "aws_security_group" "nodes-minimal-example-com" {
+  description = "Security group for nodes"
+  name        = "nodes.minimal.example.com"
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "nodes.minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-example-com.id
 }
 
 resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-minimal-example-com" {
@@ -583,28 +605,6 @@ resource "aws_security_group_rule" "from-nodes-minimal-example-com-ingress-udp-1
   type                     = "ingress"
 }
 
-resource "aws_security_group" "masters-minimal-example-com" {
-  description = "Security group for masters"
-  name        = "masters.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "masters.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
-resource "aws_security_group" "nodes-minimal-example-com" {
-  description = "Security group for nodes"
-  name        = "nodes.minimal.example.com"
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "nodes.minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
-  vpc_id = aws_vpc.minimal-example-com.id
-}
-
 resource "aws_subnet" "us-test-1a-minimal-example-com" {
   availability_zone = "us-test-1a"
   cidr_block        = "172.20.32.0/19"
@@ -618,9 +618,15 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
   vpc_id = aws_vpc.minimal-example-com.id
 }
 
-resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
-  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
-  vpc_id          = aws_vpc.minimal-example-com.id
+resource "aws_vpc" "minimal-example-com" {
+  cidr_block           = "172.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    "KubernetesCluster"                         = "minimal.example.com"
+    "Name"                                      = "minimal.example.com"
+    "kubernetes.io/cluster/minimal.example.com" = "owned"
+  }
 }
 
 resource "aws_vpc_dhcp_options" "minimal-example-com" {
@@ -633,15 +639,9 @@ resource "aws_vpc_dhcp_options" "minimal-example-com" {
   }
 }
 
-resource "aws_vpc" "minimal-example-com" {
-  cidr_block           = "172.20.0.0/16"
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-  tags = {
-    "KubernetesCluster"                         = "minimal.example.com"
-    "Name"                                      = "minimal.example.com"
-    "kubernetes.io/cluster/minimal.example.com" = "owned"
-  }
+resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
+  dhcp_options_id = aws_vpc_dhcp_options.minimal-example-com.id
+  vpc_id          = aws_vpc.minimal-example-com.id
 }
 
 terraform {

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -70,6 +70,7 @@ go_library(
         "//upup/pkg/fi/cloudup/gce:go_default_library",
         "//upup/pkg/fi/cloudup/openstack:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
+        "//upup/pkg/fi/cloudup/terraformWriter:go_default_library",
         "//upup/pkg/fi/loader:go_default_library",
         "//util/pkg/architectures:go_default_library",
         "//util/pkg/env:go_default_library",

--- a/upup/pkg/fi/cloudup/alitasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/alitasks/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/aliup:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
+        "//upup/pkg/fi/cloudup/terraformWriter:go_default_library",
         "//vendor/github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests:go_default_library",
         "//vendor/github.com/aliyun/alibaba-cloud-sdk-go/services/slb:go_default_library",
         "//vendor/github.com/denverdino/aliyungo/common:go_default_library",

--- a/upup/pkg/fi/cloudup/alitasks/eip_natgateway_association.go
+++ b/upup/pkg/fi/cloudup/alitasks/eip_natgateway_association.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 const (
@@ -141,8 +142,8 @@ type terraformEip struct {
 }
 
 type terraformEipAssociation struct {
-	InstanceID   *terraform.Literal `json:"instance_id,omitempty" cty:"instance_id"`
-	AllocationID *terraform.Literal `json:"allocation_id,omitempty" cty:"allocation_id"`
+	InstanceID   *terraformWriter.Literal `json:"instance_id,omitempty" cty:"instance_id"`
+	AllocationID *terraformWriter.Literal `json:"allocation_id,omitempty" cty:"allocation_id"`
 }
 
 func (_ *EIP) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EIP) error {
@@ -160,6 +161,6 @@ func (_ *EIP) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EIP) 
 	return t.RenderResource("alicloud_eip_association", *e.Name+"_asso", associationtf)
 }
 
-func (e *EIP) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_eip", *e.Name, "id")
+func (e *EIP) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_eip", *e.Name, "id")
 }

--- a/upup/pkg/fi/cloudup/alitasks/launchconfiguration.go
+++ b/upup/pkg/fi/cloudup/alitasks/launchconfiguration.go
@@ -29,6 +29,7 @@ import (
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ess"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
@@ -307,10 +308,10 @@ type terraformLaunchConfiguration struct {
 	SystemDiskCategory *string `json:"system_disk_category,omitempty" cty:"system_disk_category"`
 	UserData           *string `json:"user_data,omitempty" cty:"user_data"`
 
-	RAMRole       *terraform.Literal `json:"role_name,omitempty" cty:"role_name"`
-	ScalingGroup  *terraform.Literal `json:"scaling_group_id,omitempty" cty:"scaling_group_id"`
-	SSHKey        *terraform.Literal `json:"key_name,omitempty" cty:"key_name"`
-	SecurityGroup *terraform.Literal `json:"security_group_id,omitempty" cty:"security_group_id"`
+	RAMRole       *terraformWriter.Literal `json:"role_name,omitempty" cty:"role_name"`
+	ScalingGroup  *terraformWriter.Literal `json:"scaling_group_id,omitempty" cty:"scaling_group_id"`
+	SSHKey        *terraformWriter.Literal `json:"key_name,omitempty" cty:"key_name"`
+	SecurityGroup *terraformWriter.Literal `json:"security_group_id,omitempty" cty:"security_group_id"`
 }
 
 func (_ *LaunchConfiguration) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *LaunchConfiguration) error {
@@ -336,8 +337,8 @@ func (_ *LaunchConfiguration) RenderTerraform(t *terraform.TerraformTarget, a, e
 	return t.RenderResource("alicloud_ess_scaling_configuration", *e.Name, tf)
 }
 
-func (l *LaunchConfiguration) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_ess_scaling_configuration", fi.StringValue(l.Name), "id")
+func (l *LaunchConfiguration) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_ess_scaling_configuration", fi.StringValue(l.Name), "id")
 }
 
 // deleteLaunchConfiguration tracks a LaunchConfiguration that we're going to delete

--- a/upup/pkg/fi/cloudup/alitasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/alitasks/loadbalancer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/slb"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
@@ -264,6 +265,6 @@ func (_ *LoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e, chang
 	return t.RenderResource("alicloud_slb", *e.Name, tf)
 }
 
-func (l *LoadBalancer) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_slb", *l.Name, "id")
+func (l *LoadBalancer) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_slb", *l.Name, "id")
 }

--- a/upup/pkg/fi/cloudup/alitasks/loadbalancerlistener.go
+++ b/upup/pkg/fi/cloudup/alitasks/loadbalancerlistener.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"github.com/denverdino/aliyungo/slb"
 	"k8s.io/kops/upup/pkg/fi"
@@ -149,10 +150,10 @@ func (_ *LoadBalancerListener) RenderALI(t *aliup.ALIAPITarget, a, e, changes *L
 }
 
 type terraformLoadBalancerListener struct {
-	ListenerPort      *int               `json:"frontend_port,omitempty" cty:"frontend_port"`
-	BackendServerPort *int               `json:"backend_port,omitempty" cty:"backend_port"`
-	Protocol          *string            `json:"protocol,omitempty" cty:"protocol"`
-	LoadBalancerId    *terraform.Literal `json:"load_balancer_id,omitempty" cty:"load_balancer_id"`
+	ListenerPort      *int                     `json:"frontend_port,omitempty" cty:"frontend_port"`
+	BackendServerPort *int                     `json:"backend_port,omitempty" cty:"backend_port"`
+	Protocol          *string                  `json:"protocol,omitempty" cty:"protocol"`
+	LoadBalancerId    *terraformWriter.Literal `json:"load_balancer_id,omitempty" cty:"load_balancer_id"`
 }
 
 func (_ *LoadBalancerListener) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *LoadBalancerListener) error {
@@ -167,6 +168,6 @@ func (_ *LoadBalancerListener) RenderTerraform(t *terraform.TerraformTarget, a, 
 	return t.RenderResource("alicloud_slb_listener", *e.Name, tf)
 }
 
-func (s *LoadBalancerListener) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_slb_listener", *s.Name, "frontend_port")
+func (s *LoadBalancerListener) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_slb_listener", *s.Name, "frontend_port")
 }

--- a/upup/pkg/fi/cloudup/alitasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/alitasks/natgateway.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -114,8 +115,8 @@ func (_ *NatGateway) RenderALI(t *aliup.ALIAPITarget, a, e, changes *NatGateway)
 }
 
 type terraformNatGateway struct {
-	Name  *string            `json:"name,omitempty" cty:"name"`
-	VpcId *terraform.Literal `json:"vpc_id,omitempty" cty:"vpc_id"`
+	Name  *string                  `json:"name,omitempty" cty:"name"`
+	VpcId *terraformWriter.Literal `json:"vpc_id,omitempty" cty:"vpc_id"`
 }
 
 func (_ *NatGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *NatGateway) error {
@@ -127,6 +128,6 @@ func (_ *NatGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes
 	return t.RenderResource("alicloud_nat_gateway", *e.Name, tf)
 }
 
-func (e *NatGateway) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_nat_gateway", *e.Name, "id")
+func (e *NatGateway) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_nat_gateway", *e.Name, "id")
 }

--- a/upup/pkg/fi/cloudup/alitasks/rampolicy.go
+++ b/upup/pkg/fi/cloudup/alitasks/rampolicy.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ram"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"
@@ -146,9 +147,9 @@ type terraformRAMPolicy struct {
 }
 
 type terraformRAMPolicyAttach struct {
-	PolicyName *terraform.Literal `json:"policy_name,omitempty" cty:"policy_name"`
-	PolicyType *string            `json:"policy_type,omitempty" cty:"policy_type"`
-	RoleName   *terraform.Literal `json:"role_name,omitempty" cty:"role_name"`
+	PolicyName *terraformWriter.Literal `json:"policy_name,omitempty" cty:"policy_name"`
+	PolicyType *string                  `json:"policy_type,omitempty" cty:"policy_type"`
+	RoleName   *terraformWriter.Literal `json:"role_name,omitempty" cty:"role_name"`
 }
 
 func (_ *RAMPolicy) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *RAMPolicy) error {
@@ -176,6 +177,6 @@ func (_ *RAMPolicy) RenderTerraform(t *terraform.TerraformTarget, a, e, changes 
 	return err
 }
 
-func (s *RAMPolicy) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_ram_policy", *s.Name, "id")
+func (s *RAMPolicy) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_ram_policy", *s.Name, "id")
 }

--- a/upup/pkg/fi/cloudup/alitasks/ramrole.go
+++ b/upup/pkg/fi/cloudup/alitasks/ramrole.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ram"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"
@@ -136,6 +137,6 @@ func (_ *RAMRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *R
 	return t.RenderResource("alicloud_ram_role", *e.Name, tf)
 }
 
-func (s *RAMRole) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_ram_role", *s.Name, "name")
+func (s *RAMRole) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_ram_role", *s.Name, "name")
 }

--- a/upup/pkg/fi/cloudup/alitasks/scalinggroup.go
+++ b/upup/pkg/fi/cloudup/alitasks/scalinggroup.go
@@ -24,6 +24,7 @@ import (
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ess"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
@@ -181,8 +182,8 @@ type terraformScalingGroup struct {
 	MaxSize *int    `json:"max_size,omitempty" cty:"max_size"`
 	MinSize *int    `json:"min_size,omitempty" cty:"min_size"`
 
-	VSwitchs     []*terraform.Literal `json:"vswitch_ids,omitempty" cty:"vswitch_ids"`
-	LoadBalancer []*terraform.Literal `json:"loadbalancer_ids,omitempty" cty:"loadbalancer_ids"`
+	VSwitchs     []*terraformWriter.Literal `json:"vswitch_ids,omitempty" cty:"vswitch_ids"`
+	LoadBalancer []*terraformWriter.Literal `json:"loadbalancer_ids,omitempty" cty:"loadbalancer_ids"`
 }
 
 func (_ *ScalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ScalingGroup) error {
@@ -205,6 +206,6 @@ func (_ *ScalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, chang
 	return t.RenderResource("alicloud_ess_scaling_group", *e.Name, tf)
 }
 
-func (a *ScalingGroup) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_ess_scaling_group", *a.Name, "id")
+func (a *ScalingGroup) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_ess_scaling_group", *a.Name, "id")
 }

--- a/upup/pkg/fi/cloudup/alitasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/alitasks/securitygroup.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
@@ -184,8 +185,8 @@ func (s *SecurityGroup) getGroupTagsToDelete(currentTags map[string]string) map[
 }
 
 type terraformSecurityGroup struct {
-	Name  *string            `json:"name,omitempty" cty:"name"`
-	VPCId *terraform.Literal `json:"vpc_id,omitempty" cty:"vpc_id"`
+	Name  *string                  `json:"name,omitempty" cty:"name"`
+	VPCId *terraformWriter.Literal `json:"vpc_id,omitempty" cty:"vpc_id"`
 }
 
 func (_ *SecurityGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SecurityGroup) error {
@@ -197,6 +198,6 @@ func (_ *SecurityGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, chan
 	return t.RenderResource("alicloud_security_group", *e.Name, tf)
 }
 
-func (l *SecurityGroup) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_security_group", *l.Name, "id")
+func (l *SecurityGroup) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_security_group", *l.Name, "id")
 }

--- a/upup/pkg/fi/cloudup/alitasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/alitasks/securitygrouprule.go
@@ -23,6 +23,7 @@ import (
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
@@ -180,13 +181,13 @@ func (_ *SecurityGroupRule) RenderALI(t *aliup.ALIAPITarget, a, e, changes *Secu
 }
 
 type terraformSecurityGroupRole struct {
-	Name            *string            `json:"name,omitempty" cty:"name"`
-	Type            *string            `json:"type,omitempty" cty:"type"`
-	IpProtocol      *string            `json:"ip_protocol,omitempty" cty:"ip_protocol"`
-	SourceCidrIp    *string            `json:"cidr_ip,omitempty" cty:"cidr_ip"`
-	SecurityGroupId *terraform.Literal `json:"security_group_id,omitempty" cty:"security_group_id"`
-	SourceGroupId   *terraform.Literal `json:"source_security_group_id,omitempty" cty:"source_security_group_id"`
-	PortRange       *string            `json:"port_range,omitempty" cty:"port_range"`
+	Name            *string                  `json:"name,omitempty" cty:"name"`
+	Type            *string                  `json:"type,omitempty" cty:"type"`
+	IpProtocol      *string                  `json:"ip_protocol,omitempty" cty:"ip_protocol"`
+	SourceCidrIp    *string                  `json:"cidr_ip,omitempty" cty:"cidr_ip"`
+	SecurityGroupId *terraformWriter.Literal `json:"security_group_id,omitempty" cty:"security_group_id"`
+	SourceGroupId   *terraformWriter.Literal `json:"source_security_group_id,omitempty" cty:"source_security_group_id"`
+	PortRange       *string                  `json:"port_range,omitempty" cty:"port_range"`
 }
 
 func (_ *SecurityGroupRule) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SecurityGroupRule) error {
@@ -217,6 +218,6 @@ func (_ *SecurityGroupRule) RenderTerraform(t *terraform.TerraformTarget, a, e, 
 	return t.RenderResource("alicloud_security_group_rule", *e.Name, tf)
 }
 
-func (l *SecurityGroupRule) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_security_group_rule", *l.Name, "id")
+func (l *SecurityGroupRule) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_security_group_rule", *l.Name, "id")
 }

--- a/upup/pkg/fi/cloudup/alitasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/alitasks/sshkey.go
@@ -22,6 +22,7 @@ import (
 
 	common "github.com/denverdino/aliyungo/common"
 	ecs "github.com/denverdino/aliyungo/ecs"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/pki"
@@ -163,6 +164,6 @@ func (_ *SSHKey) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SS
 	return t.RenderResource("alicloud_key_pair", *e.Name, tf)
 }
 
-func (s *SSHKey) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_key_pair", *s.Name, "name")
+func (s *SSHKey) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_key_pair", *s.Name, "name")
 }

--- a/upup/pkg/fi/cloudup/alitasks/vpc.go
+++ b/upup/pkg/fi/cloudup/alitasks/vpc.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -173,6 +174,6 @@ func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) 
 	return t.RenderResource("alicloud_vpc", *e.Name, tf)
 }
 
-func (e *VPC) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_vpc", *e.Name, "id")
+func (e *VPC) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_vpc", *e.Name, "id")
 }

--- a/upup/pkg/fi/cloudup/alitasks/vswitch.go
+++ b/upup/pkg/fi/cloudup/alitasks/vswitch.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
@@ -175,10 +176,10 @@ func (_ *VSwitch) RenderALI(t *aliup.ALIAPITarget, a, e, changes *VSwitch) error
 }
 
 type terraformVSwitch struct {
-	Name      *string            `json:"name,omitempty" cty:"name"`
-	CidrBlock *string            `json:"cidr_block,omitempty" cty:"cidr_block"`
-	ZoneId    *string            `json:"availability_zone,omitempty" cty:"availability_zone"`
-	VPCId     *terraform.Literal `json:"vpc_id,omitempty" cty:"vpc_id"`
+	Name      *string                  `json:"name,omitempty" cty:"name"`
+	CidrBlock *string                  `json:"cidr_block,omitempty" cty:"cidr_block"`
+	ZoneId    *string                  `json:"availability_zone,omitempty" cty:"availability_zone"`
+	VPCId     *terraformWriter.Literal `json:"vpc_id,omitempty" cty:"vpc_id"`
 }
 
 func (_ *VSwitch) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VSwitch) error {
@@ -192,6 +193,6 @@ func (_ *VSwitch) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *V
 	return t.RenderResource("alicloud_vswitch", *e.Name, tf)
 }
 
-func (v *VSwitch) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("alicloud_vswitch", *v.Name, "id")
+func (v *VSwitch) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("alicloud_vswitch", *v.Name, "id")
 }

--- a/upup/pkg/fi/cloudup/alitasks/vswitchSNAT.go
+++ b/upup/pkg/fi/cloudup/alitasks/vswitchSNAT.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
@@ -183,8 +184,8 @@ func (_ *VSwitchSNAT) RenderALI(t *aliup.ALIAPITarget, a, e, changes *VSwitchSNA
 }
 
 type terraformVSwitchSNAT struct {
-	SnatTableId *string            `json:"snat_table_id,omitempty" cty:"snat_table_id"`
-	VSwitchId   *terraform.Literal `json:"source_vswitch_id,omitempty" cty:"source_vswitch_id"`
+	SnatTableId *string                  `json:"snat_table_id,omitempty" cty:"snat_table_id"`
+	VSwitchId   *terraformWriter.Literal `json:"source_vswitch_id,omitempty" cty:"source_vswitch_id"`
 }
 
 func (_ *VSwitchSNAT) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VSwitchSNAT) error {

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -67,6 +67,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 	"k8s.io/kops/util/pkg/architectures"
 	"k8s.io/kops/util/pkg/hashing"
 	"k8s.io/kops/util/pkg/mirrors"
@@ -699,17 +700,17 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		tf := terraform.NewTerraformTarget(cloud, project, outDir, cluster.Spec.Target)
 
 		// We include a few "util" variables in the TF output
-		if err := tf.AddOutputVariable("region", terraform.LiteralFromStringValue(cloud.Region())); err != nil {
+		if err := tf.AddOutputVariable("region", terraformWriter.LiteralFromStringValue(cloud.Region())); err != nil {
 			return err
 		}
 
 		if project != "" {
-			if err := tf.AddOutputVariable("project", terraform.LiteralFromStringValue(project)); err != nil {
+			if err := tf.AddOutputVariable("project", terraformWriter.LiteralFromStringValue(project)); err != nil {
 				return err
 			}
 		}
 
-		if err := tf.AddOutputVariable("cluster_name", terraform.LiteralFromStringValue(cluster.ObjectMeta.Name)); err != nil {
+		if err := tf.AddOutputVariable("cluster_name", terraformWriter.LiteralFromStringValue(cluster.ObjectMeta.Name)); err != nil {
 			return err
 		}
 

--- a/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/awstasks/BUILD.bazel
@@ -96,6 +96,7 @@ go_library(
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/cloudformation:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
+        "//upup/pkg/fi/cloudup/terraformWriter:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",
         "//util/pkg/maps:go_default_library",
         "//util/pkg/slice:go_default_library",

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 	"k8s.io/kops/util/pkg/maps"
 )
 
@@ -805,16 +806,16 @@ type terraformASGTag struct {
 
 type terraformAutoscalingLaunchTemplateSpecification struct {
 	// LaunchTemplateID is the ID of the template to use.
-	LaunchTemplateID *terraform.Literal `json:"id,omitempty" cty:"id"`
+	LaunchTemplateID *terraformWriter.Literal `json:"id,omitempty" cty:"id"`
 	// Version is the version of the Launch Template to use.
-	Version *terraform.Literal `json:"version,omitempty" cty:"version"`
+	Version *terraformWriter.Literal `json:"version,omitempty" cty:"version"`
 }
 
 type terraformAutoscalingMixedInstancesPolicyLaunchTemplateSpecification struct {
 	// LaunchTemplateID is the ID of the template to use
-	LaunchTemplateID *terraform.Literal `json:"launch_template_id,omitempty" cty:"launch_template_id"`
+	LaunchTemplateID *terraformWriter.Literal `json:"launch_template_id,omitempty" cty:"launch_template_id"`
 	// Version is the version of the Launch Template to use
-	Version *terraform.Literal `json:"version,omitempty" cty:"version"`
+	Version *terraformWriter.Literal `json:"version,omitempty" cty:"version"`
 }
 
 type terraformAutoscalingMixedInstancesPolicyLaunchTemplateOverride struct {
@@ -853,19 +854,19 @@ type terraformMixedInstancesPolicy struct {
 
 type terraformAutoscalingGroup struct {
 	Name                    *string                                          `json:"name,omitempty" cty:"name"`
-	LaunchConfigurationName *terraform.Literal                               `json:"launch_configuration,omitempty" cty:"launch_configuration"`
+	LaunchConfigurationName *terraformWriter.Literal                         `json:"launch_configuration,omitempty" cty:"launch_configuration"`
 	LaunchTemplate          *terraformAutoscalingLaunchTemplateSpecification `json:"launch_template,omitempty" cty:"launch_template"`
 	MaxSize                 *int64                                           `json:"max_size,omitempty" cty:"max_size"`
 	MinSize                 *int64                                           `json:"min_size,omitempty" cty:"min_size"`
 	MixedInstancesPolicy    []*terraformMixedInstancesPolicy                 `json:"mixed_instances_policy,omitempty" cty:"mixed_instances_policy"`
-	VPCZoneIdentifier       []*terraform.Literal                             `json:"vpc_zone_identifier,omitempty" cty:"vpc_zone_identifier"`
+	VPCZoneIdentifier       []*terraformWriter.Literal                       `json:"vpc_zone_identifier,omitempty" cty:"vpc_zone_identifier"`
 	Tags                    []*terraformASGTag                               `json:"tag,omitempty" cty:"tag"`
 	MetricsGranularity      *string                                          `json:"metrics_granularity,omitempty" cty:"metrics_granularity"`
 	EnabledMetrics          []*string                                        `json:"enabled_metrics,omitempty" cty:"enabled_metrics"`
 	SuspendedProcesses      []*string                                        `json:"suspended_processes,omitempty" cty:"suspended_processes"`
 	InstanceProtection      *bool                                            `json:"protect_from_scale_in,omitempty" cty:"protect_from_scale_in"`
-	LoadBalancers           []*terraform.Literal                             `json:"load_balancers,omitempty" cty:"load_balancers"`
-	TargetGroupARNs         []*terraform.Literal                             `json:"target_group_arns,omitempty" cty:"target_group_arns"`
+	LoadBalancers           []*terraformWriter.Literal                       `json:"load_balancers,omitempty" cty:"load_balancers"`
+	TargetGroupARNs         []*terraformWriter.Literal                       `json:"target_group_arns,omitempty" cty:"target_group_arns"`
 }
 
 // RenderTerraform is responsible for rendering the terraform codebase
@@ -895,12 +896,12 @@ func (_ *AutoscalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, c
 	for _, k := range e.LoadBalancers {
 		tf.LoadBalancers = append(tf.LoadBalancers, k.TerraformLink())
 	}
-	terraform.SortLiterals(tf.LoadBalancers)
+	terraformWriter.SortLiterals(tf.LoadBalancers)
 
 	for _, tg := range e.TargetGroups {
 		tf.TargetGroupARNs = append(tf.TargetGroupARNs, tg.TerraformLink())
 	}
-	terraform.SortLiterals(tf.TargetGroupARNs)
+	terraformWriter.SortLiterals(tf.TargetGroupARNs)
 
 	if e.UseMixedInstancesPolicy() {
 		// Temporary warning until https://github.com/terraform-providers/terraform-provider-aws/issues/9750 is resolved
@@ -988,8 +989,8 @@ func (_ *AutoscalingGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, c
 }
 
 // TerraformLink fills in the property
-func (e *AutoscalingGroup) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("aws_autoscaling_group", fi.StringValue(e.Name), "id")
+func (e *AutoscalingGroup) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("aws_autoscaling_group", fi.StringValue(e.Name), "id")
 }
 
 type cloudformationASGTag struct {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinglifecyclehook.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -120,11 +121,11 @@ func (*AutoscalingLifecycleHook) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 }
 
 type terraformASGLifecycleHook struct {
-	Name                 *string            `json:"name" cty:"name"`
-	AutoScalingGroupName *terraform.Literal `json:"autoscaling_group_name" cty:"autoscaling_group_name"`
-	DefaultResult        *string            `json:"default_result" cty:"default_result"`
-	HeartbeatTimeout     *int64             `json:"heartbeat_timeout" cty:"heartbeat_timeout"`
-	LifecycleTransition  *string            `json:"lifecycle_transition" cty:"lifecycle_transition"`
+	Name                 *string                  `json:"name" cty:"name"`
+	AutoScalingGroupName *terraformWriter.Literal `json:"autoscaling_group_name" cty:"autoscaling_group_name"`
+	DefaultResult        *string                  `json:"default_result" cty:"default_result"`
+	HeartbeatTimeout     *int64                   `json:"heartbeat_timeout" cty:"heartbeat_timeout"`
+	LifecycleTransition  *string                  `json:"lifecycle_transition" cty:"lifecycle_transition"`
 }
 
 func (_ *AutoscalingLifecycleHook) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *AutoscalingLifecycleHook) error {

--- a/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
+++ b/upup/pkg/fi/cloudup/awstasks/dhcp_options.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -189,8 +190,8 @@ func (_ *DHCPOptions) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 	return t.RenderResource("aws_vpc_dhcp_options", *e.Name, tf)
 }
 
-func (e *DHCPOptions) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("aws_vpc_dhcp_options", *e.Name, "id")
+func (e *DHCPOptions) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("aws_vpc_dhcp_options", *e.Name, "id")
 }
 
 type cloudformationDHCPOptions struct {

--- a/upup/pkg/fi/cloudup/awstasks/dnsname.go
+++ b/upup/pkg/fi/cloudup/awstasks/dnsname.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -49,7 +50,7 @@ type DNSTarget interface {
 	getHostedZoneId() *string
 	CloudformationAttrDNSName() *cloudformation.Literal
 	CloudformationAttrCanonicalHostedZoneNameID() *cloudformation.Literal
-	TerraformLink(...string) *terraform.Literal
+	TerraformLink(...string) *terraformWriter.Literal
 }
 
 func (e *DNSName) Find(c *fi.Context) (*DNSName, error) {
@@ -290,14 +291,14 @@ type terraformRoute53Record struct {
 	TTL     *string  `json:"ttl,omitempty" cty:"ttl"`
 	Records []string `json:"records,omitempty" cty:"records"`
 
-	Alias  *terraformAlias    `json:"alias,omitempty" cty:"alias"`
-	ZoneID *terraform.Literal `json:"zone_id" cty:"zone_id"`
+	Alias  *terraformAlias          `json:"alias,omitempty" cty:"alias"`
+	ZoneID *terraformWriter.Literal `json:"zone_id" cty:"zone_id"`
 }
 
 type terraformAlias struct {
-	Name                 *terraform.Literal `json:"name" cty:"name"`
-	ZoneID               *terraform.Literal `json:"zone_id" cty:"zone_id"`
-	EvaluateTargetHealth *bool              `json:"evaluate_target_health" cty:"evaluate_target_health"`
+	Name                 *terraformWriter.Literal `json:"name" cty:"name"`
+	ZoneID               *terraformWriter.Literal `json:"zone_id" cty:"zone_id"`
+	EvaluateTargetHealth *bool                    `json:"evaluate_target_health" cty:"evaluate_target_health"`
 }
 
 func (_ *DNSName) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *DNSName) error {
@@ -318,8 +319,8 @@ func (_ *DNSName) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *D
 	return t.RenderResource("aws_route53_record", *e.Name, tf)
 }
 
-func (e *DNSName) TerraformLink() *terraform.Literal {
-	return terraform.LiteralSelfLink("aws_route53_record", *e.Name)
+func (e *DNSName) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralSelfLink("aws_route53_record", *e.Name)
 }
 
 type cloudformationRoute53Record struct {

--- a/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
+++ b/upup/pkg/fi/cloudup/awstasks/ebsvolume.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
@@ -243,9 +244,9 @@ func (_ *EBSVolume) RenderTerraform(t *terraform.TerraformTarget, a, e, changes 
 	return t.RenderResource("aws_ebs_volume", tfName, tf)
 }
 
-func (e *EBSVolume) TerraformLink() *terraform.Literal {
+func (e *EBSVolume) TerraformLink() *terraformWriter.Literal {
 	tfName, _ := e.TerraformName()
-	return terraform.LiteralSelfLink("aws_ebs_volume", tfName)
+	return terraformWriter.LiteralSelfLink("aws_ebs_volume", tfName)
 }
 
 // TerraformName returns the terraform-safe name, along with a boolean indicating of whether name-prefixing was needed.

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -292,15 +293,15 @@ func (_ *ElasticIP) RenderTerraform(t *terraform.TerraformTarget, a, e, changes 
 	return t.RenderResource("aws_eip", *e.Name, tf)
 }
 
-func (e *ElasticIP) TerraformLink() *terraform.Literal {
+func (e *ElasticIP) TerraformLink() *terraformWriter.Literal {
 	if fi.BoolValue(e.Shared) {
 		if e.ID == nil {
 			klog.Fatalf("ID must be set, if ElasticIP is shared: %v", e)
 		}
-		return terraform.LiteralFromStringValue(*e.ID)
+		return terraformWriter.LiteralFromStringValue(*e.ID)
 	}
 
-	return terraform.LiteralProperty("aws_eip", *e.Name, "id")
+	return terraformWriter.LiteralProperty("aws_eip", *e.Name, "id")
 }
 
 type cloudformationElasticIP struct {

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
@@ -132,7 +132,7 @@ type terraformEventBridgeRule struct {
 }
 
 func (_ *EventBridgeRule) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EventBridgeRule) error {
-	m, err := t.AddFile("aws_cloudwatch_event_rule", *e.Name, "event_pattern", fi.NewStringResource(*e.EventPattern), false)
+	m, err := t.AddFileBytes("aws_cloudwatch_event_rule", *e.Name, "event_pattern", []byte(*e.EventPattern), false)
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgerule.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -126,9 +127,9 @@ func (eb *EventBridgeRule) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Event
 }
 
 type terraformEventBridgeRule struct {
-	Name         *string            `json:"name" cty:"name"`
-	EventPattern *terraform.Literal `json:"event_pattern" cty:"event_pattern"`
-	Tags         map[string]string  `json:"tags,omitempty" cty:"tags"`
+	Name         *string                  `json:"name" cty:"name"`
+	EventPattern *terraformWriter.Literal `json:"event_pattern" cty:"event_pattern"`
+	Tags         map[string]string        `json:"tags,omitempty" cty:"tags"`
 }
 
 func (_ *EventBridgeRule) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EventBridgeRule) error {
@@ -146,8 +147,8 @@ func (_ *EventBridgeRule) RenderTerraform(t *terraform.TerraformTarget, a, e, ch
 	return t.RenderResource("aws_cloudwatch_event_rule", *e.Name, tf)
 }
 
-func (eb *EventBridgeRule) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("aws_cloudwatch_event_rule", fi.StringValue(eb.Name), "id")
+func (eb *EventBridgeRule) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("aws_cloudwatch_event_rule", fi.StringValue(eb.Name), "id")
 }
 
 type cloudformationTarget struct {

--- a/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
+++ b/upup/pkg/fi/cloudup/awstasks/eventbridgetarget.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eventbridge"
@@ -127,8 +128,8 @@ func (eb *EventBridgeTarget) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Eve
 }
 
 type terraformEventBridgeTarget struct {
-	RuleName  *terraform.Literal `json:"rule" cty:"rule"`
-	TargetArn *string            `json:"arn" cty:"arn"`
+	RuleName  *terraformWriter.Literal `json:"rule" cty:"rule"`
+	TargetArn *string                  `json:"arn" cty:"arn"`
 }
 
 func (_ *EventBridgeTarget) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *EventBridgeTarget) error {

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofile.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -165,11 +166,11 @@ func (_ *IAMInstanceProfile) RenderTerraform(t *terraform.TerraformTarget, a, e,
 	return nil
 }
 
-func (e *IAMInstanceProfile) TerraformLink() *terraform.Literal {
+func (e *IAMInstanceProfile) TerraformLink() *terraformWriter.Literal {
 	if fi.BoolValue(e.Shared) {
-		return terraform.LiteralFromStringValue(fi.StringValue(e.Name))
+		return terraformWriter.LiteralFromStringValue(fi.StringValue(e.Name))
 	}
-	return terraform.LiteralProperty("aws_iam_instance_profile", *e.Name, "id")
+	return terraformWriter.LiteralProperty("aws_iam_instance_profile", *e.Name, "id")
 }
 
 func (_ *IAMInstanceProfile) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *IAMInstanceProfile) error {

--- a/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iaminstanceprofilerole.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -110,9 +111,9 @@ func (_ *IAMInstanceProfileRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes 
 }
 
 type terraformIAMInstanceProfile struct {
-	Name *string            `json:"name" cty:"name"`
-	Role *terraform.Literal `json:"role" cty:"role"`
-	Tags map[string]string  `json:"tags,omitempty" cty:"tags"`
+	Name *string                  `json:"name" cty:"name"`
+	Role *terraformWriter.Literal `json:"role" cty:"role"`
+	Tags map[string]string        `json:"tags,omitempty" cty:"tags"`
 }
 
 func (_ *IAMInstanceProfileRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMInstanceProfileRole) error {

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -186,8 +187,8 @@ type terraformIAMOIDCProvider struct {
 	ClientIDList   []*string `json:"client_id_list" cty:"client_id_list"`
 	ThumbprintList []*string `json:"thumbprint_list" cty:"thumbprint_list"`
 
-	AssumeRolePolicy *terraform.Literal `json:"assume_role_policy" cty:"assume_role_policy"`
-	Tags             map[string]string  `json:"tags,omitempty" cty:"tags"`
+	AssumeRolePolicy *terraformWriter.Literal `json:"assume_role_policy" cty:"assume_role_policy"`
+	Tags             map[string]string        `json:"tags,omitempty" cty:"tags"`
 }
 
 func (p *IAMOIDCProvider) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMOIDCProvider) error {
@@ -202,8 +203,8 @@ func (p *IAMOIDCProvider) RenderTerraform(t *terraform.TerraformTarget, a, e, ch
 	return t.RenderResource("aws_iam_openid_connect_provider", *e.Name, tf)
 }
 
-func (e *IAMOIDCProvider) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("aws_iam_openid_connect_provider", *e.Name, "arn")
+func (e *IAMOIDCProvider) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("aws_iam_openid_connect_provider", *e.Name, "arn")
 }
 
 func (_ *IAMOIDCProvider) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *IAMOIDCProvider) error {

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -251,10 +252,10 @@ func (_ *IAMRole) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *IAMRole) error
 }
 
 type terraformIAMRole struct {
-	Name                *string            `json:"name" cty:"name"`
-	AssumeRolePolicy    *terraform.Literal `json:"assume_role_policy" cty:"assume_role_policy"`
-	PermissionsBoundary *string            `json:"permissions_boundary,omitempty" cty:"permissions_boundary"`
-	Tags                map[string]string  `json:"tags,omitempty" cty:"tags"`
+	Name                *string                  `json:"name" cty:"name"`
+	AssumeRolePolicy    *terraformWriter.Literal `json:"assume_role_policy" cty:"assume_role_policy"`
+	PermissionsBoundary *string                  `json:"permissions_boundary,omitempty" cty:"permissions_boundary"`
+	Tags                map[string]string        `json:"tags,omitempty" cty:"tags"`
 }
 
 func (_ *IAMRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMRole) error {
@@ -274,15 +275,15 @@ func (_ *IAMRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *I
 	}
 
 	if fi.StringValue(e.ExportWithID) != "" {
-		t.AddOutputVariable(*e.ExportWithID+"_role_arn", terraform.LiteralProperty("aws_iam_role", *e.Name, "arn"))
+		t.AddOutputVariable(*e.ExportWithID+"_role_arn", terraformWriter.LiteralProperty("aws_iam_role", *e.Name, "arn"))
 		t.AddOutputVariable(*e.ExportWithID+"_role_name", e.TerraformLink())
 	}
 
 	return t.RenderResource("aws_iam_role", *e.Name, tf)
 }
 
-func (e *IAMRole) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("aws_iam_role", *e.Name, "name")
+func (e *IAMRole) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("aws_iam_role", *e.Name, "name")
 }
 
 type cloudformationIAMRole struct {

--- a/upup/pkg/fi/cloudup/awstasks/iamrole.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrole.go
@@ -258,7 +258,7 @@ type terraformIAMRole struct {
 }
 
 func (_ *IAMRole) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMRole) error {
-	policy, err := t.AddFile("aws_iam_role", *e.Name, "policy", e.RolePolicyDocument, false)
+	policy, err := t.AddFileResource("aws_iam_role", *e.Name, "policy", e.RolePolicyDocument, false)
 	if err != nil {
 		return fmt.Errorf("error rendering RolePolicyDocument: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -331,7 +331,7 @@ func (_ *IAMRolePolicy) RenderTerraform(t *terraform.TerraformTarget, a, e, chan
 		return nil
 	}
 
-	policy, err := t.AddFile("aws_iam_role_policy", *e.Name, "policy", e.PolicyDocument, false)
+	policy, err := t.AddFileResource("aws_iam_role_policy", *e.Name, "policy", e.PolicyDocument, false)
 	if err != nil {
 		return fmt.Errorf("error rendering PolicyDocument: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -294,10 +295,10 @@ func (e *IAMRolePolicy) policyDocumentString() (string, error) {
 }
 
 type terraformIAMRolePolicy struct {
-	Name           *string            `json:"name,omitempty" cty:"name"`
-	Role           *terraform.Literal `json:"role" cty:"role"`
-	PolicyDocument *terraform.Literal `json:"policy,omitempty" cty:"policy"`
-	PolicyArn      *string            `json:"policy_arn,omitempty" cty:"policy_arn"`
+	Name           *string                  `json:"name,omitempty" cty:"name"`
+	Role           *terraformWriter.Literal `json:"role" cty:"role"`
+	PolicyDocument *terraformWriter.Literal `json:"policy,omitempty" cty:"policy"`
+	PolicyArn      *string                  `json:"policy_arn,omitempty" cty:"policy_arn"`
 }
 
 func (_ *IAMRolePolicy) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMRolePolicy) error {
@@ -345,8 +346,8 @@ func (_ *IAMRolePolicy) RenderTerraform(t *terraform.TerraformTarget, a, e, chan
 	return t.RenderResource("aws_iam_role_policy", *e.Name, tf)
 }
 
-func (e *IAMRolePolicy) TerraformLink() *terraform.Literal {
-	return terraform.LiteralSelfLink("aws_iam_role_policy", *e.Name)
+func (e *IAMRolePolicy) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralSelfLink("aws_iam_role_policy", *e.Name)
 }
 
 type cloudformationIAMRolePolicy struct {

--- a/upup/pkg/fi/cloudup/awstasks/instance.go
+++ b/upup/pkg/fi/cloudup/awstasks/instance.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
-	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // MaxUserDataSize is the max size of the userdata
@@ -297,14 +297,14 @@ func (_ *Instance) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Instance) err
 	return t.AddAWSTags(*e.ID, e.Tags)
 }
 
-func (e *Instance) TerraformLink() *terraform.Literal {
+func (e *Instance) TerraformLink() *terraformWriter.Literal {
 	if fi.BoolValue(e.Shared) {
 		if e.ID == nil {
 			klog.Fatalf("ID must be set, if NAT Instance is shared: %s", e)
 		}
 
-		return terraform.LiteralFromStringValue(*e.ID)
+		return terraformWriter.LiteralFromStringValue(*e.ID)
 	}
 
-	return terraform.LiteralSelfLink("aws_instance", *e.Name)
+	return terraformWriter.LiteralSelfLink("aws_instance", *e.Name)
 }

--- a/upup/pkg/fi/cloudup/awstasks/internetgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/internetgateway.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -179,8 +180,8 @@ func (_ *InternetGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Intern
 }
 
 type terraformInternetGateway struct {
-	VPCID *terraform.Literal `json:"vpc_id" cty:"vpc_id"`
-	Tags  map[string]string  `json:"tags,omitempty" cty:"tags"`
+	VPCID *terraformWriter.Literal `json:"vpc_id" cty:"vpc_id"`
+	Tags  map[string]string        `json:"tags,omitempty" cty:"tags"`
 }
 
 func (_ *InternetGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *InternetGateway) error {
@@ -218,7 +219,7 @@ func (_ *InternetGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, ch
 	return t.RenderResource("aws_internet_gateway", *e.Name, tf)
 }
 
-func (e *InternetGateway) TerraformLink() *terraform.Literal {
+func (e *InternetGateway) TerraformLink() *terraformWriter.Literal {
 	shared := fi.BoolValue(e.Shared)
 	if shared {
 		if e.ID == nil {
@@ -226,10 +227,10 @@ func (e *InternetGateway) TerraformLink() *terraform.Literal {
 		}
 
 		klog.V(4).Infof("reusing existing InternetGateway with id %q", *e.ID)
-		return terraform.LiteralFromStringValue(*e.ID)
+		return terraformWriter.LiteralFromStringValue(*e.ID)
 	}
 
-	return terraform.LiteralProperty("aws_internet_gateway", *e.Name, "id")
+	return terraformWriter.LiteralProperty("aws_internet_gateway", *e.Name, "id")
 }
 
 type cloudformationInternetGateway struct {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -254,18 +254,16 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 		}
 		if d != nil {
 			if featureflag.TerraformJSON.Enabled() {
-				b64d := base64.StdEncoding.EncodeToString(d)
-				if b64d != "" {
-					b64UserDataResource := fi.NewStringResource(b64d)
-					tf.UserData, err = target.AddFile("aws_launch_template", fi.StringValue(e.Name), "user_data", b64UserDataResource, false)
+				b64d := make([]byte, base64.StdEncoding.EncodedLen(len(d)))
+				base64.StdEncoding.Encode(b64d, d)
+				if len(b64d) != 0 {
+					tf.UserData, err = target.AddFileBytes("aws_launch_template", fi.StringValue(e.Name), "user_data", b64d, false)
 					if err != nil {
 						return err
 					}
 				}
 			} else {
-				userDataResource := fi.NewBytesResource(d)
-
-				tf.UserData, err = target.AddFile("aws_launch_template", fi.StringValue(e.Name), "user_data", userDataResource, true)
+				tf.UserData, err = target.AddFileBytes("aws_launch_template", fi.StringValue(e.Name), "user_data", d, true)
 				if err != nil {
 					return err
 				}

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 type terraformLaunchTemplateNetworkInterface struct {
@@ -31,7 +32,7 @@ type terraformLaunchTemplateNetworkInterface struct {
 	// DeleteOnTermination indicates whether the network interface should be destroyed on instance termination.
 	DeleteOnTermination *bool `json:"delete_on_termination,omitempty" cty:"delete_on_termination"`
 	// SecurityGroups is a list of security group ids.
-	SecurityGroups []*terraform.Literal `json:"security_groups,omitempty" cty:"security_groups"`
+	SecurityGroups []*terraformWriter.Literal `json:"security_groups,omitempty" cty:"security_groups"`
 }
 
 type terraformLaunchTemplateMonitoring struct {
@@ -56,7 +57,7 @@ type terraformLaunchTemplatePlacement struct {
 
 type terraformLaunchTemplateIAMProfile struct {
 	// Name is the name of the profile
-	Name *terraform.Literal `json:"name,omitempty" cty:"name"`
+	Name *terraformWriter.Literal `json:"name,omitempty" cty:"name"`
 }
 
 type terraformLaunchTemplateMarketOptionsSpotOptions struct {
@@ -144,7 +145,7 @@ type terraformLaunchTemplate struct {
 	// InstanceType is the type of instance
 	InstanceType *string `json:"instance_type,omitempty" cty:"instance_type"`
 	// KeyName is the ssh key to use
-	KeyName *terraform.Literal `json:"key_name,omitempty" cty:"key_name"`
+	KeyName *terraformWriter.Literal `json:"key_name,omitempty" cty:"key_name"`
 	// MarketOptions are the spot pricing options
 	MarketOptions []*terraformLaunchTemplateMarketOptions `json:"instance_market_options,omitempty" cty:"instance_market_options"`
 	// MetadataOptions are the instance metadata options.
@@ -160,17 +161,17 @@ type terraformLaunchTemplate struct {
 	// TagSpecifications are the tags to apply to a resource when it is created.
 	TagSpecifications []*terraformLaunchTemplateTagSpecification `json:"tag_specifications,omitempty" cty:"tag_specifications"`
 	// UserData is the user data for the instances
-	UserData *terraform.Literal `json:"user_data,omitempty" cty:"user_data"`
+	UserData *terraformWriter.Literal `json:"user_data,omitempty" cty:"user_data"`
 }
 
 // TerraformLink returns the terraform reference
-func (t *LaunchTemplate) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("aws_launch_template", fi.StringValue(t.Name), "id")
+func (t *LaunchTemplate) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("aws_launch_template", fi.StringValue(t.Name), "id")
 }
 
 // VersionLink returns the terraform version reference
-func (t *LaunchTemplate) VersionLink() *terraform.Literal {
-	return terraform.LiteralProperty("aws_launch_template", fi.StringValue(t.Name), "latest_version")
+func (t *LaunchTemplate) VersionLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("aws_launch_template", fi.StringValue(t.Name), "latest_version")
 }
 
 // RenderTerraform is responsible for rendering the terraform json

--- a/upup/pkg/fi/cloudup/awstasks/natgateway.go
+++ b/upup/pkg/fi/cloudup/awstasks/natgateway.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -361,9 +362,9 @@ func (_ *NatGateway) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *NatGateway)
 }
 
 type terraformNATGateway struct {
-	AllocationID *terraform.Literal `json:"allocation_id,omitempty" cty:"allocation_id"`
-	SubnetID     *terraform.Literal `json:"subnet_id,omitempty" cty:"subnet_id"`
-	Tag          map[string]string  `json:"tags,omitempty" cty:"tags"`
+	AllocationID *terraformWriter.Literal `json:"allocation_id,omitempty" cty:"allocation_id"`
+	SubnetID     *terraformWriter.Literal `json:"subnet_id,omitempty" cty:"subnet_id"`
+	Tag          map[string]string        `json:"tags,omitempty" cty:"tags"`
 }
 
 func (_ *NatGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *NatGateway) error {
@@ -385,16 +386,16 @@ func (_ *NatGateway) RenderTerraform(t *terraform.TerraformTarget, a, e, changes
 	return t.RenderResource("aws_nat_gateway", *e.Name, tf)
 }
 
-func (e *NatGateway) TerraformLink() *terraform.Literal {
+func (e *NatGateway) TerraformLink() *terraformWriter.Literal {
 	if fi.BoolValue(e.Shared) {
 		if e.ID == nil {
 			klog.Fatalf("ID must be set, if NatGateway is shared: %s", e)
 		}
 
-		return terraform.LiteralFromStringValue(*e.ID)
+		return terraformWriter.LiteralFromStringValue(*e.ID)
 	}
 
-	return terraform.LiteralProperty("aws_nat_gateway", *e.Name, "id")
+	return terraformWriter.LiteralProperty("aws_nat_gateway", *e.Name, "id")
 }
 
 type cloudformationNATGateway struct {

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // NetworkLoadBalancer manages an NLB.  We find the existing NLB using the Name tag.
@@ -736,13 +737,13 @@ type terraformNetworkLoadBalancer struct {
 }
 
 type terraformNetworkLoadBalancerSubnetMapping struct {
-	Subnet             *terraform.Literal `json:"subnet_id" cty:"subnet_id"`
-	AllocationID       *string            `json:"allocation_id,omitempty" cty:"allocation_id"`
-	PrivateIPv4Address *string            `json:"private_ipv4_address,omitempty" cty:"private_ipv4_address"`
+	Subnet             *terraformWriter.Literal `json:"subnet_id" cty:"subnet_id"`
+	AllocationID       *string                  `json:"allocation_id,omitempty" cty:"allocation_id"`
+	PrivateIPv4Address *string                  `json:"private_ipv4_address,omitempty" cty:"private_ipv4_address"`
 }
 
 type terraformNetworkLoadBalancerListener struct {
-	LoadBalancer   *terraform.Literal                           `json:"load_balancer_arn" cty:"load_balancer_arn"`
+	LoadBalancer   *terraformWriter.Literal                     `json:"load_balancer_arn" cty:"load_balancer_arn"`
 	Port           int64                                        `json:"port" cty:"port"`
 	Protocol       string                                       `json:"protocol" cty:"protocol"`
 	CertificateARN *string                                      `json:"certificate_arn,omitempty" cty:"certificate_arn"`
@@ -751,8 +752,8 @@ type terraformNetworkLoadBalancerListener struct {
 }
 
 type terraformNetworkLoadBalancerListenerAction struct {
-	Type           string             `json:"type" cty:"type"`
-	TargetGroupARN *terraform.Literal `json:"target_group_arn,omitempty" cty:"target_group_arn"`
+	Type           string                   `json:"type" cty:"type"`
+	TargetGroupARN *terraformWriter.Literal `json:"target_group_arn,omitempty" cty:"target_group_arn"`
 }
 
 func (_ *NetworkLoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *NetworkLoadBalancer) error {
@@ -816,12 +817,12 @@ func (_ *NetworkLoadBalancer) RenderTerraform(t *terraform.TerraformTarget, a, e
 	return nil
 }
 
-func (e *NetworkLoadBalancer) TerraformLink(params ...string) *terraform.Literal {
+func (e *NetworkLoadBalancer) TerraformLink(params ...string) *terraformWriter.Literal {
 	prop := "id"
 	if len(params) > 0 {
 		prop = params[0]
 	}
-	return terraform.LiteralProperty("aws_lb", *e.Name, prop)
+	return terraformWriter.LiteralProperty("aws_lb", *e.Name, prop)
 }
 
 type cloudformationNetworkLoadBalancer struct {

--- a/upup/pkg/fi/cloudup/awstasks/route.go
+++ b/upup/pkg/fi/cloudup/awstasks/route.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -236,12 +237,12 @@ func checkNotNil(s *string) *string {
 }
 
 type terraformRoute struct {
-	RouteTableID      *terraform.Literal `json:"route_table_id" cty:"route_table_id"`
-	CIDR              *string            `json:"destination_cidr_block,omitempty" cty:"destination_cidr_block"`
-	InternetGatewayID *terraform.Literal `json:"gateway_id,omitempty" cty:"gateway_id"`
-	NATGatewayID      *terraform.Literal `json:"nat_gateway_id,omitempty" cty:"nat_gateway_id"`
-	TransitGatewayID  *string            `json:"transit_gateway_id,omitempty" cty:"transit_gateway_id"`
-	InstanceID        *terraform.Literal `json:"instance_id,omitempty" cty:"instance_id"`
+	RouteTableID      *terraformWriter.Literal `json:"route_table_id" cty:"route_table_id"`
+	CIDR              *string                  `json:"destination_cidr_block,omitempty" cty:"destination_cidr_block"`
+	InternetGatewayID *terraformWriter.Literal `json:"gateway_id,omitempty" cty:"gateway_id"`
+	NATGatewayID      *terraformWriter.Literal `json:"nat_gateway_id,omitempty" cty:"nat_gateway_id"`
+	TransitGatewayID  *string                  `json:"transit_gateway_id,omitempty" cty:"transit_gateway_id"`
+	InstanceID        *terraformWriter.Literal `json:"instance_id,omitempty" cty:"instance_id"`
 }
 
 func (_ *Route) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Route) error {

--- a/upup/pkg/fi/cloudup/awstasks/routetable.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetable.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -191,8 +192,8 @@ func (_ *RouteTable) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *RouteTable)
 }
 
 type terraformRouteTable struct {
-	VPCID *terraform.Literal `json:"vpc_id" cty:"vpc_id"`
-	Tags  map[string]string  `json:"tags,omitempty" cty:"tags"`
+	VPCID *terraformWriter.Literal `json:"vpc_id" cty:"vpc_id"`
+	Tags  map[string]string        `json:"tags,omitempty" cty:"tags"`
 }
 
 func (_ *RouteTable) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *RouteTable) error {
@@ -212,8 +213,8 @@ func (_ *RouteTable) RenderTerraform(t *terraform.TerraformTarget, a, e, changes
 	return t.RenderResource("aws_route_table", *e.Name, tf)
 }
 
-func (e *RouteTable) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("aws_route_table", *e.Name, "id")
+func (e *RouteTable) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("aws_route_table", *e.Name, "id")
 }
 
 type cloudformationRouteTable struct {

--- a/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
+++ b/upup/pkg/fi/cloudup/awstasks/routetableassociation.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -187,8 +188,8 @@ func (_ *RouteTableAssociation) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *
 }
 
 type terraformRouteTableAssociation struct {
-	SubnetID     *terraform.Literal `json:"subnet_id" cty:"subnet_id"`
-	RouteTableID *terraform.Literal `json:"route_table_id" cty:"route_table_id"`
+	SubnetID     *terraformWriter.Literal `json:"subnet_id" cty:"subnet_id"`
+	RouteTableID *terraformWriter.Literal `json:"route_table_id" cty:"route_table_id"`
 }
 
 func (_ *RouteTableAssociation) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *RouteTableAssociation) error {
@@ -200,8 +201,8 @@ func (_ *RouteTableAssociation) RenderTerraform(t *terraform.TerraformTarget, a,
 	return t.RenderResource("aws_route_table_association", *e.Name, tf)
 }
 
-func (e *RouteTableAssociation) TerraformLink() *terraform.Literal {
-	return terraform.LiteralSelfLink("aws_route_table_association", *e.Name)
+func (e *RouteTableAssociation) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralSelfLink("aws_route_table_association", *e.Name)
 }
 
 type cloudformationRouteTableAssociation struct {

--- a/upup/pkg/fi/cloudup/awstasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygroup.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -184,10 +185,10 @@ func (_ *SecurityGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Security
 }
 
 type terraformSecurityGroup struct {
-	Name        *string            `json:"name" cty:"name"`
-	VPCID       *terraform.Literal `json:"vpc_id" cty:"vpc_id"`
-	Description *string            `json:"description" cty:"description"`
-	Tags        map[string]string  `json:"tags,omitempty" cty:"tags"`
+	Name        *string                  `json:"name" cty:"name"`
+	VPCID       *terraformWriter.Literal `json:"vpc_id" cty:"vpc_id"`
+	Description *string                  `json:"description" cty:"description"`
+	Tags        map[string]string        `json:"tags,omitempty" cty:"tags"`
 }
 
 func (_ *SecurityGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SecurityGroup) error {
@@ -207,18 +208,18 @@ func (_ *SecurityGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, chan
 	return t.RenderResource("aws_security_group", *e.Name, tf)
 }
 
-func (e *SecurityGroup) TerraformLink() *terraform.Literal {
+func (e *SecurityGroup) TerraformLink() *terraformWriter.Literal {
 	shared := fi.BoolValue(e.Shared)
 	if shared {
 		// Not terraform owned / managed
 		if e.ID != nil {
-			return terraform.LiteralFromStringValue(*e.ID)
+			return terraformWriter.LiteralFromStringValue(*e.ID)
 		} else {
 			klog.Warningf("ID not set on shared subnet %v", e)
 		}
 	}
 
-	return terraform.LiteralProperty("aws_security_group", *e.Name, "id")
+	return terraformWriter.LiteralProperty("aws_security_group", *e.Name, "id")
 }
 
 type cloudformationSecurityGroup struct {

--- a/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
+++ b/upup/pkg/fi/cloudup/awstasks/securitygrouprule.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -293,8 +294,8 @@ func (_ *SecurityGroupRule) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Secu
 type terraformSecurityGroupIngress struct {
 	Type *string `json:"type" cty:"type"`
 
-	SecurityGroup *terraform.Literal `json:"security_group_id" cty:"security_group_id"`
-	SourceGroup   *terraform.Literal `json:"source_security_group_id,omitempty" cty:"source_security_group_id"`
+	SecurityGroup *terraformWriter.Literal `json:"security_group_id" cty:"security_group_id"`
+	SourceGroup   *terraformWriter.Literal `json:"source_security_group_id,omitempty" cty:"source_security_group_id"`
 
 	FromPort *int64 `json:"from_port,omitempty" cty:"from_port"`
 	ToPort   *int64 `json:"to_port,omitempty" cty:"to_port"`

--- a/upup/pkg/fi/cloudup/awstasks/sqs.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs.go
@@ -183,7 +183,7 @@ type terraformSQSQueue struct {
 }
 
 func (_ *SQS) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SQS) error {
-	p, err := t.AddFile("aws_sqs_queue", *e.Name, "policy", e.Policy, false)
+	p, err := t.AddFileResource("aws_sqs_queue", *e.Name, "policy", e.Policy, false)
 	if err != nil {
 		return err
 	}

--- a/upup/pkg/fi/cloudup/awstasks/sqs.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -176,10 +177,10 @@ func (q *SQS) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *SQS) error {
 }
 
 type terraformSQSQueue struct {
-	Name                    *string            `json:"name" cty:"name"`
-	MessageRetentionSeconds int                `json:"message_retention_seconds" cty:"message_retention_seconds"`
-	Policy                  *terraform.Literal `json:"policy" cty:"policy"`
-	Tags                    map[string]string  `json:"tags" cty:"tags"`
+	Name                    *string                  `json:"name" cty:"name"`
+	MessageRetentionSeconds int                      `json:"message_retention_seconds" cty:"message_retention_seconds"`
+	Policy                  *terraformWriter.Literal `json:"policy" cty:"policy"`
+	Tags                    map[string]string        `json:"tags" cty:"tags"`
 }
 
 func (_ *SQS) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SQS) error {

--- a/upup/pkg/fi/cloudup/awstasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 
 	"k8s.io/kops/pkg/pki"
 	"k8s.io/kops/upup/pkg/fi"
@@ -182,9 +183,9 @@ func (_ *SSHKey) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *SSHKey) error {
 }
 
 type terraformSSHKey struct {
-	Name      *string            `json:"key_name" cty:"key_name"`
-	PublicKey *terraform.Literal `json:"public_key" cty:"public_key"`
-	Tags      map[string]string  `json:"tags" cty:"tags"`
+	Name      *string                  `json:"key_name" cty:"key_name"`
+	PublicKey *terraformWriter.Literal `json:"public_key" cty:"public_key"`
+	Tags      map[string]string        `json:"tags" cty:"tags"`
 }
 
 func (_ *SSHKey) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SSHKey) error {
@@ -213,15 +214,15 @@ func (e *SSHKey) IsExistingKey() bool {
 	return e.PublicKey == nil
 }
 
-func (e *SSHKey) TerraformLink() *terraform.Literal {
+func (e *SSHKey) TerraformLink() *terraformWriter.Literal {
 	if e.NoSSHKey() {
 		return nil
 	}
 	if e.IsExistingKey() {
-		return terraform.LiteralFromStringValue(*e.Name)
+		return terraformWriter.LiteralFromStringValue(*e.Name)
 	}
 	tfName := strings.Replace(*e.Name, ":", "", -1)
-	return terraform.LiteralProperty("aws_key_pair", tfName, "id")
+	return terraformWriter.LiteralProperty("aws_key_pair", tfName, "id")
 }
 
 func (_ *SSHKey) RenderCloudformation(t *cloudformation.CloudformationTarget, a, e, changes *SSHKey) error {

--- a/upup/pkg/fi/cloudup/awstasks/sshkey.go
+++ b/upup/pkg/fi/cloudup/awstasks/sshkey.go
@@ -193,7 +193,7 @@ func (_ *SSHKey) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *SS
 		return nil
 	}
 	tfName := strings.Replace(*e.Name, ":", "", -1)
-	publicKey, err := t.AddFile("aws_key_pair", tfName, "public_key", e.PublicKey, false)
+	publicKey, err := t.AddFileResource("aws_key_pair", tfName, "public_key", e.PublicKey, false)
 	if err != nil {
 		return fmt.Errorf("error rendering PublicKey: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 	"k8s.io/kops/upup/pkg/fi/utils"
 )
 
@@ -215,10 +216,10 @@ func subnetSlicesEqualIgnoreOrder(l, r []*Subnet) bool {
 }
 
 type terraformSubnet struct {
-	VPCID            *terraform.Literal `json:"vpc_id" cty:"vpc_id"`
-	CIDR             *string            `json:"cidr_block" cty:"cidr_block"`
-	AvailabilityZone *string            `json:"availability_zone" cty:"availability_zone"`
-	Tags             map[string]string  `json:"tags,omitempty" cty:"tags"`
+	VPCID            *terraformWriter.Literal `json:"vpc_id" cty:"vpc_id"`
+	CIDR             *string                  `json:"cidr_block" cty:"cidr_block"`
+	AvailabilityZone *string                  `json:"availability_zone" cty:"availability_zone"`
+	Tags             map[string]string        `json:"tags,omitempty" cty:"tags"`
 }
 
 func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Subnet) error {
@@ -237,7 +238,7 @@ func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Su
 		// We probably shouldn't output subnet_ids only in this case - we normally output them by role,
 		// but removing it now might break people.  We could always output subnet_ids though, if we
 		// ever get a request for that.
-		return t.AddOutputVariableArray("subnet_ids", terraform.LiteralFromStringValue(*e.ID))
+		return t.AddOutputVariableArray("subnet_ids", terraformWriter.LiteralFromStringValue(*e.ID))
 	}
 
 	tf := &terraformSubnet{
@@ -250,7 +251,7 @@ func (_ *Subnet) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Su
 	return t.RenderResource("aws_subnet", *e.Name, tf)
 }
 
-func (e *Subnet) TerraformLink() *terraform.Literal {
+func (e *Subnet) TerraformLink() *terraformWriter.Literal {
 	shared := fi.BoolValue(e.Shared)
 	if shared {
 		if e.ID == nil {
@@ -258,10 +259,10 @@ func (e *Subnet) TerraformLink() *terraform.Literal {
 		}
 
 		klog.V(4).Infof("reusing existing subnet with id %q", *e.ID)
-		return terraform.LiteralFromStringValue(*e.ID)
+		return terraformWriter.LiteralFromStringValue(*e.ID)
 	}
 
-	return terraform.LiteralProperty("aws_subnet", *e.Name, "id")
+	return terraformWriter.LiteralProperty("aws_subnet", *e.Name, "id")
 }
 
 type cloudformationSubnet struct {

--- a/upup/pkg/fi/cloudup/awstasks/targetgroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/targetgroup.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -210,7 +211,7 @@ type terraformTargetGroup struct {
 	Name        string                          `json:"name" cty:"name"`
 	Port        int64                           `json:"port" cty:"port"`
 	Protocol    string                          `json:"protocol" cty:"protocol"`
-	VPCID       terraform.Literal               `json:"vpc_id" cty:"vpc_id"`
+	VPCID       terraformWriter.Literal         `json:"vpc_id" cty:"vpc_id"`
 	Tags        map[string]string               `json:"tags,omitempty" cty:"tags"`
 	HealthCheck terraformTargetGroupHealthCheck `json:"health_check" cty:"health_check"`
 }
@@ -247,16 +248,16 @@ func (_ *TargetGroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 	return t.RenderResource("aws_lb_target_group", *e.Name, tf)
 }
 
-func (e *TargetGroup) TerraformLink(params ...string) *terraform.Literal {
+func (e *TargetGroup) TerraformLink(params ...string) *terraformWriter.Literal {
 	shared := fi.BoolValue(e.Shared)
 	if shared {
 		if e.ARN != nil {
-			return terraform.LiteralFromStringValue(*e.ARN)
+			return terraformWriter.LiteralFromStringValue(*e.ARN)
 		} else {
 			klog.Warningf("ID not set on shared Target Group %v", e)
 		}
 	}
-	return terraform.LiteralProperty("aws_lb_target_group", *e.Name, "id")
+	return terraformWriter.LiteralProperty("aws_lb_target_group", *e.Name, "id")
 }
 
 type cloudformationTargetGroup struct {

--- a/upup/pkg/fi/cloudup/awstasks/vpc.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -267,7 +268,7 @@ func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) 
 		return nil
 	}
 
-	if err := t.AddOutputVariable("vpc_cidr_block", terraform.LiteralProperty("aws_vpc", *e.Name, "cidr_block")); err != nil {
+	if err := t.AddOutputVariable("vpc_cidr_block", terraformWriter.LiteralProperty("aws_vpc", *e.Name, "cidr_block")); err != nil {
 		// TODO: Should we try to output vpc_cidr_block for shared vpcs?
 		return err
 	}
@@ -282,7 +283,7 @@ func (_ *VPC) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPC) 
 	return t.RenderResource("aws_vpc", *e.Name, tf)
 }
 
-func (e *VPC) TerraformLink() *terraform.Literal {
+func (e *VPC) TerraformLink() *terraformWriter.Literal {
 	shared := fi.BoolValue(e.Shared)
 	if shared {
 		if e.ID == nil {
@@ -290,10 +291,10 @@ func (e *VPC) TerraformLink() *terraform.Literal {
 		}
 
 		klog.V(4).Infof("reusing existing VPC with id %q", *e.ID)
-		return terraform.LiteralFromStringValue(*e.ID)
+		return terraformWriter.LiteralFromStringValue(*e.ID)
 	}
 
-	return terraform.LiteralProperty("aws_vpc", *e.Name, "id")
+	return terraformWriter.LiteralProperty("aws_vpc", *e.Name, "id")
 }
 
 type cloudformationVPC struct {

--- a/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpc_dhcpoptions_association.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -102,8 +103,8 @@ func (_ *VPCDHCPOptionsAssociation) RenderAWS(t *awsup.AWSAPITarget, a, e, chang
 }
 
 type terraformVPCDHCPOptionsAssociation struct {
-	VPCID         *terraform.Literal `json:"vpc_id" cty:"vpc_id"`
-	DHCPOptionsID *terraform.Literal `json:"dhcp_options_id" cty:"dhcp_options_id"`
+	VPCID         *terraformWriter.Literal `json:"vpc_id" cty:"vpc_id"`
+	DHCPOptionsID *terraformWriter.Literal `json:"dhcp_options_id" cty:"dhcp_options_id"`
 }
 
 func (_ *VPCDHCPOptionsAssociation) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPCDHCPOptionsAssociation) error {

--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -124,8 +125,8 @@ func (_ *VPCCIDRBlock) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *VPCCIDRBl
 }
 
 type terraformVPCCIDRBlock struct {
-	VPCID     *terraform.Literal `json:"vpc_id" cty:"vpc_id"`
-	CIDRBlock *string            `json:"cidr_block" cty:"cidr_block"`
+	VPCID     *terraformWriter.Literal `json:"vpc_id" cty:"vpc_id"`
+	CIDRBlock *string                  `json:"cidr_block" cty:"cidr_block"`
 }
 
 func (_ *VPCCIDRBlock) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *VPCCIDRBlock) error {

--- a/upup/pkg/fi/cloudup/gcetasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/gcetasks/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
+        "//upup/pkg/fi/cloudup/terraformWriter:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/storage/v1:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -163,8 +164,8 @@ func (_ *Address) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *A
 	return t.RenderResource("google_compute_address", *e.Name, tf)
 }
 
-func (e *Address) TerraformAddress() *terraform.Literal {
+func (e *Address) TerraformAddress() *terraformWriter.Literal {
 	name := fi.StringValue(e.Name)
 
-	return terraform.LiteralProperty("google_compute_address", name, "address")
+	return terraformWriter.LiteralProperty("google_compute_address", name, "address")
 }

--- a/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/firewallrule.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // FirewallRule represents a GCE firewall rules
@@ -163,8 +164,8 @@ type terraformAllow struct {
 }
 
 type terraformFirewall struct {
-	Name    string             `json:"name" cty:"name"`
-	Network *terraform.Literal `json:"network" cty:"network"`
+	Name    string                   `json:"name" cty:"name"`
+	Network *terraformWriter.Literal `json:"network" cty:"network"`
 
 	Allowed []*terraformAllow `json:"allow,omitempty" cty:"allow"`
 

--- a/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
+++ b/upup/pkg/fi/cloudup/gcetasks/forwardingrule.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // ForwardingRule represents a GCE ForwardingRule
@@ -138,11 +139,11 @@ func (_ *ForwardingRule) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Forwardin
 }
 
 type terraformForwardingRule struct {
-	Name       string             `json:"name" cty:"name"`
-	PortRange  string             `json:"port_range,omitempty" cty:"port_range"`
-	Target     *terraform.Literal `json:"target,omitempty" cty:"target"`
-	IPAddress  *terraform.Literal `json:"ip_address,omitempty" cty:"ip_address"`
-	IPProtocol string             `json:"ip_protocol,omitempty" cty:"ip_protocol"`
+	Name       string                   `json:"name" cty:"name"`
+	PortRange  string                   `json:"port_range,omitempty" cty:"port_range"`
+	Target     *terraformWriter.Literal `json:"target,omitempty" cty:"target"`
+	IPAddress  *terraformWriter.Literal `json:"ip_address,omitempty" cty:"ip_address"`
+	IPProtocol string                   `json:"ip_protocol,omitempty" cty:"ip_protocol"`
 }
 
 func (_ *ForwardingRule) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ForwardingRule) error {
@@ -165,8 +166,8 @@ func (_ *ForwardingRule) RenderTerraform(t *terraform.TerraformTarget, a, e, cha
 	return t.RenderResource("google_compute_forwarding_rule", name, tf)
 }
 
-func (e *ForwardingRule) TerraformLink() *terraform.Literal {
+func (e *ForwardingRule) TerraformLink() *terraformWriter.Literal {
 	name := fi.StringValue(e.Name)
 
-	return terraform.LiteralSelfLink("google_compute_forwarding_rule", name)
+	return terraformWriter.LiteralSelfLink("google_compute_forwarding_rule", name)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/instance.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instance.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 var scopeAliases map[string]string
@@ -393,17 +394,17 @@ func ShortenImageURL(defaultProject string, imageURL string) (string, error) {
 }
 
 type terraformInstance struct {
-	Name                  string                           `json:"name" cty:"name"`
-	CanIPForward          bool                             `json:"can_ip_forward" cty:"can_ip_forward"`
-	MachineType           string                           `json:"machine_type,omitempty" cty:"machine_type"`
-	ServiceAccount        *terraformServiceAccount         `json:"service_account,omitempty" cty:"service_account"`
-	Scheduling            *terraformScheduling             `json:"scheduling,omitempty" cty:"scheduling"`
-	Disks                 []*terraformInstanceAttachedDisk `json:"disk,omitempty" cty:"disk"`
-	NetworkInterfaces     []*terraformNetworkInterface     `json:"network_interface,omitempty" cty:"network_interface"`
-	Metadata              map[string]*terraform.Literal    `json:"metadata,omitempty" cty:"metadata"`
-	MetadataStartupScript *terraform.Literal               `json:"metadata_startup_script,omitempty" cty:"metadata_startup_script"`
-	Tags                  []string                         `json:"tags,omitempty" cty:"tags"`
-	Zone                  string                           `json:"zone,omitempty" cty:"zone"`
+	Name                  string                              `json:"name" cty:"name"`
+	CanIPForward          bool                                `json:"can_ip_forward" cty:"can_ip_forward"`
+	MachineType           string                              `json:"machine_type,omitempty" cty:"machine_type"`
+	ServiceAccount        *terraformServiceAccount            `json:"service_account,omitempty" cty:"service_account"`
+	Scheduling            *terraformScheduling                `json:"scheduling,omitempty" cty:"scheduling"`
+	Disks                 []*terraformInstanceAttachedDisk    `json:"disk,omitempty" cty:"disk"`
+	NetworkInterfaces     []*terraformNetworkInterface        `json:"network_interface,omitempty" cty:"network_interface"`
+	Metadata              map[string]*terraformWriter.Literal `json:"metadata,omitempty" cty:"metadata"`
+	MetadataStartupScript *terraformWriter.Literal            `json:"metadata_startup_script,omitempty" cty:"metadata_startup_script"`
+	Tags                  []string                            `json:"tags,omitempty" cty:"tags"`
+	Zone                  string                              `json:"zone,omitempty" cty:"zone"`
 }
 
 type terraformInstanceAttachedDisk struct {

--- a/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancegroupmanager.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -171,16 +172,16 @@ func (_ *InstanceGroupManager) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Ins
 }
 
 type terraformInstanceGroupManager struct {
-	Name             *string              `json:"name" cty:"name"`
-	Zone             *string              `json:"zone" cty:"zone"`
-	BaseInstanceName *string              `json:"base_instance_name" cty:"base_instance_name"`
-	Version          *terraformVersion    `json:"version" cty:"version"`
-	TargetSize       *int64               `json:"target_size" cty:"target_size"`
-	TargetPools      []*terraform.Literal `json:"target_pools,omitempty" cty:"target_pools"`
+	Name             *string                    `json:"name" cty:"name"`
+	Zone             *string                    `json:"zone" cty:"zone"`
+	BaseInstanceName *string                    `json:"base_instance_name" cty:"base_instance_name"`
+	Version          *terraformVersion          `json:"version" cty:"version"`
+	TargetSize       *int64                     `json:"target_size" cty:"target_size"`
+	TargetPools      []*terraformWriter.Literal `json:"target_pools,omitempty" cty:"target_pools"`
 }
 
 type terraformVersion struct {
-	InstanceTemplate *terraform.Literal `json:"instance_template" cty:"instance_template"`
+	InstanceTemplate *terraformWriter.Literal `json:"instance_template" cty:"instance_template"`
 }
 
 func (_ *InstanceGroupManager) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *InstanceGroupManager) error {

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -526,8 +526,7 @@ func addMetadata(target *terraform.TerraformTarget, name string, metadata *compu
 	for _, g := range metadata.Items {
 		val := fi.StringValue(g.Value)
 		if strings.Contains(val, "\n") {
-			v := fi.NewStringResource(val)
-			tfResource, err := target.AddFile("google_compute_instance_template", name, "metadata_"+g.Key, v, false)
+			tfResource, err := target.AddFileBytes("google_compute_instance_template", name, "metadata_"+g.Key, []byte(val), false)
 			if err != nil {
 				return nil, err
 			}

--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 const (
@@ -451,8 +452,8 @@ type terraformInstanceTemplate struct {
 	Scheduling            *terraformScheduling                     `json:"scheduling,omitempty" cty:"scheduling"`
 	Disks                 []*terraformInstanceTemplateAttachedDisk `json:"disk,omitempty" cty:"disk"`
 	NetworkInterfaces     []*terraformNetworkInterface             `json:"network_interface,omitempty" cty:"network_interface"`
-	Metadata              map[string]*terraform.Literal            `json:"metadata,omitempty" cty:"metadata"`
-	MetadataStartupScript *terraform.Literal                       `json:"metadata_startup_script,omitempty" cty:"metadata_startup_script"`
+	Metadata              map[string]*terraformWriter.Literal      `json:"metadata,omitempty" cty:"metadata"`
+	MetadataStartupScript *terraformWriter.Literal                 `json:"metadata_startup_script,omitempty" cty:"metadata_startup_script"`
 	Tags                  []string                                 `json:"tags,omitempty" cty:"tags"`
 }
 
@@ -484,13 +485,13 @@ type terraformInstanceTemplateAttachedDisk struct {
 }
 
 type terraformNetworkInterface struct {
-	Network      *terraform.Literal       `json:"network,omitempty" cty:"network"`
-	Subnetwork   *terraform.Literal       `json:"subnetwork,omitempty" cty:"subnetwork"`
+	Network      *terraformWriter.Literal `json:"network,omitempty" cty:"network"`
+	Subnetwork   *terraformWriter.Literal `json:"subnetwork,omitempty" cty:"subnetwork"`
 	AccessConfig []*terraformAccessConfig `json:"access_config" cty:"access_config"`
 }
 
 type terraformAccessConfig struct {
-	NatIP *terraform.Literal `json:"nat_ip,omitempty" cty:"nat_ip"`
+	NatIP *terraformWriter.Literal `json:"nat_ip,omitempty" cty:"nat_ip"`
 }
 
 func addNetworks(network *Network, subnet *Subnet, networkInterfaces []*compute.NetworkInterface) []*terraformNetworkInterface {
@@ -507,7 +508,7 @@ func addNetworks(network *Network, subnet *Subnet, networkInterfaces []*compute.
 			tac := &terraformAccessConfig{}
 			natIP := gac.NatIP
 			if natIP != "" {
-				tac.NatIP = terraform.LiteralFromStringValue(natIP)
+				tac.NatIP = terraformWriter.LiteralFromStringValue(natIP)
 			}
 
 			tf.AccessConfig = append(tf.AccessConfig, tac)
@@ -518,11 +519,11 @@ func addNetworks(network *Network, subnet *Subnet, networkInterfaces []*compute.
 	return ni
 }
 
-func addMetadata(target *terraform.TerraformTarget, name string, metadata *compute.Metadata) (map[string]*terraform.Literal, error) {
+func addMetadata(target *terraform.TerraformTarget, name string, metadata *compute.Metadata) (map[string]*terraformWriter.Literal, error) {
 	if metadata == nil {
 		return nil, nil
 	}
-	m := make(map[string]*terraform.Literal)
+	m := make(map[string]*terraformWriter.Literal)
 	for _, g := range metadata.Items {
 		val := fi.StringValue(g.Value)
 		if strings.Contains(val, "\n") {
@@ -532,7 +533,7 @@ func addMetadata(target *terraform.TerraformTarget, name string, metadata *compu
 			}
 			m[g.Key] = tfResource
 		} else {
-			m[g.Key] = terraform.LiteralFromStringValue(val)
+			m[g.Key] = terraformWriter.LiteralFromStringValue(val)
 		}
 	}
 	return m, nil
@@ -612,6 +613,6 @@ func (_ *InstanceTemplate) RenderTerraform(t *terraform.TerraformTarget, a, e, c
 	return t.RenderResource("google_compute_instance_template", name, tf)
 }
 
-func (i *InstanceTemplate) TerraformLink() *terraform.Literal {
-	return terraform.LiteralSelfLink("google_compute_instance_template", *i.Name)
+func (i *InstanceTemplate) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralSelfLink("google_compute_instance_template", *i.Name)
 }

--- a/upup/pkg/fi/cloudup/gcetasks/network.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -175,6 +176,6 @@ func (_ *Network) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *N
 	return t.RenderResource("google_compute_network", *e.Name, tf)
 }
 
-func (i *Network) TerraformName() *terraform.Literal {
-	return terraform.LiteralProperty("google_compute_network", *i.Name, "name")
+func (i *Network) TerraformName() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("google_compute_network", *i.Name, "name")
 }

--- a/upup/pkg/fi/cloudup/gcetasks/router.go
+++ b/upup/pkg/fi/cloudup/gcetasks/router.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 const (
@@ -202,6 +203,6 @@ func (*Router) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Rout
 }
 
 // TerraformName returns the Terraform name.
-func (r *Router) TerraformName() *terraform.Literal {
-	return terraform.LiteralProperty("google_compute_router_nat", *r.Name, "name")
+func (r *Router) TerraformName() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("google_compute_router_nat", *r.Name, "name")
 }

--- a/upup/pkg/fi/cloudup/gcetasks/subnet.go
+++ b/upup/pkg/fi/cloudup/gcetasks/subnet.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -202,10 +203,10 @@ func (e *Subnet) URL(project string, region string) string {
 }
 
 type terraformSubnet struct {
-	Name    *string            `json:"name" cty:"name"`
-	Network *terraform.Literal `json:"network" cty:"network"`
-	Region  *string            `json:"region" cty:"region"`
-	CIDR    *string            `json:"ip_cidr_range" cty:"ip_cidr_range"`
+	Name    *string                  `json:"name" cty:"name"`
+	Network *terraformWriter.Literal `json:"network" cty:"network"`
+	Region  *string                  `json:"region" cty:"region"`
+	CIDR    *string                  `json:"ip_cidr_range" cty:"ip_cidr_range"`
 
 	// SecondaryIPRange defines additional IP ranges
 	SecondaryIPRange []terraformSubnetRange `json:"secondary_ip_range,omitempty" cty:"secondary_ip_range"`
@@ -234,6 +235,6 @@ func (_ *Subnet) RenderSubnet(t *terraform.TerraformTarget, a, e, changes *Subne
 	return t.RenderResource("google_compute_subnetwork", *e.Name, tf)
 }
 
-func (i *Subnet) TerraformName() *terraform.Literal {
-	return terraform.LiteralProperty("google_compute_subnetwork", *i.Name, "name")
+func (i *Subnet) TerraformName() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("google_compute_subnetwork", *i.Name, "name")
 }

--- a/upup/pkg/fi/cloudup/gcetasks/targetpool.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // TargetPool represents a GCE TargetPool
@@ -117,8 +118,8 @@ func (_ *TargetPool) RenderTerraform(t *terraform.TerraformTarget, a, e, changes
 	return t.RenderResource("google_compute_target_pool", name, tf)
 }
 
-func (e *TargetPool) TerraformLink() *terraform.Literal {
+func (e *TargetPool) TerraformLink() *terraformWriter.Literal {
 	name := fi.StringValue(e.Name)
 
-	return terraform.LiteralSelfLink("google_compute_target_pool", name)
+	return terraformWriter.LiteralSelfLink("google_compute_target_pool", name)
 }

--- a/upup/pkg/fi/cloudup/spotinsttasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/spotinsttasks/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
+        "//upup/pkg/fi/cloudup/terraformWriter:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/elb:go_default_library",

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -1506,7 +1506,7 @@ func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 	// User data.
 	if e.UserData != nil {
 		var err error
-		tf.UserData, err = t.AddFile("spotinst_elastigroup_aws", *e.Name, "user_data", e.UserData, false)
+		tf.UserData, err = t.AddFileResource("spotinst_elastigroup_aws", *e.Name, "user_data", e.UserData, false)
 		if err != nil {
 			return err
 		}

--- a/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/elastigroup.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 	"k8s.io/kops/upup/pkg/fi/utils"
 )
 
@@ -1346,8 +1347,8 @@ type terraformElastigroup struct {
 	Description          *string                                 `json:"description,omitempty" cty:"description"`
 	Product              *string                                 `json:"product,omitempty" cty:"product"`
 	Region               *string                                 `json:"region,omitempty" cty:"region"`
-	SubnetIDs            []*terraform.Literal                    `json:"subnet_ids,omitempty" cty:"subnet_ids"`
-	LoadBalancers        []*terraform.Literal                    `json:"elastic_load_balancers,omitempty" cty:"elastic_load_balancers"`
+	SubnetIDs            []*terraformWriter.Literal              `json:"subnet_ids,omitempty" cty:"subnet_ids"`
+	LoadBalancers        []*terraformWriter.Literal              `json:"elastic_load_balancers,omitempty" cty:"elastic_load_balancers"`
 	NetworkInterfaces    []*terraformElastigroupNetworkInterface `json:"network_interface,omitempty" cty:"network_interface"`
 	RootBlockDevice      *terraformElastigroupBlockDevice        `json:"ebs_block_device,omitempty" cty:"ebs_block_device"`
 	EphemeralBlockDevice []*terraformElastigroupBlockDevice      `json:"ephemeral_block_device,omitempty" cty:"ephemeral_block_device"`
@@ -1368,14 +1369,14 @@ type terraformElastigroup struct {
 	OnDemand *string  `json:"instance_types_ondemand,omitempty" cty:"instance_types_ondemand"`
 	Spot     []string `json:"instance_types_spot,omitempty" cty:"instance_types_spot"`
 
-	Monitoring         *bool                `json:"enable_monitoring,omitempty" cty:"enable_monitoring"`
-	EBSOptimized       *bool                `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
-	ImageID            *string              `json:"image_id,omitempty" cty:"image_id"`
-	HealthCheckType    *string              `json:"health_check_type,omitempty" cty:"health_check_type"`
-	SecurityGroups     []*terraform.Literal `json:"security_groups,omitempty" cty:"security_groups"`
-	UserData           *terraform.Literal   `json:"user_data,omitempty" cty:"user_data"`
-	IAMInstanceProfile *terraform.Literal   `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
-	KeyName            *terraform.Literal   `json:"key_name,omitempty" cty:"key_name"`
+	Monitoring         *bool                      `json:"enable_monitoring,omitempty" cty:"enable_monitoring"`
+	EBSOptimized       *bool                      `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
+	ImageID            *string                    `json:"image_id,omitempty" cty:"image_id"`
+	HealthCheckType    *string                    `json:"health_check_type,omitempty" cty:"health_check_type"`
+	SecurityGroups     []*terraformWriter.Literal `json:"security_groups,omitempty" cty:"security_groups"`
+	UserData           *terraformWriter.Literal   `json:"user_data,omitempty" cty:"user_data"`
+	IAMInstanceProfile *terraformWriter.Literal   `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
+	KeyName            *terraformWriter.Literal   `json:"key_name,omitempty" cty:"key_name"`
 }
 
 type terraformElastigroupBlockDevice struct {
@@ -1665,8 +1666,8 @@ func (_ *Elastigroup) RenderTerraform(t *terraform.TerraformTarget, a, e, change
 	return t.RenderResource("spotinst_elastigroup_aws", *e.Name, tf)
 }
 
-func (e *Elastigroup) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("spotinst_elastigroup_aws", *e.Name, "id")
+func (e *Elastigroup) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("spotinst_elastigroup_aws", *e.Name, "id")
 }
 
 func (e *Elastigroup) buildTags() []*aws.Tag {

--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -874,7 +874,7 @@ func (_ *LaunchSpec) RenderTerraform(t *terraform.TerraformTarget, a, e, changes
 	{
 		if e.UserData != nil {
 			var err error
-			tf.UserData, err = t.AddFile("spotinst_ocean_aws_launch_spec", *e.Name, "user_data", e.UserData, false)
+			tf.UserData, err = t.AddFileResource("spotinst_ocean_aws_launch_spec", *e.Name, "user_data", e.UserData, false)
 			if err != nil {
 				return err
 			}

--- a/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/launch_spec.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -770,8 +771,8 @@ func (_ *LaunchSpec) update(cloud awsup.AWSCloud, a, e, changes *LaunchSpec) err
 }
 
 type terraformLaunchSpec struct {
-	Name    *string            `json:"name,omitempty" cty:"name"`
-	OceanID *terraform.Literal `json:"ocean_id,omitempty" cty:"ocean_id"`
+	Name    *string                  `json:"name,omitempty" cty:"name"`
+	OceanID *terraformWriter.Literal `json:"ocean_id,omitempty" cty:"ocean_id"`
 
 	Monitoring               *bool                          `json:"monitoring,omitempty" cty:"monitoring"`
 	EBSOptimized             *bool                          `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
@@ -779,12 +780,12 @@ type terraformLaunchSpec struct {
 	AssociatePublicIPAddress *bool                          `json:"associate_public_ip_address,omitempty" cty:"associate_public_ip_address"`
 	RestrictScaleDown        *bool                          `json:"restrict_scale_down,omitempty" cty:"restrict_scale_down"`
 	RootVolumeSize           *int64                         `json:"root_volume_size,omitempty" cty:"root_volume_size"`
-	UserData                 *terraform.Literal             `json:"user_data,omitempty" cty:"user_data"`
-	IAMInstanceProfile       *terraform.Literal             `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
-	KeyName                  *terraform.Literal             `json:"key_name,omitempty" cty:"key_name"`
+	UserData                 *terraformWriter.Literal       `json:"user_data,omitempty" cty:"user_data"`
+	IAMInstanceProfile       *terraformWriter.Literal       `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
+	KeyName                  *terraformWriter.Literal       `json:"key_name,omitempty" cty:"key_name"`
 	InstanceTypes            []string                       `json:"instance_types,omitempty" cty:"instance_types"`
-	SubnetIDs                []*terraform.Literal           `json:"subnet_ids,omitempty" cty:"subnet_ids"`
-	SecurityGroups           []*terraform.Literal           `json:"security_groups,omitempty" cty:"security_groups"`
+	SubnetIDs                []*terraformWriter.Literal     `json:"subnet_ids,omitempty" cty:"subnet_ids"`
+	SecurityGroups           []*terraformWriter.Literal     `json:"security_groups,omitempty" cty:"security_groups"`
 	Taints                   []*terraformTaint              `json:"taints,omitempty" cty:"taints"`
 	Labels                   []*terraformKV                 `json:"labels,omitempty" cty:"labels"`
 	Tags                     []*terraformKV                 `json:"tags,omitempty" cty:"tags"`
@@ -981,8 +982,8 @@ func (_ *LaunchSpec) RenderTerraform(t *terraform.TerraformTarget, a, e, changes
 	return t.RenderResource("spotinst_ocean_aws_launch_spec", *e.Name, tf)
 }
 
-func (o *LaunchSpec) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("spotinst_ocean_aws_launch_spec", *o.Name, "id")
+func (o *LaunchSpec) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("spotinst_ocean_aws_launch_spec", *o.Name, "id")
 }
 
 func (o *LaunchSpec) buildTags() []*aws.Tag {

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -1059,7 +1059,7 @@ func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Oce
 	// User data.
 	if e.UserData != nil {
 		var err error
-		tf.UserData, err = t.AddFile("spotinst_ocean_aws", *e.Name, "user_data", e.UserData, false)
+		tf.UserData, err = t.AddFileResource("spotinst_ocean_aws", *e.Name, "user_data", e.UserData, false)
 		if err != nil {
 			return err
 		}

--- a/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
+++ b/upup/pkg/fi/cloudup/spotinsttasks/ocean.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 // +kops:fitask
@@ -977,14 +978,14 @@ func (_ *Ocean) update(cloud awsup.AWSCloud, a, e, changes *Ocean) error {
 }
 
 type terraformOcean struct {
-	Name                   *string              `json:"name,omitempty" cty:"name"`
-	ControllerClusterID    *string              `json:"controller_id,omitempty" cty:"controller_id"`
-	Region                 *string              `json:"region,omitempty" cty:"region"`
-	InstanceTypesWhitelist []string             `json:"whitelist,omitempty" cty:"whitelist"`
-	InstanceTypesBlacklist []string             `json:"blacklist,omitempty" cty:"blacklist"`
-	SubnetIDs              []*terraform.Literal `json:"subnet_ids,omitempty" cty:"subnet_ids"`
-	AutoScaler             *terraformAutoScaler `json:"autoscaler,omitempty" cty:"autoscaler"`
-	Tags                   []*terraformKV       `json:"tags,omitempty" cty:"tags"`
+	Name                   *string                    `json:"name,omitempty" cty:"name"`
+	ControllerClusterID    *string                    `json:"controller_id,omitempty" cty:"controller_id"`
+	Region                 *string                    `json:"region,omitempty" cty:"region"`
+	InstanceTypesWhitelist []string                   `json:"whitelist,omitempty" cty:"whitelist"`
+	InstanceTypesBlacklist []string                   `json:"blacklist,omitempty" cty:"blacklist"`
+	SubnetIDs              []*terraformWriter.Literal `json:"subnet_ids,omitempty" cty:"subnet_ids"`
+	AutoScaler             *terraformAutoScaler       `json:"autoscaler,omitempty" cty:"autoscaler"`
+	Tags                   []*terraformKV             `json:"tags,omitempty" cty:"tags"`
 
 	MinSize         *int64 `json:"min_size,omitempty" cty:"min_size"`
 	MaxSize         *int64 `json:"max_size,omitempty" cty:"max_size"`
@@ -995,15 +996,15 @@ type terraformOcean struct {
 	DrainingTimeout          *int64 `json:"draining_timeout,omitempty" cty:"draining_timeout"`
 	GracePeriod              *int64 `json:"grace_period,omitempty" cty:"grace_period"`
 
-	Monitoring               *bool                `json:"monitoring,omitempty" cty:"monitoring"`
-	EBSOptimized             *bool                `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
-	ImageID                  *string              `json:"image_id,omitempty" cty:"image_id"`
-	AssociatePublicIPAddress *bool                `json:"associate_public_ip_address,omitempty" cty:"associate_public_ip_address"`
-	RootVolumeSize           *int64               `json:"root_volume_size,omitempty" cty:"root_volume_size"`
-	UserData                 *terraform.Literal   `json:"user_data,omitempty" cty:"user_data"`
-	IAMInstanceProfile       *terraform.Literal   `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
-	KeyName                  *terraform.Literal   `json:"key_name,omitempty" cty:"key_name"`
-	SecurityGroups           []*terraform.Literal `json:"security_groups,omitempty" cty:"security_groups"`
+	Monitoring               *bool                      `json:"monitoring,omitempty" cty:"monitoring"`
+	EBSOptimized             *bool                      `json:"ebs_optimized,omitempty" cty:"ebs_optimized"`
+	ImageID                  *string                    `json:"image_id,omitempty" cty:"image_id"`
+	AssociatePublicIPAddress *bool                      `json:"associate_public_ip_address,omitempty" cty:"associate_public_ip_address"`
+	RootVolumeSize           *int64                     `json:"root_volume_size,omitempty" cty:"root_volume_size"`
+	UserData                 *terraformWriter.Literal   `json:"user_data,omitempty" cty:"user_data"`
+	IAMInstanceProfile       *terraformWriter.Literal   `json:"iam_instance_profile,omitempty" cty:"iam_instance_profile"`
+	KeyName                  *terraformWriter.Literal   `json:"key_name,omitempty" cty:"key_name"`
+	SecurityGroups           []*terraformWriter.Literal `json:"security_groups,omitempty" cty:"security_groups"`
 }
 
 func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Ocean) error {
@@ -1171,8 +1172,8 @@ func (_ *Ocean) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Oce
 	return t.RenderResource("spotinst_ocean_aws", *e.Name, tf)
 }
 
-func (o *Ocean) TerraformLink() *terraform.Literal {
-	return terraform.LiteralProperty("spotinst_ocean_aws", *o.Name, "id")
+func (o *Ocean) TerraformLink() *terraformWriter.Literal {
+	return terraformWriter.LiteralProperty("spotinst_ocean_aws", *o.Name, "id")
 }
 
 func (o *Ocean) buildTags() []*aws.Tag {

--- a/upup/pkg/fi/cloudup/terraform/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/terraform/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     srcs = [
         "hcl2.go",
         "lifecycle.go",
-        "literal.go",
         "target.go",
         "target_hcl2.go",
         "target_json.go",
@@ -16,6 +15,7 @@ go_library(
         "//pkg/apis/kops:go_default_library",
         "//pkg/featureflag:go_default_library",
         "//upup/pkg/fi:go_default_library",
+        "//upup/pkg/fi/cloudup/terraformWriter:go_default_library",
         "//vendor/github.com/hashicorp/hcl/v2:go_default_library",
         "//vendor/github.com/hashicorp/hcl/v2/hclsyntax:go_default_library",
         "//vendor/github.com/hashicorp/hcl/v2/hclwrite:go_default_library",
@@ -34,6 +34,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/diff:go_default_library",
+        "//upup/pkg/fi/cloudup/terraformWriter:go_default_library",
         "//vendor/github.com/hashicorp/hcl/v2/hclwrite:go_default_library",
         "//vendor/github.com/zclconf/go-cty/cty:go_default_library",
         "//vendor/github.com/zclconf/go-cty/cty/gocty:go_default_library",

--- a/upup/pkg/fi/cloudup/terraform/literal.go
+++ b/upup/pkg/fi/cloudup/terraform/literal.go
@@ -134,9 +134,13 @@ func SortLiterals(v []*Literal) {
 	}
 }
 
-// DedupLiterals removes any duplicate Literals before returning the slice.
+// dedupLiterals removes any duplicate Literals before returning the slice.
 // As a side-effect, it currently returns the Literals in sorted order.
-func DedupLiterals(v []*Literal) ([]*Literal, error) {
+func dedupLiterals(v []*Literal) ([]*Literal, error) {
+	if v == nil {
+		return nil, nil
+	}
+
 	proxies, err := buildSortProxies(v)
 	if err != nil {
 		return nil, err

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -94,19 +94,24 @@ func tfSanitize(name string) string {
 	return strings.NewReplacer(".", "-", "/", "--", ":", "_").Replace(name)
 }
 
-func (t *TerraformTarget) AddFile(resourceType string, resourceName string, key string, r fi.Resource, base64 bool) (*Literal, error) {
-	id := resourceType + "_" + resourceName + "_" + key
-
+func (t *TerraformTarget) AddFileResource(resourceType string, resourceName string, key string, r fi.Resource, base64 bool) (*Literal, error) {
 	d, err := fi.ResourceAsBytes(r)
 	if err != nil {
+		id := resourceType + "_" + resourceName + "_" + key
 		return nil, fmt.Errorf("error rending resource %s %v", id, err)
 	}
+
+	return t.AddFileBytes(resourceType, resourceName, key, d, base64)
+}
+
+func (t *TerraformTarget) AddFileBytes(resourceType string, resourceName string, key string, data []byte, base64 bool) (*Literal, error) {
+	id := resourceType + "_" + resourceName + "_" + key
 
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
 	p := path.Join("data", id)
-	t.files[p] = d
+	t.files[p] = data
 
 	modulePath := path.Join("${path.module}", p)
 	l := LiteralFileExpression(modulePath, base64)

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -21,77 +21,41 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strconv"
-	"strings"
-	"sync"
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 type TerraformTarget struct {
+	terraformWriter.TerraformWriter
 	Cloud   fi.Cloud
 	Project string
 
 	ClusterName string
 
 	outDir string
-
-	// mutex protects the following items (resources & files)
-	mutex sync.Mutex
-	// resources is a list of TF items that should be created
-	resources []*terraformResource
-	// outputs is a list of our TF output variables
-	outputs map[string]*terraformOutputVariable
-	// files is a map of TF resource files that should be created
-	files map[string][]byte
 	// extra config to add to the provider block
 	clusterSpecTarget *kops.TargetSpec
 }
 
 func NewTerraformTarget(cloud fi.Cloud, project string, outDir string, clusterSpecTarget *kops.TargetSpec) *TerraformTarget {
-	return &TerraformTarget{
+	target := TerraformTarget{
 		Cloud:   cloud,
 		Project: project,
 
 		outDir:            outDir,
-		files:             make(map[string][]byte),
-		outputs:           make(map[string]*terraformOutputVariable),
 		clusterSpecTarget: clusterSpecTarget,
 	}
+	target.InitTerraformWriter()
+	return &target
 }
 
 var _ fi.Target = &TerraformTarget{}
 
-type terraformResource struct {
-	ResourceType string
-	ResourceName string
-	Item         interface{}
-}
-
-type terraformOutputVariable struct {
-	Key        string
-	Value      *Literal
-	ValueArray []*Literal
-}
-
-type terraformOutputValue struct {
-	Value      *Literal
-	ValueArray []*Literal
-}
-
-// A TF name can't have dots in it (if we want to refer to it from a literal),
-// so we replace them
-func tfSanitize(name string) string {
-	if _, err := strconv.Atoi(string(name[0])); err == nil {
-		panic(fmt.Sprintf("Terraform resource names cannot start with a digit. This is a bug in Kops, please report this in a GitHub Issue. Name: %v", name))
-	}
-	return strings.NewReplacer(".", "-", "/", "--", ":", "_").Replace(name)
-}
-
-func (t *TerraformTarget) AddFileResource(resourceType string, resourceName string, key string, r fi.Resource, base64 bool) (*Literal, error) {
+func (t *TerraformTarget) AddFileResource(resourceType string, resourceName string, key string, r fi.Resource, base64 bool) (*terraformWriter.Literal, error) {
 	d, err := fi.ResourceAsBytes(r)
 	if err != nil {
 		id := resourceType + "_" + resourceName + "_" + key
@@ -101,74 +65,9 @@ func (t *TerraformTarget) AddFileResource(resourceType string, resourceName stri
 	return t.AddFileBytes(resourceType, resourceName, key, d, base64)
 }
 
-func (t *TerraformTarget) AddFileBytes(resourceType string, resourceName string, key string, data []byte, base64 bool) (*Literal, error) {
-	id := resourceType + "_" + resourceName + "_" + key
-
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-
-	p := path.Join("data", id)
-	t.files[p] = data
-
-	modulePath := path.Join("${path.module}", p)
-	l := LiteralFileExpression(modulePath, base64)
-	return l, nil
-}
-
 func (t *TerraformTarget) ProcessDeletions() bool {
 	// Terraform tracks & performs deletions itself
 	return false
-}
-
-func (t *TerraformTarget) RenderResource(resourceType string, resourceName string, e interface{}) error {
-	res := &terraformResource{
-		ResourceType: resourceType,
-		ResourceName: resourceName,
-		Item:         e,
-	}
-
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-
-	t.resources = append(t.resources, res)
-
-	return nil
-}
-
-func (t *TerraformTarget) AddOutputVariable(key string, literal *Literal) error {
-	v := &terraformOutputVariable{
-		Key:   key,
-		Value: literal,
-	}
-
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-
-	if t.outputs[key] != nil {
-		return fmt.Errorf("duplicate variable: %q", key)
-	}
-	t.outputs[key] = v
-
-	return nil
-}
-
-func (t *TerraformTarget) AddOutputVariableArray(key string, literal *Literal) error {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-
-	if t.outputs[key] == nil {
-		v := &terraformOutputVariable{
-			Key: key,
-		}
-		t.outputs[key] = v
-	}
-	if t.outputs[key].Value != nil {
-		return fmt.Errorf("variable %q is both an array and a scalar", key)
-	}
-
-	t.outputs[key].ValueArray = append(t.outputs[key].ValueArray, literal)
-
-	return nil
 }
 
 // tfGetProviderExtraConfig is a helper function to get extra config with safety checks on the pointers.
@@ -192,7 +91,7 @@ func (t *TerraformTarget) Finish(taskMap map[string]fi.Task) error {
 		return err
 	}
 
-	for relativePath, contents := range t.files {
+	for relativePath, contents := range t.Files {
 		p := path.Join(t.outDir, relativePath)
 
 		err = os.MkdirAll(path.Dir(p), os.FileMode(0755))
@@ -208,45 +107,4 @@ func (t *TerraformTarget) Finish(taskMap map[string]fi.Task) error {
 	klog.Infof("Terraform output is in %s", t.outDir)
 
 	return nil
-}
-
-func (t *TerraformTarget) getResourcesByType() (map[string]map[string]interface{}, error) {
-	resourcesByType := make(map[string]map[string]interface{})
-
-	for _, res := range t.resources {
-		resources := resourcesByType[res.ResourceType]
-		if resources == nil {
-			resources = make(map[string]interface{})
-			resourcesByType[res.ResourceType] = resources
-		}
-
-		tfName := tfSanitize(res.ResourceName)
-
-		if resources[tfName] != nil {
-			return nil, fmt.Errorf("duplicate resource found: %s.%s", res.ResourceType, tfName)
-		}
-
-		resources[tfName] = res.Item
-	}
-
-	return resourcesByType, nil
-}
-
-func (t *TerraformTarget) getOutputs() (map[string]terraformOutputValue, error) {
-	values := map[string]terraformOutputValue{}
-	for _, v := range t.outputs {
-		tfName := tfSanitize(v.Key)
-		if _, found := values[tfName]; found {
-			return nil, fmt.Errorf("duplicate variable found: %s", tfName)
-		}
-		deduped, err := dedupLiterals(v.ValueArray)
-		if err != nil {
-			return nil, err
-		}
-		values[tfName] = terraformOutputValue{
-			Value:      v.Value,
-			ValueArray: deduped,
-		}
-	}
-	return values, nil
 }

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -75,7 +75,7 @@ type byTypeAndName []*terraformResource
 
 func (a byTypeAndName) Len() int { return len(a) }
 func (a byTypeAndName) Less(i, j int) bool {
-	return a[i].ResourceType+a[i].ResourceName < a[j].ResourceType+a[j].ResourceName
+	return a[i].ResourceType+" "+tfSanitize(a[i].ResourceName) < a[j].ResourceType+" "+tfSanitize(a[j].ResourceName)
 }
 func (a byTypeAndName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -145,7 +145,9 @@ func writeLocalsOutputs(body *hclwrite.Body, outputs map[string]*terraformOutput
 	for k := range outputs {
 		outputNames = append(outputNames, k)
 	}
-	sort.Strings(outputNames)
+	sort.Slice(outputNames, func(i, j int) bool {
+		return tfSanitize(outputs[outputNames[i]].Key) < tfSanitize(outputs[outputNames[j]].Key)
+	})
 
 	for _, n := range outputNames {
 		v := outputs[n]

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -26,13 +26,14 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 func (t *TerraformTarget) finishHCL2(taskMap map[string]fi.Task) error {
 	f := hclwrite.NewEmptyFile()
 	rootBody := f.Body()
 
-	outputs, err := t.getOutputs()
+	outputs, err := t.GetOutputs()
 	if err != nil {
 		return err
 	}
@@ -50,7 +51,7 @@ func (t *TerraformTarget) finishHCL2(taskMap map[string]fi.Task) error {
 	}
 	rootBody.AppendNewline()
 
-	resourcesByType, err := t.getResourcesByType()
+	resourcesByType, err := t.GetResourcesByType()
 	if err != nil {
 		return err
 	}
@@ -117,7 +118,7 @@ func (t *TerraformTarget) finishHCL2(taskMap map[string]fi.Task) error {
 	}
 
 	bytes := hclwrite.Format(f.Bytes())
-	t.files["kubernetes.tf"] = bytes
+	t.Files["kubernetes.tf"] = bytes
 
 	return nil
 }
@@ -134,7 +135,7 @@ func (t *TerraformTarget) finishHCL2(taskMap map[string]fi.Task) error {
 // output "key2" {
 //   value = "value2"
 // }
-func writeLocalsOutputs(body *hclwrite.Body, outputs map[string]terraformOutputValue) error {
+func writeLocalsOutputs(body *hclwrite.Body, outputs map[string]terraformWriter.OutputValue) error {
 	if len(outputs) == 0 {
 		return nil
 	}

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2_test.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2_test.go
@@ -27,7 +27,7 @@ import (
 func TestWriteLocalsOutputs(t *testing.T) {
 	cases := []struct {
 		name        string
-		values      map[string]*terraformOutputVariable
+		values      map[string]terraformOutputValue
 		expected    string
 		errExpected bool
 	}{
@@ -37,9 +37,8 @@ func TestWriteLocalsOutputs(t *testing.T) {
 		},
 		{
 			name: "single output",
-			values: map[string]*terraformOutputVariable{
+			values: map[string]terraformOutputValue{
 				"key1": {
-					Key:   "key1",
 					Value: LiteralFromStringValue("value1"),
 				},
 			},
@@ -54,45 +53,9 @@ output "key1" {
 		},
 		{
 			name: "list output",
-			values: map[string]*terraformOutputVariable{
+			values: map[string]terraformOutputValue{
 				"key1": {
-					Key: "key1",
 					ValueArray: []*Literal{
-						LiteralFromStringValue("value2"),
-						LiteralFromStringValue("value1"),
-					},
-				},
-			},
-			expected: `
-locals {
-  key1 = ["value1", "value2"]
-}
-
-output "key1" {
-  value = ["value1", "value2"]
-}`,
-		},
-		{
-			name: "duplicate names",
-			values: map[string]*terraformOutputVariable{
-				"key.1": {
-					Key:   "key.1",
-					Value: LiteralFromStringValue("value1"),
-				},
-				"key-1": {
-					Key:   "key-1",
-					Value: LiteralFromStringValue("value2"),
-				},
-			},
-			errExpected: true,
-		},
-		{
-			name: "duplicate values",
-			values: map[string]*terraformOutputVariable{
-				"key1": {
-					Key: "key1",
-					ValueArray: []*Literal{
-						LiteralFromStringValue("value1"),
 						LiteralFromStringValue("value1"),
 						LiteralFromStringValue("value2"),
 					},

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2_test.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2_test.go
@@ -22,12 +22,13 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"k8s.io/kops/pkg/diff"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
 )
 
 func TestWriteLocalsOutputs(t *testing.T) {
 	cases := []struct {
 		name        string
-		values      map[string]terraformOutputValue
+		values      map[string]terraformWriter.OutputValue
 		expected    string
 		errExpected bool
 	}{
@@ -37,9 +38,9 @@ func TestWriteLocalsOutputs(t *testing.T) {
 		},
 		{
 			name: "single output",
-			values: map[string]terraformOutputValue{
+			values: map[string]terraformWriter.OutputValue{
 				"key1": {
-					Value: LiteralFromStringValue("value1"),
+					Value: terraformWriter.LiteralFromStringValue("value1"),
 				},
 			},
 			expected: `
@@ -53,11 +54,11 @@ output "key1" {
 		},
 		{
 			name: "list output",
-			values: map[string]terraformOutputValue{
+			values: map[string]terraformWriter.OutputValue{
 				"key1": {
-					ValueArray: []*Literal{
-						LiteralFromStringValue("value1"),
-						LiteralFromStringValue("value2"),
+					ValueArray: []*terraformWriter.Literal{
+						terraformWriter.LiteralFromStringValue("value1"),
+						terraformWriter.LiteralFromStringValue("value2"),
 					},
 				},
 			},

--- a/upup/pkg/fi/cloudup/terraform/target_json.go
+++ b/upup/pkg/fi/cloudup/terraform/target_json.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (t *TerraformTarget) finishJSON(taskMap map[string]fi.Task) error {
-	resourcesByType, err := t.getResourcesByType()
+	resourcesByType, err := t.GetResourcesByType()
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func (t *TerraformTarget) finishJSON(taskMap map[string]fi.Task) error {
 		providersByName["aws"] = providerAWS
 	}
 
-	outputs, err := t.getOutputs()
+	outputs, err := t.GetOutputs()
 	if err != nil {
 		return err
 	}
@@ -110,6 +110,6 @@ func (t *TerraformTarget) finishJSON(taskMap map[string]fi.Task) error {
 		return fmt.Errorf("error marshaling terraform data to json: %v", err)
 	}
 
-	t.files["kubernetes.tf.json"] = jsonBytes
+	t.Files["kubernetes.tf.json"] = jsonBytes
 	return nil
 }

--- a/upup/pkg/fi/cloudup/terraform/target_json.go
+++ b/upup/pkg/fi/cloudup/terraform/target_json.go
@@ -25,22 +25,9 @@ import (
 )
 
 func (t *TerraformTarget) finishJSON(taskMap map[string]fi.Task) error {
-	resourcesByType := make(map[string]map[string]interface{})
-
-	for _, res := range t.resources {
-		resources := resourcesByType[res.ResourceType]
-		if resources == nil {
-			resources = make(map[string]interface{})
-			resourcesByType[res.ResourceType] = resources
-		}
-
-		tfName := tfSanitize(res.ResourceName)
-
-		if resources[tfName] != nil {
-			return fmt.Errorf("duplicate resource found: %s.%s", res.ResourceType, tfName)
-		}
-
-		resources[tfName] = res.Item
+	resourcesByType, err := t.getResourcesByType()
+	if err != nil {
+		return err
 	}
 
 	providersByName := make(map[string]map[string]interface{})

--- a/upup/pkg/fi/cloudup/terraform/target_test.go
+++ b/upup/pkg/fi/cloudup/terraform/target_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetOutputs(t *testing.T) {
+	cases := []struct {
+		name        string
+		values      map[string]*terraformOutputVariable
+		expected    map[string]terraformOutputValue
+		errExpected bool
+	}{
+		{
+			name: "empty map",
+		},
+		{
+			name: "single output",
+			values: map[string]*terraformOutputVariable{
+				"keyOne": {
+					Key:   "key1",
+					Value: LiteralFromStringValue("value1"),
+				},
+			},
+			expected: map[string]terraformOutputValue{
+				"key1": {
+					Value: LiteralFromStringValue("value1"),
+				},
+			},
+		},
+		{
+			name: "list output",
+			values: map[string]*terraformOutputVariable{
+				"keyOne": {
+					Key: "key1",
+					ValueArray: []*Literal{
+						LiteralFromStringValue("value2"),
+						LiteralFromStringValue("value1"),
+					},
+				},
+			},
+			expected: map[string]terraformOutputValue{
+				"key1": {
+					ValueArray: []*Literal{
+						LiteralFromStringValue("value1"),
+						LiteralFromStringValue("value2"),
+					},
+				},
+			},
+		},
+		{
+			name: "duplicate names",
+			values: map[string]*terraformOutputVariable{
+				"key.1": {
+					Key:   "key.1",
+					Value: LiteralFromStringValue("value1"),
+				},
+				"key-1": {
+					Key:   "key-1",
+					Value: LiteralFromStringValue("value2"),
+				},
+			},
+			errExpected: true,
+		},
+		{
+			name: "duplicate values",
+			values: map[string]*terraformOutputVariable{
+				"keyOne": {
+					Key: "key1",
+					ValueArray: []*Literal{
+						LiteralFromStringValue("value1"),
+						LiteralFromStringValue("value1"),
+						LiteralFromStringValue("value2"),
+					},
+				},
+			},
+			expected: map[string]terraformOutputValue{
+				"key1": {
+					ValueArray: []*Literal{
+						LiteralFromStringValue("value1"),
+						LiteralFromStringValue("value2"),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target := TerraformTarget{
+				outputs: tc.values,
+			}
+			actual, err := target.getOutputs()
+			if tc.errExpected {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.ObjectsAreEqual(tc.expected, actual)
+		})
+	}
+}

--- a/upup/pkg/fi/cloudup/terraformWriter/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/terraformWriter/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "literal.go",
+        "writer.go",
+    ],
+    importpath = "k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/klog/v2:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["writer_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
+    ],
+)

--- a/upup/pkg/fi/cloudup/terraformWriter/literal.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/literal.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package terraform
+package terraformWriter
 
 import (
 	"encoding/json"

--- a/upup/pkg/fi/cloudup/terraformWriter/writer.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/writer.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terraformWriter
+
+import (
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+type TerraformWriter struct {
+	// mutex protects the following items (resources & Files)
+	mutex sync.Mutex
+	// resources is a list of TF items that should be created
+	resources []*terraformResource
+	// outputs is a list of our TF output variables
+	outputs map[string]*terraformOutputVariable
+	// Files is a map of TF resource Files that should be created
+	Files map[string][]byte
+}
+
+type OutputValue struct {
+	Value      *Literal
+	ValueArray []*Literal
+}
+
+type terraformResource struct {
+	ResourceType string
+	ResourceName string
+	Item         interface{}
+}
+
+type terraformOutputVariable struct {
+	Key        string
+	Value      *Literal
+	ValueArray []*Literal
+}
+
+// A TF name can't have dots in it (if we want to refer to it from a literal),
+// so we replace them
+func tfSanitize(name string) string {
+	if _, err := strconv.Atoi(string(name[0])); err == nil {
+		panic(fmt.Sprintf("Terraform resource names cannot start with a digit. This is a bug in Kops, please report this in a GitHub Issue. Name: %v", name))
+	}
+	return strings.NewReplacer(".", "-", "/", "--", ":", "_").Replace(name)
+}
+
+func (t *TerraformWriter) InitTerraformWriter() {
+	t.Files = make(map[string][]byte)
+	t.outputs = make(map[string]*terraformOutputVariable)
+}
+
+func (t *TerraformWriter) AddFileBytes(resourceType string, resourceName string, key string, data []byte, base64 bool) (*Literal, error) {
+	id := resourceType + "_" + resourceName + "_" + key
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	p := path.Join("data", id)
+	t.Files[p] = data
+
+	modulePath := path.Join("${path.module}", p)
+	l := LiteralFileExpression(modulePath, base64)
+	return l, nil
+}
+
+func (t *TerraformWriter) RenderResource(resourceType string, resourceName string, e interface{}) error {
+	res := &terraformResource{
+		ResourceType: resourceType,
+		ResourceName: resourceName,
+		Item:         e,
+	}
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	t.resources = append(t.resources, res)
+
+	return nil
+}
+
+func (t *TerraformWriter) AddOutputVariable(key string, literal *Literal) error {
+	v := &terraformOutputVariable{
+		Key:   key,
+		Value: literal,
+	}
+
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	if t.outputs[key] != nil {
+		return fmt.Errorf("duplicate variable: %q", key)
+	}
+	t.outputs[key] = v
+
+	return nil
+}
+
+func (t *TerraformWriter) AddOutputVariableArray(key string, literal *Literal) error {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	if t.outputs[key] == nil {
+		v := &terraformOutputVariable{
+			Key: key,
+		}
+		t.outputs[key] = v
+	}
+	if t.outputs[key].Value != nil {
+		return fmt.Errorf("variable %q is both an array and a scalar", key)
+	}
+
+	t.outputs[key].ValueArray = append(t.outputs[key].ValueArray, literal)
+
+	return nil
+}
+
+func (t *TerraformWriter) GetResourcesByType() (map[string]map[string]interface{}, error) {
+	resourcesByType := make(map[string]map[string]interface{})
+
+	for _, res := range t.resources {
+		resources := resourcesByType[res.ResourceType]
+		if resources == nil {
+			resources = make(map[string]interface{})
+			resourcesByType[res.ResourceType] = resources
+		}
+
+		tfName := tfSanitize(res.ResourceName)
+
+		if resources[tfName] != nil {
+			return nil, fmt.Errorf("duplicate resource found: %s.%s", res.ResourceType, tfName)
+		}
+
+		resources[tfName] = res.Item
+	}
+
+	return resourcesByType, nil
+}
+
+func (t *TerraformWriter) GetOutputs() (map[string]OutputValue, error) {
+	values := map[string]OutputValue{}
+	for _, v := range t.outputs {
+		tfName := tfSanitize(v.Key)
+		if _, found := values[tfName]; found {
+			return nil, fmt.Errorf("duplicate variable found: %s", tfName)
+		}
+		deduped, err := dedupLiterals(v.ValueArray)
+		if err != nil {
+			return nil, err
+		}
+		values[tfName] = OutputValue{
+			Value:      v.Value,
+			ValueArray: deduped,
+		}
+	}
+	return values, nil
+}

--- a/upup/pkg/fi/cloudup/terraformWriter/writer_test.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/writer_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package terraform
+package terraformWriter
 
 import (
 	"testing"
@@ -27,7 +27,7 @@ func TestGetOutputs(t *testing.T) {
 	cases := []struct {
 		name        string
 		values      map[string]*terraformOutputVariable
-		expected    map[string]terraformOutputValue
+		expected    map[string]OutputValue
 		errExpected bool
 	}{
 		{
@@ -41,7 +41,7 @@ func TestGetOutputs(t *testing.T) {
 					Value: LiteralFromStringValue("value1"),
 				},
 			},
-			expected: map[string]terraformOutputValue{
+			expected: map[string]OutputValue{
 				"key1": {
 					Value: LiteralFromStringValue("value1"),
 				},
@@ -58,7 +58,7 @@ func TestGetOutputs(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]terraformOutputValue{
+			expected: map[string]OutputValue{
 				"key1": {
 					ValueArray: []*Literal{
 						LiteralFromStringValue("value1"),
@@ -93,7 +93,7 @@ func TestGetOutputs(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]terraformOutputValue{
+			expected: map[string]OutputValue{
 				"key1": {
 					ValueArray: []*Literal{
 						LiteralFromStringValue("value1"),
@@ -105,10 +105,10 @@ func TestGetOutputs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			target := TerraformTarget{
+			target := TerraformWriter{
 				outputs: tc.values,
 			}
-			actual, err := target.getOutputs()
+			actual, err := target.GetOutputs()
 			if tc.errExpected {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
When working on #9621 I tried pushing Terraform generation into VFS but ran into an import loop. In order to break that import loop this breaks out a separate `terraformWriter.TerraformWriter` API in a separate package so that things that generate Terraform don't have to depend on the `fi` package.
