### PR TITLE
Fix service-account-issuer url when specify s3 bucket as serviceAccountIssuerDiscovery

### DIFF
--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -447,7 +447,8 @@ func (p *S3Path) GetHTTPsUrl() (string, error) {
 		}
 		p.bucketDetails = bucketDetails
 	}
-	return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", p.bucketDetails.name, p.bucketDetails.region, p.Key()), nil
+	url := fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", p.bucketDetails.name, p.bucketDetails.region, p.Key())
+	return strings.TrimSuffix(url, "/"), nil
 }
 
 // AWSErrorCode returns the aws error code, if it is an awserr.Error, otherwise ""


### PR DESCRIPTION
This PR is a small change.

Service account issuer URL is wrong when I specify  serviceAccountIssuerDiscovery according to https://kops.sigs.k8s.io/cluster_spec/#service-account-issuer-discovery-and-aws-iam-roles-for-service-accounts-irsa .

For example, when I specify following spec 
```yaml
spec:
  serviceAccountIssuerDiscovery:
    discoveryStore: s3://h3poteto-playground-oidc
    enableAWSOIDCProvider: true
```

kube-apiserver's parameters are

```
    - --service-account-issuer=https://h3poteto-playground-oidc.s3.us-east-1.amazonaws.com//oidc
    - --service-account-jwks-uri=https://h3poteto-playground-oidc.s3.us-east-1.amazonaws.com//oidc/openid/v1/jwks
    - --service-account-key-file=/srv/kubernetes/service-account.key
    - --service-account-signing-key-file=/srv/kubernetes/service-account.key
    - --service-cluster-ip-range=100.64.0.0/13
```

There is no conent in `https://h3poteto-playground-oidc.s3.us-east-1.amazonaws.com//oidc`, it should be `https://h3poteto-playground-oidc.s3.us-east-1.amazonaws.com/oidc` . So I removed trailing slash from S3 bucket URL.