### PR TITLE
Refactor etcd-client-cilium secrets

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -404,7 +404,7 @@ func (c *NodeupModelContext) KubectlPath() string {
 }
 
 // BuildCertificatePairTask creates the tasks to create the certificate and private key files.
-func (c *NodeupModelContext) BuildCertificatePairTask(ctx *fi.ModelBuilderContext, name, path, filename string, owner *string) error {
+func (c *NodeupModelContext) BuildCertificatePairTask(ctx *fi.ModelBuilderContext, name, path, filename string, owner *string, beforeServices []string) error {
 	p := filepath.Join(path, filename)
 	if !filepath.IsAbs(p) {
 		p = filepath.Join(c.PathSrvKubernetes(), p)
@@ -440,11 +440,12 @@ func (c *NodeupModelContext) BuildCertificatePairTask(ctx *fi.ModelBuilderContex
 	}
 
 	ctx.AddTask(&nodetasks.File{
-		Path:     p + ".crt",
-		Contents: fi.NewStringResource(cert),
-		Type:     nodetasks.FileType_File,
-		Mode:     s("0600"),
-		Owner:    owner,
+		Path:           p + ".crt",
+		Contents:       fi.NewStringResource(cert),
+		Type:           nodetasks.FileType_File,
+		Mode:           s("0600"),
+		Owner:          owner,
+		BeforeServices: beforeServices,
 	})
 
 	privateKey := item.PrivateKey

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -240,6 +240,9 @@ func (c *NodeupModelContext) BuildIssuedKubeconfig(name string, subject nodetask
 
 // GetBootstrapCert requests a certificate keypair from kops-controller.
 func (c *NodeupModelContext) GetBootstrapCert(name string) (cert, key fi.Resource) {
+	if c.IsMaster {
+		panic("control plane nodes can't get certs from kops-controller")
+	}
 	b, ok := c.bootstrapCerts[name]
 	if !ok {
 		b = &nodetasks.BootstrapCert{

--- a/nodeup/pkg/model/kops_controller.go
+++ b/nodeup/pkg/model/kops_controller.go
@@ -84,7 +84,7 @@ func (b *KopsControllerBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 	for _, cert := range caList {
 		owner := wellknownusers.KopsControllerName
-		err := b.BuildCertificatePairTask(c, cert, pkiDir, cert, &owner)
+		err := b.BuildCertificatePairTask(c, cert, pkiDir, cert, &owner, nil)
 		if err != nil {
 			return err
 		}

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -54,7 +54,7 @@ func (b *KubeControllerManagerBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	// Include the CA Key
 	// @TODO: use a per-machine key?  use KMS?
-	if err := b.BuildCertificatePairTask(c, fi.CertificateIDCA, pathSrvKCM, "ca", nil); err != nil {
+	if err := b.BuildCertificatePairTask(c, fi.CertificateIDCA, pathSrvKCM, "ca", nil, nil); err != nil {
 		return err
 	}
 

--- a/nodeup/pkg/model/networking/BUILD.bazel
+++ b/nodeup/pkg/model/networking/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     deps = [
         "//nodeup/pkg/model:go_default_library",
         "//pkg/apis/kops:go_default_library",
+        "//pkg/apis/nodeup:go_default_library",
         "//pkg/pki:go_default_library",
         "//upup/pkg/fi:go_default_library",
     ],

--- a/nodeup/pkg/model/networking/cilium_test.go
+++ b/nodeup/pkg/model/networking/cilium_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kops/nodeup/pkg/model"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/nodeup"
 	"k8s.io/kops/pkg/pki"
 	"k8s.io/kops/upup/pkg/fi"
 )
@@ -46,6 +47,11 @@ func TestCiliumBuilder(t *testing.T) {
 						EtcdManaged: true,
 					},
 				},
+			},
+		},
+		NodeupConfig: &nodeup.Config{
+			CAs: map[string]string{
+				"etcd-clients-ca-cilium": "-----BEGIN CERTIFICATE-----\nMIIBbjCCARigAwIBAgIMFnbWaYo6t3AwKQtWMA0GCSqGSIb3DQEBCwUAMBgxFjAU\nBgNVBAMTDWNuPWt1YmVybmV0ZXMwHhcNMjEwNDE2MDMzNDI0WhcNMzEwNDE2MDMz\nNDI0WjAYMRYwFAYDVQQDEw1jbj1rdWJlcm5ldGVzMFwwDQYJKoZIhvcNAQEBBQAD\nSwAwSAJBANLVh1dSDxJ5EcCd36av7++6+sDKqEm2GAzKIwOlfvPsm+pT+pClr51s\nd1m7V16nhWE6lhWjtsiMF8Q32+P5XZkCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG\nMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFIaNS7TlHC6K0r8yWYM1wExengDq\nMA0GCSqGSIb3DQEBCwUAA0EAoxha8yD6JLJcog/EOMdc5BpVPupQ/0FyO38Mb3l9\n0N7uZle0Tz1FQuadRtouySj37iq9nIxEeTh03Q52hNcl3A==\n-----END CERTIFICATE-----\n",
 			},
 		},
 		HasAPIServer: true,

--- a/pkg/model/awsmodel/autoscalinggroup_test.go
+++ b/pkg/model/awsmodel/autoscalinggroup_test.go
@@ -70,6 +70,11 @@ func TestRootVolumeOptimizationFlag(t *testing.T) {
 		},
 		BootstrapScriptBuilder: &model.BootstrapScriptBuilder{
 			Lifecycle: fi.LifecycleSync,
+			Cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					Networking: &kops.NetworkingSpec{},
+				},
+			},
 		},
 		Cluster: cluster,
 	}
@@ -159,6 +164,7 @@ func TestAPIServerAdditionalSecurityGroupsWithNLB(t *testing.T) {
 		},
 		BootstrapScriptBuilder: &model.BootstrapScriptBuilder{
 			Lifecycle: fi.LifecycleSync,
+			Cluster:   cluster,
 		},
 		Cluster: cluster,
 	}

--- a/pkg/model/azuremodel/vmscaleset_test.go
+++ b/pkg/model/azuremodel/vmscaleset_test.go
@@ -35,6 +35,11 @@ func TestVMScaleSetModelBuilder_Build(t *testing.T) {
 		AzureModelContext: newTestAzureModelContext(),
 		BootstrapScriptBuilder: &model.BootstrapScriptBuilder{
 			Lifecycle: fi.LifecycleSync,
+			Cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					Networking: &kops.NetworkingSpec{},
+				},
+			},
 		},
 	}
 	c := &fi.ModelBuilderContext{

--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -64,7 +64,7 @@ type nodeupConfigBuilder struct {
 	cluster *kops.Cluster
 }
 
-func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, caTask *fitasks.Keypair) (*nodeup.Config, *nodeup.BootConfig, error) {
+func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, caTasks map[string]*fitasks.Keypair) (*nodeup.Config, *nodeup.BootConfig, error) {
 	config, bootConfig := nodeup.NewConfig(n.cluster, ig)
 	return config, bootConfig, nil
 }
@@ -152,6 +152,7 @@ func TestBootstrapUserData(t *testing.T) {
 					Hash:      hashing.MustFromString("e525c28a65ff0ce4f95f9e730195b4e67fdcb15ceb1f36b5ad6921a8a4490c71"),
 				},
 			},
