### PR TITLE
Automated cherry pick of #11433: Update verify-terraform to use 0.15.3

### DIFF
--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -21,7 +21,7 @@ set -o pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 # Terraform versions
-TF_TAG=0.15.0
+TF_TAG=0.15.3
 
 PROVIDER_CACHE="${KOPS_ROOT}/.cache/terraform"
 


### PR DESCRIPTION
Cherry pick of #11433 on release-1.21.

#11433: Update verify-terraform to use 0.15.3

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.