### PR TITLE
Also set haveUserInfo=true in case --user was provided in "kops export kubecfg"

### DIFF
--- a/pkg/kubeconfig/kubecfg_builder.go
+++ b/pkg/kubeconfig/kubecfg_builder.go
@@ -163,6 +163,7 @@ func (b *KubeconfigBuilder) WriteKubecfg(configAccess clientcmd.ConfigAccess) er
 		if config.AuthInfos[b.User] == nil {
 			return fmt.Errorf("could not find user %q", b.User)
 		}
+		haveUserInfo = true
 	}
 
 	// If we have a bearer token, also create a credential entry with basic auth


### PR DESCRIPTION
Without setting it to true, --user is completely ignored.