### PR TITLE
Add proxy envs to calico to make possible usage of AWS source destination check

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3924,6 +3924,11 @@ spec:
             # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
             - name: FELIX_WIREGUARDENABLED
               value: "{{ .Networking.Calico.WireguardEnabled }}"
+            # Enable support for HTTP forward proxy
+            {{ range $name, $value := ProxyEnv }}
+            - name: {{ $name }}
+              value: {{ $value }}
+            {{ end }}
           securityContext:
             privileged: true
           resources:
@@ -4129,5 +4134,4 @@ spec:
 
 ---
 # Source: calico/templates/configure-canal.yaml
-
 


### PR DESCRIPTION
After 1.19 update calico was also updated and source-destination check was included in calico natively. So when you're using proxy and cluster created it can't be validated without manual patch:
```
kubectl set env daemonset/calico-node -n kube-system http_proxy=http://<proxy_url>:<proxy_port>
kubectl set env daemonset/calico-node -n kube-system https_proxy=http://<proxy_url>:<proxy_port>
kubectl set env daemonset/calico-node -n kube-system no_proxy=<no_proxy_list>
```

Signed-off-by: Dmytro Oboznyi <dmytro.oboznyi@syncier.com>