### PR TITLE
Automated cherry pick of #11559: Allow using insecure TLS for metrics-server with

### DIFF
--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -139,7 +139,7 @@ spec:
 {{ else }}
           - --cert-dir=/tmp
 {{ end }}
-{{ if not UseKopsControllerForNodeBootstrap }}
+{{ if and UseKopsControllerForNodeBootstrap (not (WithDefaultBool .MetricsServer.Insecure true)) }}
           - --kubelet-insecure-tls
 {{ end }} 
         image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.2" }}

--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -1,4 +1,4 @@
-# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
+# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.4/components.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -141,8 +141,8 @@ spec:
 {{ end }}
 {{ if and UseKopsControllerForNodeBootstrap (not (WithDefaultBool .MetricsServer.Insecure true)) }}
           - --kubelet-insecure-tls
-{{ end }} 
-        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.2" }}
+{{ end }}
+        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.4" }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -498,7 +498,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	if b.Cluster.Spec.MetricsServer != nil && fi.BoolValue(b.Cluster.Spec.MetricsServer.Enabled) {
 		{
 			key := "metrics-server.addons.k8s.io"
-			version := "0.3.7"
+			version := "0.4.4"
 
 			{
 				location := key + "/k8s-1.11.yaml"


### PR DESCRIPTION
Cherry pick of #11559 on release-1.20.

#11559: Allow using insecure TLS for metrics-server with

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.