### PR TITLE
Automated cherry pick of #11514: enable prometheus scraping

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -417,6 +417,12 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        # Annotation required for prometheus auto-discovery scrapping
+        # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
+        {{ if .EnablePrometheusMetrics }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .AgentPrometheusPort | quote }}
+        {{ end }}
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -417,11 +417,11 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        {{ if .Networking.Cilium.EnablePrometheusMetrics }}
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
-        {{ if .EnablePrometheusMetrics }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
+        prometheus.io/port: {{ printf "%q" .Networking.Cilium.AgentPrometheusPort }}
         {{ end }}
       labels:
         k8s-app: cilium

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -417,7 +417,7 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        # Annotation required for prometheus auto-discovery scrapping
+        # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         {{ if .EnablePrometheusMetrics }}
         prometheus.io/scrape: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -421,7 +421,7 @@ spec:
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         {{ if .EnablePrometheusMetrics }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .AgentPrometheusPort | quote }}
+        prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
         {{ end }}
       labels:
         k8s-app: cilium

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -503,7 +503,7 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        # Annotation required for prometheus auto-discovery scrapping
+        # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         {{ if .EnablePrometheusMetrics }}
         prometheus.io/scrape: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -507,7 +507,7 @@ spec:
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         {{ if .EnablePrometheusMetrics }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .AgentPrometheusPort | quote }}
+        prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
         {{ end }}
       labels:
         k8s-app: cilium

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -503,9 +503,9 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        {{ if .EnablePrometheusMetrics }}
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
-        {{ if .EnablePrometheusMetrics }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
         {{ end }}

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -503,6 +503,12 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        # Annotation required for prometheus auto-discovery scrapping
+        # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
+        {{ if .EnablePrometheusMetrics }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .AgentPrometheusPort | quote }}
+        {{ end }}
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -523,7 +523,7 @@ spec:
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         {{ if .EnablePrometheusMetrics }}
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .AgentPrometheusPort | quote }}
+        prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
         {{ end }}
       labels:
         k8s-app: cilium

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -519,7 +519,7 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        # Annotation required for prometheus auto-discovery scrapping
+        # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         {{ if .EnablePrometheusMetrics }}
         prometheus.io/scrape: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -519,6 +519,12 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        # Annotation required for prometheus auto-discovery scrapping
+        # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
+        {{ if .EnablePrometheusMetrics }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .AgentPrometheusPort | quote }}
+        {{ end }}
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -519,9 +519,9 @@ spec:
         # gets priority scheduling.
         # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        {{ if .EnablePrometheusMetrics }}
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
-        {{ if .EnablePrometheusMetrics }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
         {{ end }}


### PR DESCRIPTION
Cherry pick of #11514 on release-1.21.

#11514: enable prometheus scraping

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.