### PR TITLE
Automated cherry pick of #11098: Use etcd-manager built from etcdadm repo

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
 
-const DefaultBackupImage = "kopeio/etcd-backup:3.0.20210122"
+const DefaultBackupImage = "k8s.gcr.io/etcdadm/etcd-backup:3.0.20210430"
 
 // EtcdOptionsBuilder adds options for etcd to the model
 type EtcdOptionsBuilder struct {

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -170,7 +170,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: kopeio/etcd-manager:3.0.20210122
+  - image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -80,7 +80,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997 --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20210122
+        image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
         name: etcd-manager
         resources:
           requests:
@@ -139,7 +139,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996 --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20210122
+        image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/old_versions_mount_hosts/tasks.yaml
@@ -80,7 +80,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3997 --insecure=false --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20210122
+        image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
         name: etcd-manager
         resources:
           requests:
@@ -145,7 +145,7 @@ Contents:
         - /bin/sh
         - -c
         - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true --dns-suffix=.internal.minimal.example.com --etcd-insecure=true --grpc-port=3996 --insecure=false --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-        image: kopeio/etcd-manager:3.0.20210122
+        image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -83,7 +83,7 @@ Contents:
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
-        image: kopeio/etcd-manager:3.0.20210122
+        image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
         name: etcd-manager
         resources:
           requests:
@@ -145,7 +145,7 @@ Contents:
         env:
         - name: ETCD_QUOTA_BACKEND_BYTES
           value: "10737418240"
-        image: kopeio/etcd-manager:3.0.20210122
+        image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
         name: etcd-manager
         resources:
           requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -89,7 +89,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20210122
+        image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
         name: etcd-manager
         resources:
           requests:
@@ -163,7 +163,7 @@ Contents:
           value: http://proxy.example.com
         - name: no_proxy
           value: noproxy.example.com
-        image: kopeio/etcd-manager:3.0.20210122
+        image: k8s.gcr.io/etcdadm/etcd-manager:3.0.20210430
         name: etcd-manager
         resources:
           requests:


### PR DESCRIPTION
Cherry pick of #11098 on release-1.19.

#11098: Use etcd-manager built from etcdadm repo

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.