### PR TITLE
Release images bundle instead of separate images

### DIFF
--- a/.shipbot.yaml
+++ b/.shipbot.yaml
@@ -41,27 +41,7 @@ assets:
     githubName: channels-linux-arm64
   - source: linux/arm64/channels.sha256
     githubName: channels-linux-arm64.sha256
-  - source: images/dns-controller-amd64.tar.gz
-    githubName: images-dns-controller-amd64.tar.gz
-  - source: images/dns-controller-amd64.tar.gz.sha256
-    githubName: images-dns-controller-amd64.tar.gz.sha256
-  - source: images/dns-controller-arm64.tar.gz
-    githubName: images-dns-controller-arm64.tar.gz
-  - source: images/dns-controller-arm64.tar.gz.sha256
-    githubName: images-dns-controller-arm64.tar.gz.sha256
-  - source: images/kops-controller-amd64.tar.gz
-    githubName: images-kops-controller-amd64.tar.gz
-  - source: images/kops-controller-amd64.tar.gz.sha256
-    githubName: images-kops-controller-amd64.tar.gz.sha256
-  - source: images/kops-controller-arm64.tar.gz
-    githubName: images-kops-controller-arm64.tar.gz
-  - source: images/kops-controller-arm64.tar.gz.sha256
-    githubName: images-kops-controller-arm64.tar.gz.sha256
-  - source: images/kube-apiserver-healthcheck-amd64.tar.gz
-    githubName: images-kube-apiserver-healthcheck-amd64.tar.gz
-  - source: images/kube-apiserver-healthcheck-amd64.tar.gz.sha256
-    githubName: images-kube-apiserver-healthcheck-amd64.tar.gz.sha256
-  - source: images/kube-apiserver-healthcheck-arm64.tar.gz
-    githubName: images-kube-apiserver-healthcheck-arm64.tar.gz
-  - source: images/kube-apiserver-healthcheck-arm64.tar.gz.sha256
-    githubName: images-kube-apiserver-healthcheck-arm64.tar.gz.sha256
+  - source: images/images.tar.gz
+    githubName: images.tar.gz
+  - source: images/images.tar.gz.sha256
+    githubName: images.tar.gz.sha256

--- a/Makefile
+++ b/Makefile
@@ -769,6 +769,8 @@ bazel-version-dist: bazel-version-dist-linux-amd64 bazel-version-dist-linux-arm6
 	tools/sha256 ${BAZELUPLOAD}/kops/${VERSION}/darwin/amd64/kops ${BAZELUPLOAD}/kops/${VERSION}/darwin/amd64/kops.sha256
 	cp bazel-bin/cmd/kops/windows-amd64/kops ${BAZELUPLOAD}/kops/${VERSION}/windows/amd64/kops.exe
 	tools/sha256 ${BAZELUPLOAD}/kops/${VERSION}/windows/amd64/kops.exe ${BAZELUPLOAD}/kops/${VERSION}/windows/amd64/kops.exe.sha256
+	tar cfvz ${BAZELUPLOAD}/kops/${VERSION}/images/images.tar.gz -C ${BAZELIMAGES} --exclude "*.sha256" .
+	tools/sha256 ${BAZELUPLOAD}/kops/${VERSION}/images/images.tar.gz ${BAZELUPLOAD}/kops/${VERSION}/images/images.tar.gz.sha256
 	cp -fr ${BAZELUPLOAD}/kops/${VERSION}/* ${BAZELDIST}/
 
 .PHONY: bazel-upload


### PR DESCRIPTION
kOps releases contain a considerable number of files, out of which only the binaries are currently used for mirrors.
As agreed during Office Hours, images should be bundled into a single archive file.