### PR TITLE
bump aws lb controller to 2.2.0

### DIFF
--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -207,6 +207,12 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			case kops.SubnetTypePublic, kops.SubnetTypeUtility:
 				tags[aws.TagNameSubnetPublicELB] = "1"
 
+				// AWS ALB contoller won't provision any internal ELBs unless this tag is set.
+				// So we add this to public subnets as well if we do not expect any private subnets.
+				if b.Cluster.Spec.Topology.Nodes == kops.TopologyPublic {
+					tags[aws.TagNameSubnetInternalELB] = "1"
+				}
+
 			case kops.SubnetTypePrivate:
 				tags[aws.TagNameSubnetInternalELB] = "1"
 

--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
+
+REPORT_DIR="${ARTIFACTS:-$(pwd)/_artifacts}/aws-lb-controller/"
+
+export KOPS_FEATURE_FLAGS="SpecOverrideFlag,${KOPS_FEATURE_FLAGS:-}"
+REPO_ROOT=$(git rev-parse --show-toplevel);
+
+KOPS="${REPO_ROOT}/bazel-bin/cmd/kops/linux-amd64/kops"
+
+KUBETEST2="kubetest2 kops -v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-}"
+KUBETEST2="${KUBETEST2} --admin-access=${ADMIN_ACCESS:-}"
+
+export GO111MODULE=on
+
+cd "${REPO_ROOT}/tests/e2e"
+go install sigs.k8s.io/kubetest2
+go install ./kubetest2-kops
+go install ./kubetest2-tester-kops
+
+${KUBETEST2} --build --kops-root="${REPO_ROOT}" --stage-location="${STAGE_LOCATION:-}" --kops-binary-path="${KOPS}"
+
+# Always tear-down the cluster when we're done
+function finish {
+  ${KUBETEST2} --kops-binary-path="${KOPS}" --down || echo "kubetest2 down failed"
+}
+trap finish EXIT
+
+${KUBETEST2} \
+		--up \
+		--kops-binary-path="${KOPS}" \
+		--kubernetes-version="1.21.0" \
+		--create-args="--networking amazonvpc --override=cluster.spec.cloudConfig.awsLoadBalancerController.enabled=true --override=cluster.spec.cloudConfig.certManager.enabled=true"
+
+
+VPC=$(${KOPS} toolbox dump -o json | jq -r .vpc.id)
+
+ZONE=$(${KOPS} get ig -o json | jq -r '[.[] | select(.spec.role=="Node") | .spec.subnets[0]][0]')
+
+REGION=${ZONE::-1}
+
+cd "$(mktemp -dt kops.XXXXXXXXX)"
+go get github.com/onsi/ginkgo/ginkgo
+
+# Using a custom fork until https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2012 has merged
+git clone --branch e2e-filter-non-eligible-targets https://github.com/olemarkus/aws-load-balancer-controller .
+
+ginkgo -v -r test/e2e -- \
+    -cluster-name="${CLUSTER_NAME}" \
+    -aws-region="${REGION}" \
+    -aws-vpc-id="$VPC" \
+    -ginkgo.reportFile="${REPORT_DIR}/junit.xml"

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json
@@ -951,6 +951,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -99,14 +99,26 @@
       ]
     },
     {
+      "Action": "ec2:DescribeAvailabilityZones",
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
       "Action": [
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:DeleteSecurityGroup",
-        "ec2:RevokeSecurityGroupIngress"
+        "ec2:RevokeSecurityGroupIngress",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:DeleteRule",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
       ],
       "Condition": {
         "StringEquals": {
-          "ec2:ResourceTag/elbv2.k8s.aws/cluster": "minimal.example.com"
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "minimal.example.com"
         }
       },
       "Effect": "Allow",
@@ -121,7 +133,6 @@
         "elasticloadbalancing:DescribeRules",
         "elasticloadbalancing:DescribeTargetHealth",
         "elasticloadbalancing:DescribeListenerCertificates",
-        "elasticloadbalancing:ModifyTargetGroupAttributes",
         "elasticloadbalancing:CreateRule"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -666,6 +666,7 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
     "SubnetType"                                = "Public"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/role/internal-elb"           = "1"
   }
   vpc_id = aws_vpc.minimal-example-com.id
 }

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -1187,6 +1187,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }
@@ -1226,6 +1230,10 @@
           },
           {
             "Key": "kubernetes.io/role/elb",
+            "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
             "Value": "1"
           }
         ]

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -954,6 +954,7 @@ resource "aws_subnet" "us-east-1a-utility-complex-example-com" {
     "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/role/internal-elb"           = "1"
   }
   vpc_id = aws_vpc.complex-example-com.id
 }
