### PR TITLE
Fix copying of images from docker.io

### DIFF
--- a/upup/pkg/fi/assettasks/docker_api.go
+++ b/upup/pkg/fi/assettasks/docker_api.go
@@ -19,6 +19,7 @@ package assettasks
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -60,6 +61,7 @@ func newDockerAPI() (*dockerAPI, error) {
 
 // findImage does a `docker images` via the API, and finds the specified image
 func (d *dockerAPI) findImage(name string) (*types.ImageSummary, error) {
+	name = strings.TrimPrefix(name, "docker.io/")
 	klog.V(4).Infof("docker query for image %q", name)
 	filter := filters.NewArgs(filters.KeyValuePair{Key: "reference", Value: name})
 	options := types.ImageListOptions{


### PR DESCRIPTION
When copying image assets, it pulls the image and then looks for it by name. When the name starts with "docker.io/", it doesn't find it because Docker omits that prefix for images in that domain.


/kind bug