### PR TITLE
Automated cherry pick of #11764: Don't try to build etcd-manager secrets for cilium twice

### DIFF
--- a/nodeup/pkg/model/etcd_manager_tls.go
+++ b/nodeup/pkg/model/etcd_manager_tls.go
@@ -43,6 +43,12 @@ func (b *EtcdManagerTLSBuilder) Build(ctx *fi.ModelBuilderContext) error {
 
 	for _, etcdCluster := range b.Cluster.Spec.EtcdClusters {
 		k := etcdCluster.Name
+
+		// The certs for cilium etcd is managed by CiliumBuilder
+		if k == "cilium" {
+			continue
+		}
+
 		d := "/etc/kubernetes/pki/etcd-manager-" + k
 
 		keys := make(map[string]string)

--- a/nodeup/pkg/model/etcd_manager_tls.go
+++ b/nodeup/pkg/model/etcd_manager_tls.go
@@ -44,7 +44,7 @@ func (b *EtcdManagerTLSBuilder) Build(ctx *fi.ModelBuilderContext) error {
 	for _, etcdCluster := range b.Cluster.Spec.EtcdClusters {
 		k := etcdCluster.Name
 
-		// The certs for cilium etcd is managed by CiliumBuilder
+		// The certs for cilium etcd are managed by CiliumBuilder
 		if k == "cilium" {
 			continue
 		}

--- a/nodeup/pkg/model/networking/BUILD.bazel
+++ b/nodeup/pkg/model/networking/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -25,5 +25,17 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cilium_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//nodeup/pkg/model:go_default_library",
+        "//pkg/apis/kops:go_default_library",
+        "//pkg/pki:go_default_library",
+        "//upup/pkg/fi:go_default_library",
     ],
 )

--- a/nodeup/pkg/model/networking/cilium_test.go
+++ b/nodeup/pkg/model/networking/cilium_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import (
+	"runtime"
+	"testing"
+
+	"k8s.io/kops/nodeup/pkg/model"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/pki"
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+func TestCiliumBuilder(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("cilium nodeup test will only work on linux")
+	}
+	context := &model.NodeupModelContext{
+		Cluster: &kops.Cluster{
+			Spec: kops.ClusterSpec{
+				CloudProvider: "aws",
+				EtcdClusters: []kops.EtcdClusterSpec{
+					{
+						Name:     "cilium",
+						Provider: kops.EtcdProviderTypeManager,
+					},
+				},
+				KubernetesVersion: "1.19.0",
+				Networking: &kops.NetworkingSpec{
+					Cilium: &kops.CiliumNetworkingSpec{
+						EtcdManaged: true,
+					},
+				},
+			},
+		},
+		HasAPIServer: true,
+		KeyStore:     &fakeKeyStore{},
+		IsMaster:     true,
+	}
+	etcdBuilder := &model.EtcdManagerTLSBuilder{
+		NodeupModelContext: context,
+	}
+	ciliumBuilder := &CiliumBuilder{
+		NodeupModelContext: context,
+	}
+
+	modelContext := &fi.ModelBuilderContext{
+		Tasks: make(map[string]fi.Task),
+	}
+
+	if err := etcdBuilder.Build(modelContext); err != nil {
+		t.Errorf("unexpected error building etcd: %v", err)
+	}
+
+	if err := ciliumBuilder.Build(modelContext); err != nil {
+		t.Errorf("unexpected error building cilium: %v", err)
+	}
+}
+
+type fakeKeyStore struct {
+	fi.CAStore
+}
+
+func (*fakeKeyStore) FindCert(name string) (*pki.Certificate, error) {
+	return &pki.Certificate{}, nil
+}
+
+func (*fakeKeyStore) FindPrivateKey(name string) (*pki.PrivateKey, error) {
+	return &pki.PrivateKey{}, nil
+}

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -327,6 +327,9 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec) (*v1.Pod
 		peerPort = 2382
 		grpcPort = wellknownports.EtcdCiliumGRPC
 		quarantinedClientPort = wellknownports.EtcdCiliumQuarantinedClientPort
+		if !featureflag.APIServerNodes.Enabled() {
+			clientHost = b.Cluster.Spec.MasterInternalName
+		}
 	default:
 		return nil, fmt.Errorf("unknown etcd cluster key %q", etcdCluster.Name)
 	}


### PR DESCRIPTION
Cherry pick of #11764 on release-1.21.

#11764: Don't try to build etcd-manager secrets for cilium twice

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.