### PR TITLE
Automated cherry pick of #11304: [csi/aws] Bump templates to latest#11326: Fix arguments to csi-provisioner after bump to v2.2.0#11418: Bump to GA release

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -260,8 +260,20 @@ spec:
                       driver
                     properties:
                       enabled:
-                        description: Enabled enables the AWS EBS CSI driver
+                        description: 'Enabled enables the AWS EBS CSI driver Default:
+                          false'
                         type: boolean
+                      version:
+                        description: 'Version is the container image tag used. Default:
+                          The latest stable release which is compatible with your
+                          Kubernetes version'
+                        type: string
+                      volumeAttachLimit:
+                        description: 'VolumeAttachLimit is the maximum number of volumes
+                          attachable per node. If specified, the limit applies to
+                          all nodes. If not specified, the value is approximated from
+                          the instance type. Default: -'
+                        type: integer
                     type: object
                   azure:
                     description: Azure cloud-config options

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -836,8 +836,19 @@ type CloudConfiguration struct {
 
 // AWSEBSCSIDriver is the config for the AWS EBS CSI driver
 type AWSEBSCSIDriver struct {
-	//Enabled enables the AWS EBS CSI driver
+	// Enabled enables the AWS EBS CSI driver
+	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
+
+	// Version is the container image tag used.
+	// Default: The latest stable release which is compatible with your Kubernetes version
+	Version *string `json:"version,omitempty"`
+
+	// VolumeAttachLimit is the maximum number of volumes attachable per node.
+	// If specified, the limit applies to all nodes.
+	// If not specified, the value is approximated from the instance type.
+	// Default: -
+	VolumeAttachLimit *int `json:"volumeAttachLimit,omitempty"`
 }
 
 // NodeTerminationHandlerConfig determines the node termination handler configuration.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -835,8 +835,19 @@ type CloudConfiguration struct {
 
 // AWSEBSCSIDriver is the config for the AWS EBS CSI driver
 type AWSEBSCSIDriver struct {
-	//Enabled enables the AWS EBS CSI driver
+	// Enabled enables the AWS EBS CSI driver
+	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
+
+	// Version is the container image tag used.
+	// Default: The latest stable release which is compatible with your Kubernetes version
+	Version *string `json:"version,omitempty"`
+
+	// VolumeAttachLimit is the maximum number of volumes attachable per node.
+	// If specified, the limit applies to all nodes.
+	// If not specified, the value is approximated from the instance type.
+	// Default: -
+	VolumeAttachLimit *int `json:"volumeAttachLimit,omitempty"`
 }
 
 // NodeTerminationHandlerConfig determines the node termination handler configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1058,6 +1058,8 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1alpha2_AWSEBSCSIDriver_To_kops_AWSEBSCSIDriver(in *AWSEBSCSIDriver, out *kops.AWSEBSCSIDriver, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Version = in.Version
+	out.VolumeAttachLimit = in.VolumeAttachLimit
 	return nil
 }
 
