### PR TITLE
Make forwardToKubeDNS work in the NodeLocal DNSCache template

### DIFF
--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -56,7 +56,7 @@ data:
         prometheus :9253
         health {{ KubeDNS.NodeLocalDNS.LocalIP }}:{{ NodeLocalDNSHealthCheck }}
     }
-    {{- if KubeDNS.NodeLocalDNS.ForwardToKubeDNS }}
+    {{- if WithDefaultBool KubeDNS.NodeLocalDNS.ForwardToKubeDNS false }}
     .:53 {
         errors
         cache 30


### PR DESCRIPTION
This fixes https://github.com/kubernetes/kops/issues/11742 which discusses the broken rendering of the Corefile of the NodeLocal DNSCache template when setting forwardToKubeDNS to false (or not setting it).

Previously, due to not dereferencing the bool pointer, the Corefile was always rendered with the true clause, due to checking the address instead of the actual value of the variable.

With this fix, the templating mechanism will actually respect the value of forwardToKubeDNS and render it accordingly.