@@ -969,6 +970,7 @@ resource "aws_subnet" "us-test-1a-complex-example-com" {
     "foo/bar"                                   = "fib+baz"
     "kubernetes.io/cluster/complex.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/role/internal-elb"           = "1"
   }
   vpc_id = aws_vpc.complex-example-com.id
 }

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -591,6 +591,7 @@ resource "aws_subnet" "us-test-1a-compress-example-com" {
     "SubnetType"                                 = "Public"
     "kubernetes.io/cluster/compress.example.com" = "owned"
     "kubernetes.io/role/elb"                     = "1"
+    "kubernetes.io/role/internal-elb"            = "1"
   }
   vpc_id = aws_vpc.compress-example-com.id
 }

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json
@@ -748,6 +748,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/containerd/cloudformation.json
+++ b/tests/integration/update_cluster/containerd/cloudformation.json
@@ -748,6 +748,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json
@@ -748,6 +748,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -903,6 +903,7 @@ resource "aws_subnet" "us-test-1a-existing-iam-example-com" {
     "SubnetType"                                     = "Public"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
     "kubernetes.io/role/elb"                         = "1"
+    "kubernetes.io/role/internal-elb"                = "1"
   }
   vpc_id = aws_vpc.existing-iam-example-com.id
 }
@@ -916,6 +917,7 @@ resource "aws_subnet" "us-test-1b-existing-iam-example-com" {
     "SubnetType"                                     = "Public"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
     "kubernetes.io/role/elb"                         = "1"
+    "kubernetes.io/role/internal-elb"                = "1"
   }
   vpc_id = aws_vpc.existing-iam-example-com.id
 }
@@ -929,6 +931,7 @@ resource "aws_subnet" "us-test-1c-existing-iam-example-com" {
     "SubnetType"                                     = "Public"
     "kubernetes.io/cluster/existing-iam.example.com" = "owned"
     "kubernetes.io/role/elb"                         = "1"
+    "kubernetes.io/role/internal-elb"                = "1"
   }
   vpc_id = aws_vpc.existing-iam-example-com.id
 }

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
@@ -744,6 +744,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -1247,6 +1247,7 @@ resource "aws_subnet" "us-test-1a-existingsg-example-com" {
     "SubnetType"                                   = "Public"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
     "kubernetes.io/role/elb"                       = "1"
+    "kubernetes.io/role/internal-elb"              = "1"
   }
   vpc_id = aws_vpc.existingsg-example-com.id
 }
@@ -1260,6 +1261,7 @@ resource "aws_subnet" "us-test-1b-existingsg-example-com" {
     "SubnetType"                                   = "Public"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
     "kubernetes.io/role/elb"                       = "1"
+    "kubernetes.io/role/internal-elb"              = "1"
   }
   vpc_id = aws_vpc.existingsg-example-com.id
 }
@@ -1273,6 +1275,7 @@ resource "aws_subnet" "us-test-1c-existingsg-example-com" {
     "SubnetType"                                   = "Public"
     "kubernetes.io/cluster/existingsg.example.com" = "owned"
     "kubernetes.io/role/elb"                       = "1"
+    "kubernetes.io/role/internal-elb"              = "1"
   }
   vpc_id = aws_vpc.existingsg-example-com.id
 }

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -764,6 +764,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -607,6 +607,7 @@ resource "aws_subnet" "us-test-1a-externallb-example-com" {
     "SubnetType"                                   = "Public"
     "kubernetes.io/cluster/externallb.example.com" = "owned"
     "kubernetes.io/role/elb"                       = "1"
+    "kubernetes.io/role/internal-elb"              = "1"
   }
   vpc_id = aws_vpc.externallb-example-com.id
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -789,6 +789,7 @@ resource "aws_subnet" "us-test-1a-externalpolicies-example-com" {
     "foo/bar"                                            = "fib+baz"
     "kubernetes.io/cluster/externalpolicies.example.com" = "owned"
     "kubernetes.io/role/elb"                             = "1"
+    "kubernetes.io/role/internal-elb"                    = "1"
   }
   vpc_id = aws_vpc.externalpolicies-example-com.id
 }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -975,6 +975,7 @@ resource "aws_subnet" "us-test-1a-ha-example-com" {
     "SubnetType"                           = "Public"
     "kubernetes.io/cluster/ha.example.com" = "owned"
     "kubernetes.io/role/elb"               = "1"
+    "kubernetes.io/role/internal-elb"      = "1"
   }
   vpc_id = aws_vpc.ha-example-com.id
 }
