### PR TITLE
Bump the cas addon version.

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -516,7 +516,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	if b.Cluster.Spec.ClusterAutoscaler != nil && fi.BoolValue(b.Cluster.Spec.ClusterAutoscaler.Enabled) {
 		{
 			key := "cluster-autoscaler.addons.k8s.io"
-			version := "1.19.0"
+			version := "1.19.2"
 
 			{
 				location := key + "/k8s-1.15.yaml"


### PR DESCRIPTION
Between kOps 1.19 and 1.20, the version went from 1.19.1 to 1.19.0, which prevents any further changes from being applied to the cluster. Bumping to 1.19.2 so that channels can apply again.

fixes #11759 