### PR TITLE
Automated cherry pick of #11098: Use etcd-manager built from etcdadm repo

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
 
-const DefaultBackupImage = "kopeio/etcd-backup:3.0.20210122"
+const DefaultBackupImage = "k8s.gcr.io/etcdadm/etcd-backup:3.0.20210430"
 
 // EtcdOptionsBuilder adds options for etcd to the model
 type EtcdOptionsBuilder struct {

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -172,7 +172,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20210228
+  - image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -83,7 +83,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:
@@ -154,7 +154,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -83,7 +83,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:
@@ -160,7 +160,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -86,7 +86,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:
@@ -160,7 +160,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
@@ -83,7 +83,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:
@@ -154,7 +154,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -92,7 +92,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:
@@ -178,7 +178,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: kopeio/etcd-manager:3.0.20210228
+      image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
       name: etcd-manager
       resources:
         requests:


### PR DESCRIPTION
Cherry pick of #11098 on release-1.21.

#11098: Use etcd-manager built from etcdadm repo

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.