### PR TITLE
Automated cherry pick of #11618: Set lifecycle on WarmPool task

### DIFF
--- a/cloudmock/aws/mockautoscaling/warmpool.go
+++ b/cloudmock/aws/mockautoscaling/warmpool.go
@@ -28,3 +28,7 @@ func (m *MockAutoscaling) DescribeWarmPool(input *autoscaling.DescribeWarmPoolIn
 	}
 	return ret, nil
 }
+
+func (m *MockAutoscaling) DeleteWarmPool(*autoscaling.DeleteWarmPoolInput) (*autoscaling.DeleteWarmPoolOutput, error) {
+	return &autoscaling.DeleteWarmPoolOutput{}, nil
+}

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -92,8 +92,9 @@ func (b *AutoscalingGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		{
 			enabled := fi.Bool(warmPool.IsEnabled())
 			warmPoolTask := &awstasks.WarmPool{
-				Name:    &name,
-				Enabled: enabled,
+				Name:      &name,
+				Lifecycle: b.Lifecycle,
+				Enabled:   enabled,
 			}
 			if warmPool.IsEnabled() {
 				warmPoolTask.MinSize = warmPool.MinSize

--- a/upup/pkg/fi/cloudup/awstasks/warmpool.go
+++ b/upup/pkg/fi/cloudup/awstasks/warmpool.go
@@ -59,16 +59,18 @@ func (e *WarmPool) Find(c *fi.Context) (*WarmPool, error) {
 	}
 	if warmPool.WarmPoolConfiguration == nil {
 		return &WarmPool{
-			Name:    e.Name,
-			Enabled: fi.Bool(false),
+			Name:      e.Name,
+			Lifecycle: e.Lifecycle,
+			Enabled:   fi.Bool(false),
 		}, nil
 	}
 
 	actual := &WarmPool{
-		Name:    e.Name,
-		Enabled: fi.Bool(true),
-		MaxSize: warmPool.WarmPoolConfiguration.MaxGroupPreparedCapacity,
-		MinSize: fi.Int64Value(warmPool.WarmPoolConfiguration.MinSize),
+		Name:      e.Name,
+		Lifecycle: e.Lifecycle,
+		Enabled:   fi.Bool(true),
+		MaxSize:   warmPool.WarmPoolConfiguration.MaxGroupPreparedCapacity,
+		MinSize:   fi.Int64Value(warmPool.WarmPoolConfiguration.MinSize),
 	}
 	return actual, nil
 }


### PR DESCRIPTION
Cherry pick of #11618 on release-1.21.

#11618: Set lifecycle on WarmPool task

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.