### PR TITLE
Weaken some interfaces

### DIFF
--- a/pkg/model/awsmodel/oidc_provider.go
+++ b/pkg/model/awsmodel/oidc_provider.go
@@ -25,7 +25,7 @@ import (
 // OIDCProviderBuilder configures IAM OIDC Provider
 type OIDCProviderBuilder struct {
 	*AWSModelContext
-	KeyStore  fi.CAStore
+	KeyStore  fi.Keystore
 	Lifecycle fi.Lifecycle
 }
 

--- a/pkg/pki/certificate_test.go
+++ b/pkg/pki/certificate_test.go
@@ -18,7 +18,6 @@ package pki
 
 import (
 	"bytes"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -42,7 +41,7 @@ func TestGenerateCertificate(t *testing.T) {
 
 	{
 		var b bytes.Buffer
-		pkData, err := x509.MarshalPKIXPublicKey(key.Key.(*rsa.PrivateKey).Public())
+		pkData, err := x509.MarshalPKIXPublicKey(key.Key.Public())
 		require.NoError(t, err, "MarshalPKIXPublicKey")
 
 		err = pem.Encode(&b, &pem.Block{Type: "RSA PUBLIC KEY", Bytes: pkData})

--- a/pkg/pki/csr.go
+++ b/pkg/pki/csr.go
@@ -18,7 +18,6 @@ package pki
 
 import (
 	crypto_rand "crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
 	"math/big"
@@ -47,10 +46,7 @@ func BuildPKISerial(timestamp int64) *big.Int {
 
 func signNewCertificate(privateKey *PrivateKey, template *x509.Certificate, signer *x509.Certificate, signerPrivateKey *PrivateKey) (*Certificate, error) {
 	if template.PublicKey == nil {
-		rsaPrivateKey, ok := privateKey.Key.(*rsa.PrivateKey)
-		if ok {
-			template.PublicKey = rsaPrivateKey.Public()
-		}
+		template.PublicKey = privateKey.Key.Public()
 	}
 
 	if template.PublicKey == nil {

--- a/pkg/pki/privatekey.go
+++ b/pkg/pki/privatekey.go
@@ -72,7 +72,7 @@ func GeneratePrivateKey() (*PrivateKey, error) {
 }
 
 type PrivateKey struct {
-	Key crypto.PrivateKey
+	Key crypto.Signer
 }
 
 func (k *PrivateKey) AsString() (string, error) {
@@ -177,7 +177,7 @@ func (k *PrivateKey) WriteToFile(filename string, perm os.FileMode) error {
 	return err
 }
 
-func parsePEMPrivateKey(pemData []byte) (crypto.PrivateKey, error) {
+func parsePEMPrivateKey(pemData []byte) (crypto.Signer, error) {
 	for {
 		block, rest := pem.Decode(pemData)
 		if block == nil {
@@ -193,7 +193,7 @@ func parsePEMPrivateKey(pemData []byte) (crypto.PrivateKey, error) {
 			if err != nil {
 				return nil, err
 			}
-			return k.(crypto.PrivateKey), nil
+			return k.(crypto.Signer), nil
 		} else {
 			klog.Infof("Ignoring unexpected PEM block: %q", block.Type)
 		}

--- a/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -103,7 +102,7 @@ func (b *BootstrapClientTask) Run(c *fi.Context) error {
 			b.keys[name] = key
 		}
 
-		pkData, err := x509.MarshalPKIXPublicKey(key.Key.(*rsa.PrivateKey).Public())
+		pkData, err := x509.MarshalPKIXPublicKey(key.Key.Public())
 		if err != nil {
 			return fmt.Errorf("marshalling public key: %v", err)
 		}


### PR DESCRIPTION
The change of `pki.PrivateKey` to containing a `crypto.Signer` contemplates a future in which we might be able to store keys in HSMs.