@@ -988,6 +989,7 @@ resource "aws_subnet" "us-test-1b-ha-example-com" {
     "SubnetType"                           = "Public"
     "kubernetes.io/cluster/ha.example.com" = "owned"
     "kubernetes.io/role/elb"               = "1"
+    "kubernetes.io/role/internal-elb"      = "1"
   }
   vpc_id = aws_vpc.ha-example-com.id
 }
@@ -1001,6 +1003,7 @@ resource "aws_subnet" "us-test-1c-ha-example-com" {
     "SubnetType"                           = "Public"
     "kubernetes.io/cluster/ha.example.com" = "owned"
     "kubernetes.io/role/elb"               = "1"
+    "kubernetes.io/role/internal-elb"      = "1"
   }
   vpc_id = aws_vpc.ha-example-com.id
 }

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -665,6 +665,7 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
     "SubnetType"                                = "Public"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/role/internal-elb"           = "1"
   }
   vpc_id = aws_vpc.minimal-example-com.id
 }

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -748,6 +748,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/minimal-etcd/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-etcd/cloudformation.json
@@ -748,6 +748,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json
@@ -744,6 +744,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -599,6 +599,7 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
     "SubnetType"                                = "Public"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/role/internal-elb"           = "1"
   }
   vpc_id = aws_vpc.minimal-example-com.id
 }

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -668,7 +668,8 @@
           "Name": "us-test-1a.minimal-json.example.com",
           "SubnetType": "Public",
           "kubernetes.io/cluster/minimal-json.example.com": "owned",
-          "kubernetes.io/role/elb": "1"
+          "kubernetes.io/role/elb": "1",
+          "kubernetes.io/role/internal-elb": "1"
         }
       }
     },

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -603,6 +603,7 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
     "SubnetType"                                = "Public"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/role/internal-elb"           = "1"
   }
   vpc_id = aws_vpc.minimal-example-com.id
 }

--- a/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
@@ -603,6 +603,7 @@ resource "aws_subnet" "us-test-1a-minimal-k8s-local" {
     "SubnetType"                              = "Public"
     "kubernetes.io/cluster/minimal.k8s.local" = "owned"
     "kubernetes.io/role/elb"                  = "1"
+    "kubernetes.io/role/internal-elb"         = "1"
   }
   vpc_id = aws_vpc.minimal-k8s-local.id
 }

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -1255,6 +1255,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }
@@ -1287,6 +1291,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }
@@ -1318,6 +1326,10 @@
           },
           {
             "Key": "kubernetes.io/role/elb",
+            "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
             "Value": "1"
           }
         ]

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -993,6 +993,7 @@ resource "aws_subnet" "us-test-1a-mixedinstances-example-com" {
     "SubnetType"                                       = "Public"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     "kubernetes.io/role/elb"                           = "1"
+    "kubernetes.io/role/internal-elb"                  = "1"
   }
   vpc_id = aws_vpc.mixedinstances-example-com.id
 }
@@ -1006,6 +1007,7 @@ resource "aws_subnet" "us-test-1b-mixedinstances-example-com" {
     "SubnetType"                                       = "Public"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     "kubernetes.io/role/elb"                           = "1"
+    "kubernetes.io/role/internal-elb"                  = "1"
   }
   vpc_id = aws_vpc.mixedinstances-example-com.id
 }
