### PR TITLE
Automated cherry pick of #11780: Bump the cas addon version.

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -477,7 +477,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	if b.Cluster.Spec.ClusterAutoscaler != nil && fi.BoolValue(b.Cluster.Spec.ClusterAutoscaler.Enabled) {
 		{
 			key := "cluster-autoscaler.addons.k8s.io"
-			version := "1.19.0"
+			version := "1.19.2"
 
 			{
 				location := key + "/k8s-1.15.yaml"


### PR DESCRIPTION
Cherry pick of #11780 on release-1.20.

#11780: Bump the cas addon version.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.