### PR TITLE
Split genkgo in two

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -64,8 +64,14 @@ go get github.com/onsi/ginkgo/ginkgo
 # Using a custom fork until https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2012 has merged
 git clone --branch e2e-filter-non-eligible-targets https://github.com/olemarkus/aws-load-balancer-controller .
 
-ginkgo -v -r test/e2e -- \
+ginkgo -v -r test/e2e/ingress -- \
     -cluster-name="${CLUSTER_NAME}" \
     -aws-region="${REGION}" \
     -aws-vpc-id="$VPC" \
-    -ginkgo.reportFile="${REPORT_DIR}/junit.xml"
+    -ginkgo.reportFile="${REPORT_DIR}/junit-ingress.xml"
+
+ginkgo -v -r test/e2e/service -- \
+    -cluster-name="${CLUSTER_NAME}" \
+    -aws-region="${REGION}" \
+    -aws-vpc-id="$VPC" \
+    -ginkgo.reportFile="${REPORT_DIR}/junit-service.xml"


### PR DESCRIPTION
With the way the two e2e suites are implemented, the last suite will overwrite the junit report of the former suites. So we need to split this in order to capture the output from both suites