### PR TITLE
Dump all CP node logs to artifacts

### DIFF
--- a/tests/e2e/scenarios/kops-upgrade/run-test.sh
+++ b/tests/e2e/scenarios/kops-upgrade/run-test.sh
@@ -46,9 +46,19 @@ KOPS="${FIRST_KOPS}"
 
 # Always tear-down the cluster when we're done
 function finish {
-  ${KUBETEST2} --kops-binary-path="${KOPS}" --down || echo "kubetest2 down failed"
+ 
+KOPS_LOG_DIR="${ARTIFACTS}/logs"
+mkdir -p "${KOPS_LOG_DIR}"
+
+KOPS_CP=$(${KOPS} toolbox dump -o json | jq -r '.instances[] | select( .roles | index("master" )) | .publicAddresses[0]')
+
+ssh -i "${AWS_SSH_PRIVATE_KEY_FILE}" "ubuntu@${KOPS_CP}" sudo chmod -R a+r /var/log
+scp -i "${AWS_SSH_PRIVATE_KEY_FILE}" -r "ubuntu@${KOPS_CP}:/var/log/" "${KOPS_LOG_DIR}"
+
+${KUBETEST2} --kops-binary-path="${KOPS}" --down || echo "kubetest2 down failed"
 }
 trap finish EXIT
+
 
 ${KUBETEST2} \
 	--up \

--- a/tests/e2e/scenarios/kops-upgrade/run-test.sh
+++ b/tests/e2e/scenarios/kops-upgrade/run-test.sh
@@ -47,15 +47,15 @@ KOPS="${FIRST_KOPS}"
 # Always tear-down the cluster when we're done
 function finish {
  
-KOPS_LOG_DIR="${ARTIFACTS}/logs"
-mkdir -p "${KOPS_LOG_DIR}"
+  KOPS_LOG_DIR="${ARTIFACTS}/logs"
+  mkdir -p "${KOPS_LOG_DIR}"
 
-KOPS_CP=$(${KOPS} toolbox dump -o json | jq -r '.instances[] | select( .roles | index("master" )) | .publicAddresses[0]')
+  KOPS_CP=$(${KOPS} toolbox dump -o json | jq -r '.instances[] | select( .roles | index("master" )) | .publicAddresses[0]')
 
-ssh -i "${AWS_SSH_PRIVATE_KEY_FILE}" "ubuntu@${KOPS_CP}" sudo chmod -R a+r /var/log
-scp -i "${AWS_SSH_PRIVATE_KEY_FILE}" -r "ubuntu@${KOPS_CP}:/var/log/" "${KOPS_LOG_DIR}"
+  ssh -i "${AWS_SSH_PRIVATE_KEY_FILE}" "ubuntu@${KOPS_CP}" sudo chmod -R a+r /var/log
+  scp -i "${AWS_SSH_PRIVATE_KEY_FILE}" -r "ubuntu@${KOPS_CP}:/var/log/" "${KOPS_LOG_DIR}"
 
-${KUBETEST2} --kops-binary-path="${KOPS}" --down || echo "kubetest2 down failed"
+  ${KUBETEST2} --kops-binary-path="${KOPS}" --down || echo "kubetest2 down failed"
 }
 trap finish EXIT
 


### PR DESCRIPTION
A bit brutish, but I need to have a look at the logs at test failure time to understand why dns-controller is not doing its thing.

/cc @rifelpet @hakman 