### PR TITLE
Move asset copying out of apply_cluster

### DIFF
--- a/cmd/kops/BUILD.bazel
+++ b/cmd/kops/BUILD.bazel
@@ -90,6 +90,7 @@ go_library(
         "//pkg/util/templater:go_default_library",
         "//pkg/validation:go_default_library",
         "//upup/pkg/fi:go_default_library",
+        "//upup/pkg/fi/assettasks:go_default_library",
         "//upup/pkg/fi/cloudup:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/utils:go_default_library",

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -526,7 +526,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		return err
 	}
 
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	fullCluster, err := cloudup.PopulateClusterSpec(clientset, cluster, cloud, assetBuilder)
 	if err != nil {
 		return err

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -216,7 +216,7 @@ func RunEditCluster(ctx context.Context, f *util.Factory, cmd *cobra.Command, ar
 			return preservedFile(fmt.Errorf("error populating configuration: %v", err), file, out)
 		}
 
-		assetBuilder := assets.NewAssetBuilder(newCluster, "")
+		assetBuilder := assets.NewAssetBuilder(newCluster, false)
 		fullCluster, err := cloudup.PopulateClusterSpec(clientset, newCluster, cloud, assetBuilder)
 		if err != nil {
 			results = editResults{

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -171,7 +171,7 @@ func RunEditInstanceGroup(ctx context.Context, f *util.Factory, cmd *cobra.Comma
 		return fmt.Errorf("error populating configuration: %v", err)
 	}
 
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	fullCluster, err := cloudup.PopulateClusterSpec(clientset, cluster, cloud, assetBuilder)
 	if err != nil {
 		return err

--- a/docs/cli/kops_get_assets.md
+++ b/docs/cli/kops_get_assets.md
@@ -23,6 +23,7 @@ kops get assets [flags]
 ### Options
 
 ```
+      --copy   copy assets to local repository
   -h, --help   help for assets
 ```
 

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -32,7 +32,7 @@ kops update cluster [flags]
       --internal                      Use the cluster's internal DNS name. Implies --create-kube-config
       --lifecycle-overrides strings   comma separated list of phase overrides, example: SecurityGroups=Ignore,InternetGateway=ExistsAndWarnIfChanges
       --out string                    Path to write any local output
-      --phase string                  Subset of tasks to run: assets, cluster, network, security
+      --phase string                  Subset of tasks to run: cluster, network, security
       --ssh-public-key string         SSH public key to use (deprecated: use kops create secret instead)
       --target string                 Target - direct, terraform, cloudformation (default "direct")
       --user string                   Re-use an existing user in kubeconfig. Value must specify an existing user block in your kubeconfig file.  Implies --create-kube-config

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -254,7 +254,7 @@ func BuildNodeupModelContext(basedir string) (*NodeupModelContext, error) {
 func mockedPopulateClusterSpec(c *kops.Cluster, cloud fi.Cloud) (*kops.Cluster, error) {
 	vfs.Context.ResetMemfsContext(true)
 
-	assetBuilder := assets.NewAssetBuilder(c, "")
+	assetBuilder := assets.NewAssetBuilder(c, false)
 	basePath, err := vfs.Context.BuildVfsPath("memfs://tests")
 	if err != nil {
 		return nil, fmt.Errorf("error building vfspath: %v", err)

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -275,7 +275,7 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 		if etcdContainerImage != "" {
 			image = etcdContainerImage
 		}
-		assets := assets.NewAssetBuilder(t.Cluster, "")
+		assets := assets.NewAssetBuilder(t.Cluster, false)
 		remapped, err := assets.RemapImage(image)
 		if err != nil {
 			return nil, fmt.Errorf("unable to remap container %q: %v", image, err)

--- a/pkg/commands/helpers_readwrite.go
+++ b/pkg/commands/helpers_readwrite.go
@@ -40,7 +40,7 @@ func UpdateCluster(ctx context.Context, clientset simple.Clientset, cluster *kop
 		return fmt.Errorf("error populating configuration: %v", err)
 	}
 
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	fullCluster, err := cloudup.PopulateClusterSpec(clientset, cluster, cloud, assetBuilder)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func UpdateInstanceGroup(ctx context.Context, clientset simple.Clientset, cluste
 		return fmt.Errorf("error populating configuration: %v", err)
 	}
 
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	fullCluster, err := cloudup.PopulateClusterSpec(clientset, cluster, cloud, assetBuilder)
 	if err != nil {
 		return err

--- a/pkg/instancegroups/rollingupdate_os_test.go
+++ b/pkg/instancegroups/rollingupdate_os_test.go
@@ -60,7 +60,7 @@ func getTestSetupOS(t *testing.T) (*RollingUpdateCluster, *openstack.MockCloud) 
 		t.Fatalf("Failed to perform assignments: %v", err)
 	}
 
-	assetBuilder := assets.NewAssetBuilder(inCluster, "")
+	assetBuilder := assets.NewAssetBuilder(inCluster, false)
 	basePath, _ := vfs.Context.BuildVfsPath(inCluster.Spec.ConfigBase)
 	clientset := vfsclientset.NewVFSClientset(basePath)
 	cluster, err := cloudup.PopulateClusterSpec(clientset, inCluster, mockcloud, assetBuilder)

--- a/pkg/model/components/containerd_test.go
+++ b/pkg/model/components/containerd_test.go
@@ -43,7 +43,7 @@ func Test_Build_Containerd_Supported_Version(t *testing.T) {
 
 		c := buildContainerdCluster(v)
 		c.Spec.ContainerRuntime = "containerd"
-		b := assets.NewAssetBuilder(c, "")
+		b := assets.NewAssetBuilder(c, false)
 
 		version, err := util.ParseKubernetesVersion(v)
 		if err != nil {
@@ -78,7 +78,7 @@ func Test_Build_Containerd_Unneeded_Runtime(t *testing.T) {
 		c.Spec.Docker = &kopsapi.DockerConfig{
 			Version: &v,
 		}
-		b := assets.NewAssetBuilder(c, "")
+		b := assets.NewAssetBuilder(c, false)
 
 		ob := &ContainerdOptionsBuilder{
 			&OptionsContext{
@@ -107,7 +107,7 @@ func Test_Build_Containerd_Needed_Runtime(t *testing.T) {
 		c.Spec.Docker = &kopsapi.DockerConfig{
 			Version: &v,
 		}
-		b := assets.NewAssetBuilder(c, "")
+		b := assets.NewAssetBuilder(c, false)
 
 		ob := &ContainerdOptionsBuilder{
 			&OptionsContext{

--- a/pkg/model/components/etcdmanager/model_test.go
+++ b/pkg/model/components/etcdmanager/model_test.go
@@ -50,7 +50,7 @@ func Test_RunEtcdManagerBuilder(t *testing.T) {
 
 			builder := EtcdManagerBuilder{
 				KopsModelContext: kopsModelContext,
-				AssetBuilder:     assets.NewAssetBuilder(kopsModelContext.Cluster, ""),
+				AssetBuilder:     assets.NewAssetBuilder(kopsModelContext.Cluster, false),
 			}
 
 			if err := builder.Build(context); err != nil {

--- a/pkg/model/components/image_test.go
+++ b/pkg/model/components/image_test.go
@@ -74,7 +74,7 @@ func TestImage(t *testing.T) {
 			}
 		}
 
-		assetBuilder := assets.NewAssetBuilder(g.Cluster, "")
+		assetBuilder := assets.NewAssetBuilder(g.Cluster, false)
 		actual, err := Image(g.Component, &g.Cluster.Spec, assetBuilder)
 		if err != nil {
 			t.Errorf("unexpected error from image %q %v: %v",

--- a/pkg/model/components/kubeapiserver/model_test.go
+++ b/pkg/model/components/kubeapiserver/model_test.go
@@ -47,7 +47,7 @@ func Test_RunKubeApiserverBuilder(t *testing.T) {
 
 			builder := KubeApiserverBuilder{
 				KopsModelContext: kopsModelContext,
-				AssetBuilder:     assets.NewAssetBuilder(kopsModelContext.Cluster, ""),
+				AssetBuilder:     assets.NewAssetBuilder(kopsModelContext.Cluster, false),
 			}
 
 			if err := builder.Build(context); err != nil {

--- a/pkg/model/components/kubecontrollermanager_test.go
+++ b/pkg/model/components/kubecontrollermanager_test.go
@@ -42,7 +42,7 @@ func Test_Build_KCM_Builder(t *testing.T) {
 
 		c := buildCluster()
 		c.Spec.KubernetesVersion = v
-		b := assets.NewAssetBuilder(c, "")
+		b := assets.NewAssetBuilder(c, false)
 
 		kcm := &KubeControllerManagerOptionsBuilder{
 			OptionsContext: &OptionsContext{
@@ -65,7 +65,7 @@ func Test_Build_KCM_Builder(t *testing.T) {
 func Test_Build_KCM_Builder_Change_Duration(t *testing.T) {
 
 	c := buildCluster()
-	b := assets.NewAssetBuilder(c, "")
+	b := assets.NewAssetBuilder(c, false)
 
 	kcm := &KubeControllerManagerOptionsBuilder{
 		OptionsContext: &OptionsContext{

--- a/pkg/model/components/kubelet_test.go
+++ b/pkg/model/components/kubelet_test.go
@@ -36,7 +36,7 @@ func buildKubeletTestCluster() *kops.Cluster {
 }
 
 func buildOptions(cluster *kops.Cluster) error {
-	ab := assets.NewAssetBuilder(cluster, "")
+	ab := assets.NewAssetBuilder(cluster, false)
 
 	ver, err := util.ParseKubernetesVersion(cluster.Spec.KubernetesVersion)
 	if err != nil {

--- a/pkg/model/components/kubescheduler_test.go
+++ b/pkg/model/components/kubescheduler_test.go
@@ -45,7 +45,7 @@ func Test_Build_Scheduler_Without_PolicyConfigMap(t *testing.T) {
 
 		c := buildCluster()
 		c.Spec.KubernetesVersion = v
-		b := assets.NewAssetBuilder(c, "")
+		b := assets.NewAssetBuilder(c, false)
 
 		version, err := util.ParseKubernetesVersion(v)
 		if err != nil {
@@ -74,7 +74,7 @@ func Test_Build_Scheduler_PolicyConfigMap_Supported_Version(t *testing.T) {
 	for _, v := range versions {
 
 		c := buildSchedulerConfigMapCluster(v)
-		b := assets.NewAssetBuilder(c, "")
+		b := assets.NewAssetBuilder(c, false)
 
 		version, err := util.ParseKubernetesVersion(v)
 		if err != nil {

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -59,7 +59,6 @@ go_library(
         "//pkg/wellknownports:go_default_library",
         "//upup/models:go_default_library",
         "//upup/pkg/fi:go_default_library",
-        "//upup/pkg/fi/assettasks:go_default_library",
         "//upup/pkg/fi/cloudup/aliup:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/azure:go_default_library",

--- a/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/elastic_ip_test.go
@@ -125,7 +125,7 @@ func checkNoChanges(t *testing.T, cloud fi.Cloud, allTasks map[string]fi.Task) {
 			KubernetesVersion: "v1.9.0",
 		},
 	}
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	target := fi.NewDryRunTarget(assetBuilder, os.Stderr)
 	context, err := fi.NewContext(target, nil, cloud, nil, nil, nil, true, allTasks)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -161,7 +161,7 @@ func runChannelBuilderTest(t *testing.T, key string, addonManifests []string) {
 	bcb := bootstrapchannelbuilder.NewBootstrapChannelBuilder(
 		&kopsModel,
 		fi.LifecycleSync,
-		assets.NewAssetBuilder(cluster, ""),
+		assets.NewAssetBuilder(cluster, false),
 		templates,
 		nil,
 	)

--- a/upup/pkg/fi/cloudup/networking_test.go
+++ b/upup/pkg/fi/cloudup/networking_test.go
@@ -40,7 +40,7 @@ func Test_FindCNIAssetFromEnvironmentVariable(t *testing.T) {
 	cluster := &api.Cluster{}
 	cluster.Spec.KubernetesVersion = "v1.18.0"
 
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	cniAsset, cniAssetHash, err := findCNIAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
 
 	if err != nil {
@@ -64,7 +64,7 @@ func Test_FindCNIAssetFromDefaults(t *testing.T) {
 	cluster := &api.Cluster{}
 	cluster.Spec.KubernetesVersion = "v1.18.0"
 
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	cniAsset, cniAssetHash, err := findCNIAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
 
 	if err != nil {
@@ -95,7 +95,7 @@ func Test_FindLyftAssetFromEnvironmentVariable(t *testing.T) {
 	cluster := &api.Cluster{}
 	cluster.Spec.KubernetesVersion = "v1.18.0"
 
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	lyftAsset, lyftAssetHash, err := findLyftVPCAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
 
 	if err != nil {
@@ -119,7 +119,7 @@ func Test_FindLyftAssetFromDefaults(t *testing.T) {
 	cluster := &api.Cluster{}
 	cluster.Spec.KubernetesVersion = "v1.18.0"
 
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	lyftAsset, lyftAssetHash, err := findLyftVPCAssets(cluster, assetBuilder, architectures.ArchitectureAmd64)
 
 	if err != nil {

--- a/upup/pkg/fi/cloudup/phase.go
+++ b/upup/pkg/fi/cloudup/phase.go
@@ -22,8 +22,6 @@ import "k8s.io/apimachinery/pkg/util/sets"
 type Phase string
 
 const (
-	// PhaseStageAssets uploads various assets such as containers in a private registry
-	PhaseStageAssets Phase = "assets"
 	// PhaseNetwork creates network infrastructure.
 	PhaseNetwork Phase = "network"
 	// PhaseSecurity creates IAM profiles and roles, security groups and firewalls
@@ -34,7 +32,6 @@ const (
 
 // Phases are used for validation and cli help.
 var Phases = sets.NewString(
-	string(PhaseStageAssets),
 	string(PhaseSecurity),
 	string(PhaseNetwork),
 	string(PhaseCluster),

--- a/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
@@ -55,7 +55,7 @@ func TestPopulateCluster_Default_NoError(t *testing.T) {
 func mockedPopulateClusterSpec(c *kopsapi.Cluster, cloud fi.Cloud) (*kopsapi.Cluster, error) {
 	vfs.Context.ResetMemfsContext(true)
 
-	assetBuilder := assets.NewAssetBuilder(c, "")
+	assetBuilder := assets.NewAssetBuilder(c, false)
 	basePath, err := vfs.Context.BuildVfsPath("memfs://tests")
 	if err != nil {
 		return nil, fmt.Errorf("error building vfspath: %v", err)

--- a/upup/pkg/fi/dryruntarget_test.go
+++ b/upup/pkg/fi/dryruntarget_test.go
@@ -71,7 +71,7 @@ func Test_DryrunTarget_PrintReport(t *testing.T) {
 		Spec: api.ClusterSpec{
 			KubernetesVersion: "1.17.3",
 		},
-	}, "'")
+	}, false)
 	var stdout bytes.Buffer
 	target := NewDryRunTarget(builder, &stdout)
 	tasks := map[string]Task{}

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -334,7 +334,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 			CacheDir: c.CacheDir,
 		}
 	case "dryrun":
-		assetBuilder := assets.NewAssetBuilder(c.cluster, "")
+		assetBuilder := assets.NewAssetBuilder(c.cluster, false)
 		target = fi.NewDryRunTarget(assetBuilder, out)
 	case "cloudinit":
 		checkExisting = false

--- a/upup/pkg/kutil/convert_kubeup_cluster.go
+++ b/upup/pkg/kutil/convert_kubeup_cluster.go
@@ -107,7 +107,7 @@ func (x *ConvertKubeupCluster) Upgrade(ctx context.Context) error {
 		delete(cluster.ObjectMeta.Annotations, api.AnnotationNameManagement)
 	}
 
-	assetBuilder := assets.NewAssetBuilder(cluster, "")
+	assetBuilder := assets.NewAssetBuilder(cluster, false)
 	fullCluster, err := cloudup.PopulateClusterSpec(x.Clientset, cluster, x.Cloud, assetBuilder)
 	if err != nil {
 		return err


### PR DESCRIPTION
Removes the `assets` phase, moving the functionality to the new `kops get assets --copy` flag.