### PR TITLE
e2e: only get ExternalIPRange if we need it

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -46,11 +46,6 @@ func (d *deployer) Up() error {
 		_ = d.Down()
 	}
 
-	publicIP, err := util.ExternalIPRange()
-	if err != nil {
-		return err
-	}
-
 	if d.CloudProvider == "gce" && d.createBucket {
 		if err := gce.EnsureGCSBucket(d.stateStore(), d.GCPProject); err != nil {
 			return err
@@ -59,6 +54,11 @@ func (d *deployer) Up() error {
 
 	adminAccess := d.AdminAccess
 	if adminAccess == "" {
+		publicIP, err := util.ExternalIPRange()
+		if err != nil {
+			return err
+		}
+
 		adminAccess = publicIP
 	}
 


### PR DESCRIPTION
ExternalIPRange doesn't currently support IPv6 machines, so only call
it if we need to.  This allows local testing even with IPv6 enabled
machines.