### PR TITLE
Cherry pick of #11691: Fix set-version leaving backup files with "-e" suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # git mergetool
 *.orig
 
-# Go embed files?
-*.go-e
+# Droppings from hack/set-version
+*.bak
 
 # Compiled python files
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ ci: govet verify-gofmt verify-crds verify-gomod verify-goimports verify-boilerpl
 # verify-gofmt: uses bazel, covered by pull-kops-verify
 # govet needs to be after verify-goimports because it generates bindata.go
 .PHONY: quick-ci
-quick-ci: verify-crds verify-goimports govet verify-boilerplate verify-bazel verify-versions verify-misspelling verify-shellcheck verify-bindata | verify-gendocs verify-apimachinery
+quick-ci: verify-crds verify-goimports govet verify-boilerplate verify-bazel verify-misspelling verify-shellcheck verify-bindata verify-versions | verify-gendocs verify-apimachinery
 	echo "Done!"
 
 .PHONY: pr

--- a/hack/set-version
+++ b/hack/set-version
@@ -56,21 +56,21 @@ KOPS_CI_VERSION=`grep 'KOPS_CI_VERSION\s*=' version.go  |  awk '{print $3}' | se
 echo "KOPS_RELEASE_VERSION ${KOPS_RELEASE_VERSION} -> ${NEW_RELEASE_VERSION}"
 echo "KOPS_CI_VERSION ${KOPS_CI_VERSION} -> ${NEW_CI_VERSION}"
 
-sed -i -e "s@DNS_CONTROLLER_TAG=${KOPS_RELEASE_VERSION}@DNS_CONTROLLER_TAG=${NEW_RELEASE_VERSION}@g" Makefile
-sed -i -e "s@KOPS_CONTROLLER_TAG=${KOPS_RELEASE_VERSION}@KOPS_CONTROLLER_TAG=${NEW_RELEASE_VERSION}@g" Makefile
-sed -i -e "s@KUBE_APISERVER_HEALTHCHECK_TAG=${KOPS_RELEASE_VERSION}@KUBE_APISERVER_HEALTHCHECK_TAG=${NEW_RELEASE_VERSION}@g" Makefile
-sed -i -e "s@\"${KOPS_RELEASE_VERSION}\"@\"${NEW_RELEASE_VERSION}\"@g" upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
-sed -i -e "s@${KOPS_RELEASE_VERSION}@${NEW_RELEASE_VERSION}@g" upup/pkg/fi/cloudup/urls_test.go
+sed -i.bak -e "s@DNS_CONTROLLER_TAG=${KOPS_RELEASE_VERSION}@DNS_CONTROLLER_TAG=${NEW_RELEASE_VERSION}@g" Makefile
+sed -i.bak -e "s@KOPS_CONTROLLER_TAG=${KOPS_RELEASE_VERSION}@KOPS_CONTROLLER_TAG=${NEW_RELEASE_VERSION}@g" Makefile
+sed -i.bak -e "s@KUBE_APISERVER_HEALTHCHECK_TAG=${KOPS_RELEASE_VERSION}@KUBE_APISERVER_HEALTHCHECK_TAG=${NEW_RELEASE_VERSION}@g" Makefile
+sed -i.bak -e "s@\"${KOPS_RELEASE_VERSION}\"@\"${NEW_RELEASE_VERSION}\"@g" upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+sed -i.bak -e "s@${KOPS_RELEASE_VERSION}@${NEW_RELEASE_VERSION}@g" upup/pkg/fi/cloudup/urls_test.go
 
-git grep -l k8s.gcr.io/kops/dns-controller | xargs -I {} sed -i -e "s@dns-controller:${KOPS_RELEASE_VERSION}@dns-controller:${NEW_RELEASE_VERSION}@g" {}
-git grep -l "version..v${KOPS_RELEASE_VERSION}" upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/ | xargs -I {} sed -i -e "s@version: v${KOPS_RELEASE_VERSION}@version: v${NEW_RELEASE_VERSION}@g" {}
+git grep -l k8s.gcr.io/kops/dns-controller | xargs -I {} sed -i.bak -e "s@dns-controller:${KOPS_RELEASE_VERSION}@dns-controller:${NEW_RELEASE_VERSION}@g" {}
+git grep -l "version..v${KOPS_RELEASE_VERSION}" upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/ | xargs -I {} sed -i.bak -e "s@version: v${KOPS_RELEASE_VERSION}@version: v${NEW_RELEASE_VERSION}@g" {}
 
-git grep -l k8s.gcr.io/kops/kops-controller | xargs -I {} sed -i -e "s@kops-controller:${KOPS_RELEASE_VERSION}@kops-controller:${NEW_RELEASE_VERSION}@g" {}
-git grep -l "version..v${KOPS_RELEASE_VERSION}" upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/ | xargs -I {} sed -i -e "s@version: v${KOPS_RELEASE_VERSION}@version: v${NEW_RELEASE_VERSION}@g" {}
+git grep -l k8s.gcr.io/kops/kops-controller | xargs -I {} sed -i.bak -e "s@kops-controller:${KOPS_RELEASE_VERSION}@kops-controller:${NEW_RELEASE_VERSION}@g" {}
+git grep -l "version..v${KOPS_RELEASE_VERSION}" upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/ | xargs -I {} sed -i.bak -e "s@version: v${KOPS_RELEASE_VERSION}@version: v${NEW_RELEASE_VERSION}@g" {}
 
-git grep -l k8s.gcr.io/kops/kube-apiserver-healthcheck | xargs -I {} sed -i -e "s@kube-apiserver-healthcheck:${KOPS_RELEASE_VERSION}@kube-apiserver-healthcheck:${NEW_RELEASE_VERSION}@g" {}
+git grep -l k8s.gcr.io/kops/kube-apiserver-healthcheck | xargs -I {} sed -i.bak -e "s@kube-apiserver-healthcheck:${KOPS_RELEASE_VERSION}@kube-apiserver-healthcheck:${NEW_RELEASE_VERSION}@g" {}
 
-git grep -l "version..${KOPS_RELEASE_VERSION}" upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/ | xargs -I {} sed -i -e "s@version: ${KOPS_RELEASE_VERSION}@version: ${NEW_RELEASE_VERSION}@g" {}
+git grep -l "version..${KOPS_RELEASE_VERSION}" upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/ | xargs -I {} sed -i.bak -e "s@version: ${KOPS_RELEASE_VERSION}@version: ${NEW_RELEASE_VERSION}@g" {}
 
-sed -i -e "s@${KOPS_CI_VERSION}@${NEW_CI_VERSION}@g" version.go
-sed -i -e "s@${KOPS_RELEASE_VERSION}@${NEW_RELEASE_VERSION}@g" version.go
+sed -i.bak -e "s@${KOPS_CI_VERSION}@${NEW_CI_VERSION}@g" version.go
+sed -i.bak -e "s@${KOPS_RELEASE_VERSION}@${NEW_RELEASE_VERSION}@g" version.go


### PR DESCRIPTION
Cherry pick of #11691 on release-1.20.

#11691: Fix set-version leaving backup files with "-e" suffix

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.