### PR TITLE
Automated cherry pick of #11709: Add proxy envs to calico to make possible usage of AWS source

### DIFF
--- a/upup/models/bindata.go
+++ b/upup/models/bindata.go
@@ -39588,6 +39588,11 @@ spec:
             # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
             - name: FELIX_WIREGUARDENABLED
               value: "{{ .Networking.Calico.WireguardEnabled }}"
+            # Enable support for HTTP forward proxy
+            {{ range $name, $value := ProxyEnv }}
+            - name: {{ $name }}
+              value: {{ $value }}
+            {{ end }}
           securityContext:
             privileged: true
           resources:
@@ -39790,7 +39795,6 @@ spec:
 
 ---
 # Source: calico/templates/configure-canal.yaml
-
 
 `)
 

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3944,6 +3944,11 @@ spec:
             # Enable WireGuard encryption for all on-the-wire pod-to-pod traffic
             - name: FELIX_WIREGUARDENABLED
               value: "{{ .Networking.Calico.WireguardEnabled }}"
+            # Enable support for HTTP forward proxy
+            {{ range $name, $value := ProxyEnv }}
+            - name: {{ $name }}
+              value: {{ $value }}
+            {{ end }}
           securityContext:
             privileged: true
           resources:
@@ -4146,5 +4151,4 @@ spec:
 
 ---
 # Source: calico/templates/configure-canal.yaml
-
 


### PR DESCRIPTION
Cherry pick of #11709 on release-1.20.

#11709: Add proxy envs to calico to make possible usage of AWS source

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.