### PR TITLE
Kubetest2 scenario script cleanup

### DIFF
--- a/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
+++ b/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
@@ -17,6 +17,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
 

--- a/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
+++ b/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
@@ -29,7 +29,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel);
 KOPS="${REPO_ROOT}/bazel-bin/cmd/kops/linux-amd64/kops"
 
 KUBETEST2="kubetest2 kops -v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-}"
-KUBETEST2="${KUBETEST2} --admin-access=${ADMIN_ACCESS:-}"
+KUBETEST2="${KUBETEST2} --admin-access=${ADMIN_ACCESS:-} --kops-binary-path=${KOPS}"
 
 export GO111MODULE=on
 
@@ -38,11 +38,11 @@ go install sigs.k8s.io/kubetest2
 go install ./kubetest2-kops
 go install ./kubetest2-tester-kops
 
-${KUBETEST2} --build --kops-root="${REPO_ROOT}" --stage-location="${STAGE_LOCATION:-}" --kops-binary-path="${KOPS}"
+${KUBETEST2} --build --kops-root="${REPO_ROOT}" --stage-location="${STAGE_LOCATION:-}"
 
 # Always tear-down the cluster when we're done
 function finish {
-  ${KUBETEST2} --kops-binary-path="${KOPS}" --down || echo "kubetest2 down failed"
+  ${KUBETEST2} --down || echo "kubetest2 down failed"
 }
 trap finish EXIT
 
@@ -53,7 +53,6 @@ OVERRIDES="$OVERRIDES --override=cluster.spec.certManager.enabled=true"
 
 ${KUBETEST2} \
 		--up \
-		--kops-binary-path="${KOPS}" \
 		--kubernetes-version="1.21.0" \
 		--create-args="--networking calico $OVERRIDES"
 

--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -17,6 +17,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
 

--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -54,8 +54,7 @@ REGION=${ZONE::-1}
 cd "$(mktemp -dt kops.XXXXXXXXX)"
 go get github.com/onsi/ginkgo/ginkgo
 
-# Using a custom fork until https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2012 has merged
-git clone --branch e2e-filter-non-eligible-targets https://github.com/olemarkus/aws-load-balancer-controller .
+git clone https://github.com/kubernetes-sigs/aws-load-balancer-controller .
 
 ginkgo -v -r test/e2e/ingress -- \
     -cluster-name="${CLUSTER_NAME}" \

--- a/tests/e2e/scenarios/digital-ocean/run-test
+++ b/tests/e2e/scenarios/digital-ocean/run-test
@@ -17,6 +17,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 export KOPS_FEATURE_FLAGS="SpecOverrideFlag,${KOPS_FEATURE_FLAGS:-}"
 REPO_ROOT=$(git rev-parse --show-toplevel);

--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -17,8 +17,6 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-
-# Print all commands
 set -o xtrace
 
 echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"

--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -52,7 +52,7 @@ if [[ "${KOPS_VERSION_B}" == "source" ]]; then
 	wget -qO "${KOPS_B}" "$KOPS_BASE_URL/$(go env GOOS)/$(go env GOARCH)/kops"
 	chmod +x "${KOPS_B}"
 else
-	wget -O "${KOPS_B}" "https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION_B/kops-$(go env GOOS)-$(go env GOARCH)"
+	wget -qO "${KOPS_B}" "https://github.com/kubernetes/kops/releases/download/$KOPS_VERSION_B/kops-$(go env GOOS)-$(go env GOARCH)"
 	chmod +x "${KOPS_B}"
 fi
 


### PR DESCRIPTION
This improves the consistency of the scenario scripts. My initial intention was to fix [this command failure](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-kops-e2e-aws-ebs-csi-driver/1399525045788741632#1:build-log.txt%3A5092) so I'm hoping the `set -x` will help with visibility into whats going wrong.