### PR TITLE
Don't publish OIDC discovery if DiscoveryStore not set

### DIFF
--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -374,7 +374,7 @@ func ValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 	}
 
 	said := c.Spec.ServiceAccountIssuerDiscovery
-	if said != nil {
+	if said != nil && said.DiscoveryStore != "" {
 		saidStore := said.DiscoveryStore
 		saidStoreField := fieldSpec.Child("serviceAccountIssuerDiscovery", "discoveryStore")
 		base, err := vfs.Context.BuildVfsPath(saidStore)

--- a/pkg/model/issuerdiscovery.go
+++ b/pkg/model/issuerdiscovery.go
@@ -53,7 +53,7 @@ type oidcDiscovery struct {
 
 func (b *IssuerDiscoveryModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	said := b.Cluster.Spec.ServiceAccountIssuerDiscovery
-	if said == nil {
+	if said == nil || said.DiscoveryStore == "" {
 		return nil
 	}
 


### PR DESCRIPTION
Allows enabling trust by AWS with an externally-pubished or public-apiserver provider.