### PR TITLE
Enable IPv6 support for Cilium

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -820,6 +820,10 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "Only versions 1.8 through 1.10 are supported"))
 		}
 
+		if version.Minor < 10 && c.IsIPv6Only() {
+			allErrs = append(allErrs, field.Invalid(versionFld, v.Version, "kOps only supports IPv6 on version 1.10 or later"))
+		}
+
 		if v.Hubble != nil && fi.BoolValue(v.Hubble.Enabled) {
 			if !components.IsCertManagerEnabled(cluster) {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("hubble", "enabled"), "Hubble requires that cert manager is enabled"))
@@ -857,6 +861,9 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 			}
 			if !v.DisableMasquerade {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("disableMasquerade"), "Masquerade must be disabled when ENI IPAM is used"))
+			}
+			if c.IsIPv6Only() {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("ipam"), "Cilium ENI IPAM does not support IPv6"))
 			}
 		}
 	}

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -367,6 +367,10 @@ func (b *KopsModelContext) IsKubernetesLT(version string) bool {
 	return !b.IsKubernetesGTE(version)
 }
 
+func (b *KopsModelContext) IsIPv6Only() bool {
+	return b.Cluster.Spec.IsIPv6Only()
+}
+
 // WellKnownServiceIP returns a service ip with the service cidr
 func (b *KopsModelContext) WellKnownServiceIP(id int) (net.IP, error) {
 	return components.WellKnownServiceIP(&b.Cluster.Spec, id)

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -81,10 +81,10 @@ data:
   {{ end }}
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
   # address.
-  enable-ipv4: "true"
+  enable-ipv4: "{{ not IsIPv6Only }}"
   # Enable IPv6 addressing. If enabled, all endpoints are allocated an IPv6
   # address.
-  enable-ipv6: "false"
+  enable-ipv6: "{{ IsIPv6Only }}"
   # If you want cilium monitor to aggregate tracing for packets, set this level
   # to "low", "medium", or "maximum". The higher the level, the less packets
   # that will be seen in monitor output.
@@ -554,7 +554,7 @@ spec:
         - cilium-agent
         startupProbe:
           httpGet:
-            host: '127.0.0.1'
+            host: '{{- if IsIPv6Only -}}::1{{- else -}}127.0.0.1{{- end -}}'
             path: /healthz
             port: 9876
             scheme: HTTP
@@ -566,7 +566,7 @@ spec:
           successThreshold: 
         livenessProbe:
           httpGet:
-            host: '127.0.0.1'
+            host: '{{- if IsIPv6Only -}}::1{{- else -}}127.0.0.1{{- end -}}'
             path: /healthz
             port: 9876
             scheme: HTTP
@@ -583,7 +583,7 @@ spec:
             memory: {{ or .MemoryRequest "128Mi" }}
         readinessProbe:
           httpGet:
-            host: '127.0.0.1'
+            host: '{{- if IsIPv6Only -}}::1{{- else -}}127.0.0.1{{- end -}}'
             path: /healthz
             port: 9876
             scheme: HTTP

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -223,6 +223,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 		return strings.Join(labels, ",")
 	}
 
+	dest["IsIPv6Only"] = tf.IsIPv6Only
 	dest["UseServiceAccountIAM"] = tf.UseServiceAccountIAM
 
 	if cluster.Spec.NodeTerminationHandler != nil {


### PR DESCRIPTION
/cc @olemarkus @hakman 

Needs `--override=spec.kubeControllerManager.nodeCIDRMaskSize=80`. Will send that as a separate PR as it isn't specific to Cilium.