### PR TITLE
Avoid error when first creating VPC with IPv6

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
@@ -42,6 +42,11 @@ type VPCAmazonIPv6CIDRBlock struct {
 func (e *VPCAmazonIPv6CIDRBlock) Find(c *fi.Context) (*VPCAmazonIPv6CIDRBlock, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
+	// If the VPC doesn't (yet) exist, there is no association
+	if e.VPC.ID == nil {
+		return nil, nil
+	}
+
 	vpc, err := cloud.DescribeVPC(aws.StringValue(e.VPC.ID))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When the VPC isn't yet created, the search for associations was failing
as we were trying to pass an empty ID.