### PR TITLE
Add options for configuring IPv4 and IPv6 support with Calico

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3233,6 +3233,10 @@ spec:
                           (default), "can-reach=DESTINATION", "interface=INTERFACE-REGEX",
                           or "skip-interface=INTERFACE-REGEX"'
                         type: string
+                      ipv4Support:
+                        description: 'IPv4Support enables Calico networking and security
+                          for IPv4 traffic. Default: "true"'
+                        type: boolean
                       ipv6AutoDetectionMethod:
                         description: 'IPv6AutoDetectionMethod configures how Calico
                           chooses the IP address used to route between nodes.  This
@@ -3241,6 +3245,10 @@ spec:
                           (default), "can-reach=DESTINATION", "interface=INTERFACE-REGEX",
                           or "skip-interface=INTERFACE-REGEX"'
                         type: string
+                      ipv6Support:
+                        description: 'IPv6Support enables Calico networking and security
+                          for IPv6 traffic. Default: "false"'
+                        type: boolean
                       logSeverityScreen:
                         description: 'LogSeverityScreen lets us set the desired log
                           level. (Default: info)'

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -150,12 +150,18 @@ type CalicoNetworkingSpec struct {
 	// Options: "first-found" (default), "can-reach=DESTINATION",
 	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
 	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
+	// IPv4Support enables Calico networking and security for IPv4 traffic.
+	// Default: "true"
+	IPv4Support *bool `json:"ipv4Support,omitempty"`
 	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
 	// between nodes.  This should be set when the host has multiple interfaces
 	// and it is important to select the interface used.
 	// Options: "first-found" (default), "can-reach=DESTINATION",
 	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
 	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
+	// IPv6Support enables Calico networking and security for IPv6 traffic.
+	// Default: "false"
+	IPv6Support *bool `json:"ipv6Support,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
 	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -150,12 +150,18 @@ type CalicoNetworkingSpec struct {
 	// Options: "first-found" (default), "can-reach=DESTINATION",
 	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
 	IPv4AutoDetectionMethod string `json:"ipv4AutoDetectionMethod,omitempty"`
+	// IPv4Support enables Calico networking and security for IPv4 traffic.
+	// Default: "true"
+	IPv4Support *bool `json:"ipv4Support,omitempty"`
 	// IPv6AutoDetectionMethod configures how Calico chooses the IP address used to route
 	// between nodes.  This should be set when the host has multiple interfaces
 	// and it is important to select the interface used.
 	// Options: "first-found" (default), "can-reach=DESTINATION",
 	// "interface=INTERFACE-REGEX", or "skip-interface=INTERFACE-REGEX"
 	IPv6AutoDetectionMethod string `json:"ipv6AutoDetectionMethod,omitempty"`
+	// IPv6Support enables Calico networking and security for IPv6 traffic.
+	// Default: "false"
+	IPv6Support *bool `json:"ipv6Support,omitempty"`
 	// IptablesBackend controls which variant of iptables binary Felix uses
 	// Default: Auto (other options: Legacy, NFT)
 	IptablesBackend string `json:"iptablesBackend,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1594,7 +1594,9 @@ func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *
 	out.EncapsulationMode = in.EncapsulationMode
 	out.IPIPMode = in.IPIPMode
 	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
+	out.IPv4Support = in.IPv4Support
 	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
+	out.IPv6Support = in.IPv6Support
 	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU
@@ -1629,7 +1631,9 @@ func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *
 	out.EncapsulationMode = in.EncapsulationMode
 	out.IPIPMode = in.IPIPMode
 	out.IPv4AutoDetectionMethod = in.IPv4AutoDetectionMethod
+	out.IPv4Support = in.IPv4Support
 	out.IPv6AutoDetectionMethod = in.IPv6AutoDetectionMethod
+	out.IPv6Support = in.IPv6Support
 	out.IptablesBackend = in.IptablesBackend
 	out.LogSeverityScreen = in.LogSeverityScreen
 	out.MTU = in.MTU

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -389,6 +389,16 @@ func (in *CalicoNetworkingSpec) DeepCopyInto(out *CalicoNetworkingSpec) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.IPv4Support != nil {
+		in, out := &in.IPv4Support, &out.IPv4Support
+		*out = new(bool)
+		**out = **in
+	}
+	if in.IPv6Support != nil {
+		in, out := &in.IPv6Support, &out.IPv6Support
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MTU != nil {
 		in, out := &in.MTU, &out.MTU
 		*out = new(int32)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -389,6 +389,16 @@ func (in *CalicoNetworkingSpec) DeepCopyInto(out *CalicoNetworkingSpec) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.IPv4Support != nil {
+		in, out := &in.IPv4Support, &out.IPv4Support
+		*out = new(bool)
+		**out = **in
+	}
+	if in.IPv6Support != nil {
+		in, out := &in.IPv6Support, &out.IPv6Support
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MTU != nil {
 		in, out := &in.MTU, &out.MTU
 		*out = new(int32)

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -84,7 +84,7 @@ data:
           ttl 30
         }
         prometheus :9153
-        forward . /etc/resolv.conf {
+        forward . {{ or (join KubeDNS.UpstreamNameservers " ") "/etc/resolv.conf" }} {
           max_concurrent 1000
         }
         loop

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -52,6 +52,8 @@ data:
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": __CNI_MTU__,
           "ipam": {
+              "assign_ipv4": "{{ WithDefaultBool .Networking.Calico.IPv4Support true }}",
+              "assign_ipv6": "{{ WithDefaultBool .Networking.Calico.IPv6Support false }}",
               "type": "calico-ipam"
           },
           "policy": {
@@ -3825,7 +3827,9 @@ spec:
               value: "kops,bgp"
             # Auto-detect the BGP IP address.
             - name: IP
-              value: "autodetect"
+              value: "{{- if (WithDefaultBool .Networking.Calico.IPv4Support true) -}}autodetect{{- else -}}none{{- end -}}"
+            - name: IP6
+              value: "{{- if (WithDefaultBool .Networking.Calico.IPv6Support false) -}}autodetect{{- else -}}none{{- end -}}"
             - name: IP_AUTODETECTION_METHOD
               value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "first-found" }}"
             - name: IP6_AUTODETECTION_METHOD
@@ -3857,8 +3861,17 @@ spec:
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
+            {{- if (WithDefaultBool .Networking.Calico.IPv6Support false) }}
+            - name: CALICO_IPV6POOL_CIDR
+              value: "{{ .KubeControllerManager.ClusterCIDR }}"
+            - name: CALICO_IPV6POOL_NAT_OUTGOING
+              value: "true"
+            - name: CALICO_ROUTER_ID
+              value: "hash"
+            {{- else if (WithDefaultBool .Networking.Calico.IPv4Support true) }}
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .KubeControllerManager.ClusterCIDR }}"
+            {{- end }}
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
@@ -3867,7 +3880,7 @@ spec:
               value: "ACCEPT"
             # Disable IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
-              value: "false"
+              value: "{{ WithDefaultBool .Networking.Calico.IPv6Support false }}"
             - name: FELIX_HEALTHENABLED
               value: "true"
 
@@ -3924,6 +3937,9 @@ spec:
               {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
               - -bird-live
               {{- end }}
+              {{- if (WithDefaultBool .Networking.Calico.IPv6Support false) }}
+              - -bird6-live
+              {{- end }}
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
@@ -3934,6 +3950,9 @@ spec:
               - -felix-ready
               {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
               - -bird-ready
+              {{- end }}
+              {{- if (WithDefaultBool .Networking.Calico.IPv6Support false) }}
+              - -bird6-ready
               {{- end }}
             periodSeconds: 10
           {{- if .Networking.Calico.PrometheusMetricsEnabled }}


### PR DESCRIPTION
Sample config to get started with AWS, Calico and IPv6, using a kOps cluster with public topology:
```yaml
  kubeAPIServer:
    bindAddress: "::"
  nonMasqueradeCIDR: fd00:10:96::/64
  serviceClusterIPRange: fd00:10:96::/108
  kubeControllerManager:
    clusterCIDR: fd00:10:96::/80
    allocateNodeCIDRs: false
  kubeDNS:
    provider: CoreDNS
    upstreamNameservers:
    - 2620:119:35::35
    - 2620:119:53::53
  networking:
    calico:
      ipv4Support: false
      ipv6Support: true
  subnets:
   - type: Public
     ipv6CIDR: 2a05:d014:...::/64
```

Ref: #8432 

/cc @justinsb @johngmyers @aojea 