### PR TITLE
add replaceBeforeVersion field for channel

### DIFF
--- a/channels/pkg/api/channel.go
+++ b/channels/pkg/api/channel.go
@@ -70,6 +70,13 @@ type AddonSpec struct {
 
 	// NeedsPKI determines if channels should provision a CA and a cert-manager issuer for the addon.
 	NeedsPKI bool `json:"needsPKI,omitempty"`
+
+	// ReplaceBeforeVersion is the version before which upgrades should replace instead of apply the
+	// manifest. For example, we made a change on an immutable field in version "1.1.0-kops.2" of an
+	// addon spec which cannot be successfully updated with kubectl apply. Setting ReplaceBeforeVersion
+	// to "1.1.0-kops.2" makes sure when updating from any version below "1.1.0-kops.2" the channel should
+	// update the addon using kubectl replace instead of kubectl apply.
+	ReplaceBeforeVersion *string `json:"replaceBeforeVersion,omitempty"`
 }
 
 func (a *Addons) Verify() error {

--- a/channels/pkg/channels/addons.go
+++ b/channels/pkg/channels/addons.go
@@ -88,7 +88,9 @@ func (a *Addons) GetCurrent(kubernetesVersion semver.Version) (*AddonMenu, error
 		name := addon.Name
 
 		existing := menu.Addons[name]
-		if existing == nil || addon.ChannelVersion().replaces(existing.ChannelVersion()) {
+		if existing == nil {
+			menu.Addons[name] = addon
+		} else if update, _ := addon.ChannelVersion().updates(existing.ChannelVersion()); update {
 			menu.Addons[name] = addon
 		}
 	}

--- a/channels/pkg/channels/addons_test.go
+++ b/channels/pkg/channels/addons_test.go
@@ -93,90 +93,117 @@ func Test_Filtering(t *testing.T) {
 
 func Test_Replacement(t *testing.T) {
 	grid := []struct {
-		Old      *ChannelVersion
-		New      *ChannelVersion
-		Replaces bool
+		Name    string
+		Old     *ChannelVersion
+		New     *ChannelVersion
+		Updates bool
+		replace bool
 	}{
 		// With no id, update if and only if newer semver
 		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.0"), Id: "", ManifestHash: ""},
-			Replaces: false,
+			Name:    "no id same version",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.0"), Id: "", ManifestHash: ""},
+			Updates: false,
 		},
 		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.1"), Id: "", ManifestHash: ""},
-			Replaces: true,
+			Name:    "no id higher version",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.1"), Id: "", ManifestHash: ""},
+			Updates: true,
 		},
 		{
-			Old:      &ChannelVersion{Version: s("1.0.1"), Id: "", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.0"), Id: "", ManifestHash: ""},
-			Replaces: false,
+			Name:    "no id lower version",
+			Old:     &ChannelVersion{Version: s("1.0.1"), Id: "", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.0"), Id: "", ManifestHash: ""},
+			Updates: false,
 		},
 		{
-			Old:      &ChannelVersion{Version: s("1.1.0"), Id: "", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.1.1"), Id: "", ManifestHash: ""},
-			Replaces: true,
+			Name:    "no id higher version",
+			Old:     &ChannelVersion{Version: s("1.1.0"), Id: "", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.1.1"), Id: "", ManifestHash: ""},
+			Updates: true,
 		},
 		{
-			Old:      &ChannelVersion{Version: s("1.1.1"), Id: "", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.1.0"), Id: "", ManifestHash: ""},
-			Replaces: false,
+			Name:    "no id lower version",
+			Old:     &ChannelVersion{Version: s("1.1.1"), Id: "", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.1.0"), Id: "", ManifestHash: ""},
+			Updates: false,
 		},
 
 		// With id, update if different id and same version, otherwise follow semver
 		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
-			Replaces: false,
+			Name:    "same id same version",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
+			Updates: false,
 		},
 		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.0"), Id: "b", ManifestHash: ""},
-			Replaces: true,
+			Name:    "new id same version",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.0"), Id: "b", ManifestHash: ""},
+			Updates: true,
 		},
 		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "b", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
-			Replaces: true,
+			Name:    "new id same version",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "b", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
+			Updates: true,
 		},
 		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.1"), Id: "a", ManifestHash: ""},
-			Replaces: true,
-		},
-		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.1"), Id: "a", ManifestHash: ""},
-			Replaces: true,
-		},
-		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.1"), Id: "a", ManifestHash: ""},
-			Replaces: true,
+			Name:    "same if higher version",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.1"), Id: "a", ManifestHash: ""},
+			Updates: true,
 		},
 		//Test ManifestHash Changes
 		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "3544de6578b2b582c0323b15b7b05a28c60b9430"},
-			New:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "3544de6578b2b582c0323b15b7b05a28c60b9430"},
-			Replaces: false,
+			Name:    "same ManifestHash",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "3544de6578b2b582c0323b15b7b05a28c60b9430"},
+			New:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "3544de6578b2b582c0323b15b7b05a28c60b9430"},
+			Updates: false,
 		},
 		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
