### PR TITLE
Update alpha channel with K8s releases from May-12 2021

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -88,13 +88,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.20.0"
-    recommendedVersion: 1.20.6
+    recommendedVersion: 1.20.7
     requiredVersion: 1.20.0
   - range: ">=1.19.0"
-    recommendedVersion: 1.19.10
+    recommendedVersion: 1.19.11
     requiredVersion: 1.19.0
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.18
+    recommendedVersion: 1.18.19
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
     recommendedVersion: 1.17.17
@@ -124,15 +124,15 @@ spec:
   - range: ">=1.20.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.20.0
-    kubernetesVersion: 1.20.6
+    kubernetesVersion: 1.20.7
   - range: ">=1.19.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.10
+    kubernetesVersion: 1.19.11
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.18
+    kubernetesVersion: 1.18.19
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.17.0


### PR DESCRIPTION
* https://github.com/kubernetes/kubernetes/releases/tag/v1.20.7
* https://github.com/kubernetes/kubernetes/releases/tag/v1.19.11
* https://github.com/kubernetes/kubernetes/releases/tag/v1.18.19