### PR TITLE
Add small note about rotating cluster after backup restore

### DIFF
--- a/docs/operations/etcd_backup_restore_encryption.md
+++ b/docs/operations/etcd_backup_restore_encryption.md
@@ -91,8 +91,14 @@ NOTE: You will need to run it multiple times for each old IP, regarding the size
 After that, you can check again the endpoint and everything should be fixed.
 
 After the restore is complete, api server should come back up, and you should have a working cluster.
-Note that the api server might be very busy for a while as it changes the cluster back to the state of the backup.
-It's a good idea to temporarily increase the instance size of your masters and roll your worker nodes.
+Note that the api server might be very busy for a while as it changes the cluster back to the state of the backup. 
+You can consider temporarily increase the instance size of your masters and roll your worker nodes.
+
+Because the state on each of the Nodes may differ from the state in etcd, it is also a good idea to do a rolling-update of the entire cluster:
+
+```sh
+kops rolling-update cluster --force --yes
+```
 
 For more information and troubleshooting, please check the [etcd-manager documentation](https://github.com/kopeio/etcd-manager).
 

--- a/docs/operations/etcd_backup_restore_encryption.md
+++ b/docs/operations/etcd_backup_restore_encryption.md
@@ -92,7 +92,7 @@ After that, you can check again the endpoint and everything should be fixed.
 
 After the restore is complete, api server should come back up, and you should have a working cluster.
 Note that the api server might be very busy for a while as it changes the cluster back to the state of the backup. 
-You can consider temporarily increase the instance size of your masters and roll your worker nodes.
+You might consider temporarily increasing the instance size of your control plane.
 
 Because the state on each of the Nodes may differ from the state in etcd, it is also a good idea to do a rolling-update of the entire cluster:
 


### PR DESCRIPTION
We just did such a backup restore and ended up with Pods in Pending state without any events or errors indicating what may be wrong. Also had issues with EndpointSlices. Rolling the cluster solved all these issues.