### PR TITLE
Automated cherry pick of #11460: upup: gcetasks: fix diffs in instance template and router

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -152,6 +152,8 @@ func (e *InstanceTemplate) Find(c *fi.Context) (*InstanceTemplate, error) {
 					return nil, fmt.Errorf("unexpected access type in template %q: %s", *actual.Name, acs[0].Type)
 				}
 				actual.HasExternalIP = fi.Bool(true)
+			} else {
+				actual.HasExternalIP = fi.Bool(false)
 			}
 		}
 

--- a/upup/pkg/fi/cloudup/gcetasks/router.go
+++ b/upup/pkg/fi/cloudup/gcetasks/router.go
@@ -97,7 +97,7 @@ func (r *Router) Find(c *fi.Context) (*Router, error) {
 		Name:                          &found.Name,
 		Lifecycle:                     r.Lifecycle,
 		Network:                       &found.Network,
-		Region:                        &found.Region,
+		Region:                        fi.String(lastComponent(found.Region)),
 		NATIPAllocationOption:         &nat.NatIpAllocateOption,
 		SourceSubnetworkIPRangesToNAT: &nat.SourceSubnetworkIpRangesToNat,
 	}, nil


### PR DESCRIPTION
Cherry pick of #11460 on release-1.21.

#11460: upup: gcetasks: fix diffs in instance template and router

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.