### PR TITLE
WIP Stop feature-flagging SpecOverride

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -295,9 +295,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", options.DryRun, "If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.")
 	cmd.Flags().StringVarP(&options.Output, "output", "o", options.Output, "Output format. One of json|yaml. Used with the --dry-run flag.")
 
-	if featureflag.SpecOverrideFlag.Enabled() {
-		cmd.Flags().StringSliceVar(&options.Overrides, "override", options.Overrides, "Directly configure values in the spec")
-	}
+	cmd.Flags().StringSliceVar(&options.Overrides, "override", options.Overrides, "Directly configure values in the spec")
 
 	// GCE flags
 	cmd.Flags().StringVar(&options.Project, "project", options.Project, "Project to use (must be set on GCE)")

--- a/cmd/kops/lifecycle_integration_test.go
+++ b/cmd/kops/lifecycle_integration_test.go
@@ -181,12 +181,6 @@ func TestLifecycleNodeTerminationHandlerQueueProcessor(t *testing.T) {
 func runLifecycleTest(h *testutils.IntegrationTestHarness, o *LifecycleTestOptions, cloud *awsup.MockAWSCloud) {
 	ctx := context.Background()
 
-	featureflag.ParseFlags("+SpecOverrideFlag")
-	unsetFeatureFlags := func() {
-		featureflag.ParseFlags("-SpecOverrideFlag")
-	}
-	defer unsetFeatureFlags()
-
 	t := o.t
 
 	t.Logf("running lifecycle test for cluster %s", o.ClusterName)

--- a/docs/advanced/experimental.md
+++ b/docs/advanced/experimental.md
@@ -11,7 +11,6 @@ The following experimental features are currently available:
 * `+SkipTerraformFormat` - Do not `terraform fmt` the generated terraform files.
 * `+EnableExternalCloudController` - Enables the use of cloud-controller-manager introduced in v1.7.
 * `+EnableSeparateConfigBase` - Allow a config-base that is different from the state store.
-* `+SpecOverrideFlag` - Allow setting spec values on `kops create`.
 * `+ExperimentalClusterDNS` - Turns off validation of the kubelet cluster dns flag.
 * `+EnableNodeAuthorization` - Enable support of Node Authorization, see [node_authorization.md](../node_authorization.md).
 * `+GoogleCloudBucketAcl` - Enables setting the ACL on the state store bucket when using GCS

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -112,6 +112,7 @@ kops create cluster [flags]
       --os-octavia                       If true octavia loadbalancer api will be used
       --out string                       Path to write any local output
   -o, --output string                    Output format. One of json|yaml. Used with the --dry-run flag.
+      --override strings                 Directly configure values in the spec
       --project string                   Project to use (must be set on GCE)
       --ssh-access strings               Restrict SSH access to this CIDR.  If not set, access will not be restricted by IP. (default [0.0.0.0/0])
       --ssh-public-key string            SSH public key to use (defaults to ~/.ssh/id_rsa.pub on AWS)

--- a/pkg/commands/BUILD.bazel
+++ b/pkg/commands/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/assets:go_default_library",
         "//pkg/client/simple:go_default_library",
         "//pkg/commands/helpers:go_default_library",
-        "//pkg/featureflag:go_default_library",
         "//upup/pkg/fi/cloudup:go_default_library",
         "//util/pkg/reflectutils:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",

--- a/pkg/commands/set_cluster.go
+++ b/pkg/commands/set_cluster.go
@@ -27,7 +27,6 @@ import (
 
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/util/pkg/reflectutils"
 )
 
@@ -38,10 +37,6 @@ type SetClusterOptions struct {
 
 // RunSetCluster implements the set cluster command logic
 func RunSetCluster(ctx context.Context, f *util.Factory, cmd *cobra.Command, out io.Writer, options *SetClusterOptions) error {
-	if !featureflag.SpecOverrideFlag.Enabled() {
-		return fmt.Errorf("set cluster command is current feature gated; set `export KOPS_FEATURE_FLAGS=SpecOverrideFlag`")
-	}
-
 	if options.ClusterName == "" {
 		return field.Required(field.NewPath("clusterName"), "Cluster name is required")
 	}

--- a/pkg/commands/set_instancegroups.go
+++ b/pkg/commands/set_instancegroups.go
@@ -27,7 +27,6 @@ import (
 
 	"k8s.io/kops/cmd/kops/util"
 	api "k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/util/pkg/reflectutils"
 )
 
@@ -41,10 +40,6 @@ type SetInstanceGroupOptions struct {
 
 // RunSetInstancegroup implements the set instancegroup command logic.
 func RunSetInstancegroup(ctx context.Context, f *util.Factory, cmd *cobra.Command, out io.Writer, options *SetInstanceGroupOptions) error {
-	if !featureflag.SpecOverrideFlag.Enabled() {
-		return fmt.Errorf("set instancegroup is currently feature gated; set `export KOPS_FEATURE_FLAGS=SpecOverrideFlag`")
-	}
-
 	if options.ClusterName == "" {
 		return field.Required(field.NewPath("clusterName"), "Cluster name is required")
 	}

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -70,7 +70,7 @@ var (
 	// It allows for experiments with alternative DNS configurations - in particular local proxies.
 	SkipTerraformFormat = New("SkipTerraformFormat", Bool(false))
 	// SpecOverrideFlag allows setting spec values on create
-	SpecOverrideFlag = New("SpecOverrideFlag", Bool(false))
+	SpecOverrideFlag = New("SpecOverrideFlag", Bool(true))
 	// Spotinst toggles the use of Spotinst integration.
 	Spotinst = New("Spotinst", Bool(false))
 	// SpotinstOcean toggles the use of Spotinst Ocean instance group implementation.


### PR DESCRIPTION
We turn it into an unchecked default-on feature flag because the e2e upgrade tests use it.