### PR TITLE
Calculate IPv6 subnet CIDR based on cluster CIDR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1059
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/amazon-ec2-instance-selector/v2 v2.0.2
 	github.com/aws/aws-sdk-go v1.38.29
 	github.com/blang/semver/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/aliyun/alibaba-cloud-sdk-go v1.61.1059/go.mod h1:pUKYbK5JQ+1Dfxk80P0q
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -333,7 +333,7 @@ func validateIPv6CIDR(cidr string, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if strings.HasPrefix(cidr, "/") {
-		newSize, _, err := utils.ParseCidrSubnet(cidr)
+		newSize, _, err := utils.ParseCIDRNotation(cidr)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(fieldPath, cidr, fmt.Sprintf("IPv6 CIDR subnet is not parsable: %v", err)))
 			return allErrs

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -330,10 +330,23 @@ func validateCIDR(cidr string, fieldPath *field.Path) field.ErrorList {
 }
 
 func validateIPv6CIDR(cidr string, fieldPath *field.Path) field.ErrorList {
-	allErrs := validateCIDR(cidr, fieldPath)
+	allErrs := field.ErrorList{}
 
-	if !utils.IsIPv6CIDR(cidr) {
-		allErrs = append(allErrs, field.Invalid(fieldPath, cidr, "Network is not an IPv6 CIDR"))
+	if strings.HasPrefix(cidr, "/") {
+		newSize, _, err := utils.ParseCidrSubnet(cidr)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fieldPath, cidr, fmt.Sprintf("IPv6 CIDR subnet is not parsable: %v", err)))
+			return allErrs
+		}
+		if newSize < 0 || newSize > 128 {
+			allErrs = append(allErrs, field.Invalid(fieldPath, cidr, "IPv6 CIDR subnet size must be a value between 0 and 128"))
+		}
+	} else {
+		allErrs = append(allErrs, validateCIDR(cidr, fieldPath)...)
+
+		if !utils.IsIPv6CIDR(cidr) {
+			allErrs = append(allErrs, field.Invalid(fieldPath, cidr, "Network is not an IPv6 CIDR"))
+		}
 	}
 
 	return allErrs

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -252,6 +252,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 
 		if subnetSpec.IPv6CIDR != "" {
+			subnet.AmazonIPv6CIDR = b.LinkToAmazonVPCIPv6CIDR()
 			subnet.IPv6CIDR = fi.String(subnetSpec.IPv6CIDR)
 		}
 		if subnetSpec.ProviderID != "" {

--- a/pkg/model/names.go
+++ b/pkg/model/names.go
@@ -123,6 +123,10 @@ func (b *KopsModelContext) LinkToVPC() *awstasks.VPC {
 	return &awstasks.VPC{Name: &name}
 }
 
+func (b *KopsModelContext) LinkToAmazonVPCIPv6CIDR() *awstasks.VPCAmazonIPv6CIDRBlock {
+	return &awstasks.VPCAmazonIPv6CIDRBlock{Name: fi.String("AmazonIPv6")}
+}
+
 func (b *KopsModelContext) LinkToDNSZone() *awstasks.DNSZone {
 	name := b.NameForDNSZone()
 	return &awstasks.DNSZone{Name: &name}

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -204,6 +204,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -465,12 +465,12 @@ func calculateSubnetCIDR(vpcCIDR, subnetCIDR *string) (*string, error) {
 		return nil, fmt.Errorf("expecting subnet cidr to start with %q: %q", "/", aws.StringValue(subnetCIDR))
 	}
 
-	newSize, netNum, err := utils.ParseCidrSubnet(aws.StringValue(subnetCIDR))
+	newSize, netNum, err := utils.ParseCIDRNotation(aws.StringValue(subnetCIDR))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing CIDR subnet: %v", err)
 	}
 
-	newCIDR, err := utils.CidrSubnet(aws.StringValue(vpcCIDR), newSize, netNum)
+	newCIDR, err := utils.CIDRSubnet(aws.StringValue(vpcCIDR), newSize, netNum)
 	if err != nil {
 		return nil, fmt.Errorf("error calculating CIDR subnet: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -100,18 +100,20 @@ func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
 		}
 
 		actual.IPv6CIDR = association.Ipv6CidrBlock
-		if e.VPC.IPv6CIDR != nil && strings.HasPrefix(aws.StringValue(e.IPv6CIDR), "/") {
-			subnetIPv6CIDR, err := calculateSubnetCIDR(e.VPC.IPv6CIDR, e.IPv6CIDR)
-			if err != nil {
-				return nil, err
-			}
-			e.IPv6CIDR = subnetIPv6CIDR
-		}
 		break
 	}
 
 	klog.V(2).Infof("found matching subnet %q", *actual.ID)
 	e.ID = actual.ID
+
+	// Calculate expected IPv6 CIDR if possible and in the "/64#N" format
+	if e.VPC.IPv6CIDR != nil && strings.HasPrefix(aws.StringValue(e.IPv6CIDR), "/") {
+		subnetIPv6CIDR, err := calculateSubnetCIDR(e.VPC.IPv6CIDR, e.IPv6CIDR)
+		if err != nil {
+			return nil, err
+		}
+		e.IPv6CIDR = subnetIPv6CIDR
+	}
 
 	// Prevent spurious changes
 	actual.Lifecycle = e.Lifecycle // Not materialized in AWS

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -45,6 +45,7 @@ type Subnet struct {
 
 	ID               *string
 	VPC              *VPC
+	AmazonIPv6CIDR   *VPCAmazonIPv6CIDRBlock
 	AvailabilityZone *string
 	CIDR             *string
 	IPv6CIDR         *string
@@ -116,6 +117,8 @@ func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
 	actual.Lifecycle = e.Lifecycle // Not materialized in AWS
 	actual.ShortName = e.ShortName // Not materialized in AWS
 	actual.Name = e.Name           // Name is part of Tags
+	// Task dependencies
+	actual.AmazonIPv6CIDR = e.AmazonIPv6CIDR
 
 	return actual, nil
 }

--- a/upup/pkg/fi/utils/BUILD.bazel
+++ b/upup/pkg/fi/utils/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "k8s.io/kops/upup/pkg/fi/utils",
     visibility = ["//visibility:public"],
     deps = [
+        "//vendor/github.com/apparentlymart/go-cidr/cidr:go_default_library",
         "//vendor/k8s.io/client-go/util/homedir:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/upup/pkg/fi/utils/cidr.go
+++ b/upup/pkg/fi/utils/cidr.go
@@ -65,9 +65,9 @@ func IsIPv6CIDR(cidr string) bool {
 	return true
 }
 
-// ParseCidrSubnet parses a string in the format "/<newSize>#<netNum>"
+// ParseCIDRNotation parses a string in the format "/<newSize>#<netNum>"
 // and returns the values of <newSize> and <netNum>.
-func ParseCidrSubnet(subnet string) (int, int64, error) {
+func ParseCIDRNotation(subnet string) (int, int64, error) {
 	re := regexp.MustCompile(`^/(\d+)#([a-f0-9]+)$`)
 	s := re.FindStringSubmatch(subnet)
 	if len(s) != 3 {
@@ -87,10 +87,10 @@ func ParseCidrSubnet(subnet string) (int, int64, error) {
 	return newSize, netNum, nil
 }
 
-// CidrSubnet calculates a subnet address within given IP network address prefix.
+// CIDRSubnet calculates a subnet address within given IP network address prefix.
 // Inspired by the Terraform implementation of the "cidrsubnet" function
 // https://www.terraform.io/docs/language/functions/cidrsubnet.html
-func CidrSubnet(prefix string, newSize int, netNum int64) (string, error) {
+func CIDRSubnet(prefix string, newSize int, netNum int64) (string, error) {
 	_, baseCIDR, err := net.ParseCIDR(prefix)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse CIDR for %q: %v", prefix, err)

--- a/vendor/github.com/apparentlymart/go-cidr/LICENSE
+++ b/vendor/github.com/apparentlymart/go-cidr/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015 Martin Atkins
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/BUILD.bazel
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cidr.go",
+        "wrangling.go",
+    ],
+    importmap = "k8s.io/kops/vendor/github.com/apparentlymart/go-cidr/cidr",
+    importpath = "github.com/apparentlymart/go-cidr/cidr",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
@@ -1,0 +1,236 @@
+// Package cidr is a collection of assorted utilities for computing
+// network and host addresses within network ranges.
+//
+// It expects a CIDR-type address structure where addresses are divided into
+// some number of prefix bits representing the network and then the remaining
+// suffix bits represent the host.
+//
+// For example, it can help to calculate addresses for sub-networks of a
+// parent network, or to calculate host addresses within a particular prefix.
+//
+// At present this package is prioritizing simplicity of implementation and
+// de-prioritizing speed and memory usage. Thus caution is advised before
+// using this package in performance-critical applications or hot codepaths.
+// Patches to improve the speed and memory usage may be accepted as long as
+// they do not result in a significant increase in code complexity.
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+// Subnet takes a parent CIDR range and creates a subnet within it
+// with the given number of additional prefix bits and the given
+// network number.
+//
+// For example, 10.3.0.0/16, extended by 8 bits, with a network number
+// of 5, becomes 10.3.5.0/24 .
+func Subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
+	return SubnetBig(base, newBits, big.NewInt(int64(num)))
+}
+
+// SubnetBig takes a parent CIDR range and creates a subnet within it with the
+// given number of additional prefix bits and the given network number. It
+// differs from Subnet in that it takes a *big.Int for the num, instead of an int.
+//
+// For example, 10.3.0.0/16, extended by 8 bits, with a network number of 5,
+// becomes 10.3.5.0/24 .
+func SubnetBig(base *net.IPNet, newBits int, num *big.Int) (*net.IPNet, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	newPrefixLen := parentLen + newBits
+
+	if newPrefixLen > addrLen {
+		return nil, fmt.Errorf("insufficient address space to extend prefix of %d by %d", parentLen, newBits)
+	}
+
+	maxNetNum := uint64(1<<uint64(newBits)) - 1
+	if num.Uint64() > maxNetNum {
+		return nil, fmt.Errorf("prefix extension of %d does not accommodate a subnet numbered %d", newBits, num)
+	}
+
+	return &net.IPNet{
+		IP:   insertNumIntoIP(ip, num, newPrefixLen),
+		Mask: net.CIDRMask(newPrefixLen, addrLen),
+	}, nil
+}
+
+// Host takes a parent CIDR range and turns it into a host IP address with the
+// given host number.
+//
+// For example, 10.3.0.0/16 with a host number of 2 gives 10.3.0.2.
+func Host(base *net.IPNet, num int) (net.IP, error) {
+	return HostBig(base, big.NewInt(int64(num)))
+}
+
+// HostBig takes a parent CIDR range and turns it into a host IP address with
+// the given host number. It differs from Host in that it takes a *big.Int for
+// the num, instead of an int.
+//
+// For example, 10.3.0.0/16 with a host number of 2 gives 10.3.0.2.
+func HostBig(base *net.IPNet, num *big.Int) (net.IP, error) {
+	ip := base.IP
+	mask := base.Mask
+
+	parentLen, addrLen := mask.Size()
+	hostLen := addrLen - parentLen
+
+	maxHostNum := big.NewInt(int64(1))
+	maxHostNum.Lsh(maxHostNum, uint(hostLen))
+	maxHostNum.Sub(maxHostNum, big.NewInt(1))
+
+	numUint64 := big.NewInt(int64(num.Uint64()))
+	if num.Cmp(big.NewInt(0)) == -1 {
+		numUint64.Neg(num)
+		numUint64.Sub(numUint64, big.NewInt(int64(1)))
+		num.Sub(maxHostNum, numUint64)
+	}
+
+	if numUint64.Cmp(maxHostNum) == 1 {
+		return nil, fmt.Errorf("prefix of %d does not accommodate a host numbered %d", parentLen, num)
+	}
+	var bitlength int
+	if ip.To4() != nil {
+		bitlength = 32
+	} else {
+		bitlength = 128
+	}
+	return insertNumIntoIP(ip, num, bitlength), nil
+}
+
+// AddressRange returns the first and last addresses in the given CIDR range.
+func AddressRange(network *net.IPNet) (net.IP, net.IP) {
+	// the first IP is easy
+	firstIP := network.IP
+
+	// the last IP is the network address OR NOT the mask address
+	prefixLen, bits := network.Mask.Size()
+	if prefixLen == bits {
+		// Easy!
+		// But make sure that our two slices are distinct, since they
+		// would be in all other cases.
+		lastIP := make([]byte, len(firstIP))
+		copy(lastIP, firstIP)
+		return firstIP, lastIP
+	}
+
+	firstIPInt, bits := ipToInt(firstIP)
+	hostLen := uint(bits) - uint(prefixLen)
+	lastIPInt := big.NewInt(1)
+	lastIPInt.Lsh(lastIPInt, hostLen)
+	lastIPInt.Sub(lastIPInt, big.NewInt(1))
+	lastIPInt.Or(lastIPInt, firstIPInt)
+
+	return firstIP, intToIP(lastIPInt, bits)
+}
+
+// AddressCount returns the number of distinct host addresses within the given
+// CIDR range.
+//
+// Since the result is a uint64, this function returns meaningful information
+// only for IPv4 ranges and IPv6 ranges with a prefix size of at least 65.
+func AddressCount(network *net.IPNet) uint64 {
+	prefixLen, bits := network.Mask.Size()
+	return 1 << (uint64(bits) - uint64(prefixLen))
+}
+
+//VerifyNoOverlap takes a list subnets and supernet (CIDRBlock) and verifies
+//none of the subnets overlap and all subnets are in the supernet
+//it returns an error if any of those conditions are not satisfied
+func VerifyNoOverlap(subnets []*net.IPNet, CIDRBlock *net.IPNet) error {
+	firstLastIP := make([][]net.IP, len(subnets))
+	for i, s := range subnets {
+		first, last := AddressRange(s)
+		firstLastIP[i] = []net.IP{first, last}
+	}
+	for i, s := range subnets {
+		if !CIDRBlock.Contains(firstLastIP[i][0]) || !CIDRBlock.Contains(firstLastIP[i][1]) {
+			return fmt.Errorf("%s does not fully contain %s", CIDRBlock.String(), s.String())
+		}
+		for j := 0; j < len(subnets); j++ {
+			if i == j {
+				continue
+			}
+
+			first := firstLastIP[j][0]
+			last := firstLastIP[j][1]
+			if s.Contains(first) || s.Contains(last) {
+				return fmt.Errorf("%s overlaps with %s", subnets[j].String(), s.String())
+			}
+		}
+	}
+	return nil
+}
+
+// PreviousSubnet returns the subnet of the desired mask in the IP space
+// just lower than the start of IPNet provided. If the IP space rolls over
+// then the second return value is true
+func PreviousSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	startIP := checkIPv4(network.IP)
+	previousIP := make(net.IP, len(startIP))
+	copy(previousIP, startIP)
+	cMask := net.CIDRMask(prefixLen, 8*len(previousIP))
+	previousIP = Dec(previousIP)
+	previous := &net.IPNet{IP: previousIP.Mask(cMask), Mask: cMask}
+	if startIP.Equal(net.IPv4zero) || startIP.Equal(net.IPv6zero) {
+		return previous, true
+	}
+	return previous, false
+}
+
+// NextSubnet returns the next available subnet of the desired mask size
+// starting for the maximum IP of the offset subnet
+// If the IP exceeds the maxium IP then the second return value is true
+func NextSubnet(network *net.IPNet, prefixLen int) (*net.IPNet, bool) {
+	_, currentLast := AddressRange(network)
+	mask := net.CIDRMask(prefixLen, 8*len(currentLast))
+	currentSubnet := &net.IPNet{IP: currentLast.Mask(mask), Mask: mask}
+	_, last := AddressRange(currentSubnet)
+	last = Inc(last)
+	next := &net.IPNet{IP: last.Mask(mask), Mask: mask}
+	if last.Equal(net.IPv4zero) || last.Equal(net.IPv6zero) {
+		return next, true
+	}
+	return next, false
+}
+
+//Inc increases the IP by one this returns a new []byte for the IP
+func Inc(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	incIP := make([]byte, len(IP))
+	copy(incIP, IP)
+	for j := len(incIP) - 1; j >= 0; j-- {
+		incIP[j]++
+		if incIP[j] > 0 {
+			break
+		}
+	}
+	return incIP
+}
+
+//Dec decreases the IP by one this returns a new []byte for the IP
+func Dec(IP net.IP) net.IP {
+	IP = checkIPv4(IP)
+	decIP := make([]byte, len(IP))
+	copy(decIP, IP)
+	decIP = checkIPv4(decIP)
+	for j := len(decIP) - 1; j >= 0; j-- {
+		decIP[j]--
+		if decIP[j] < 255 {
+			break
+		}
+	}
+	return decIP
+}
+
+func checkIPv4(ip net.IP) net.IP {
+	// Go for some reason allocs IPv6len for IPv4 so we have to correct it
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
+}

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
@@ -1,0 +1,37 @@
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+)
+
+func ipToInt(ip net.IP) (*big.Int, int) {
+	val := &big.Int{}
+	val.SetBytes([]byte(ip))
+	if len(ip) == net.IPv4len {
+		return val, 32
+	} else if len(ip) == net.IPv6len {
+		return val, 128
+	} else {
+		panic(fmt.Errorf("Unsupported address length %d", len(ip)))
+	}
+}
+
+func intToIP(ipInt *big.Int, bits int) net.IP {
+	ipBytes := ipInt.Bytes()
+	ret := make([]byte, bits/8)
+	// Pack our IP bytes into the end of the return array,
+	// since big.Int.Bytes() removes front zero padding.
+	for i := 1; i <= len(ipBytes); i++ {
+		ret[len(ret)-i] = ipBytes[len(ipBytes)-i]
+	}
+	return net.IP(ret)
+}
+
+func insertNumIntoIP(ip net.IP, bigNum *big.Int, prefixLen int) net.IP {
+	ipInt, totalBits := ipToInt(ip)
+	bigNum.Lsh(bigNum, uint(totalBits-prefixLen))
+	ipInt.Or(ipInt, bigNum)
+	return intToIP(ipInt, totalBits)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,6 +100,9 @@ github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests
 github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses
 github.com/aliyun/alibaba-cloud-sdk-go/sdk/utils
 github.com/aliyun/alibaba-cloud-sdk-go/services/slb
+# github.com/apparentlymart/go-cidr v1.1.0
+## explicit
+github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 github.com/apparentlymart/go-textseg/v13/textseg
 # github.com/armon/go-metrics v0.3.0


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/issues/8432#issuecomment-843777374

Inspired by https://github.com/kubernetes/kops/pull/11163.

This PR makes it possible to set subnet CIDR based on VPC CIDR on cluster creation similarly to:
  * https://www.terraform.io/docs/language/functions/cidrsubnet.html
  * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html

There is some feedback from @johngmyers in https://github.com/kubernetes/kops/pull/11442#discussion_r631712081, which suggests using a `cidrsubnet(8,1)` syntax instead of a `cidrsubnet-8-1` syntax for configuring a subnet.
The reason I chose the `cidrsubnet-8-1` is to maybe allow using this as a flag on create cluster and that it seems similar to other places, like https://kops.sigs.k8s.io/cluster_spec/#egress.

/cc @justinsb @johngmyers @rifelpet 