@@ -1019,6 +1021,7 @@ resource "aws_subnet" "us-test-1c-mixedinstances-example-com" {
     "SubnetType"                                       = "Public"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     "kubernetes.io/role/elb"                           = "1"
+    "kubernetes.io/role/internal-elb"                  = "1"
   }
   vpc_id = aws_vpc.mixedinstances-example-com.id
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -1256,6 +1256,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }
@@ -1288,6 +1292,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }
@@ -1319,6 +1327,10 @@
           },
           {
             "Key": "kubernetes.io/role/elb",
+            "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
             "Value": "1"
           }
         ]

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -993,6 +993,7 @@ resource "aws_subnet" "us-test-1a-mixedinstances-example-com" {
     "SubnetType"                                       = "Public"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     "kubernetes.io/role/elb"                           = "1"
+    "kubernetes.io/role/internal-elb"                  = "1"
   }
   vpc_id = aws_vpc.mixedinstances-example-com.id
 }
@@ -1006,6 +1007,7 @@ resource "aws_subnet" "us-test-1b-mixedinstances-example-com" {
     "SubnetType"                                       = "Public"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     "kubernetes.io/role/elb"                           = "1"
+    "kubernetes.io/role/internal-elb"                  = "1"
   }
   vpc_id = aws_vpc.mixedinstances-example-com.id
 }
@@ -1019,6 +1021,7 @@ resource "aws_subnet" "us-test-1c-mixedinstances-example-com" {
     "SubnetType"                                       = "Public"
     "kubernetes.io/cluster/mixedinstances.example.com" = "owned"
     "kubernetes.io/role/elb"                           = "1"
+    "kubernetes.io/role/internal-elb"                  = "1"
   }
   vpc_id = aws_vpc.mixedinstances-example-com.id
 }

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
@@ -798,6 +798,10 @@
           {
             "Key": "kubernetes.io/role/elb",
             "Value": "1"
+          },
+          {
+            "Key": "kubernetes.io/role/internal-elb",
+            "Value": "1"
           }
         ]
       }

--- a/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
+++ b/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
@@ -691,6 +691,7 @@ resource "aws_subnet" "us-test-1a-nthsqsresources-example-com" {
     "SubnetType"                                        = "Public"
     "kubernetes.io/cluster/nthsqsresources.example.com" = "owned"
     "kubernetes.io/role/elb"                            = "1"
+    "kubernetes.io/role/internal-elb"                   = "1"
   }
   vpc_id = aws_vpc.nthsqsresources-example-com.id
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -640,6 +640,7 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
     "SubnetType"                                = "Public"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/role/internal-elb"           = "1"
   }
   vpc_id = aws_vpc.minimal-example-com.id
 }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -589,6 +589,7 @@ resource "aws_subnet" "us-test-1a-sharedvpc-example-com" {
     "SubnetType"                                  = "Public"
     "kubernetes.io/cluster/sharedvpc.example.com" = "owned"
     "kubernetes.io/role/elb"                      = "1"
+    "kubernetes.io/role/internal-elb"             = "1"
   }
   vpc_id = "vpc-12345678"
 }

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -614,6 +614,7 @@ resource "aws_subnet" "us-test-1a-minimal-example-com" {
     "SubnetType"                                = "Public"
     "kubernetes.io/cluster/minimal.example.com" = "owned"
     "kubernetes.io/role/elb"                    = "1"
+    "kubernetes.io/role/internal-elb"           = "1"
   }
   vpc_id = aws_vpc.minimal-example-com.id
 }

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
@@ -1,185 +1,151 @@
-# sourced from https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/v2_1_2_full.yaml
+# sourced from https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/v2_2_0_full.yaml
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
   labels:
     app.kubernetes.io/name: aws-load-balancer-controller
-  name: targetgroupbindings.elbv2.k8s.aws
+  name: ingressclassparams.elbv2.k8s.aws
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .spec.serviceRef.name
-      description: The Kubernetes Service's name
-      name: SERVICE-NAME
-      type: string
-    - JSONPath: .spec.serviceRef.port
-      description: The Kubernetes Service's port
-      name: SERVICE-PORT
-      type: string
-    - JSONPath: .spec.targetType
-      description: The AWS TargetGroup's TargetType
-      name: TARGET-TYPE
-      type: string
-    - JSONPath: .spec.targetGroupARN
-      description: The AWS TargetGroup's Amazon Resource Name
-      name: ARN
-      priority: 1
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: AGE
-      type: date
   group: elbv2.k8s.aws
   names:
