### PR TITLE
Adjustments to SpecOverride

### DIFF
--- a/tests/integration/create_cluster/overrides/options.yaml
+++ b/tests/integration/create_cluster/overrides/options.yaml
@@ -4,5 +4,5 @@ Zones:
 CloudProvider: aws
 Networking: cni
 KubernetesVersion: v1.21.0
-Overrides:
+Sets:
 - cluster.spec.nodePortAccess=1.2.3.4/32,10.20.30.0/24

--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -95,12 +95,12 @@ func setPrimitive(v reflect.Value, newValue string) error {
 	}
 
 	if v.Type().Kind() == reflect.Slice {
-		// Because this function generally sets values, we overwrite instead of appending.
-		// Then to support multiple values, we split on commas.
+		// To support multiple values, we split on commas.
 		// We have no way to escape a comma currently; but in general we prefer having a slice in the schema,
 		// rather than having values that need to be parsed, so we may not need it.
 		tokens := strings.Split(newValue, ",")
-		valueArray := reflect.MakeSlice(v.Type(), 0, len(tokens))
+		valueArray := reflect.MakeSlice(v.Type(), 0, v.Len()+len(tokens))
+		valueArray = reflect.AppendSlice(valueArray, v)
 		for _, s := range tokens {
 			valueItem := reflect.New(v.Type().Elem())
 			if err := setPrimitive(valueItem.Elem(), s); err != nil {

--- a/util/pkg/reflectutils/access_test.go
+++ b/util/pkg/reflectutils/access_test.go
@@ -163,6 +163,13 @@ func TestSet(t *testing.T) {
 			Path:     "spec.containers[0].enumSlice",
 			Value:    "ABC,DEF",
 		},
+		{
+			Name:     "append enum slice",
+			Input:    "{ 'spec': { 'containers': [ { 'enumSlice': [ 'ABC', 'DEF' ] } ] } }",
+			Expected: "{ 'spec': { 'containers': [ { 'enumSlice': [ 'ABC', 'DEF', 'GHI', 'JKL' ] } ] } }",
+			Path:     "spec.containers[0].enumSlice",
+			Value:    "GHI,JKL",
+		},
 		// Not sure if we should do this...
 		// {
 		// 	Name:     "creating missing array elements",


### PR DESCRIPTION
* Rename `--override` to `--set`, leaving backwards compatibility to allow a transition period for our e2e jobs.
* Append to slices instead of replacing them. Replacement can be done by combining an unset with a set.
