### PR TITLE
Kubetest2 - set node-os-arch flag instead of skipping kubectl test on arm64

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -70,17 +70,6 @@ func (t *Tester) setSkipRegexFlag() error {
 		}
 	}
 
-	igs, err := t.getKopsInstanceGroups()
-	if err != nil {
-		return err
-	}
-	for _, ig := range igs {
-		if strings.Contains(ig.Spec.Image, "arm64") {
-			skipRegex += "|Simple.pod.should.handle.in-cluster.config"
-			break
-		}
-	}
-
 	// Ensure it is valid regex
 	if _, err := regexp.Compile(skipRegex); err != nil {
 		return err

--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -302,6 +302,21 @@ func (t *Tester) getZones() ([]string, error) {
 	return zoneNames, nil
 }
 
+func (t *Tester) addNodeOSArchFlag() error {
+	igs, err := t.getKopsInstanceGroups()
+	if err != nil {
+		return err
+	}
+	for _, ig := range igs {
+		if strings.Contains(ig.Spec.Image, "arm64") {
+			klog.Info("Setting --node-os-arch=arm64")
+			t.TestArgs += " --node-os-arch=arm64"
+			break
+		}
+	}
+	return nil
+}
+
 func (t *Tester) execute() error {
 	fs, err := gpflag.Parse(t)
 	if err != nil {
@@ -352,6 +367,10 @@ func (t *Tester) execute() error {
 	}
 
 	if err := t.setSkipRegexFlag(); err != nil {
+		return err
+	}
+
+	if err := t.addNodeOSArchFlag(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/93000 skips the test we are skipping via regex, if the --node-os-arch flag is not set to amd64. kubetest2-tester-kops will now set --node-os-arch so that the test context itself will skip the test rather than relying on --skip-regex.