### PR TITLE
upup: gcetasks: fix diffs in instance template and router

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -152,6 +152,8 @@ func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
 					return nil, fmt.Errorf("unexpected access type in template %q: %s", *actual.Name, acs[0].Type)
 				}
 				actual.HasExternalIP = fi.Bool(true)
+			} else {
+				actual.HasExternalIP = fi.Bool(false)
 			}
 		}
 

--- a/upup/pkg/fi/cloudup/gcetasks/router.go
+++ b/upup/pkg/fi/cloudup/gcetasks/router.go
@@ -97,7 +97,7 @@ func (r *Router) Find(c *fi.Context) (*Router, error) {
 		Name:                          &found.Name,
 		Lifecycle:                     r.Lifecycle,
 		Network:                       &found.Network,
-		Region:                        &found.Region,
+		Region:                        fi.String(lastComponent(found.Region)),
 		NATIPAllocationOption:         &nat.NatIpAllocateOption,
 		SourceSubnetworkIPRangesToNAT: &nat.SourceSubnetworkIpRangesToNat,
 	}, nil


### PR DESCRIPTION
Use the last component of the self-url for a router's region, rather
than the full URL.

Explicitly set the boolean pointer for `HasExternalIP` if the interface
attached to the instance does not have an access config (i.e. has no
public internet access).

Without this patch, both the router and instance template show pending
updates, neither of which can be applied as both are immutable
resources.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>