### PR TITLE
[cilium] Add validation rule for IPtables/Masquerade config combination

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -867,6 +867,10 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableL7Proxy"), "Cilium L7 Proxy requires IPTablesRules to be installed"))
 	}
 
+	if v.IPTablesRulesNoinstall && !fi.BoolValue(v.EnableBPFMasquerade) {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("IPTablesRulesNoinstall"), "Cilium without IPTables in place, require switching Masquerade to BPF mode. Configure enableBPFMasquerade key."))
+	}
+
 	if v.Ipam != "" {
 		// "azure" not supported by kops
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("ipam"), &v.Ipam, []string{"hostscope", "kubernetes", "crd", "eni"})...)

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -833,6 +833,13 @@ func Test_Validate_Cilium(t *testing.T) {
 		},
 		{
 			Cilium: kops.CiliumNetworkingSpec{
+				EnableBPFMasquerade:    fi.Bool(false),
+				IPTablesRulesNoinstall: true,
+			},
+			ExpectedErrors: []string{"Forbidden::cilium.IPTablesRulesNoinstall"},
+		},
+		{
+			Cilium: kops.CiliumNetworkingSpec{
 				Ipam: "eni",
 			},
 			Spec: kops.ClusterSpec{


### PR DESCRIPTION
The `IPTablesRulesNoinstall` option will instruct Cilium to not create
any iptables rules to mess with pod traffic. But in order to carry
this setting, Cilium also needs eBPF masquerade enabled. 

Otherwise, Cilium will fallback to absent iptables rules/chains and eventually
network nodes will gradually be totally unreachable, without any sign of failure 
as Cilium pods will continue to operate normally.

In this commit, we add a validation rule to prevent users from applying configuration
that may break their network layer.

Ref: https://docs.cilium.io/en/v1.10/concepts/networking/masquerading/

Co-authored-by: hwoarang <markos@chandras.me>
Signed-off-by: dntosas <ntosas@gmail.com>