### PR TITLE
add permission to create sa tokens

### DIFF
--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
@@ -88,6 +88,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create


### PR DESCRIPTION
https://github.com/kubernetes/controller-manager/blob/v0.21.0/pkg/clientbuilder/client_builder_dynamic.go#L201

seems that controller manager needs new permission that is not documented anywhere.