### PR TITLE
Escape --skip-regex pattern

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	skipRegexBase = "[Slow]|[Serial]|[Disruptive]|[Flaky]|[Feature:.+]|[HPA]|[Driver:.nfs]|Dashboard|RuntimeClass|RuntimeHandler"
+	skipRegexBase = "\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|\\[Driver:.nfs\\]|Dashboard|RuntimeClass|RuntimeHandler"
 )
 
 func (t *Tester) setSkipRegexFlag() error {


### PR DESCRIPTION
jobs using this logic are now skipping all tests: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-cni-amazon-vpc/1407658529614991360

compared to an older job: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-cni-amazon-vpc/1407417059549122560

```diff
- --ginkgo.skip=[Slow]|[Serial]|[Disruptive]|[Flaky]|[Feature:.+]|[HPA]|[Driver:.nfs]|Dashboard|RuntimeClass|RuntimeHandler|Invalid.AWS.KMS.key
+ --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|\[Driver:.nfs\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Invalid.AWS.KMS.key
```