### PR TITLE
Simplify config server protocol

### DIFF
--- a/cmd/kops-controller/pkg/server/node_config.go
+++ b/cmd/kops-controller/pkg/server/node_config.go
@@ -61,27 +61,5 @@ func (s *Server) getNodeConfig(ctx context.Context, req *nodeup.BootstrapRequest
 		nodeConfig.NodeupConfig = string(b)
 	}
 
-	// We populate some certificates that we know the node will need.
-	for _, name := range []string{"ca"} {
-		cert, _, err := s.keystore.FindPrimaryKeypair(name)
-		if err != nil {
-			return nil, fmt.Errorf("error getting certificate %q: %w", name, err)
-		}
-
-		if cert == nil {
-			return nil, fmt.Errorf("certificate %q not found", name)
-		}
-
-		certData, err := cert.AsString()
-		if err != nil {
-			return nil, fmt.Errorf("error marshalling certificate %q: %w", name, err)
-		}
-
-		nodeConfig.Certificates = append(nodeConfig.Certificates, &nodeup.NodeConfigCertificate{
-			Name: name,
-			Cert: certData,
-		})
-	}
-
 	return nodeConfig, nil
 }

--- a/pkg/apis/nodeup/bootstrap.go
+++ b/pkg/apis/nodeup/bootstrap.go
@@ -41,14 +41,11 @@ type BootstrapResponse struct {
 
 // NodeConfig holds configuration needed to boot a node (without the kops state store)
 type NodeConfig struct {
-	// ClusterFullConfig holds the configuration for the cluster
+	// ClusterFullConfig holds the completed configuration for the cluster.
 	ClusterFullConfig string `json:"clusterFullConfig,omitempty"`
 
 	// NodeupConfig holds the nodeup.Config for the node's instance group.
 	NodeupConfig string `json:"nodeupConfig,omitempty"`
-
-	// Certificates holds certificates that are already issued
-	Certificates []*NodeConfigCertificate `json:"certificates,omitempty"`
 }
 
 // NodeConfigCertificate holds a certificate that the node needs to boot.

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -240,7 +240,7 @@ func (c *NodeUpCommand) Run(out io.Writer) error {
 	}
 
 	if nodeConfig != nil {
-		modelContext.KeyStore = configserver.NewKeyStore(nodeConfig)
+		modelContext.KeyStore = configserver.NewKeyStore(nodeupConfig.CAs[fi.CertificateIDCA])
 	} else if c.cluster.Spec.KeyStore != "" {
 		klog.Infof("Building KeyStore at %q", c.cluster.Spec.KeyStore)
 		p, err := vfs.Context.BuildVfsPath(c.cluster.Spec.KeyStore)


### PR DESCRIPTION
Configserver clients already have the "ca" trust bundle as they need it to talk to configserver in the first place.

/kind cleanup