@@ -1068,6 +1070,8 @@ func Convert_v1alpha2_AWSEBSCSIDriver_To_kops_AWSEBSCSIDriver(in *AWSEBSCSIDrive
 
 func autoConvert_kops_AWSEBSCSIDriver_To_v1alpha2_AWSEBSCSIDriver(in *kops.AWSEBSCSIDriver, out *AWSEBSCSIDriver, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Version = in.Version
+	out.VolumeAttachLimit = in.VolumeAttachLimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -34,6 +34,16 @@ func (in *AWSEBSCSIDriver) DeepCopyInto(out *AWSEBSCSIDriver) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Version != nil {
+		in, out := &in.Version, &out.Version
+		*out = new(string)
+		**out = **in
+	}
+	if in.VolumeAttachLimit != nil {
+		in, out := &in.VolumeAttachLimit, &out.VolumeAttachLimit
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -34,6 +34,16 @@ func (in *AWSEBSCSIDriver) DeepCopyInto(out *AWSEBSCSIDriver) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Version != nil {
+		in, out := &in.Version, &out.Version
+		*out = new(string)
+		**out = **in
+	}
+	if in.VolumeAttachLimit != nil {
+		in, out := &in.VolumeAttachLimit, &out.VolumeAttachLimit
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/components/BUILD.bazel
+++ b/pkg/model/components/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "apiserver.go",
+        "awsebscsidriver.go",
         "calico.go",
         "cilium.go",
         "cloudconfiguration.go",

--- a/pkg/model/components/awsebscsidriver.go
+++ b/pkg/model/components/awsebscsidriver.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/loader"
+)
+
+// AWSEBSCSIDriverOptionsBuilder adds options for the AWS EBS CSI driver to the model
+type AWSEBSCSIDriverOptionsBuilder struct {
+	*OptionsContext
+}
+
+var _ loader.OptionsBuilder = &AWSEBSCSIDriverOptionsBuilder{}
+
+func (b *AWSEBSCSIDriverOptionsBuilder) BuildOptions(o interface{}) error {
+	clusterSpec := o.(*kops.ClusterSpec)
+	c := clusterSpec.CloudConfig.AWSEBSCSIDriver
+	if c == nil {
+		return nil
+	}
+
+	if c.Version == nil {
+		version := "v0.10.1"
+		c.Version = fi.String(version)
+	}
+
+	return nil
+
+}

--- a/pkg/model/components/awsebscsidriver.go
+++ b/pkg/model/components/awsebscsidriver.go
@@ -37,7 +37,7 @@ func (b *AWSEBSCSIDriverOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == nil {
-		version := "v0.10.1"
+		version := "v1.0.0"
 		c.Version = fi.String(version)
 	}
 

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -1162,8 +1162,7 @@ spec:
             - --csi-address=$(ADDRESS)
             - --v=5
             - --feature-gates=Topology=true
-            - --enable-leader-election
-            - --leader-election-type=leases
+            - --leader-election=true
             - --extra-create-metadata=true
           env:
             - name: ADDRESS

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -970,6 +970,45 @@ roleRef:
   name: ebs-external-snapshotter-role
   apiGroup: rbac.authorization.k8s.io
 ---
+# Source: aws-ebs-csi-driver/templates/clusterrolebinding-csi-node.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node-binding
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-node-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ebs-external-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: aws-ebs-csi-driver/templates/clusterrole-csi-node.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node-role
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+# Source: aws-ebs-csi-driver/templates/serviceaccount-csi-node.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-node-sa
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+    app.kubernetes.io/instance: aws-ebs-csi-driver
+    app.kubernetes.io/version: {{ .Version }}
+---
 # Source: aws-ebs-csi-driver/templates/node.yaml
 # Node Service
 kind: DaemonSet
@@ -998,6 +1037,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      serviceAccountName: ebs-csi-node-sa
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists
@@ -1017,6 +1057,10 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: CSI_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet

--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -757,7 +757,9 @@ func cloudupResourcesAddonsAwsCloudControllerAddonsK8sIoK8s118YamlTemplate() (*a
 	return a, nil
 }
 
-var _cloudupResourcesAddonsAwsEbsCsiDriverAddonsK8sIoK8s117YamlTemplate = []byte(`---
+var _cloudupResourcesAddonsAwsEbsCsiDriverAddonsK8sIoK8s117YamlTemplate = []byte(`{{ with .CloudConfig.AWSEBSCSIDriver }}
+# Latest Images Source: aws-ebs-csi-driver/values.yaml#L7-L34
+---
 # Source: aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -767,7 +769,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 ---
 # Source: aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
 kind: ClusterRole
@@ -777,7 +779,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -791,6 +793,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments/status" ]
+    verbs: [ "patch" ]
 ---
 # Source: aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
 kind: ClusterRole
@@ -800,35 +805,38 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch", "create", "delete" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch", "update" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "storageclasses" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "list", "watch", "create", "update", "patch" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshots" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csinodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources: [ "leases" ]
+    verbs: [ "get", "watch", "list", "delete", "update", "create" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments" ]
+    verbs: [ "get", "list", "watch" ]
 ---
 # Source: aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
 kind: ClusterRole
@@ -838,7 +846,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 rules:
   # The following rule should be uncommented for plugins that require secrets
   # for provisioning.
@@ -860,7 +868,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
 ---
 # Source: aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
 kind: ClusterRole
@@ -870,7 +880,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -896,7 +906,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
@@ -914,7 +924,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
@@ -932,7 +942,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
@@ -950,7 +960,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
@@ -970,7 +980,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 spec:
   selector:
     matchLabels:
@@ -983,7 +993,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        app.kubernetes.io/version: "0.8.0"
+        app.kubernetes.io/version: {{ .Version }}
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -995,10 +1005,13 @@ spec:
         - name: ebs-plugin
           securityContext:
             privileged: true
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:{{ .Version }}
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)
+            {{- if .VolumeAttachLimit }}
+            - --volume-attach-limit={{ .VolumeAttachLimit }}
+            {{- end }}
             - --logtostderr
             - --v=5
           env:
@@ -1025,7 +1038,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -1045,7 +1058,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.2.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:
@@ -1079,7 +1092,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 spec:
   replicas: 2
   selector:
@@ -1093,7 +1106,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        app.kubernetes.io/version: "0.8.0"
+        app.kubernetes.io/version: {{ .Version }}
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -1104,7 +1117,7 @@ spec:
         - operator: Exists
       containers:
         - name: ebs-plugin
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:{{ .Version }}
           imagePullPolicy: IfNotPresent
           args:
             - controller
@@ -1144,7 +1157,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -1159,7 +1172,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -1171,7 +1184,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
@@ -1182,7 +1195,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
           imagePullPolicy: Always
           args:
             - --csi-address=$(ADDRESS)
@@ -1194,7 +1207,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.1.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:
@@ -1205,17 +1218,18 @@ spec:
           emptyDir: {}
 ---
 # Source: aws-ebs-csi-driver/templates/csidriver.yaml
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 spec:
   attachRequired: true
   podInfoOnMount: false
+{{ end }}
 `)
 
 func cloudupResourcesAddonsAwsEbsCsiDriverAddonsK8sIoK8s117YamlTemplateBytes() ([]byte, error) {

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -1,3 +1,5 @@
+{{ with .CloudConfig.AWSEBSCSIDriver }}
+# Latest Images Source: aws-ebs-csi-driver/values.yaml#L7-L34
 ---
 # Source: aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
 apiVersion: v1
@@ -8,7 +10,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 ---
 # Source: aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
 kind: ClusterRole
@@ -18,7 +20,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -32,6 +34,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments/status" ]
+    verbs: [ "patch" ]
 ---
 # Source: aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
 kind: ClusterRole
@@ -41,35 +46,38 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 rules:
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csinodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumes" ]
+    verbs: [ "get", "list", "watch", "create", "delete" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims" ]
+    verbs: [ "get", "list", "watch", "update" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "storageclasses" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "list", "watch", "create", "update", "patch" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshots" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources: [ "volumesnapshotcontents" ]
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "csinodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "nodes" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources: [ "leases" ]
+    verbs: [ "get", "watch", "list", "delete", "update", "create" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattachments" ]
+    verbs: [ "get", "list", "watch" ]
 ---
 # Source: aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
 kind: ClusterRole
@@ -79,7 +87,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 rules:
   # The following rule should be uncommented for plugins that require secrets
   # for provisioning.
@@ -101,7 +109,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
 ---
 # Source: aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
 kind: ClusterRole
@@ -111,7 +121,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -137,7 +147,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
@@ -155,7 +165,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
@@ -173,7 +183,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
@@ -191,7 +201,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
@@ -211,7 +221,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 spec:
   selector:
     matchLabels:
@@ -224,7 +234,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        app.kubernetes.io/version: "0.8.0"
+        app.kubernetes.io/version: {{ .Version }}
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -236,10 +246,13 @@ spec:
         - name: ebs-plugin
           securityContext:
             privileged: true
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:{{ .Version }}
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)
+            {{- if .VolumeAttachLimit }}
+            - --volume-attach-limit={{ .VolumeAttachLimit }}
+            {{- end }}
             - --logtostderr
             - --v=5
           env:
@@ -266,7 +279,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -286,7 +299,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.2.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:
@@ -320,7 +333,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 spec:
   replicas: 2
   selector:
@@ -334,7 +347,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        app.kubernetes.io/version: "0.8.0"
+        app.kubernetes.io/version: {{ .Version }}
     spec:
       nodeSelector:
         kubernetes.io/os: linux
@@ -345,7 +358,7 @@ spec:
         - operator: Exists
       containers:
         - name: ebs-plugin
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:{{ .Version }}
           imagePullPolicy: IfNotPresent
           args:
             - controller
@@ -385,7 +398,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -400,7 +413,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.2.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -412,7 +425,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v2.1.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
@@ -423,7 +436,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
           imagePullPolicy: Always
           args:
             - --csi-address=$(ADDRESS)
@@ -435,7 +448,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.1.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:
@@ -446,14 +459,15 @@ spec:
           emptyDir: {}
 ---
 # Source: aws-ebs-csi-driver/templates/csidriver.yaml
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    app.kubernetes.io/version: "0.8.0"
+    app.kubernetes.io/version: {{ .Version }}
 spec:
   attachRequired: true
   podInfoOnMount: false
+{{ end }}

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -211,6 +211,45 @@ roleRef:
   name: ebs-external-snapshotter-role
   apiGroup: rbac.authorization.k8s.io
 ---
+# Source: aws-ebs-csi-driver/templates/clusterrolebinding-csi-node.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node-binding
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-node-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ebs-external-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: aws-ebs-csi-driver/templates/clusterrole-csi-node.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node-role
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+# Source: aws-ebs-csi-driver/templates/serviceaccount-csi-node.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-node-sa
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+    app.kubernetes.io/instance: aws-ebs-csi-driver
+    app.kubernetes.io/version: {{ .Version }}
+---
 # Source: aws-ebs-csi-driver/templates/node.yaml
 # Node Service
 kind: DaemonSet
@@ -239,6 +278,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      serviceAccountName: ebs-csi-node-sa
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists
@@ -258,6 +298,10 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: CSI_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -403,8 +403,7 @@ spec:
             - --csi-address=$(ADDRESS)
             - --v=5
             - --feature-gates=Topology=true
-            - --enable-leader-election
-            - --leader-election-type=leases
+            - --leader-election=true
             - --extra-create-metadata=true
           env:
             - name: ADDRESS

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -1022,7 +1022,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		if b.Cluster.Spec.CloudConfig != nil && b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver != nil && fi.BoolValue(b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled) {
 			key := "aws-ebs-csi-driver.addons.k8s.io"
 
-			version := "0.8.0-kops.2"
+			version := "0.10.1-kops.2"
 			{
 				id := "k8s-1.17"
 				location := key + "/" + id + ".yaml"

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -280,6 +280,7 @@ func (c *populateClusterSpec) run(clientset simple.Clientset) error {
 			codeModels = append(codeModels, &components.DiscoveryOptionsBuilder{OptionsContext: optionsContext})
 			codeModels = append(codeModels, &components.ClusterAutoscalerOptionsBuilder{OptionsContext: optionsContext})
 			codeModels = append(codeModels, &components.NodeTerminationHandlerOptionsBuilder{OptionsContext: optionsContext})
+			codeModels = append(codeModels, &components.AWSEBSCSIDriverOptionsBuilder{OptionsContext: optionsContext})
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -72,7 +72,7 @@ spec:
   - id: k8s-1.17
     kubernetesVersion: '>=1.17.0'
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 8cbf9a749585244e8bb8aef4700e336688b68733
+    manifestHash: e45ac8dd7101dbe4de83e8451a9764293136c998
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -72,7 +72,7 @@ spec:
   - id: k8s-1.17
     kubernetesVersion: '>=1.17.0'
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e45ac8dd7101dbe4de83e8451a9764293136c998
+    manifestHash: 38c8d59bb44e4c2c24ebbdc7ac7255e7135e623e
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -72,8 +72,8 @@ spec:
   - id: k8s-1.17
     kubernetesVersion: '>=1.17.0'
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 764e53dc640a307c42a075797e6307d2014a28b6
+    manifestHash: 8cbf9a749585244e8bb8aef4700e336688b68733
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
-    version: 0.8.0-kops.2
+    version: 0.10.1-kops.2


### PR DESCRIPTION
Cherry pick of #11304 #11326 #11418 on release-1.20.

#11304: [csi/aws] Bump templates to latest
#11326: Fix arguments to csi-provisioner after bump to v2.2.0
#11418: Bump to GA release

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Note! The warmpool support commit was **not** cherry picked