### PR TITLE
Automated cherry pick of #11393: Add elasticloadbalancing:ModifyTargetGroupAttributes to aws

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -696,6 +696,7 @@ func addAWSLoadbalancerControllerPermissions(p *Policy, clusterName string) {
 				"elasticloadbalancing:DescribeRules",
 				"elasticloadbalancing:DescribeTargetHealth",
 				"elasticloadbalancing:DescribeListenerCertificates",
+				"elasticloadbalancing:ModifyTargetGroupAttributes",
 				"elasticloadbalancing:CreateRule",
 			),
 			Resource: stringorslice.Slice([]string{"*"}),


### PR DESCRIPTION
Cherry pick of #11393 on release-1.20.

#11393: Add elasticloadbalancing:ModifyTargetGroupAttributes to aws

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.