### PR TITLE
Automated cherry pick of #11590: Use the OnDelete updateStrategy for AWS VPC CNI DaemonSet

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -226,9 +226,7 @@
           "type": "DirectoryOrCreate"
         "name": "run-dir"
   "updateStrategy":
-    "rollingUpdate":
-      "maxUnavailable": "10%"
-    "type": "RollingUpdate"
+    "type": "OnDelete"
 ---
 "apiVersion": "v1"
 "kind": "ServiceAccount"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -893,12 +893,13 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 			location := key + "/" + id + ".yaml"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
-				Selector:          networkingSelector(),
-				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.16.0",
-				Id:                id,
+				Name:               fi.String(key),
+				Version:            fi.String(versions[id]),
+				Selector:           networkingSelector(),
+				Manifest:           fi.String(location),
+				KubernetesVersion:  ">=1.16.0",
+				NeedsRollingUpdate: "all",
+				Id:                 id,
 			})
 		}
 	}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -80,8 +80,9 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0'
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: ba5c98ae679d9feb8a84a063075acee4956cc126
+    manifestHash: 997781194bcdfa7602dfb69e2a1f42cb5106fc81
     name: networking.amazon-vpc-routed-eni
+    needsRollingUpdate: all
     selector:
       role.kubernetes.io/networking: "1"
     version: 1.7.8-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -252,9 +252,7 @@ spec:
           type: DirectoryOrCreate
         name: run-dir
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 10%
-    type: RollingUpdate
+    type: OnDelete
 
 ---
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -80,8 +80,9 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0'
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 992ea59e207a3905600f7b9fbf99809093d6f964
+    manifestHash: eaa47d83fad808dd4d4d807b17108de185729e93
     name: networking.amazon-vpc-routed-eni
+    needsRollingUpdate: all
     selector:
       role.kubernetes.io/networking: "1"
     version: 1.7.8-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -252,9 +252,7 @@ spec:
           type: DirectoryOrCreate
         name: run-dir
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 10%
-    type: RollingUpdate
+    type: OnDelete
 
 ---
 


### PR DESCRIPTION
Cherry pick of #11590 on release-1.21.

#11590: Use the OnDelete updateStrategy for AWS VPC CNI DaemonSet

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.