### PR TITLE
Compare OpenStack security groups deterministically

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/port.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/port.go
@@ -18,6 +18,7 @@ package openstacktasks
 
 import (
 	"fmt"
+	"sort"
 
 	secgroup "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
@@ -88,6 +89,10 @@ func newPortTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lifecycle
 			Lifecycle: lifecycle,
 		})
 	}
+
+	// sort for consistent comparison
+	sort.Sort(SecurityGroupsByID(sgs))
+
 	subnets := make([]*Subnet, len(port.FixedIPs))
 	for i, subn := range port.FixedIPs {
 		subnets[i] = &Subnet{
@@ -131,6 +136,10 @@ func (s *Port) Find(context *fi.Context) (*Port, error) {
 	} else if len(rs) != 1 {
 		return nil, fmt.Errorf("found multiple ports with name: %s", fi.StringValue(s.Name))
 	}
+
+	// sort for consistent comparison
+	sort.Sort(SecurityGroupsByID(s.SecurityGroups))
+
 	return newPortTaskFromCloud(cloud, s.Lifecycle, &rs[0], s)
 }
 

--- a/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/securitygroup.go
@@ -38,6 +38,15 @@ type SecurityGroup struct {
 	Lifecycle        fi.Lifecycle
 }
 
+// SecurityGroupsByID implements sort.Interface based on the ID field.
+type SecurityGroupsByID []*SecurityGroup
+
+func (a SecurityGroupsByID) Len() int      { return len(a) }
+func (a SecurityGroupsByID) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a SecurityGroupsByID) Less(i, j int) bool {
+	return fi.StringValue(a[i].ID) < fi.StringValue(a[j].ID)
+}
+
 var _ fi.CompareWithID = &SecurityGroup{}
 
 func (s *SecurityGroup) CompareWithID() *string {


### PR DESCRIPTION
This fixes #11740 by sorting the security groups of the port model and when querying the cloud, which will result in tasks comparing those slices deterministically.