### PR TITLE
Set priority class for AWS CCM addon

### DIFF
--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -37,6 +37,7 @@ spec:
             requests:
               cpu: 200m
       hostNetwork: true
+      priorityClassName: system-cluster-critical
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -36,6 +36,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       tolerations:
       - effect: NoSchedule

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -55,7 +55,7 @@ spec:
   - id: k8s-1.18
     kubernetesVersion: '>=1.18.0'
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 66da0144f0b1b8077fe52179bc38268a3548579f
+    manifestHash: 802a42830a525a9083c80e2ad58efb72ea34945e
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
External cloud provider will add a taint `node.cloudprovider.kubernetes.io/uninitialized` with an effect NoSchedule during initialization. This effectively blocks cluster initialization until the cloud controller manager is ready, so it should have higher priority.
As an important side-effect of adding priority class,  kOps validation will track status of AWS CCM pods.

/cc @olemarkus @rifelpet 