+			Cluster: cluster,
 		}
 
 		res, err := bs.ResourceNodeUp(c, group)
@@ -256,6 +257,7 @@ func makeTestCluster(hookSpecRoles []kops.InstanceGroupRole, fileAssetSpecRoles 
 					Port: 80,
 				},
 			},
+			Networking: &kops.NetworkingSpec{},
 			Hooks: []kops.HookSpec{
 				{
 					ExecContainer: &kops.ExecContainerAction{

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -142,12 +142,23 @@ func (b *EtcdManagerBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 
 		if etcdCluster.Name == "cilium" {
-			c.AddTask(&fitasks.Keypair{
+			clientsCaCilium := &fitasks.Keypair{
 				Name:      fi.String("etcd-clients-ca-cilium"),
 				Lifecycle: b.Lifecycle,
 				Subject:   "cn=etcd-clients-ca-cilium",
 				Type:      "ca",
-			})
+			}
+			c.AddTask(clientsCaCilium)
+
+			if !b.UseKopsControllerForNodeBootstrap() {
+				c.AddTask(&fitasks.Keypair{
+					Name:      fi.String("etcd-client-cilium"),
+					Lifecycle: b.Lifecycle,
+					Subject:   "cn=cilium",
+					Type:      "client",
+					Signer:    clientsCaCilium,
+				})
+			}
 		}
 	}
 

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -623,7 +623,7 @@ func ReadableStatePaths(cluster *kops.Cluster, role Subject) ([]string, error) {
 				// @check if cilium is enabled as the CNI provider and permit access to the cilium etc client TLS certificate by default
 				// As long as the Cilium Etcd cluster exists, we should do this
 				if networkingSpec.Cilium != nil && model.UseCiliumEtcd(cluster) {
-					paths = append(paths, "/pki/private/etcd-clients-ca-cilium/*")
+					paths = append(paths, "/pki/private/etcd-client-cilium/*")
 				}
 			}
 		}

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -1012,7 +1012,7 @@ func createBuilderForCluster(cluster *kops.Cluster, instanceGroups []*kops.Insta
 type nodeupConfigBuilder struct {
 }
 
-func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, caTask *fitasks.Keypair) (*nodeup.Config, *nodeup.BootConfig, error) {
+func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, caTasks map[string]*fitasks.Keypair) (*nodeup.Config, *nodeup.BootConfig, error) {
 	return &nodeup.Config{}, &nodeup.BootConfig{}, nil
 }
 
@@ -1031,6 +1031,9 @@ func RunGoldenTest(t *testing.T, basedir string, testCase serverGroupModelBuilde
 	testutils.SetupMockOpenstack()
 
 	clusterLifecycle := fi.LifecycleSync
+	if testCase.cluster.Spec.Networking == nil {
+		testCase.cluster.Spec.Networking = &kops.NetworkingSpec{}
+	}
 	bootstrapScriptBuilder := &model.BootstrapScriptBuilder{
 		NodeUpConfigBuilder: &nodeupConfigBuilder{},
 		NodeUpAssets: map[architectures.Architecture]*mirrors.MirroredAsset{
@@ -1043,6 +1046,7 @@ func RunGoldenTest(t *testing.T, basedir string, testCase serverGroupModelBuilde
 				Hash:      hashing.MustFromString("e525c28a65ff0ce4f95f9e730195b4e67fdcb15ceb1f36b5ad6921a8a4490c71"),
 			},
 		},
+		Cluster: testCase.cluster,
 	}
 
 	builder := createBuilderForCluster(testCase.cluster, testCase.instanceGroups, clusterLifecycle, bootstrapScriptBuilder)

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
@@ -249,7 +249,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumadvancedexamplec
   ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
   InstanceGroupName: master-us-test-1a
   InstanceGroupRole: Master
-  NodeupConfigHash: bRfnIu1P/bOf6azf9b2o5Dl8hjdt+rlKL9GJwuTgmLs=
+  NodeupConfigHash: EpNH+uZvBIReosuDe20uLGhdD1PuI83Ewp979z0JsrE=
 
   __EOF_KUBE_ENV
 
@@ -421,7 +421,7 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumadvancedexamplecom.Properties.La
   ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: TcEhf4AmLmWCRh+0r9RC1PxaJEXfff4jHU1Pv5/MKDA=
+  NodeupConfigHash: UoM0gz2kOOat/kWK4++dCsgM+K/HwYqKpbEFkuAO0vs=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
@@ -249,7 +249,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumadvancedexamplec
   ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
   InstanceGroupName: master-us-test-1a
   InstanceGroupRole: Master
-  NodeupConfigHash: EpNH+uZvBIReosuDe20uLGhdD1PuI83Ewp979z0JsrE=
+  NodeupConfigHash: 58rDov0rcoNX88fBs1Bs0tVQEjTzd5sXhdXUXLnPc0Q=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
@@ -247,7 +247,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: EpNH+uZvBIReosuDe20uLGhdD1PuI83Ewp979z0JsrE=
+NodeupConfigHash: 58rDov0rcoNX88fBs1Bs0tVQEjTzd5sXhdXUXLnPc0Q=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
@@ -247,7 +247,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: bRfnIu1P/bOf6azf9b2o5Dl8hjdt+rlKL9GJwuTgmLs=
+NodeupConfigHash: EpNH+uZvBIReosuDe20uLGhdD1PuI83Ewp979z0JsrE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
@@ -163,7 +163,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: TcEhf4AmLmWCRh+0r9RC1PxaJEXfff4jHU1Pv5/MKDA=
+NodeupConfigHash: UoM0gz2kOOat/kWK4++dCsgM+K/HwYqKpbEFkuAO0vs=
 
 __EOF_KUBE_ENV
 

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1335,6 +1335,9 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 
 	if isMaster {
 		config.KeypairIDs[fi.CertificateIDCA] = caTasks[fi.CertificateIDCA].Keyset().Primary.Id
+		if caTasks["etcd-clients-ca-cilium"] != nil {
+			config.KeypairIDs["etcd-clients-ca-cilium"] = caTasks["etcd-clients-ca-cilium"].Keyset().Primary.Id
+		}
 	} else {
 		if caTasks["etcd-client-cilium"] != nil {
 			config.KeypairIDs["etcd-client-cilium"] = caTasks["etcd-client-cilium"].Keyset().Primary.Id

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -495,6 +495,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		Lifecycle:           clusterLifecycle,
 		NodeUpConfigBuilder: configBuilder,
 		NodeUpAssets:        c.NodeUpAssets,
+		Cluster:             cluster,
 	}
 
 	{
@@ -1296,7 +1297,7 @@ func newNodeUpConfigBuilder(cluster *kops.Cluster, assetBuilder *assets.AssetBui
 }
 
 // BuildConfig returns the NodeUp config and auxiliary config.
-func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, caTask *fitasks.Keypair) (*nodeup.Config, *nodeup.BootConfig, error) {
+func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, caTasks map[string]*fitasks.Keypair) (*nodeup.Config, *nodeup.BootConfig, error) {
 	cluster := n.cluster
 
 	if ig == nil {
@@ -1321,15 +1322,23 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 		}
 	}
 
-	cas, err := fi.ResourceAsString(caTask.Certificates())
+	err := getTasksCertificate(caTasks, fi.CertificateIDCA, config)
 	if err != nil {
-		// CA task may not have run yet; we'll retry
-		return nil, nil, fmt.Errorf("failed to read CA certificates: %w", err)
+		return nil, nil, err
 	}
-	config.CAs[fi.CertificateIDCA] = cas
+	if caTasks["etcd-clients-ca-cilium"] != nil {
+		err := getTasksCertificate(caTasks, "etcd-clients-ca-cilium", config)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 
 	if isMaster {
-		config.KeypairIDs[fi.CertificateIDCA] = caTask.Keyset().Primary.Id
+		config.KeypairIDs[fi.CertificateIDCA] = caTasks[fi.CertificateIDCA].Keyset().Primary.Id
+	} else {
+		if caTasks["etcd-client-cilium"] != nil {
+			config.KeypairIDs["etcd-client-cilium"] = caTasks["etcd-client-cilium"].Keyset().Primary.Id
+		}
 	}
 
 	if isMaster || useGossip {
@@ -1403,6 +1412,16 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 	}
 
 	return config, bootConfig, nil
+}
+
+func getTasksCertificate(caTasks map[string]*fitasks.Keypair, name string, config *nodeup.Config) error {
+	cas, err := fi.ResourceAsString(caTasks[name].Certificates())
+	if err != nil {
+		// CA task may not have run yet; we'll retry
+		return fmt.Errorf("failed to read %s certificates: %w", name, err)
+	}
+	config.CAs[name] = cas
+	return nil
 }
 
 func buildContainerdConfig(cluster *kops.Cluster) string {


### PR DESCRIPTION
For non-kops-controller-bootstrap worker nodes, gives them a prebaked client cert/key instead of the private key of the CA.