### PR TITLE
kubetest2 - remove unnecessary flags from upgrade scripts

### DIFF
--- a/tests/e2e/scenarios/k8s-upgrade/run-test.sh
+++ b/tests/e2e/scenarios/k8s-upgrade/run-test.sh
@@ -62,6 +62,4 @@ ${KUBETEST2} \
 		-- \
 		--test-package-version=v1.20.6 \
 		--parallel 25 \
-		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|TCP.CLOSE_WAIT|Projected.configMap.optional.updates" \
-		--test-args="${TEST_ARGS}"
-
+		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|TCP.CLOSE_WAIT|Projected.configMap.optional.updates"

--- a/tests/e2e/scenarios/kops-upgrade/run-test.sh
+++ b/tests/e2e/scenarios/kops-upgrade/run-test.sh
@@ -69,9 +69,6 @@ ${KUBETEST2} \
 
 "${SECOND_KOPS}" validate cluster
 
-KUBECONFIG=${HOME}/.kube/config
-TEST_ARGS="--kubeconfig=${KUBECONFIG}"
-
 ${KUBETEST2} \
 		--cloud-provider="${CLOUD_PROVIDER}" \
 		--kops-binary-path="${SECOND_KOPS}" \
@@ -79,6 +76,4 @@ ${KUBETEST2} \
 		-- \
 		--test-package-version="${K8S_VERSION}" \
 		--parallel 25 \
-		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|TCP.CLOSE_WAIT|Projected.configMap.optional.updates" \
-		--test-args="${TEST_ARGS}"
-
+		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|TCP.CLOSE_WAIT|Projected.configMap.optional.updates"


### PR DESCRIPTION
The test arg logic is now handled internally within kubetest2-tester-kops so we don't need these flags

fixes https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-misc-upgrade/1390082366361309184#1:build-log.txt%3A1483