-			New:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "3544de6578b2b582c0323b15b7b05a28c60b9430"},
-			Replaces: true,
+			Name:    "new ManifestHash without old ManifestHash",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "3544de6578b2b582c0323b15b7b05a28c60b9430"},
+			Updates: true,
 		},
 		{
-			Old:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "3544de6578b2b582c0323b15b7b05a28c60b9430"},
-			New:      &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "ea9e79bf29adda450446487d65a8fc6b3fdf8c2b"},
-			Replaces: true,
+			Name:    "new ManifestHash",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "3544de6578b2b582c0323b15b7b05a28c60b9430"},
+			New:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "ea9e79bf29adda450446487d65a8fc6b3fdf8c2b"},
+			Updates: true,
+		},
+		//Test ReplaceBeforeVersion
+		{
+			Name:    "ReplaceBeforeVersion same as new and old veriosn",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: "", ReplaceBeforeVersion: s("1.0.0")},
+			Updates: false,
+			replace: false,
+		},
+		{
+			Name:    "ReplaceBeforeVersion same as old version",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.1"), Id: "a", ManifestHash: "", ReplaceBeforeVersion: s("1.0.0")},
+			Updates: true,
+			replace: false,
+		},
+		{
+			Name:    "ReplaceBeforeVersion higher than old version",
+			Old:     &ChannelVersion{Version: s("1.0.0"), Id: "a", ManifestHash: ""},
+			New:     &ChannelVersion{Version: s("1.0.1"), Id: "a", ManifestHash: "", ReplaceBeforeVersion: s("1.0.1")},
+			Updates: true,
+			replace: true,
 		},
 	}
 	for _, g := range grid {
-		actual := g.New.replaces(g.Old)
-		if actual != g.Replaces {
-			t.Errorf("unexpected result from %v -> %v, expect %t.  actual %v", g.Old, g.New, g.Replaces, actual)
-		}
+		t.Run(g.Name, func(t *testing.T) {
+			update, replace := g.New.updates(g.Old)
+			assert.Equal(t, update, g.Updates, "unexpected update result from %v -> %v, expect %t.  actual %v", g.Old, g.New, g.Updates, update)
+			assert.Equal(t, replace, g.replace, "unexpected replace result from %v -> %v, expect %t.  actual %v", g.Old, g.New, g.replace, replace)
+		})
 	}
 }
 

--- a/channels/pkg/channels/channel_version.go
+++ b/channels/pkg/channels/channel_version.go
@@ -40,10 +40,11 @@ type Channel struct {
 }
 
 type ChannelVersion struct {
-	Version      *string `json:"version,omitempty"`
-	Channel      *string `json:"channel,omitempty"`
-	Id           string  `json:"id,omitempty"`
-	ManifestHash string  `json:"manifestHash,omitempty"`
+	Version              *string `json:"version,omitempty"`
+	Channel              *string `json:"channel,omitempty"`
+	Id                   string  `json:"id,omitempty"`
+	ManifestHash         string  `json:"manifestHash,omitempty"`
+	ReplaceBeforeVersion *string `json:"replaceBeforeVersion,omitempty"`
 }
 
 func stringValue(s *string) string {
@@ -60,6 +61,9 @@ func (c *ChannelVersion) String() string {
 	}
 	if c.ManifestHash != "" {
 		s += " ManifestHash=" + c.ManifestHash
+	}
+	if stringValue(c.ReplaceBeforeVersion) != "" {
+		s += " ReplaceBeforeVersion=" + stringValue(c.ReplaceBeforeVersion)
 	}
 	return s
 }
