### PR TITLE
Add more lifecycles to HasLifecycle tasks

### DIFF
--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -506,9 +506,10 @@ func (b *SpotInstanceGroupModelBuilder) buildLaunchSpec(c *fi.ModelBuilderContex
 	ig, igOcean *kops.InstanceGroup, ocean *spotinsttasks.Ocean) (err error) {
 	klog.V(4).Infof("Building instance group as LaunchSpec: %q", b.AutoscalingGroupName(ig))
 	launchSpec := &spotinsttasks.LaunchSpec{
-		Name:    fi.String(b.AutoscalingGroupName(ig)),
-		ImageID: fi.String(ig.Spec.Image),
-		Ocean:   ocean, // link to Ocean
+		Name:      fi.String(b.AutoscalingGroupName(ig)),
+		Lifecycle: b.Lifecycle,
+		ImageID:   fi.String(ig.Spec.Image),
+		Ocean:     ocean, // link to Ocean
 	}
 
 	// Instance types and strategy.

--- a/pkg/model/pki.go
+++ b/pkg/model/pki.go
@@ -131,10 +131,11 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	if b.KopsModelContext.Cluster.Spec.Networking.Kuberouter != nil && !b.UseKopsControllerForNodeBootstrap() {
 		t := &fitasks.Keypair{
-			Name:    fi.String("kube-router"),
-			Subject: "cn=" + rbac.KubeRouter,
-			Type:    "client",
-			Signer:  defaultCA,
+			Name:      fi.String("kube-router"),
+			Lifecycle: b.Lifecycle,
+			Subject:   "cn=" + rbac.KubeRouter,
+			Type:      "client",
+			Signer:    defaultCA,
 		}
 		c.AddTask(t)
 	}
@@ -177,6 +178,7 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		// @note: the certificate used by the node authorizers
 		c.AddTask(&fitasks.Keypair{
 			Name:           fi.String("node-authorizer"),
+			Lifecycle:      b.Lifecycle,
 			Subject:        "cn=node-authorizaer",
 			Type:           "server",
 			AlternateNames: alternateNames,
@@ -185,10 +187,11 @@ func (b *PKIModelBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		// @note: we use this for mutual tls between node and authorizer
 		c.AddTask(&fitasks.Keypair{
-			Name:    fi.String("node-authorizer-client"),
-			Subject: "cn=node-authorizer-client",
-			Type:    "client",
-			Signer:  defaultCA,
+			Name:      fi.String("node-authorizer-client"),
+			Lifecycle: b.Lifecycle,
+			Subject:   "cn=node-authorizer-client",
+			Type:      "client",
+			Signer:    defaultCA,
 		})
 	}
 


### PR DESCRIPTION
I did a quick scan through the codebase using something similar the below to find any other tasks that were missing lifecycles.

```
for task in $(grep -rl HasLifecycle . | grep fitask | xargs basename | sed -e 's/_.*//'); do
  grep -r -A 10 --exclude-dir=vendor --exclude="*test.go" -i "${task}{" .
done
```



followup to https://github.com/kubernetes/kops/pull/11650