### PR TITLE
Remove fallback support for legacy IAM

### DIFF
--- a/docs/contributing/adding_a_feature.md
+++ b/docs/contributing/adding_a_feature.md
@@ -114,12 +114,7 @@ are built by `BuildAWSPolicyMaster()` in pkg/model/iam/iam_builder.go:
 ```
 
 ```go
-func addCiliumEniPermissions(p *Policy, resource stringorslice.StringOrSlice, legacyIAM bool) {
-	if legacyIAM {
-		// Legacy IAM provides ec2:*, so no additional permissions required
-		return
-	}
-
+func addCiliumEniPermissions(p *Policy, resource stringorslice.StringOrSlice) {
 	p.Statement = append(p.Statement,
 		&Statement{
 			Effect: StatementEffectAllow,

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -221,12 +221,8 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 		}
 	}
 
-	if (spec.IAM == nil || spec.IAM.Legacy) && !featureflag.LegacyIAM.Enabled() {
+	if spec.IAM == nil || spec.IAM.Legacy {
 		allErrs = append(allErrs, field.Forbidden(fieldPath.Child("iam", "legacy"), "legacy IAM permissions are no longer supported"))
-	}
-
-	if (spec.IAM == nil || spec.IAM.Legacy) && featureflag.UseServiceAccountIAM.Enabled() {
-		allErrs = append(allErrs, field.Forbidden(fieldPath.Child("iam", "legacy"), "legacy IAM permissions are not supported with UseServiceAccountIAM"))
 	}
 
 	if spec.RollingUpdate != nil {

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -87,8 +87,6 @@ var (
 	SkipEtcdVersionCheck = New("SkipEtcdVersionCheck", Bool(false))
 	// TerraformJSON outputs terraform in JSON instead of hcl output. JSON output can be also parsed by terraform 0.12
 	TerraformJSON = New("TerraformJSON", Bool(false))
-	// LegacyIAM will permit use of legacy IAM permissions.
-	LegacyIAM = New("LegacyIAM", Bool(false))
 	// ClusterAddons activates experimental cluster-addons support
 	ClusterAddons = New("ClusterAddons", Bool(false))
 	// UseServiceAccountIAM controls whether we use pod-level IAM permissions for our system pods and kOps addons.

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -117,61 +117,36 @@ func TestRoundTrip(t *testing.T) {
 func TestPolicyGeneration(t *testing.T) {
 	grid := []struct {
 		Role                   Subject
-		LegacyIAM              bool
 		AllowContainerRegistry bool
 		Policy                 string
 	}{
 		{
 			Role:                   &NodeRoleMaster{},
-			LegacyIAM:              true,
-			AllowContainerRegistry: false,
-			Policy:                 "tests/iam_builder_master_legacy.json",
-		},
-		{
-			Role:                   &NodeRoleMaster{},
-			LegacyIAM:              false,
 			AllowContainerRegistry: false,
 			Policy:                 "tests/iam_builder_master_strict.json",
 		},
 		{
 			Role:                   &NodeRoleMaster{},
-			LegacyIAM:              false,
 			AllowContainerRegistry: true,
 			Policy:                 "tests/iam_builder_master_strict_ecr.json",
 		},
 		{
 			Role:                   &NodeRoleNode{},
-			LegacyIAM:              true,
-			AllowContainerRegistry: false,
-			Policy:                 "tests/iam_builder_node_legacy.json",
-		},
-		{
-			Role:                   &NodeRoleNode{},
-			LegacyIAM:              false,
 			AllowContainerRegistry: false,
 			Policy:                 "tests/iam_builder_node_strict.json",
 		},
 		{
 			Role:                   &NodeRoleNode{},
-			LegacyIAM:              false,
 			AllowContainerRegistry: true,
 			Policy:                 "tests/iam_builder_node_strict_ecr.json",
 		},
 		{
 			Role:                   &NodeRoleBastion{},
-			LegacyIAM:              true,
 			AllowContainerRegistry: false,
 			Policy:                 "tests/iam_builder_bastion.json",
 		},
 		{
 			Role:                   &NodeRoleBastion{},
-			LegacyIAM:              false,
-			AllowContainerRegistry: false,
-			Policy:                 "tests/iam_builder_bastion.json",
-		},
-		{
-			Role:                   &NodeRoleBastion{},
-			LegacyIAM:              false,
 			AllowContainerRegistry: true,
 			Policy:                 "tests/iam_builder_bastion.json",
 		},
@@ -183,7 +158,6 @@ func TestPolicyGeneration(t *testing.T) {
 				Spec: kops.ClusterSpec{
 					ConfigStore: "s3://kops-tests/iam-builder-test.k8s.local",
 					IAM: &kops.IAMSpec{
-						Legacy:                 x.LegacyIAM,
 						AllowContainerRegistry: x.AllowContainerRegistry,
 					},
 					EtcdClusters: []kops.EtcdClusterSpec{

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -212,7 +212,6 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 
 	cluster.Spec.IAM = &api.IAMSpec{
 		AllowContainerRegistry: true,
-		Legacy:                 false,
 	}
 	cluster.Spec.Kubelet = &api.KubeletConfigSpec{
 		AnonymousAuth: fi.Bool(false),


### PR DESCRIPTION
This was feature-flagged in kops 1.19 and announced as scheduled to be completely removed as of kops 1.20.