### PR TITLE
Consolidate CSI livenessprobe images for multi-arch support

### DIFF
--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -343,7 +343,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.2.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -63,7 +63,7 @@ spec:
   - id: k8s-1.17
     kubernetesVersion: '>=1.17.0'
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9ba8d43d59ac121dd824e5b0942e18d9d7a2583d
+    manifestHash: 7ccbed99da6bb0409268c07fd1ab079f04dc6140
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io


### PR DESCRIPTION
This manifest includes two liveness-probe containers but they use different images.
The k8s.gcr.io image is multi-arch but the quay.io image is not.
By only using the k8s.gcr.io one we should fix arm64 clusters now that EBS CSI is enabled by default.

ref: https://testgrid.k8s.io/kops-misc#kops-aws-misc-arm64-ci&show-stale-tests=

https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-misc-arm64-ci/1397862870238105600/artifacts/cluster-info/kube-system/ebs-csi-node-g2wjb/logs.txt

```
==== START logs for container liveness-probe of pod kube-system/ebs-csi-node-g2wjb ====
standard_init_linux.go:219: exec user process caused: exec format error
==== END logs for container liveness-probe of pod kube-system/ebs-csi-node-g2wjb ====
```