### PR TITLE
WIP test multi-arch nfs-provisioner image in the sig-storage e2e suite

### DIFF
--- a/tests/e2e/scenarios/aws-ebs-csi/repos.yaml
+++ b/tests/e2e/scenarios/aws-ebs-csi/repos.yaml
@@ -1,0 +1,2 @@
+# https://hub.docker.com/r/rifelpet/nfs-provisioner/tags?page=1&ordering=last_updated
+sigStorageRegistry: rifelpet

--- a/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
+++ b/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
@@ -47,7 +47,7 @@ export KUBE_TEST_REPO_LIST="${REPO_ROOT}/tests/e2e/scenarios/aws-ebs-csi/repos.y
 ${KUBETEST2} \
 	--up --down \
 	--cloud-provider=aws \
-	--create-args="--image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210518' --channel=alpha --networking=calico --container-runtime=containerd" \
+	--create-args="--node-size=m6g.large --master-size=m6g.large --image='099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210510' --channel=alpha --networking=calico --container-runtime=containerd" \
 	--kops-version-marker=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt \
 	--kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.21.txt \
 	--test=kops \


### PR DESCRIPTION
The new multi-arch image is meant to get these sig-storage failures on ARM to pass: https://testgrid.k8s.io/kops-misc#kops-aws-misc-arm64-release&show-stale-tests=

ref: https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner/pull/50

First I will test this with the default amd64 instance types. Then i'll update the scenario to use arm64 instance types.

EDIT:

I had to retag the images I built with `v2.2.2` because `KUBE_TEST_REPO_LIST` uses the same tags as the originals.
 
[here](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/11651/pull-kops-e2e-aws-ebs-csi-driver/1399520070446616576) is the successful run on amd64 nodes