### PR TITLE
Automated cherry pick of #11590: Use the OnDelete updateStrategy for AWS VPC CNI DaemonSet

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -31045,9 +31045,7 @@ var _cloudupResourcesAddonsNetworkingAmazonVpcRoutedEniK8s116YamlTemplate = []by
           "type": "DirectoryOrCreate"
         "name": "run-dir"
   "updateStrategy":
-    "rollingUpdate":
-      "maxUnavailable": "10%"
-    "type": "RollingUpdate"
+    "type": "OnDelete"
 ---
 "apiVersion": "v1"
 "kind": "ServiceAccount"

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -226,9 +226,7 @@
           "type": "DirectoryOrCreate"
         "name": "run-dir"
   "updateStrategy":
-    "rollingUpdate":
-      "maxUnavailable": "10%"
-    "type": "RollingUpdate"
+    "type": "OnDelete"
 ---
 "apiVersion": "v1"
 "kind": "ServiceAccount"

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -889,12 +889,13 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 			location := key + "/" + id + ".yaml"
 
 			addons.Spec.Addons = append(addons.Spec.Addons, &channelsapi.AddonSpec{
-				Name:              fi.String(key),
-				Version:           fi.String(versions[id]),
-				Selector:          networkingSelector(),
-				Manifest:          fi.String(location),
-				KubernetesVersion: ">=1.16.0",
-				Id:                id,
+				Name:               fi.String(key),
+				Version:            fi.String(versions[id]),
+				Selector:           networkingSelector(),
+				Manifest:           fi.String(location),
+				KubernetesVersion:  ">=1.16.0",
+				Id:                 id,
+				NeedsRollingUpdate: "all",
 			})
 		}
 	}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -79,8 +79,9 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0'
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 0d8138335cb9603850a6b8aab814ee1f265d2dcb
+    manifestHash: c9c0b6f8ab336d602f737fe75208231f39903240
     name: networking.amazon-vpc-routed-eni
+    needsRollingUpdate: all
     selector:
       role.kubernetes.io/networking: "1"
     version: 1.7.8-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -229,9 +229,7 @@ spec:
           type: DirectoryOrCreate
         name: run-dir
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 10%
-    type: RollingUpdate
+    type: OnDelete
 
 ---
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -79,8 +79,9 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0'
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: b177339a67fdb7a73379c54b62caf95763d46557
+    manifestHash: 3949c5951498397028384a86f7e6ac17f899cd28
     name: networking.amazon-vpc-routed-eni
+    needsRollingUpdate: all
     selector:
       role.kubernetes.io/networking: "1"
     version: 1.7.8-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -229,9 +229,7 @@ spec:
           type: DirectoryOrCreate
         name: run-dir
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 10%
-    type: RollingUpdate
+    type: OnDelete
 
 ---
 


### PR DESCRIPTION
Cherry pick of #11590 on release-1.20.

#11590: Use the OnDelete updateStrategy for AWS VPC CNI DaemonSet

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.