### PR TITLE
Automated cherry pick of #11495: Set priorityClassName on critical addons

### DIFF
--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
@@ -517,6 +517,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       {{ end }}
+      priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 1337
       serviceAccountName: aws-load-balancer-controller

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -26688,6 +26688,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
+      priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-cainjector
 ---
 apiVersion: apps/v1
@@ -26744,6 +26745,7 @@ spec:
         resources: {}
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -26813,6 +26815,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
+      priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-webhook
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -138,6 +138,7 @@ spec:
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: cluster-autoscaler
       tolerations:
       - operator: "Exists"


### PR DESCRIPTION
Cherry pick of #11495 on release-1.21.

#11495: Set priorityClassName on critical addons

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.