-    categories:
-      - all
-    kind: TargetGroupBinding
-    listKind: TargetGroupBindingList
-    plural: targetgroupbindings
-    singular: targetgroupbinding
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: TargetGroupBinding is the Schema for the TargetGroupBinding API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
-          properties:
-            networking:
-              description: networking provides the networking setup for ELBV2 LoadBalancer
-                to access targets in TargetGroup.
-              properties:
-                ingress:
-                  description: List of ingress rules to allow ELBV2 LoadBalancer to
-                    access targets in TargetGroup.
-                  items:
-                    properties:
-                      from:
-                        description: List of peers which should be able to access
-                          the targets in TargetGroup. At least one NetworkingPeer
-                          should be specified.
-                        items:
-                          description: NetworkingPeer defines the source/destination
-                            peer for networking rules.
-                          properties:
-                            ipBlock:
-                              description: IPBlock defines an IPBlock peer. If specified,
-                                none of the other fields can be set.
-                              properties:
-                                cidr:
-                                  description: CIDR is the network CIDR. Both IPV4
-                                    or IPV6 CIDR are accepted.
-                                  type: string
-                              required:
-                                - cidr
-                              type: object
-                            securityGroup:
-                              description: SecurityGroup defines a SecurityGroup peer.
-                                If specified, none of the other fields can be set.
-                              properties:
-                                groupID:
-                                  description: GroupID is the EC2 SecurityGroupID.
-                                  type: string
-                              required:
-                                - groupID
-                              type: object
-                          type: object
-                        type: array
-                      ports:
-                        description: List of ports which should be made accessible
-                          on the targets in TargetGroup. If ports is empty or unspecified,
-                          it defaults to all ports with TCP.
-                        items:
-                          properties:
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: The port which traffic must match. When
-                                NodePort endpoints(instance TargetType) is used, this
-                                must be a numerical port. When Port endpoints(ip TargetType)
-                                is used, this can be either numerical or named port
-                                on pods. if port is unspecified, it defaults to all
-                                ports.
-                              x-kubernetes-int-or-string: true
-                            protocol:
-                              description: The protocol which traffic must match.
-                                If protocol is unspecified, it defaults to TCP.
-                              enum:
-                                - TCP
-                                - UDP
-                              type: string
-                          type: object
-                        type: array
-                    required:
-                      - from
-                      - ports
-                    type: object
-                  type: array
-              type: object
-            serviceRef:
-              description: serviceRef is a reference to a Kubernetes Service and ServicePort.
-              properties:
-                name:
-                  description: Name is the name of the Service.
-                  type: string
-                port:
-                  anyOf:
-                    - type: integer
-                    - type: string
-                  description: Port is the port of the ServicePort.
-                  x-kubernetes-int-or-string: true
-              required:
-                - name
-                - port
-              type: object
-            targetGroupARN:
-              description: targetGroupARN is the Amazon Resource Name (ARN) for the
-                TargetGroup.
-              type: string
-            targetType:
-              description: targetType is the TargetType of TargetGroup. If unspecified,
-                it will be automatically inferred.
-              enum:
-                - instance
-                - ip
-              type: string
-          required:
-            - serviceRef
-            - targetGroupARN
-          type: object
-        status:
-          description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
-          properties:
-            observedGeneration:
-              description: The generation observed by the TargetGroupBinding controller.
-              format: int64
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
+    kind: IngressClassParams
+    listKind: IngressClassParamsList
+    plural: ingressclassparams
+    singular: ingressclassparams
+  scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: false
-    - name: v1beta1
-      served: true
-      storage: true
+  - additionalPrinterColumns:
+    - description: The Ingress Group name
+      jsonPath: .spec.group.name
+      name: GROUP-NAME
+      type: string
+    - description: The AWS Load Balancer scheme
+      jsonPath: .spec.scheme
+      name: SCHEME
+      type: string
+    - description: The AWS Load Balancer ipAddressType
+      jsonPath: .spec.ipAddressType
+      name: IP-ADDRESS-TYPE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: IngressClassParams is the Schema for the IngressClassParams API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressClassParamsSpec defines the desired state of IngressClassParams
+            properties:
+              group:
+                description: Group defines the IngressGroup for all Ingresses that
+                  belong to IngressClass with this IngressClassParams.
+                properties:
+                  name:
+                    description: Name is the name of IngressGroup.
+                    type: string
+                required:
+                - name
+                type: object
+              ipAddressType:
+                description: IPAddressType defines the ip address type for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
+                enum:
+                - ipv4
+                - dualstack
+                type: string
+              namespaceSelector:
+                description: NamespaceSelector restrict the namespaces of Ingresses
+                  that are allowed to specify the IngressClass with this IngressClassParams.
+                  * if absent or present but empty, it selects all namespaces.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              scheme:
+                description: Scheme defines the scheme for all Ingresses that belong
+                  to IngressClass with this IngressClassParams.
+                enum:
+                - internal
+                - internet-facing
+                type: string
+              tags:
+                description: Tags defines list of Tags on AWS resources provisioned
+                  for Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  description: Tag defines a AWS Tag on resources.
+                  properties:
+                    key:
+                      description: The key of the tag.
+                      type: string
+                    value:
+                      description: The value of the tag.
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -187,58 +153,397 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: kube-system/aws-load-balancer-serving-cert
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
   labels:
     app.kubernetes.io/name: aws-load-balancer-controller
