### PR TITLE
Set default ClusterCIDR through the PodCIDR

### DIFF
--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -116,6 +116,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 
 	kcm.AllocateNodeCIDRs = fi.Bool(true)
 	kcm.ConfigureCloudRoutes = fi.Bool(false)
+	kcm.ClusterCIDR = clusterSpec.PodCIDR
 
 	networking := clusterSpec.Networking
 	if networking == nil {
@@ -125,10 +126,6 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 	} else if networking.GCE != nil {
 		kcm.ConfigureCloudRoutes = fi.Bool(false)
 		kcm.CIDRAllocatorType = fi.String("CloudAllocator")
-
-		if kcm.ClusterCIDR == "" {
-			kcm.ClusterCIDR = clusterSpec.PodCIDR
-		}
 	} else if networking.External != nil {
 		kcm.ConfigureCloudRoutes = fi.Bool(false)
 	} else if UsesCNI(networking) {

--- a/upup/pkg/fi/cloudup/populate_cluster_spec.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec.go
@@ -325,7 +325,7 @@ func (c *populateClusterSpec) assignSubnets(cluster *kopsapi.Cluster) error {
 		cluster.Spec.KubeControllerManager = &kopsapi.KubeControllerManagerConfig{}
 	}
 
-	if cluster.Spec.KubeControllerManager.ClusterCIDR == "" {
+	if cluster.Spec.PodCIDR == "" {
 		// Allocate as big a range as possible: the NonMasqueradeCIDR mask + 1, with a '1' in the extra bit
 		ip := nonMasqueradeCIDR.IP.Mask(nonMasqueradeCIDR.Mask)
 		if nmBits > 32 && nmOnes < 63 {
@@ -335,8 +335,8 @@ func (c *populateClusterSpec) assignSubnets(cluster *kopsapi.Cluster) error {
 		}
 		ip[nmOnes/8] |= 128 >> (nmOnes % 8)
 		cidr := net.IPNet{IP: ip, Mask: net.CIDRMask(nmOnes+1, nmBits)}
-		cluster.Spec.KubeControllerManager.ClusterCIDR = cidr.String()
-		klog.V(2).Infof("Defaulted KubeControllerManager.ClusterCIDR to %v", cluster.Spec.KubeControllerManager.ClusterCIDR)
+		cluster.Spec.PodCIDR = cidr.String()
+		klog.V(2).Infof("Defaulted PodCIDR to %v", cluster.Spec.PodCIDR)
 	}
 
 	if cluster.Spec.ServiceClusterIPRange == "" {


### PR DESCRIPTION
/kind bug

The AWS CCM and some GCE code pulls directly from `spec.podCIDR` instead of from `spec.kubeControllerManager.clusterCIDR`.
