### PR TITLE
Remove unused k8s version parsing

### DIFF
--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -17,10 +17,8 @@ limitations under the License.
 package model
 
 import (
-	"fmt"
 	"strings"
 
-	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
@@ -47,11 +45,6 @@ func (b *LogrotateBuilder) Build(c *fi.ModelBuilderContext) error {
 		klog.Infof("Detected Flatcar; won't install logrotate")
 	default:
 		c.AddTask(&nodetasks.Package{Name: "logrotate"})
-	}
-
-	k8sVersion, err := util.ParseKubernetesVersion(b.Cluster.Spec.KubernetesVersion)
-	if err != nil || k8sVersion == nil {
-		return fmt.Errorf("unable to parse KubernetesVersion %q", b.Cluster.Spec.KubernetesVersion)
 	}
 
 	b.addLogRotate(c, "docker", "/var/log/docker.log", logRotateOptions{})


### PR DESCRIPTION
"unused variable" linting didn't catch this because we were referencing `k8sVersion` in the error check conditional.