### PR TITLE
Automated cherry pick of #11457: upup: gcetasks: force send AutoCreateSubnetworks field when

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/network.go
+++ b/upup/pkg/fi/cloudup/gcetasks/network.go
@@ -132,6 +132,11 @@ func (_ *Network) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Network) error {
 
 		case "custom":
 			network.AutoCreateSubnetworks = false
+			// The boolean default value of "false" is omitted when the struct
+			// is serialized, which results in the network being created with
+			// the auto-create subnetworks default of "true". Explicitly send
+			// the default value.
+			network.ForceSendFields = []string{"AutoCreateSubnetworks"}
 		}
 		_, err := t.Cloud.Compute().Networks.Insert(t.Cloud.Project(), network).Do()
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #11457 on release-1.20.

#11457: upup: gcetasks: force send AutoCreateSubnetworks field when

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.