### PR TITLE
[cilium] Add support for encryption via WireGuard

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3581,6 +3581,10 @@ spec:
                         description: EnableIpv6 is not implemented and may be removed
                           in the future. Setting this has no effect.
                         type: boolean
+                      encryptionType:
+                        description: 'EncryptionType specifies Cilium Encryption method
+                          ("ipsec", "wireguard"). Default: ipsec'
+                        type: string
                       envoyLog:
                         description: EnvoyLog is not implemented and may be removed
                           in the future. Setting this has no effect.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -335,6 +335,9 @@ type CiliumNetworkingSpec struct {
 	// EnableEncryption enables Cilium Encryption.
 	// Default: false
 	EnableEncryption bool `json:"enableEncryption,omitempty"`
+	// EncryptionType specifies Cilium Encryption method ("ipsec", "wireguard").
+	// Default: ipsec
+	EncryptionType string `json:"encryptionType,omitempty"`
 	// EnvoyLog is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	EnvoyLog string `json:"envoyLog,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -335,6 +335,9 @@ type CiliumNetworkingSpec struct {
 	// EnableEncryption enables Cilium Encryption.
 	// Default: false
 	EnableEncryption bool `json:"enableEncryption,omitempty"`
+	// EncryptionType specifies Cilium Encryption method ("ipsec", "wireguard").
+	// Default: ipsec
+	EncryptionType string `json:"encryptionType,omitempty"`
 	// EnvoyLog is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	EnvoyLog string `json:"envoyLog,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1752,6 +1752,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.EnableTracing = in.EnableTracing
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
+	out.EncryptionType = in.EncryptionType
 	out.EnvoyLog = in.EnvoyLog
 	out.IdentityAllocationMode = in.IdentityAllocationMode
 	out.IdentityChangeGracePeriod = in.IdentityChangeGracePeriod
@@ -1859,6 +1860,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.EnableTracing = in.EnableTracing
 	out.EnablePrometheusMetrics = in.EnablePrometheusMetrics
 	out.EnableEncryption = in.EnableEncryption
+	out.EncryptionType = in.EncryptionType
 	out.EnvoyLog = in.EnvoyLog
 	out.IdentityAllocationMode = in.IdentityAllocationMode
 	out.IdentityChangeGracePeriod = in.IdentityChangeGracePeriod

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -863,8 +863,24 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("bpfLBAlgorithm"), &v.BPFLBAlgorithm, []string{"random", "maglev"})...)
 	}
 
+	// Cilium with Wireguard integration follow-up --> https://github.com/cilium/cilium/issues/15462.
+	// The following rule of validation should be deleted as this combination
+	// will be supported on future releases of Cilium (>= v1.11.0).
+	if v.EncryptionType == "wireguard" && v.EnableEncryption && fi.BoolValue(v.EnableL7Proxy) {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("encryptionType"), "Cilium EncryptionType=WireGuard cannot work with L7 Proxy enabled."))
+	}
+
+	if v.EncryptionType != "" {
+		allErrs = append(allErrs, IsValidValue(fldPath.Child("encryptionType"), &v.EncryptionType, []string{"ipsec", "wireguard"})...)
+
+		version, _ := semver.Parse(v.Version)
+		if v.EncryptionType == "wireguard" && version.Minor < 10 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("encryptionType"), "Cilium EncryptionType=WireGuard is not available for Cilium version < 1.10.0."))
+		}
+	}
+
 	if fi.BoolValue(v.EnableL7Proxy) && v.IPTablesRulesNoinstall {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableL7Proxy"), "Cilium L7 Proxy requires IPTablesRules to be installed"))
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableL7Proxy"), "Cilium L7 Proxy requires IPTablesRules to be installed."))
 	}
 
 	if v.Ipam != "" {

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -149,6 +149,10 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 		c.MemoryRequest = &defaultMemoryRequest
 	}
 
+	if c.EncryptionType == "" {
+		c.EncryptionType = "ipsec"
+	}
+
 	hubble := c.Hubble
 	if hubble != nil {
 		if hubble.Enabled == nil {

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -81,10 +81,16 @@ data:
   operator-prometheus-serve-addr: ":6942"
   enable-metrics: "true"
   {{ end }}
+
   {{ if .EnableEncryption }}
+  {{ if eq .EncryptionType "ipsec" }}
   enable-ipsec: "true"
   ipsec-key-file: /etc/ipsec/keys
+  {{ else if eq .EncryptionType "wireguard"  }}
+  enable-wireguard: "true"
   {{ end }}
+  {{ end }}
+
   # Enable IPv4 addressing. If enabled, all endpoints are allocated an IPv4
   # address.
   enable-ipv4: "{{ not IsIPv6Only }}"


### PR DESCRIPTION
In this commit, we enable users to choose WireGuard as their prefered
encryption type, leveraging this new feature from Cilium.

Ref: https://cilium.io/blog/2021/05/20/cilium-110#wireguard

Signed-off-by: dntosas <ntosas@gmail.com>