### PR TITLE
Automated cherry pick of #11682: Drop trailing slash from oidc issuer

### DIFF
--- a/pkg/model/issuerdiscovery.go
+++ b/pkg/model/issuerdiscovery.go
@@ -102,7 +102,7 @@ func (b *IssuerDiscoveryModelBuilder) Build(c *fi.ModelBuilderContext) error {
 
 func buildDiscoveryJSON(issuerURL string) ([]byte, error) {
 	d := oidcDiscovery{
-		Issuer:                fmt.Sprintf("%v/", issuerURL),
+		Issuer:                fmt.Sprintf("%v", issuerURL),
 		JWKSURI:               fmt.Sprintf("%v/openid/v1/jwks", issuerURL),
 		AuthorizationEndpoint: "urn:kubernetes:programmatic_authorization",
 		ResponseTypes:         []string{"id_token"},


### PR DESCRIPTION
Cherry pick of #11682 on release-1.21.

#11682: Drop trailing slash from oidc issuer

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.