### PR TITLE
Add support for arbitrary terraform functions

### DIFF
--- a/upup/pkg/fi/cloudup/terraform/hcl2_test.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl2_test.go
@@ -133,7 +133,7 @@ func TestWriteLiteral(t *testing.T) {
 		},
 		{
 			name:     "file",
-			literal:  terraformWriter.LiteralFileExpression("${path.module}/foo", false),
+			literal:  terraformWriter.LiteralFunctionExpression("file", []string{"\"${path.module}/foo\""}),
 			expected: `foo = file("${path.module}/foo")`,
 		},
 	}
@@ -272,13 +272,15 @@ func TestWriteMapLiterals(t *testing.T) {
 		{
 			name: "literal values",
 			values: map[string]terraformWriter.Literal{
-				"key1": *terraformWriter.LiteralFileExpression("${module.path}/path/to/value1", false),
-				"key2": *terraformWriter.LiteralFileExpression("${module.path}/path/to/value2", true),
+				"key1": *terraformWriter.LiteralFunctionExpression("file", []string{"\"${module.path}/path/to/value1\""}),
+				"key2": *terraformWriter.LiteralFunctionExpression("filebase64", []string{"\"${module.path}/path/to/value2\""}),
+				"key3": *terraformWriter.LiteralFunctionExpression("cidrsubnet", []string{"\"172.16.0.0/12\"", "4", "2"}),
 			},
 			expected: `
 metadata = {
   "key1" = file("${module.path}/path/to/value1")
   "key2" = filebase64("${module.path}/path/to/value2")
+  "key3" = cidrsubnet("172.16.0.0/12", 4, 2)
 }
 			`,
 		},

--- a/upup/pkg/fi/cloudup/terraformWriter/writer.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/writer.go
@@ -75,9 +75,12 @@ func (t *TerraformWriter) AddFileBytes(resourceType string, resourceName string,
 	p := path.Join("data", id)
 	t.Files[p] = data
 
-	modulePath := path.Join("${path.module}", p)
-	l := LiteralFileExpression(modulePath, base64)
-	return l, nil
+	modulePath := fmt.Sprintf("%q", path.Join("${path.module}", p))
+	fn := "file"
+	if base64 {
+		fn = "filebase64"
+	}
+	return LiteralFunctionExpression(fn, []string{modulePath}), nil
 }
 
 func (t *TerraformWriter) RenderResource(resourceType string, resourceName string, e interface{}) error {


### PR DESCRIPTION
This allows `terraformWriter.LiteralFunctionExpression` to be used with any terraform function.

The arguments must be strings, which means that any string arguments must include quotes. I was debating between this and using a slice of interfaces for `Literal.FnArgs` and passing each to `json.Marshal` to get their string representations (which would quote the strings for us). This would require either returning the `json.Marshal` error up through all of the HCL2 rendering (which doesn't currently return errors) or adding a panic which I'm not excited about.

Feedback welcome.

/hold