### PR TITLE
Automated cherry pick of #11428: Create new clusters without forcing a container runtime

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -99,8 +99,6 @@ func (o *CreateClusterOptions) InitDefaults() {
 
 	o.Yes = false
 	o.Target = cloudup.TargetDirect
-
-	o.ContainerRuntime = "containerd"
 }
 
 var (

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -76,7 +76,7 @@ kops create cluster [flags]
       --channel string                   Channel for default versions and configuration to use (default "stable")
       --cloud string                     Cloud provider to use - gce, aws, openstack
       --cloud-labels string              A list of KV pairs used to tag all instance groups in AWS (e.g. "Owner=John Doe,Team=Some Team").
-      --container-runtime string         Container runtime to use: containerd, docker (default "containerd")
+      --container-runtime string         Container runtime to use: containerd, docker
       --disable-subnet-tags              Set to disable automatic subnet tagging
       --dns string                       DNS hosted zone to use: public|private. (default "Public")
       --dns-zone string                  DNS hosted zone to use (defaults to longest matching zone)

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/complex.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -13,7 +13,6 @@ spec:
     gceServiceAccount: test-account@testproject.iam.gserviceaccount.com
   cloudProvider: gce
   configBase: memfs://tests/gce.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/ha.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/ha.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -13,7 +13,6 @@ spec:
     gceServiceAccount: default
   cloudProvider: gce
   configBase: memfs://tests/ha-gce.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/ha.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/ha.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -13,7 +13,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/private.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/minimal-1.16/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.16/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/minimal.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/minimal-1.17/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.17/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/minimal.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/minimal-1.18/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.18/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/minimal.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/minimal-1.19/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.19/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/minimal.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/minimal.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -13,7 +13,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/private.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/overrides.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -17,7 +17,6 @@ spec:
     foo/bar: fib+baz
   cloudProvider: aws
   configBase: memfs://tests/private.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -18,7 +18,6 @@ spec:
     foo/bar: fib+baz
   cloudProvider: gce
   configBase: memfs://tests/private.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -13,7 +13,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/private-subnets.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/subnet.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/subnet.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -11,7 +11,6 @@ spec:
   channel: stable
   cloudProvider: aws
   configBase: memfs://tests/vpc.example.com
-  containerRuntime: containerd
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:


### PR DESCRIPTION
Cherry pick of #11428 on release-1.20.

#11428: Create new clusters without forcing a container runtime

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.