### PR TITLE
Kubetest2 - Fix GNU mktemp syntax

### DIFF
--- a/tests/e2e/scenarios/kops-upgrade/run-test.sh
+++ b/tests/e2e/scenarios/kops-upgrade/run-test.sh
@@ -28,7 +28,7 @@ if [ -z "$FIRST_VERSION" ] || [ -z "$K8S_VERSION" ]; then
   exit 1
 fi
 
-FIRST_KOPS=$(mktemp -t kops)
+FIRST_KOPS=$(mktemp -t kops.XXXXXXXXX)
 wget -o "${FIRST_KOPS}" "https://github.com/kubernetes/kops/releases/download/$FIRST_VERSION/kops-$(go env GOOS)-$(go env GOARCH)"
 chmod +x "${FIRST_KOPS}"
 


### PR DESCRIPTION
apparently it is significantly different from BSD.

fixes https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-misc-kops-upgrade/1389903687089917952