### PR TITLE
Decrease default values for net.ipv4.tcp_rmem and net.ipv4.tcp_wmem

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -63,6 +63,7 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 
 		// See https://github.com/kubernetes/kube-deploy/issues/261
+		// and https://github.com/kubernetes/kops/issues/10206
 		sysctls = append(sysctls,
 			"# Increase the number of connections",
 			"net.core.somaxconn = 32768",
@@ -77,8 +78,8 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"",
 
 			"# Increase the maximum total buffer-space allocatable",
-			"net.ipv4.tcp_wmem = 4096 12582912 16777216",
-			"net.ipv4.tcp_rmem = 4096 12582912 16777216",
+			"net.ipv4.tcp_wmem = 4096 87380 16777216",
+			"net.ipv4.tcp_rmem = 4096 87380 16777216",
 			"",
 
 			"# Increase the number of outstanding syn requests allowed",

--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -390,7 +390,7 @@ func (b *BootstrapScript) Run(c *fi.Context) error {
 		"SetSysctls": func() string {
 			// By setting some sysctls early, we avoid broken configurations that prevent nodeup download.
 			// See https://github.com/kubernetes/kops/issues/10206 for details.
-			return "sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true\n"
+			return setSysctls()
 		},
 	}
 
@@ -476,4 +476,16 @@ func gzipBase64(data string) (string, error) {
 	}
 
 	return base64.StdEncoding.EncodeToString(b.Bytes()), nil
+}
+
+func setSysctls() string {
+	var b bytes.Buffer
+
+	// Based on https://github.com/kubernetes/kops/issues/10206#issuecomment-766852332
+	b.WriteString("sysctl -w net.core.rmem_max=16777216 || true\n")
+	b.WriteString("sysctl -w net.core.wmem_max=16777216 || true\n")
+	b.WriteString("sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true\n")
+	b.WriteString("sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n")
+
+	return b.String()
 }

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -29,7 +29,10 @@ systemctl daemon-reload
 systemctl daemon-reexec
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -29,7 +29,10 @@ systemctl daemon-reload
 systemctl daemon-reexec
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -29,7 +29,10 @@ systemctl daemon-reload
 systemctl daemon-reexec
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -29,7 +29,10 @@ systemctl daemon-reload
 systemctl daemon-reexec
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -29,7 +29,10 @@ systemctl daemon-reload
 systemctl daemon-reexec
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -29,7 +29,10 @@ systemctl daemon-reload
 systemctl daemon-reexec
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplateapiserverapiserversminimalexamplecom.Properties.La
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -257,7 +260,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -595,7 +601,10 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
@@ -22,7 +22,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -23,7 +23,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -386,7 +389,10 @@ Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateDa
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -22,7 +22,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
@@ -22,7 +22,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/compress/data/aws_launch_template_master-us-test-1a.masters.compress.example.com_user_data
+++ b/tests/integration/update_cluster/compress/data/aws_launch_template_master-us-test-1a.masters.compress.example.com_user_data
@@ -22,7 +22,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/compress/data/aws_launch_template_nodes.compress.example.com_user_data
+++ b/tests/integration/update_cluster/compress/data/aws_launch_template_nodes.compress.example.com_user_data
@@ -22,7 +22,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -369,7 +372,10 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/containerd/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properti
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -351,7 +354,10 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersdockerexamplecom.Properties.L
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -354,7 +357,10 @@ Resources.AWSEC2LaunchTemplatenodesdockerexamplecom.Properties.LaunchTemplateDat
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -351,7 +354,10 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersexternallbexamplecom.Properti
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -351,7 +354,10 @@ Resources.AWSEC2LaunchTemplatenodesexternallbexamplecom.Properties.LaunchTemplat
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
+++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
+++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
@@ -12,7 +12,10 @@ NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e8
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
@@ -12,7 +12,10 @@ NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e8
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
@@ -12,7 +12,10 @@ NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e8
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
@@ -12,7 +12,10 @@ NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e8
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-etcd/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-etcd/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimaletcdexamplecom.Propert
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -367,7 +370,10 @@ Resources.AWSEC2LaunchTemplatenodesminimaletcdexamplecom.Properties.LaunchTempla
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -357,7 +360,10 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-ipv6/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-ipv6/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Propert
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -351,7 +354,10 @@ Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTempla
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-json/data/aws_launch_template_master-us-test-1a.masters.minimal-json.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-json/data/aws_launch_template_master-us-test-1a.masters.minimal-json.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-json/data/aws_launch_template_nodes.minimal-json.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-json/data/aws_launch_template_nodes.minimal-json.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -351,7 +354,10 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -12,7 +12,10 @@ NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e8
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -12,7 +12,10 @@ NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e8
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_startup-script
@@ -12,7 +12,10 @@ NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e8
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_startup-script
@@ -12,7 +12,10 @@ NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e8
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersmixedinstancesexamplecom.Prop
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -351,7 +354,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1bmastersmixedinstancesexamplecom.Prop
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -688,7 +694,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1cmastersmixedinstancesexamplecom.Prop
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -1025,7 +1034,10 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersmixedinstancesexamplecom.Prop
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -351,7 +354,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1bmastersmixedinstancesexamplecom.Prop
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -688,7 +694,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1cmastersmixedinstancesexamplecom.Prop
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -1025,7 +1034,10 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
@@ -14,7 +14,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersnthsqsresourcesexamplecom.Pro
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -351,7 +354,10 @@ Resources.AWSEC2LaunchTemplatenodesnthsqsresourcesexamplecom.Properties.LaunchTe
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_master-us-test-1a.masters.nthsqsresources.example.com_user_data
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_master-us-test-1a.masters.nthsqsresources.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.example.com_user_data
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json.extracted.yaml
@@ -15,7 +15,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivatesharedipexamplecom.Pro
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -352,7 +355,10 @@ Resources.AWSEC2LaunchTemplatenodesprivatesharedipexamplecom.Properties.LaunchTe
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -15,7 +15,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivatecalicoexamplecom.Prope
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -352,7 +355,10 @@ Resources.AWSEC2LaunchTemplatenodesprivatecalicoexamplecom.Properties.LaunchTemp
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
@@ -15,7 +15,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -352,7 +355,10 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
@@ -15,7 +15,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -341,7 +344,10 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
@@ -15,7 +15,10 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumadvancedexamplec
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {
@@ -356,7 +359,10 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumadvancedexamplecom.Properties.La
 
 
 
-  sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+  sysctl -w net.core.rmem_max=16777216 || true
+  sysctl -w net.core.wmem_max=16777216 || true
+  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
   function ensure-install-dir() {

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privateweave/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data
+++ b/tests/integration/update_cluster/privateweave/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/privateweave/data/aws_launch_template_nodes.privateweave.example.com_user_data
+++ b/tests/integration/update_cluster/privateweave/data/aws_launch_template_nodes.privateweave.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
+++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
+++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {

--- a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -13,7 +13,10 @@ export AWS_REGION=us-test-1
 
 
 
-sysctl -w net.ipv4.tcp_rmem='4096 12582912 16777216' || true
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
 
 
 function ensure-install-dir() {


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kops/issues/10206#issuecomment-766852332
We can now reproduce the issue with IPv6: https://testgrid.k8s.io/kops-ipv6#kops-grid-scenario-ipv6-conformance.