-  name: aws-load-balancer-webhook
-webhooks:
-  - clientConfig:
-      caBundle: Cg==
-      service:
-        name: aws-load-balancer-webhook-service
-        namespace: kube-system
-        path: /mutate-v1-pod
-    failurePolicy: Fail
-    name: mpod.elbv2.k8s.aws
-    namespaceSelector:
-      matchExpressions:
-        - key: elbv2.k8s.aws/pod-readiness-gate-inject
-          operator: In
-          values:
-            - enabled
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - clientConfig:
-      caBundle: Cg==
-      service:
-        name: aws-load-balancer-webhook-service
-        namespace: kube-system
-        path: /mutate-elbv2-k8s-aws-v1beta1-targetgroupbinding
-    failurePolicy: Fail
-    name: mtargetgroupbinding.elbv2.k8s.aws
-    rules:
-      - apiGroups:
-          - elbv2.k8s.aws
-        apiVersions:
-          - v1beta1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - targetgroupbindings
-    sideEffects: None
+  name: targetgroupbindings.elbv2.k8s.aws
+spec:
+  group: elbv2.k8s.aws
+  names:
+    kind: TargetGroupBinding
+    listKind: TargetGroupBindingList
+    plural: targetgroupbindings
+    singular: targetgroupbinding
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Kubernetes Service's name
+      jsonPath: .spec.serviceRef.name
+      name: SERVICE-NAME
+      type: string
+    - description: The Kubernetes Service's port
+      jsonPath: .spec.serviceRef.port
+      name: SERVICE-PORT
+      type: string
+    - description: The AWS TargetGroup's TargetType
+      jsonPath: .spec.targetType
+      name: TARGET-TYPE
+      type: string
+    - description: The AWS TargetGroup's Amazon Resource Name
+      jsonPath: .spec.targetGroupARN
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              networking:
+                description: networking provides the networking setup for ELBV2 LoadBalancer
+                  to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
+                    items:
+                      properties:
+                        from:
+                          description: List of peers which should be able to access
+                            the targets in TargetGroup. At least one NetworkingPeer
+                            should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: IPBlock defines an IPBlock peer. If specified,
+                                  none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: CIDR is the network CIDR. Both IPV4
+                                      or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: SecurityGroup defines a SecurityGroup
+                                  peer. If specified, none of the other fields can
+                                  be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: List of ports which should be made accessible
+                            on the targets in TargetGroup. If ports is empty or unspecified,
+                            it defaults to all ports with TCP.
+                          items:
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port which traffic must match. When
+                                  NodePort endpoints(instance TargetType) is used,
+                                  this must be a numerical port. When Port endpoints(ip
+                                  TargetType) is used, this can be either numerical
+                                  or named port on pods. if port is unspecified, it
+                                  defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+            required:
+            - serviceRef
+            - targetGroupARN
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The Kubernetes Service's name
+      jsonPath: .spec.serviceRef.name
+      name: SERVICE-NAME
+      type: string
+    - description: The Kubernetes Service's port
+      jsonPath: .spec.serviceRef.port
+      name: SERVICE-PORT
+      type: string
+    - description: The AWS TargetGroup's TargetType
+      jsonPath: .spec.targetType
+      name: TARGET-TYPE
+      type: string
+    - description: The AWS TargetGroup's Amazon Resource Name
+      jsonPath: .spec.targetGroupARN
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              networking:
+                description: networking defines the networking rules to allow ELBV2
+                  LoadBalancer to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
+                    items:
+                      description: NetworkingIngressRule defines a particular set
+                        of traffic that is allowed to access TargetGroup's targets.
+                      properties:
+                        from:
+                          description: List of peers which should be able to access
+                            the targets in TargetGroup. At least one NetworkingPeer
+                            should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: IPBlock defines an IPBlock peer. If specified,
+                                  none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: CIDR is the network CIDR. Both IPV4
+                                      or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: SecurityGroup defines a SecurityGroup
+                                  peer. If specified, none of the other fields can
+                                  be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: List of ports which should be made accessible
+                            on the targets in TargetGroup. If ports is empty or unspecified,
+                            it defaults to all ports with TCP.
+                          items:
+                            description: NetworkingPort defines the port and protocol
+                              for networking rules.
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port which traffic must match. When
+                                  NodePort endpoints(instance TargetType) is used,
+                                  this must be a numerical port. When Port endpoints(ip
+                                  TargetType) is used, this can be either numerical
+                                  or named port on pods. if port is unspecified, it
+                                  defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              nodeSelector:
+                description: node selector for instance type target groups to only
+                  register certain nodes
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+            required:
+            - serviceRef
+            - targetGroupARN
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -257,162 +562,171 @@ metadata:
   name: aws-load-balancer-controller-leader-election-role
   namespace: kube-system
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-  - apiGroups:
-      - ""
-    resourceNames:
-      - aws-load-balancer-controller-leader
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - update
-      - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - aws-load-balancer-controller-leader
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   labels:
     app.kubernetes.io/name: aws-load-balancer-controller
   name: aws-load-balancer-controller-role
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods/status
-    verbs:
-      - patch
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - services
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - services/status
-    verbs:
-      - patch
-      - update
-  - apiGroups:
-      - elbv2.k8s.aws
-    resources:
-      - targetgroupbindings
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - elbv2.k8s.aws
-    resources:
-      - targetgroupbindings/status
-    verbs:
-      - patch
-      - update
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses/status
-    verbs:
-      - patch
-      - update
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses/status
-    verbs:
-      - patch
-      - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - elbv2.k8s.aws
+  resources:
+  - ingressclassparams
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - elbv2.k8s.aws
+  resources:
+  - targetgroupbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - elbv2.k8s.aws
+  resources:
+  - targetgroupbindings/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -426,9 +740,9 @@ roleRef:
   kind: Role
   name: aws-load-balancer-controller-leader-election-role
 subjects:
