### PR TITLE
Fix validating presence of AWS EBS CSI

### DIFF
--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -66,7 +66,11 @@ func TestAWSValidateExternalCloudConfig(t *testing.T) {
 		},
 	}
 	for _, g := range grid {
-		errs := awsValidateExternalCloudControllerManager(g.Input)
+		g.Input.KubernetesVersion = "1.21.0"
+		cluster := &kops.Cluster{
+			Spec: g.Input,
+		}
+		errs := awsValidateExternalCloudControllerManager(cluster)
 
 		testErrors(t, g.Input, errs, g.ExpectedErrors)
 	}

--- a/pkg/apis/kops/validation/aws_test.go
+++ b/pkg/apis/kops/validation/aws_test.go
@@ -38,6 +38,11 @@ func TestAWSValidateExternalCloudConfig(t *testing.T) {
 		{
 			Input: kops.ClusterSpec{
 				ExternalCloudControllerManager: &kops.CloudControllerManagerConfig{},
+				CloudConfig: &kops.CloudConfiguration{
+					AWSEBSCSIDriver: &kops.AWSEBSCSIDriver{
+						Enabled: fi.Bool(false),
+					},
+				},
 			},
 			ExpectedErrors: []string{"Forbidden::spec.externalCloudControllerManager"},
 		},

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1473,7 +1473,7 @@ func validateSnapshotController(cluster *kops.Cluster, spec *kops.SnapshotContro
 		if !components.IsCertManagerEnabled(cluster) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("enabled"), "Snapshot controller requires that cert manager is enabled"))
 		}
-		if cluster.Spec.CloudConfig == nil || cluster.Spec.CloudConfig.AWSEBSCSIDriver == nil || !fi.BoolValue(cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled) {
+		if !hasAWSEBSCSIDriver(cluster.Spec) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("enabled"), "Snapshot controller requires external CSI Driver"))
 		}
 	}


### PR DESCRIPTION
As of k8s 1.22, EBS driver is always installed. This PR makes validation pass when not explicitly enabling EBS CSI Driver.