### PR TITLE
Don't set the master address for aws ccm

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -73,7 +73,5 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		return fmt.Errorf("no networking mode set")
 	}
 
-	eccm.Master = "https://127.0.0.1"
-
 	return nil
 }

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       containers:
       - args:
-        - --master=https://127.0.0.1
         - --v=2
         - --cloud-provider=aws
         - --cluster-name=minimal.example.com

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -55,7 +55,7 @@ spec:
   - id: k8s-1.18
     kubernetesVersion: '>=1.18.0'
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: d1234040768f371ebb4a4e27cac699e215afb173
+    manifestHash: 66da0144f0b1b8077fe52179bc38268a3548579f
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
Use the kubernetes.default service for now. Ideally we would not rely on this as this in turn relies on CNI. But fixing this means also fixing PKI, so we have to revisit this later