### PR TITLE
Use host network for ebs-csi-controller in IPv6 only clusters

### DIFF
--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -421,6 +421,9 @@ spec:
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
       {{ if not UseServiceAccountIAM }}
+      {{ if IsIPv6Only }}
+      hostNetwork: true
+      {{ end }}
       tolerations:
         - operator: Exists
       {{ end }}
@@ -460,7 +463,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           ports:
             - name: healthz
-              containerPort: 9808
+              containerPort: 9809
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -1005,7 +1005,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 		if b.Cluster.Spec.CloudConfig != nil && b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver != nil && fi.BoolValue(b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled) {
 			key := "aws-ebs-csi-driver.addons.k8s.io"
 
-			version := "1.0.0-kops.1"
+			version := "1.1.0-kops.1"
 			{
 				id := "k8s-1.17"
 				location := key + "/" + id + ".yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -63,8 +63,8 @@ spec:
   - id: k8s-1.17
     kubernetesVersion: '>=1.17.0'
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 59c7723a8a9271558c6a87ccb0f0c61c2e36c6ed
+    manifestHash: 037b4ae065af38e8347bbec053c1503aa3c51a6c
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
-    version: 1.0.0-kops.1
+    version: 1.1.0-kops.1


### PR DESCRIPTION
This should get the IPv6 storage tests green again: https://testgrid.k8s.io/kops-misc#kops-grid-scenario-ipv6

IMDS is not available on IPv6 and this is an easy workaround while IPv6 is in experimental stage.
```
Jun 22 11:52:16.640: INFO: At 2021-06-22 11:47:14 +0000 UTC - event for awstt6j2: {persistentvolume-controller } WaitForFirstConsumer: waiting for first consumer to be created before binding
Jun 22 11:52:16.640: INFO: At 2021-06-22 11:47:14 +0000 UTC - event for awstt6j2: {persistentvolume-controller } ExternalProvisioning: waiting for a volume to be created, either by external provisioner "ebs.csi.aws.com" or manually created by system administrator
Jun 22 11:52:16.640: INFO: At 2021-06-22 11:47:14 +0000 UTC - event for awstt6j2: {ebs.csi.aws.com_ebs-csi-controller-5df8cc7bfb-hs4r4_fab53035-fcf2-404e-8d20-8e2f0bdb89dc } Provisioning: External provisioner is provisioning volume for claim "volume-4387/awstt6j2"
Jun 22 11:52:16.640: INFO: At 2021-06-22 11:47:14 +0000 UTC - event for awstt6j2: {ebs.csi.aws.com_ebs-csi-controller-5df8cc7bfb-hs4r4_fab53035-fcf2-404e-8d20-8e2f0bdb89dc } ProvisioningFailed: failed to provision volume with StorageClass "volume-4387fpvrk": rpc error: code = Internal desc = NoCredentialProviders: no valid providers in chain
caused by: EnvAccessKeyNotFound: failed to find credentials in the environment.
SharedCredsLoad: failed to load profile, .
EC2RoleRequestError: no EC2 instance role found
caused by: RequestError: send request failed
caused by: Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: connect: network is unreachable
```