### PR TITLE
Don't set Subnet dependency on AmazonIPv6CIDR for shared VPCs

### DIFF
--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -252,7 +252,9 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 
 		if subnetSpec.IPv6CIDR != "" {
-			subnet.AmazonIPv6CIDR = b.LinkToAmazonVPCIPv6CIDR()
+			if !sharedVPC {
+				subnet.AmazonIPv6CIDR = b.LinkToAmazonVPCIPv6CIDR()
+			}
 			subnet.IPv6CIDR = fi.String(subnetSpec.IPv6CIDR)
 		}
 		if subnetSpec.ProviderID != "" {


### PR DESCRIPTION
/cc @johngmyers 