-  - kind: ServiceAccount
-    name: aws-load-balancer-controller
-    namespace: kube-system
+- kind: ServiceAccount
+  name: aws-load-balancer-controller
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -441,9 +755,9 @@ roleRef:
   kind: ClusterRole
   name: aws-load-balancer-controller-role
 subjects:
-  - kind: ServiceAccount
-    name: aws-load-balancer-controller
-    namespace: kube-system
+- kind: ServiceAccount
+  name: aws-load-balancer-controller
+  namespace: kube-system
 ---
 apiVersion: v1
 kind: Service
@@ -454,8 +768,8 @@ metadata:
   namespace: kube-system
 spec:
   ports:
-    - port: 443
-      targetPort: 9443
+  - port: 443
+    targetPort: 9443
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: aws-load-balancer-controller
@@ -481,38 +795,39 @@ spec:
         app.kubernetes.io/name: aws-load-balancer-controller
     spec:
       containers:
-        - args:
-            - --cluster-name={{ ClusterName }}
-            - --enable-waf=false
-            - --enable-wafv2=false
-            - --enable-shield=false
-            - --ingress-class=alb
-          image: amazon/aws-alb-ingress-controller:{{ or .AWSLoadBalancerController.Version "v2.1.2" }}
-          livenessProbe:
-            failureThreshold: 2
-            httpGet:
-              path: /healthz
-              port: 61779
-              scheme: HTTP
-            initialDelaySeconds: 30
-            timeoutSeconds: 10
-          name: controller
-          ports:
-            - containerPort: 9443
-              name: webhook-server
-              protocol: TCP
-          resources:
-            requests:
-              cpu: 100m
-              memory: 200Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-          volumeMounts:
-            - mountPath: /tmp/k8s-webhook-server/serving-certs
-              name: cert
-              readOnly: true
+      - args:
+        - --cluster-name={{ ClusterName }}
+        - --enable-waf=false
+        - --enable-wafv2=false
+        - --enable-shield=false
+        - --ingress-class=alb
+        image: amazon/aws-alb-ingress-controller:{{ or .AWSLoadBalancerController.Version "v2.2.0" }}
+        livenessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /healthz
+            port: 61779
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
+        name: controller
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      priorityClassName: system-cluster-critical
       {{ if not UseServiceAccountIAM }}
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -527,10 +842,10 @@ spec:
         - operator: Exists
       {{ end }}
       volumes:
