### PR TITLE
Automated cherry pick of #11709: Add proxy envs to calico to make possible usage of AWS source

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3911,6 +3911,11 @@ spec:
             # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
             - name: FELIX_WIREGUARDENABLED
               value: "{{ .Networking.Calico.WireguardEnabled }}"
+            # Enable support for HTTP forward proxy
+            {{ range $name, $value := ProxyEnv }}
+            - name: {{ $name }}
+              value: {{ $value }}
+            {{ end }}
           securityContext:
             privileged: true
           resources:
@@ -4110,5 +4115,4 @@ spec:
 
 ---
 # Source: calico/templates/configure-canal.yaml
-
 


### PR DESCRIPTION
Cherry pick of #11709 on release-1.21.

#11709: Add proxy envs to calico to make possible usage of AWS source

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.