### PR TITLE
Automated cherry pick of #11354: Allow cert-manager to be provisioned externally

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -69,7 +69,23 @@ spec:
     defaultIssuer: yourDefaultIssuer
 ```
 
-**Warning: cert-manager only supports one installation per cluster. If you are already running cert-manager, you need to remove this installation prior to enabling this addon. As long as you are using v1 versions of the cert-manager resources, it is safe to remove existing installs and replace it with this addon**
+**Warning: cert-manager only supports one installation per cluster. If you are already running cert-manager, you need to
+either remove this installation prior to enabling this addon, or mark cert-manger as not being managed by kOps (see below).
+As long as you are using v1 versions of the cert-manager resources, it is safe to remove existing installs and replace it with this addon**
+
+##### Self-provisioned cert-manager
+{{ kops_feature_table(kops_added_default='1.21', k8s_min='1.16') }}
+
+The following cert-manager configuration allows provisioning cert-manager externally and allows all dependent plugins
+to be deployed. Please note that addons might run into errors until cert-manager is deployed.
+
+```yaml
+spec:
+  certManager:
+    enabled: true
+    managed: false
+```
+
 
 Read more about cert-manager in the [official documentation](https://cert-manager.io/docs/)
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -248,6 +248,11 @@ spec:
                     description: 'Image is the docker container used. Default: the
                       latest supported image for the specified kubernetes version.'
                     type: string
+                  managed:
+                    description: Managed controls if cert-manager is manged and deployed
+                      by kOps. The deployment of cert-manager is skipped if this is
+                      set to false.
+                    type: boolean
                 type: object
               channel:
                 description: The Channel we are following

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -924,6 +924,10 @@ type CertManagerConfig struct {
 	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
 
+	// Managed controls if cert-manager is manged and deployed by kOps.
+	// The deployment of cert-manager is skipped if this is set to false.
+	Managed *bool `json:"managed,omitempty"`
+
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -923,6 +923,10 @@ type CertManagerConfig struct {
 	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
 
+	// Managed controls if cert-manager is manged and deployed by kOps.
+	// The deployment of cert-manager is skipped if this is set to false.
+	Managed *bool `json:"managed,omitempty"`
+
 	// Image is the docker container used.
 	// Default: the latest supported image for the specified kubernetes version.
 	Image *string `json:"image,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1628,6 +1628,7 @@ func Convert_kops_CanalNetworkingSpec_To_v1alpha2_CanalNetworkingSpec(in *kops.C
 
 func autoConvert_v1alpha2_CertManagerConfig_To_kops_CertManagerConfig(in *CertManagerConfig, out *kops.CertManagerConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
 	return nil
@@ -1640,6 +1641,7 @@ func Convert_v1alpha2_CertManagerConfig_To_kops_CertManagerConfig(in *CertManage
 
 func autoConvert_kops_CertManagerConfig_To_v1alpha2_CertManagerConfig(in *kops.CertManagerConfig, out *CertManagerConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
 	return nil

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -420,6 +420,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Managed != nil {
+		in, out := &in.Managed, &out.Managed
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -436,6 +436,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Managed != nil {
+		in, out := &in.Managed, &out.Managed
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -516,7 +516,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		}
 	}
 
-	if b.Cluster.Spec.CertManager != nil && fi.BoolValue(b.Cluster.Spec.CertManager.Enabled) {
+	if b.Cluster.Spec.CertManager != nil && fi.BoolValue(b.Cluster.Spec.CertManager.Enabled) && (b.Cluster.Spec.CertManager.Managed == nil || fi.BoolValue(b.Cluster.Spec.CertManager.Managed)) {
 		{
 			key := "certmanager.io"
 			version := "1.1.0"


### PR DESCRIPTION
Cherry pick of #11354 on release-1.20.

#11354: Allow cert-manager to be provisioned externally

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.