-        - name: cert
-          secret:
-            defaultMode: 420
-            secretName: aws-load-balancer-webhook-tls
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: aws-load-balancer-webhook-tls
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
@@ -541,14 +856,75 @@ metadata:
   namespace: kube-system
 spec:
   dnsNames:
-    - aws-load-balancer-webhook-service.kube-system.svc
-    - aws-load-balancer-webhook-service.kube-system.svc.cluster.local
+  - aws-load-balancer-webhook-service.kube-system.svc
+  - aws-load-balancer-webhook-service.kube-system.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: aws-load-balancer-controller.addons.k8s.io
   secretName: aws-load-balancer-webhook-tls
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/aws-load-balancer-serving-cert
+  labels:
+    app.kubernetes.io/name: aws-load-balancer-controller
+  name: aws-load-balancer-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: aws-load-balancer-webhook-service
+      namespace: kube-system
+      path: /mutate-v1-pod
+  failurePolicy: Fail
+  name: mpod.elbv2.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: elbv2.k8s.aws/pod-readiness-gate-inject
+      operator: In
+      values:
+      - enabled
+  objectSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: NotIn
+      values:
+      - aws-load-balancer-controller
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: aws-load-balancer-webhook-service
+      namespace: kube-system
+      path: /mutate-elbv2-k8s-aws-v1beta1-targetgroupbinding
+  failurePolicy: Fail
+  name: mtargetgroupbinding.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - elbv2.k8s.aws
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - targetgroupbindings
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
@@ -557,22 +933,44 @@ metadata:
     app.kubernetes.io/name: aws-load-balancer-controller
   name: aws-load-balancer-webhook
 webhooks:
-  - clientConfig:
-      caBundle: Cg==
-      service:
-        name: aws-load-balancer-webhook-service
-        namespace: kube-system
-        path: /validate-elbv2-k8s-aws-v1beta1-targetgroupbinding
-    failurePolicy: Fail
-    name: vtargetgroupbinding.elbv2.k8s.aws
-    rules:
-      - apiGroups:
-          - elbv2.k8s.aws
-        apiVersions:
-          - v1beta1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - targetgroupbindings
-    sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: aws-load-balancer-webhook-service
+      namespace: kube-system
+      path: /validate-elbv2-k8s-aws-v1beta1-targetgroupbinding
+  failurePolicy: Fail
+  name: vtargetgroupbinding.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - elbv2.k8s.aws
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - targetgroupbindings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: aws-load-balancer-webhook-service
+      namespace: kube-system
+      path: /validate-networking-v1beta1-ingress
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vingress.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+  sideEffects: None


### PR DESCRIPTION
With these changes, we also pass the upstream e2e tests (with some amendments related to them expecting something more similar to EKS). 