### PR TITLE
fix enable default SC when EBS driver is not installed

### DIFF
--- a/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-aws.addons.k8s.io/v1.15.0.yaml.template
@@ -30,7 +30,7 @@ kind: StorageClass
 metadata:
   name: kops-ssd-1-17
   annotations:
-    storageclass.kubernetes.io/is-default-class: "{{ not .CloudConfig.AWSEBSCSIDriver.Enabled }}"
+    storageclass.kubernetes.io/is-default-class: "{{ not ( WithDefaultBool .CloudConfig.AWSEBSCSIDriver.Enabled true ) }}"
   labels:
     k8s-addon: storage-aws.addons.k8s.io
 provisioner: kubernetes.io/aws-ebs

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 1.22.0-alpha.1
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: b8aadc7d9d09c2626b8680c1d5f2d0699628519c
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 1.22.0-alpha.1
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: b8aadc7d9d09c2626b8680c1d5f2d0699628519c
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 1.22.0-alpha.1
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: b8aadc7d9d09c2626b8680c1d5f2d0699628519c
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 1.22.0-alpha.1
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: b8aadc7d9d09c2626b8680c1d5f2d0699628519c
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 1.22.0-alpha.1
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: b8aadc7d9d09c2626b8680c1d5f2d0699628519c
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 1.22.0-alpha.1
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: b8aadc7d9d09c2626b8680c1d5f2d0699628519c
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 1.22.0-alpha.1
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: b8aadc7d9d09c2626b8680c1d5f2d0699628519c
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io


### PR DESCRIPTION
Looks like we are not installing a default StorageClass if AWS EBS CSI driver is disabled.

@justinsb @johngmyers another one that probably should go into 1.21.

/kind bug