### PR TITLE
Update alpha channel k8s versions and ec2 ami base image

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -58,11 +58,11 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210415
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210503
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210415
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210503
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0"
@@ -88,16 +88,16 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.21.0"
-    recommendedVersion: 1.21.1
+    recommendedVersion: 1.21.2
     requiredVersion: 1.21.0
   - range: ">=1.20.0"
-    recommendedVersion: 1.20.7
+    recommendedVersion: 1.20.8
     requiredVersion: 1.20.0
   - range: ">=1.19.0"
-    recommendedVersion: 1.19.11
+    recommendedVersion: 1.19.12
     requiredVersion: 1.19.0
   - range: ">=1.18.0"
-    recommendedVersion: 1.18.19
+    recommendedVersion: 1.18.20
     requiredVersion: 1.18.0
   - range: ">=1.17.0"
     recommendedVersion: 1.17.17
@@ -127,19 +127,19 @@ spec:
   - range: ">=1.21.0-alpha.1"
     #recommendedVersion: "1.21.0-beta.1"
     #requiredVersion: 1.21.0
-    kubernetesVersion: 1.21.1
+    kubernetesVersion: 1.21.2
   - range: ">=1.20.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.20.0
-    kubernetesVersion: 1.20.7
+    kubernetesVersion: 1.20.8
   - range: ">=1.19.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.11
+    kubernetesVersion: 1.19.12
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.18.0
-    kubernetesVersion: 1.18.19
+    kubernetesVersion: 1.18.20
   - range: ">=1.17.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.17.0


### PR DESCRIPTION
* https://github.com/kubernetes/kubernetes/releases/tag/v1.21.2
* https://github.com/kubernetes/kubernetes/releases/tag/v1.20.8
* https://github.com/kubernetes/kubernetes/releases/tag/v1.19.12
* https://github.com/kubernetes/kubernetes/releases/tag/v1.18.20

[Ubuntu EC2 Locator](https://cloud-images.ubuntu.com/locator/ec2/) shows that `20210503` is the latest available in Gov Cloud, so I went with this one to maintain the highest level of availability across every possible AWS region. 