@@ -104,40 +108,53 @@ func (c *Channel) AnnotationName() string {
 	return AnnotationPrefix + c.Name
 }
 
-func (c *ChannelVersion) replaces(existing *ChannelVersion) bool {
+// updates returns two bool values. The first bool is if the new ChannelVersion if higher than the existing ChannelVersion.
+// The second bool is whether upgrading should use replace instead of apply.
+func (c *ChannelVersion) updates(existing *ChannelVersion) (updates bool, replaces bool) {
 	klog.V(4).Infof("Checking existing channel: %v compared to new channel: %v", existing, c)
 	if existing.Version != nil {
 		if c.Version == nil {
 			klog.V(4).Infof("New Version info missing")
-			return false
+			return false, false
 		}
 		cVersion, err := semver.ParseTolerant(*c.Version)
 		if err != nil {
 			klog.Warningf("error parsing version %q; will ignore this version", *c.Version)
-			return false
+			return false, false
 		}
 		existingVersion, err := semver.ParseTolerant(*existing.Version)
 		if err != nil {
 			klog.Warningf("error parsing existing version %q", *existing.Version)
-			return true
+			return true, false
 		}
 		if cVersion.LT(existingVersion) {
 			klog.V(4).Infof("New Version is less then old")
-			return false
+			return false, false
 		} else if cVersion.GT(existingVersion) {
 			klog.V(4).Infof("New Version is greater then old")
-			return true
+			if c.ReplaceBeforeVersion != nil {
+				rbVersion, err := semver.ParseTolerant(*c.ReplaceBeforeVersion)
+				if err != nil {
+					klog.Warningf("error parsing ReplaceBeforeVersion %q", *c.ReplaceBeforeVersion)
+					return true, false
+				}
+				if existingVersion.LT(rbVersion) {
+					klog.V(4).Infof("ReplaceBeforeVersion is greater then old version")
+					return true, true
+				}
+			}
+			return true, false
 		} else {
 			// Same version; check ids
 			if c.Id == existing.Id {
 				// Same id; check manifests
 				if c.ManifestHash == existing.ManifestHash {
 					klog.V(4).Infof("Manifest Match")
-					return false
+					return false, false
 				}
-				klog.V(4).Infof("Channels had same version and ids %q, %q but different ManifestHash (%q vs %q); will replace", *c.Version, c.Id, c.ManifestHash, existing.ManifestHash)
+				klog.V(4).Infof("Channels had same version and ids %q, %q but different ManifestHash (%q vs %q); will update", *c.Version, c.Id, c.ManifestHash, existing.ManifestHash)
 			} else {
-				klog.V(4).Infof("Channels had same version %q but different ids (%q vs %q); will replace", *c.Version, c.Id, existing.Id)
+				klog.V(4).Infof("Channels had same version %q but different ids (%q vs %q); will update", *c.Version, c.Id, existing.Id)
 			}
 		}
 	} else {
@@ -146,10 +163,10 @@ func (c *ChannelVersion) replaces(existing *ChannelVersion) bool {
 
 	if c.Version == nil {
 		klog.Warningf("New ChannelVersion did not have a version; can't perform real version check")
-		return false
+		return false, false
 	}
 
-	return true
+	return true, false
 }
 
 func (c *Channel) GetInstalledVersion(ctx context.Context, k8sClient kubernetes.Interface) (*ChannelVersion, error) {


### PR DESCRIPTION
This is resurrecting #8722. The original contributor gave up.

This is needed in order to change the `targetPort`s for the kube-dns `Service`, as `kubectl apply` does not work for changing the `targetPort`s of a Service that has two `ports` with the same `port` but different `protocol`s.