### PR TITLE
Automated cherry pick of #11554: Bump default cilium to 1.9.7

### DIFF
--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.9.6"
+		c.Version = "v1.9.7"
 	}
 
 	version, _ := semver.ParseTolerant(c.Version)

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -71,7 +71,7 @@ spec:
     version: 1.17.0
   - id: k8s-1.12
     manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
-    manifestHash: 7de4d6e933cda022172f7e38ecf510c20a89c81a
+    manifestHash: 2c0e0b21471e6fb1f86007c811576584a7ab8c1b
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #11554 on release-1.21.

#11554: Bump default cilium to 1.9.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.