### PR TITLE
updating doc for cluster-autoscaler addon

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -35,7 +35,7 @@ spec:
     enabled: true
     expander: least-waste
     balanceSimilarNodeGroups: false
-    scaleDownUtilizationThreshold: 0.5
+    scaleDownUtilizationThreshold: "0.5"
     skipNodesWithLocalStorage: true
     skipNodesWithSystemPods: true
     newPodScaleUpDelay: 0s


### PR DESCRIPTION
`kops update cluster` dies if the `scaleDownUtilizationThreshold` is integer in the cluster spec, because it expects string. 

This change is working, now the example can be copied and pasted directly. 