### PR TITLE
[DigitalOcean] [WIP] Increase droplet size for e2e tests

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -133,8 +133,8 @@ func (d *deployer) createCluster(zones []string, adminAccess string) error {
 		}
 		args = appendIfUnset(args, "--vpc", strings.Split(d.ClusterName, ".")[0])
 	case "digitalocean":
-		args = appendIfUnset(args, "--master-size", "s-4vcpu-8gb")
-		args = appendIfUnset(args, "--node-size", "s-4vcpu-8gb")
+		args = appendIfUnset(args, "--master-size", "s-8vcpu-16gb")
+		args = appendIfUnset(args, "--node-size", "s-8vcpu-16gb")
 	}
 
 	if d.terraform != nil {


### PR DESCRIPTION
@timoreimann helped in updating the DO account to make it work on large droplets.
We used get an error like below before.
```
W0506 19:29:15.005456   11744 executor.go:139] error running task "Droplet/master-nyc1-3.masters.e2e-test-do.k8s.local" (7m28s remaining to succeed): POST https://api.digitalocean.com/v2/droplets: 422 This size is currently restricted, please send an additional payment to unlock.
```
I'll be testing this against our DO test and check if that works. 
