### PR TITLE
Automated cherry pick of #11852: Handle containerExec hooks when using containerd

### DIFF
--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "containerd_test.go",
         "docker_test.go",
         "fakes_test.go",
+        "hooks_test.go",
         "kops_controller_test.go",
         "kube_apiserver_test.go",
         "kube_controller_manager_test.go",

--- a/nodeup/pkg/model/convenience.go
+++ b/nodeup/pkg/model/convenience.go
@@ -48,11 +48,11 @@ func containsRole(v kops.InstanceGroupRole, list []kops.InstanceGroupRole) bool 
 	return false
 }
 
-// buildDockerEnvironmentVars just converts a series of keypairs to docker environment variables switches
-func buildDockerEnvironmentVars(env map[string]string) []string {
+// buildContainerRuntimeEnvironmentVars just converts a series of keypairs to docker environment variables switches
+func buildContainerRuntimeEnvironmentVars(env map[string]string) []string {
 	var list []string
 	for k, v := range env {
-		list = append(list, []string{"-e", fmt.Sprintf("%s=%s", k, v)}...)
+		list = append(list, []string{"--env", fmt.Sprintf("%s=%s", k, v)}...)
 	}
 
 	return list

--- a/nodeup/pkg/model/hooks_test.go
+++ b/nodeup/pkg/model/hooks_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+func TestContainerdHooksBuilder(t *testing.T) {
+	RunGoldenTest(t, "tests/golden/hooks-containerd-exec", "hooks", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+		builder := HookBuilder{NodeupModelContext: nodeupModelContext}
+		return builder.Build(target)
+	})
+}
+
+func TestDockerHooksBuilder(t *testing.T) {
+	RunGoldenTest(t, "tests/golden/hooks-docker-exec", "hooks", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+		builder := HookBuilder{NodeupModelContext: nodeupModelContext}
+		return builder.Build(target)
+	})
+}

--- a/nodeup/pkg/model/tests/golden/hooks-containerd-exec/cluster.yaml
+++ b/nodeup/pkg/model/tests/golden/hooks-containerd-exec/cluster.yaml
@@ -1,0 +1,74 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: us-test-1a
+    memoryRequest: 100Mi
+    name: main
+    provider: Manager
+    backups:
+      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: us-test-1a
+    memoryRequest: 100Mi
+    name: events
+    provider: Manager
+    backups:
+      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+  iam: {}
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.22.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  hooks:
+  - execContainer:
+      command:
+      - sh
+      - -c
+      - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+      image: busybox
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  name: master-us-test-1a
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: ami-1234
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test-1a

--- a/nodeup/pkg/model/tests/golden/hooks-containerd-exec/tasks-hooks.yaml
+++ b/nodeup/pkg/model/tests/golden/hooks-containerd-exec/tasks-hooks.yaml
@@ -1,0 +1,17 @@
+Name: kops-hook-0.service
+definition: |
+  [Unit]
+  Description=Kops Hook kops-hook-0
+  Requires=docker.service
+
+  [Service]
+  ExecStartPre=/usr/bin/docker pull busybox
+  ExecStart=/usr/bin/docker run -v /:/rootfs/ -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --net=host --privileged busybox sh -c "chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common"
+  Type=oneshot
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+manageState: true
+running: true
+smartRestart: true

--- a/nodeup/pkg/model/tests/golden/hooks-containerd-exec/tasks-hooks.yaml
+++ b/nodeup/pkg/model/tests/golden/hooks-containerd-exec/tasks-hooks.yaml
@@ -2,11 +2,11 @@ Name: kops-hook-0.service
 definition: |
   [Unit]
   Description=Kops Hook kops-hook-0
-  Requires=docker.service
+  Requires=containerd.service
 
   [Service]
-  ExecStartPre=/usr/bin/docker pull busybox
-  ExecStart=/usr/bin/docker run -v /:/rootfs/ -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --net=host --privileged busybox sh -c "chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common"
+  ExecStartPre=/usr/bin/ctr --namespace k8s.io image pull docker.io/library/busybox:latest
+  ExecStart=/usr/bin/ctr --namespace k8s.io run --rm --mount type=bind,src=/,dst=/rootfs,options=rbind:rslave --mount type=bind,src=/var/run/dbus,dst=/var/run/dbus,options=rbind:rprivate --mount type=bind,src=/run/systemd,dst=/run/systemd,options=rbind:rprivate --net-host --privileged docker.io/library/busybox:latest kops-hook-0 sh -c "chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common"
   Type=oneshot
 
   [Install]

--- a/nodeup/pkg/model/tests/golden/hooks-docker-exec/cluster.yaml
+++ b/nodeup/pkg/model/tests/golden/hooks-docker-exec/cluster.yaml
@@ -1,0 +1,75 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: us-test-1a
+    memoryRequest: 100Mi
+    name: main
+    provider: Manager
+    backups:
+      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+  - cpuRequest: 100m
+    etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: us-test-1a
+    memoryRequest: 100Mi
+    name: events
+    provider: Manager
+    backups:
+      backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd-events
+  iam: {}
+  kubelet:
+    anonymousAuth: false
+  kubernetesVersion: v1.22.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    kubenet: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  containerRuntime: docker
+  hooks:
+  - execContainer:
+      command:
+      - sh
+      - -c
+      - chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common
+      image: busybox
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  name: master-us-test-1a
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: ami-1234
+  machineType: m3.medium
+  maxSize: 1
+  minSize: 1
+  role: Master
+  subnets:
+  - us-test-1a

--- a/nodeup/pkg/model/tests/golden/hooks-docker-exec/tasks-hooks.yaml
+++ b/nodeup/pkg/model/tests/golden/hooks-docker-exec/tasks-hooks.yaml
@@ -1,0 +1,17 @@
+Name: kops-hook-0.service
+definition: |
+  [Unit]
+  Description=Kops Hook kops-hook-0
+  Requires=docker.service
+
+  [Service]
+  ExecStartPre=/usr/bin/docker pull busybox
+  ExecStart=/usr/bin/docker run -v /:/rootfs/ -v /var/run/dbus:/var/run/dbus -v /run/systemd:/run/systemd --net=host --privileged busybox sh -c "chroot /rootfs apt-get update && chroot /rootfs apt-get install -y ceph-common"
+  Type=oneshot
+
+  [Install]
+  WantedBy=multi-user.target
+enabled: true
+manageState: true
+running: true
+smartRestart: true


### PR DESCRIPTION
Cherry pick of #11852 on release-1.20.

#11852: Handle containerExec hooks when using containerd

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.