### PR TITLE
Make it easy to run scenarios with irsa enabled

### DIFF
--- a/tests/e2e/scenarios/aws-lb-controller/run-test.sh
+++ b/tests/e2e/scenarios/aws-lb-controller/run-test.sh
@@ -24,12 +24,16 @@ KOPS_BASE_URL="$(curl -s https://storage.googleapis.com/kops-ci/bin/latest-ci-up
 KOPS=$(kops-download-from-base)
 
 
-${KUBETEST2} \
-    --up \
-    --kubernetes-version="1.21.0" \
-    --kops-binary-path="${KOPS}" \
-    --create-args="--networking amazonvpc --override=cluster.spec.awsLoadBalancerController.enabled=true --override=cluster.spec.certManager.enabled=true --zones=eu-west-1a,eu-west-1b,eu-west-1c"
+# shellcheck disable=SC2034
+NETWORKING="amazonvpc"
 
+OVERRIDES="${OVERRIDES-} --override=cluster.spec.awsLoadBalancerController.enabled=true"
+OVERRIDES="${OVERRIDES} --override=cluster.spec.certManager.enabled=true"
+
+# shellcheck disable=SC2034
+ZONES="eu-west-1a,eu-west-1b,eu-west-1c"
+
+kops-up
 
 VPC=$(${KOPS} toolbox dump -o json | jq -r .vpc.id)
 


### PR DESCRIPTION
This allows us to run `KOPS_IRSA=true tests/e2e/scenarios/lib/common.sh` for an IRSA version of the given scenario (only lbc scenario ported to this right now as it is the only one supporting IRSA).