### PR TITLE
Automated cherry pick of #11602: add init image field

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3150,6 +3150,9 @@ spec:
                       imageName:
                         description: The container image name to use
                         type: string
+                      initImageName:
+                        description: The init container image name to use
+                        type: string
                     type: object
                   calico:
                     description: CalicoNetworkingSpec declares that we want Calico

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -250,6 +250,8 @@ type RomanaNetworkingSpec struct {
 type AmazonVPCNetworkingSpec struct {
 	// The container image name to use
 	ImageName string `json:"imageName,omitempty"`
+	// The init container image name to use
+	InitImageName string `json:"initImageName,omitempty"`
 	// Env is a list of environment variables to set in the container.
 	Env []EnvVar `json:"env,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -250,6 +250,8 @@ type RomanaNetworkingSpec struct {
 type AmazonVPCNetworkingSpec struct {
 	// The container image name to use
 	ImageName string `json:"imageName,omitempty"`
+	// The init container image name to use
+	InitImageName string `json:"initImageName,omitempty"`
 	// Env is a list of environment variables to set in the container.
 	Env []EnvVar `json:"env,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1268,6 +1268,7 @@ func Convert_kops_AlwaysAllowAuthorizationSpec_To_v1alpha2_AlwaysAllowAuthorizat
 
 func autoConvert_v1alpha2_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in *AmazonVPCNetworkingSpec, out *kops.AmazonVPCNetworkingSpec, s conversion.Scope) error {
 	out.ImageName = in.ImageName
+	out.InitImageName = in.InitImageName
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]kops.EnvVar, len(*in))
@@ -1289,6 +1290,7 @@ func Convert_v1alpha2_AmazonVPCNetworkingSpec_To_kops_AmazonVPCNetworkingSpec(in
 
 func autoConvert_kops_AmazonVPCNetworkingSpec_To_v1alpha2_AmazonVPCNetworkingSpec(in *kops.AmazonVPCNetworkingSpec, out *AmazonVPCNetworkingSpec, s conversion.Scope) error {
 	out.ImageName = in.ImageName
+	out.InitImageName = in.InitImageName
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]EnvVar, len(*in))

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -191,7 +191,7 @@
       - "env":
         - "name": "DISABLE_TCP_EARLY_DEMUX"
           "value": "false"
-        "image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.10"
+        "image": "{{- or .Networking.AmazonVPC.InitImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.7.10" }}"
         "imagePullPolicy": "Always"
         "name": "aws-vpc-cni-init"
         "securityContext":


### PR DESCRIPTION
Cherry pick of #11602 on release-1.21.

#11602: add init image field

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.