### PR TITLE
Automated cherry pick of #11319: Bump manifest to latest stable #11559: Allow using insecure TLS for metrics-server with

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -30393,7 +30393,7 @@ func cloudupResourcesAddonsMetadataProxyAddonsK8sIoV0112Yaml() (*asset, error) {
 	return a, nil
 }
 
-var _cloudupResourcesAddonsMetricsServerAddonsK8sIoK8s111YamlTemplate = []byte(`# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
+var _cloudupResourcesAddonsMetricsServerAddonsK8sIoK8s111YamlTemplate = []byte(`# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.4/components.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -30474,7 +30474,6 @@ subjects:
   name: metrics-server
   namespace: kube-system
 ---
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -30489,8 +30488,6 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
----
-
 ---
 apiVersion: v1
 kind: Service
@@ -30528,16 +30525,17 @@ spec:
       containers:
       - args:
           - --secure-port=4443
+          - --kubelet-use-node-status-port
 {{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
           - --tls-cert-file=/srv/tls.crt
           - --tls-private-key-file=/srv/tls.key
 {{ else }}
           - --cert-dir=/tmp
 {{ end }}
-{{ if not UseKopsControllerForNodeBootstrap }}
+{{ if and UseKopsControllerForNodeBootstrap (not (WithDefaultBool .MetricsServer.Insecure true)) }}
           - --kubelet-insecure-tls
-{{ end }} 
-        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.2" }}
+{{ end }}
+        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.4" }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -30569,6 +30567,10 @@ spec:
 {{ end }}
         - mountPath: /tmp
           name: tmp-dir
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
@@ -30634,7 +30636,8 @@ spec:
   issuerRef:
     name: metrics-server.addons.k8s.io
     kind: Issuer
-{{ end }}`)
+{{ end }}
+`)
 
 func cloudupResourcesAddonsMetricsServerAddonsK8sIoK8s111YamlTemplateBytes() ([]byte, error) {
 	return _cloudupResourcesAddonsMetricsServerAddonsK8sIoK8s111YamlTemplate, nil

--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -1,4 +1,4 @@
-# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.3/components.yaml
+# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.4/components.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -140,7 +140,7 @@ spec:
 {{ if and UseKopsControllerForNodeBootstrap (not (WithDefaultBool .MetricsServer.Insecure true)) }}
           - --kubelet-insecure-tls
 {{ end }}
-        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.3" }}
+        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.4" }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -137,7 +137,7 @@ spec:
 {{ else }}
           - --cert-dir=/tmp
 {{ end }}
-{{ if not UseKopsControllerForNodeBootstrap }}
+{{ if and UseKopsControllerForNodeBootstrap (not (WithDefaultBool .MetricsServer.Insecure true)) }}
           - --kubelet-insecure-tls
 {{ end }}
         image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.3" }}

--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -1,4 +1,4 @@
-# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
+# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.3/components.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -79,7 +79,6 @@ subjects:
   name: metrics-server
   namespace: kube-system
 ---
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -94,8 +93,6 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
----
-
 ---
 apiVersion: v1
 kind: Service
@@ -133,6 +130,7 @@ spec:
       containers:
       - args:
           - --secure-port=4443
+          - --kubelet-use-node-status-port
 {{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
           - --tls-cert-file=/srv/tls.crt
           - --tls-private-key-file=/srv/tls.key
@@ -141,8 +139,8 @@ spec:
 {{ end }}
 {{ if not UseKopsControllerForNodeBootstrap }}
           - --kubelet-insecure-tls
-{{ end }} 
-        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.2" }}
+{{ end }}
+        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.3" }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -174,6 +172,10 @@ spec:
 {{ end }}
         - mountPath: /tmp
           name: tmp-dir
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -498,7 +498,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	if b.Cluster.Spec.MetricsServer != nil && fi.BoolValue(b.Cluster.Spec.MetricsServer.Enabled) {
 		{
 			key := "metrics-server.addons.k8s.io"
-			version := "0.3.7"
+			version := "0.4.4"
 
 			{
 				location := key + "/k8s-1.11.yaml"


### PR DESCRIPTION
Cherry pick of #11319 #11559 on release-1.20.

#11319: Bump manifest to latest stable
#11559: Allow using insecure TLS for metrics-server with

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.