### PR TITLE
Fix dryrun cluster creation

### DIFF
--- a/upup/pkg/fi/fitasks/keypair.go
+++ b/upup/pkg/fi/fitasks/keypair.go
@@ -304,7 +304,15 @@ func parsePkixName(s string) (*pkix.Name, error) {
 
 func (e *Keypair) ensureResources() {
 	if e.certificates == nil {
-		e.certificates = &fi.TaskDependentResource{Task: e}
+		e.certificates = &fi.TaskDependentResource{
+			Resource: fi.NewStringResource("<< TO BE GENERATED >>\n"),
+			Task:     e,
+		}
+		e.keyset = &fi.Keyset{
+			Primary: &fi.KeysetItem{
+				Id: "<< TO BE GENERATED >>",
+			},
+		}
 	}
 }
 


### PR DESCRIPTION
/kind bug

A `kops create cluster` without a `--yes` fails with:

```
I0624 22:12:15.919463    4954 executor.go:111] Tasks: 0 done / 95 total; 43 can run
W0624 22:12:16.432849    4954 vfs_castore.go:469] CA private key was not found
I0624 22:12:17.328871    4954 executor.go:111] Tasks: 43 done / 95 total; 19 can run
W0624 22:12:18.036237    4954 executor.go:139] error running task "BootstrapScript/nodes-us-east-1b" (9m59s remaining to succeed): failed to read CA certificates: error opening resource: resource opened before it is ready (task=*fitasks.Keypair {"Name":"ca","alternateNames":null,"Lifecycle":"Sync","Signer":null,"subject":"cn=kubernetes","type":"ca","oldFormat":false})
W0624 22:12:18.036652    4954 executor.go:139] error running task "BootstrapScript/nodes-us-east-1a" (9m59s remaining to succeed): failed to read CA certificates: error opening resource: resource opened before it is ready (task=*fitasks.Keypair {"Name":"ca","alternateNames":null,"Lifecycle":"Sync","Signer":null,"subject":"cn=kubernetes","type":"ca","oldFormat":false})
W0624 22:12:18.036668    4954 executor.go:139] error running task "BootstrapScript/master-us-east-1a" (9m59s remaining to succeed): failed to read CA certificates: error opening resource: resource opened before it is ready (task=*fitasks.Keypair {"Name":"ca","alternateNames":null,"Lifecycle":"Sync","Signer":null,"subject":"cn=kubernetes","type":"ca","oldFormat":false})
```

This is because the `Keypair` task is a `DefaultDeltaRunMethod()` task, but is now a dependency of `BootstrapScript`, which is not.
