### PR TITLE
Automated cherry pick of #11778: Also set haveUserInfo=true in case --user was provided in

### DIFF
--- a/pkg/kubeconfig/kubecfg_builder.go
+++ b/pkg/kubeconfig/kubecfg_builder.go
@@ -163,6 +163,7 @@ func (b *KubeconfigBuilder) WriteKubecfg(configAccess clientcmd.ConfigAccess) er
 		if config.AuthInfos[b.User] == nil {
 			return fmt.Errorf("could not find user %q", b.User)
 		}
+		haveUserInfo = true
 	}
 
 	// If we have a bearer token, also create a credential entry with basic auth


### PR DESCRIPTION
Cherry pick of #11778 on release-1.21.

#11778: Also set haveUserInfo=true in case --user was provided in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.