### PR TITLE
Automated cherry pick of #11462: Add support for CAS 1.21.0

### DIFF
--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -43,6 +43,8 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 		v, err := util.ParseKubernetesVersion(clusterSpec.KubernetesVersion)
 		if err == nil {
 			switch v.Minor {
+			case 21:
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0"
 			case 20:
 				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0"
 			case 19:


### PR DESCRIPTION
Cherry pick of #11462 on release-1.21.

#11462: Add support for CAS 1.21.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.