### PR TITLE
Update verify-terraform to use 0.15.3

### DIFF
--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -21,7 +21,7 @@ set -o pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 # Terraform versions
-TF_TAG=0.15.0
+TF_TAG=0.15.3
 
 PROVIDER_CACHE="${KOPS_ROOT}/.cache/terraform"
 


### PR DESCRIPTION
This updates the GPG key according to https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512

will cherry-pick something similar to fix https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/11390/pull-kops-verify-terraform/1391450673828073472