### PR TITLE
Set OpenStack lb listener connection limit to 500k

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -288,6 +288,7 @@ func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Name:      lbTask.Name,
 			Lifecycle: b.Lifecycle,
 			Pool:      poolTask,
+			ConnLimit: fi.Int(500000),
 		}
 		if useVIPACL {
 			// sort for consistent comparison


### PR DESCRIPTION
We are currently facing issue https://bugzilla.redhat.com/show_bug.cgi?id=1724480 and because of that I recommend that we limit the Kubernetes API loadbalancer listener max conns to 500k. At least for me it is pretty difficult to imagine that someone could have more than 500k simultaneous connections to Kubernetes API