### PR TITLE
Set EnableExternalCloudController to true by default

### DIFF
--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -53,7 +53,7 @@ var (
 	// DNSPreCreate controls whether we pre-create DNS records.
 	DNSPreCreate = New("DNSPreCreate", Bool(true))
 	//EnableExternalCloudController toggles the use of cloud-controller-manager introduced in v1.7
-	EnableExternalCloudController = New("EnableExternalCloudController", Bool(false))
+	EnableExternalCloudController = New("EnableExternalCloudController", Bool(true))
 	// EnableExternalDNS enables external DNS
 	EnableExternalDNS = New("EnableExternalDNS", Bool(false))
 	// EnableSeparateConfigBase allows a config-base that is different from the state store

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -73,11 +73,6 @@ func TestBootstrapChannelBuilder_AWSCloudController(t *testing.T) {
 
 	h.SetupMockAWS()
 
-	featureflag.ParseFlags("+EnableExternalCloudController")
-	unsetFeatureFlag := func() {
-		featureflag.ParseFlags("-EnableExternalCloudController")
-	}
-	defer unsetFeatureFlag()
 	runChannelBuilderTest(t, "awscloudcontroller", []string{"aws-cloud-controller.addons.k8s.io-k8s-1.18"})
 }
 


### PR DESCRIPTION
This is not just about AWS, the OpenStack one for example is stable.
It means that someone should still enable the feature via `spec.cloudControllerManager.cloudProvider`, but no longer need to set the feature flag too.