### PR TITLE
Fix KCM livenessProbe to use secure port

### DIFF
--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -173,9 +173,10 @@ func (b *KubeControllerManagerBuilder) buildPod() (*v1.Pod, error) {
 		LivenessProbe: &v1.Probe{
 			Handler: v1.Handler{
 				HTTPGet: &v1.HTTPGetAction{
-					Host: "127.0.0.1",
-					Path: "/healthz",
-					Port: intstr.FromInt(10252),
+					Host:   "127.0.0.1",
+					Path:   "/healthz",
+					Port:   intstr.FromInt(10257),
+					Scheme: "HTTPS",
 				},
 			},
 			InitialDelaySeconds: 15,

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
@@ -38,7 +38,8 @@ contents: |
         httpGet:
           host: 127.0.0.1
           path: /healthz
-          port: 10252
+          port: 10257
+          scheme: HTTPS
         initialDelaySeconds: 15
         timeoutSeconds: 15
       name: kube-controller-manager

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
@@ -38,7 +38,8 @@ contents: |
         httpGet:
           host: 127.0.0.1
           path: /healthz
-          port: 10252
+          port: 10257
+          scheme: HTTPS
         initialDelaySeconds: 15
         timeoutSeconds: 15
       name: kube-controller-manager

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
@@ -38,7 +38,8 @@ contents: |
         httpGet:
           host: 127.0.0.1
           path: /healthz
-          port: 10252
+          port: 10257
+          scheme: HTTPS
         initialDelaySeconds: 15
         timeoutSeconds: 15
       name: kube-controller-manager


### PR DESCRIPTION
The hourly test that uses the HEAD of k/k [has been failing](https://testgrid.k8s.io/kops-latest#kops-aws-k8s-latest&show-stale-tests=) due to connection refused errors on the KCM livenessProbe. 

The failure is due to [this PR](https://github.com/kubernetes/kubernetes/pull/96216) which landed around the same time.

This updates the KCM livenessProbe to match upstream.

[This commit](https://github.com/kubernetes/kubernetes/commit/eb27b61cdbddd17a2990d61f3fb8250636220f74) shows the secure port has been present since k8s 1.12 so I think it should be safe to update unconditionally, but feedback is welcome.

/hold for feedback