### PR TITLE
Automated cherry pick of #11873: Avoid spurious changes for ASG InstanceProtection and LT

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -251,7 +251,7 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateHelper(c *fi.ModelBuil
 		Lifecycle:              b.Lifecycle,
 		IAMInstanceProfile:     link,
 		ImageID:                fi.String(ig.Spec.Image),
-		InstanceMonitoring:     ig.Spec.DetailedInstanceMonitoring,
+		InstanceMonitoring:     fi.Bool(false),
 		InstanceType:           fi.String(strings.Split(ig.Spec.MachineType, ",")[0]),
 		RootVolumeOptimization: ig.Spec.RootVolumeOptimization,
 		RootVolumeSize:         fi.Int64(int64(volumeSize)),
@@ -351,6 +351,10 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateHelper(c *fi.ModelBuil
 		})
 	}
 
+	if ig.Spec.DetailedInstanceMonitoring != nil {
+		t.InstanceMonitoring = ig.Spec.DetailedInstanceMonitoring
+	}
+
 	if b.AWSModelContext.UseSSHKey() {
 		if t.SSHKey, err = b.LinkToSSHKey(); err != nil {
 			return nil, err
@@ -400,6 +404,8 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 			"GroupTerminatingInstances",
 			"GroupTotalInstances",
 		},
+
+		InstanceProtection: fi.Bool(false),
 	}
 
 	minSize := fi.Int64(1)
@@ -439,7 +445,9 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 	processes = append(processes, ig.Spec.SuspendProcesses...)
 	t.SuspendProcesses = &processes
 
-	t.InstanceProtection = ig.Spec.InstanceProtection
+	if ig.Spec.InstanceProtection != nil {
+		t.InstanceProtection = ig.Spec.InstanceProtection
+	}
 
 	t.LoadBalancers = []*awstasks.ClassicLoadBalancer{}
 	t.TargetGroups = []*awstasks.TargetGroup{}

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json
@@ -320,6 +320,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -437,6 +440,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {
@@ -583,6 +589,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -106,10 +106,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     id      = aws_launch_template.master-us-test-1a-masters-minimal-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-minimal-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.minimal.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -169,10 +170,11 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
     id      = aws_launch_template.nodes-minimal-example-com.id
     version = aws_launch_template.nodes-minimal-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.minimal.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -387,6 +389,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -463,6 +468,9 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.minimal.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -116,11 +116,12 @@ resource "aws_autoscaling_group" "bastion-bastionuserdata-example-com" {
     id      = aws_launch_template.bastion-bastionuserdata-example-com.id
     version = aws_launch_template.bastion-bastionuserdata-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-bastionuserdata-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.bastionuserdata.example.com"
+  load_balancers        = [aws_elb.bastion-bastionuserdata-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.bastionuserdata.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -165,11 +166,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-bastionuserdata-exam
     id      = aws_launch_template.master-us-test-1a-masters-bastionuserdata-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-bastionuserdata-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-bastionuserdata-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.bastionuserdata.example.com"
+  load_balancers        = [aws_elb.api-bastionuserdata-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.bastionuserdata.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -229,10 +231,11 @@ resource "aws_autoscaling_group" "nodes-bastionuserdata-example-com" {
     id      = aws_launch_template.nodes-bastionuserdata-example-com.id
     version = aws_launch_template.nodes-bastionuserdata-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.bastionuserdata.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.bastionuserdata.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -486,6 +489,9 @@ resource "aws_launch_template" "bastion-bastionuserdata-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.bastionuserdata.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -557,6 +563,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.bastionuserdata.example.com"
   network_interfaces {
@@ -634,6 +643,9 @@ resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.bastionuserdata.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -293,6 +293,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "required"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -101,11 +101,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com"
     id      = aws_launch_template.master-us-test-1a-masters-complex-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-complex-example-com.latest_version
   }
-  load_balancers      = ["my-external-lb-1"]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.complex.example.com"
+  load_balancers        = ["my-external-lb-1"]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.complex.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -176,12 +177,13 @@ resource "aws_autoscaling_group" "nodes-complex-example-com" {
     id      = aws_launch_template.nodes-complex-example-com.id
     version = aws_launch_template.nodes-complex-example-com.latest_version
   }
-  load_balancers      = ["my-external-lb-1"]
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.complex.example.com"
-  suspended_processes = ["AZRebalance"]
+  load_balancers        = ["my-external-lb-1"]
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.complex.example.com"
+  protect_from_scale_in = false
+  suspended_processes   = ["AZRebalance"]
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -368,6 +370,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "required"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.complex.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -86,10 +86,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-compress-example-com
     id      = aws_launch_template.master-us-test-1a-masters-compress-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-compress-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.compress.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.compress.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -149,10 +150,11 @@ resource "aws_autoscaling_group" "nodes-compress-example-com" {
     id      = aws_launch_template.nodes-compress-example-com.id
     version = aws_launch_template.nodes-compress-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.compress.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.compress.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -313,6 +315,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-compress-example-com" 
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.compress.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -388,6 +393,9 @@ resource "aws_launch_template" "nodes-compress-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.compress.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json
@@ -243,6 +243,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -380,6 +383,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/containerd/cloudformation.json
+++ b/tests/integration/update_cluster/containerd/cloudformation.json
@@ -243,6 +243,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -380,6 +383,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json
@@ -243,6 +243,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -380,6 +383,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -76,10 +76,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-existing-iam-example
     id      = aws_launch_template.master-us-test-1a-masters-existing-iam-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-existing-iam-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.existing-iam.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.existing-iam.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -139,10 +140,11 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-existing-iam-example
     id      = aws_launch_template.master-us-test-1b-masters-existing-iam-example-com.id
     version = aws_launch_template.master-us-test-1b-masters-existing-iam-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1b.masters.existing-iam.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1b.masters.existing-iam.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -202,10 +204,11 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-existing-iam-example
     id      = aws_launch_template.master-us-test-1c-masters-existing-iam-example-com.id
     version = aws_launch_template.master-us-test-1c-masters-existing-iam-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1c.masters.existing-iam.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1c.masters.existing-iam.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -265,10 +268,11 @@ resource "aws_autoscaling_group" "nodes-existing-iam-example-com" {
     id      = aws_launch_template.nodes-existing-iam-example-com.id
     version = aws_launch_template.nodes-existing-iam-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.existing-iam.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.existing-iam.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -452,6 +456,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.existing-iam.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -532,6 +539,9 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1b.masters.existing-iam.example.com"
   network_interfaces {
@@ -614,6 +624,9 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1c.masters.existing-iam.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -690,6 +703,9 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.existing-iam.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json
@@ -241,6 +241,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -376,6 +379,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -96,11 +96,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-existingsg-example-c
     id      = aws_launch_template.master-us-test-1a-masters-existingsg-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-existingsg-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-existingsg-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.existingsg.example.com"
+  load_balancers        = [aws_elb.api-existingsg-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.existingsg.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -160,11 +161,12 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-existingsg-example-c
     id      = aws_launch_template.master-us-test-1b-masters-existingsg-example-com.id
     version = aws_launch_template.master-us-test-1b-masters-existingsg-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-existingsg-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1b.masters.existingsg.example.com"
+  load_balancers        = [aws_elb.api-existingsg-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1b.masters.existingsg.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -224,11 +226,12 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-existingsg-example-c
     id      = aws_launch_template.master-us-test-1c-masters-existingsg-example-com.id
     version = aws_launch_template.master-us-test-1c-masters-existingsg-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-existingsg-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1c.masters.existingsg.example.com"
+  load_balancers        = [aws_elb.api-existingsg-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1c.masters.existingsg.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -288,10 +291,11 @@ resource "aws_autoscaling_group" "nodes-existingsg-example-com" {
     id      = aws_launch_template.nodes-existingsg-example-com.id
     version = aws_launch_template.nodes-existingsg-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.existingsg.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.existingsg.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -553,6 +557,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.existingsg.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -633,6 +640,9 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1b.masters.existingsg.example.com"
   network_interfaces {
@@ -715,6 +725,9 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1c.masters.existingsg.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -791,6 +804,9 @@ resource "aws_launch_template" "nodes-existingsg-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.existingsg.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -259,6 +259,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -396,6 +399,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -86,11 +86,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-externallb-example-c
     id      = aws_launch_template.master-us-test-1a-masters-externallb-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-externallb-example-com.latest_version
   }
-  load_balancers      = ["my-external-elb-1", "my-external-elb-2", "my-external-elb-3"]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.externallb.example.com"
+  load_balancers        = ["my-external-elb-1", "my-external-elb-2", "my-external-elb-3"]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.externallb.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -151,11 +152,12 @@ resource "aws_autoscaling_group" "nodes-externallb-example-com" {
     id      = aws_launch_template.nodes-externallb-example-com.id
     version = aws_launch_template.nodes-externallb-example-com.latest_version
   }
-  load_balancers      = ["my-external-elb-1"]
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.externallb.example.com"
+  load_balancers        = ["my-external-elb-1"]
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.externallb.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -328,6 +330,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.externallb.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -404,6 +409,9 @@ resource "aws_launch_template" "nodes-externallb-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.externallb.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -86,11 +86,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-externalpolicies-exa
     id      = aws_launch_template.master-us-test-1a-masters-externalpolicies-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-externalpolicies-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-externalpolicies-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.externalpolicies.example.com"
+  load_balancers        = [aws_elb.api-externalpolicies-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.externalpolicies.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -160,11 +161,12 @@ resource "aws_autoscaling_group" "nodes-externalpolicies-example-com" {
     id      = aws_launch_template.nodes-externalpolicies-example-com.id
     version = aws_launch_template.nodes-externalpolicies-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.externalpolicies.example.com"
-  suspended_processes = ["AZRebalance"]
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.externalpolicies.example.com"
+  protect_from_scale_in = false
+  suspended_processes   = ["AZRebalance"]
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -399,6 +401,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.externalpolicies.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -96,10 +96,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-ha-example-com" {
     id      = aws_launch_template.master-us-test-1a-masters-ha-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-ha-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.ha.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.ha.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -159,10 +160,11 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-ha-example-com" {
     id      = aws_launch_template.master-us-test-1b-masters-ha-example-com.id
     version = aws_launch_template.master-us-test-1b-masters-ha-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1b.masters.ha.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1b.masters.ha.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -222,10 +224,11 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-ha-example-com" {
     id      = aws_launch_template.master-us-test-1c-masters-ha-example-com.id
     version = aws_launch_template.master-us-test-1c-masters-ha-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1c.masters.ha.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1c.masters.ha.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -285,10 +288,11 @@ resource "aws_autoscaling_group" "nodes-ha-example-com" {
     id      = aws_launch_template.nodes-ha-example-com.id
     version = aws_launch_template.nodes-ha-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.ha.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.ha.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -524,6 +528,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.ha.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -604,6 +611,9 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1b.masters.ha.example.com"
   network_interfaces {
@@ -686,6 +696,9 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1c.masters.ha.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -762,6 +775,9 @@ resource "aws_launch_template" "nodes-ha-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.ha.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -106,10 +106,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     id      = aws_launch_template.master-us-test-1a-masters-minimal-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-minimal-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.minimal.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -169,10 +170,11 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
     id      = aws_launch_template.nodes-minimal-example-com.id
     version = aws_launch_template.nodes-minimal-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.minimal.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -386,6 +388,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -462,6 +467,9 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.minimal.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-cloudformation/cloudformation.json
@@ -243,6 +243,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -380,6 +383,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/minimal-etcd/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-etcd/cloudformation.json
@@ -243,6 +243,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -380,6 +383,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json
@@ -239,6 +239,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -376,6 +379,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -86,10 +86,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     id      = aws_launch_template.master-us-test-1a-masters-minimal-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-minimal-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.minimal.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -149,10 +150,11 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
     id      = aws_launch_template.nodes-minimal-example-com.id
     version = aws_launch_template.nodes-minimal-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.minimal.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -320,6 +322,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -396,6 +401,9 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.minimal.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -163,7 +163,8 @@
           "GroupStandbyInstances",
           "GroupTerminatingInstances",
           "GroupTotalInstances"
-        ]
+        ],
+        "protect_from_scale_in": false
       },
       "nodes-minimal-json-example-com": {
         "name": "nodes.minimal-json.example.com",
@@ -223,7 +224,8 @@
           "GroupStandbyInstances",
           "GroupTerminatingInstances",
           "GroupTotalInstances"
-        ]
+        ],
+        "protect_from_scale_in": false
       }
     },
     "aws_ebs_volume": {
@@ -369,6 +371,11 @@
           "http_put_response_hop_limit": 1,
           "http_tokens": "optional"
         },
+        "monitoring": [
+          {
+            "enabled": false
+          }
+        ],
         "network_interfaces": [
           {
             "associate_public_ip_address": true,
@@ -457,6 +464,11 @@
           "http_put_response_hop_limit": 1,
           "http_tokens": "optional"
         },
+        "monitoring": [
+          {
+            "enabled": false
+          }
+        ],
         "network_interfaces": [
           {
             "associate_public_ip_address": true,

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -86,10 +86,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     id      = aws_launch_template.master-us-test-1a-masters-minimal-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-minimal-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.minimal.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -149,10 +150,11 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
     id      = aws_launch_template.nodes-minimal-example-com.id
     version = aws_launch_template.nodes-minimal-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.minimal.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -324,6 +326,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -400,6 +405,9 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.minimal.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -444,6 +444,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -585,6 +588,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {
@@ -728,6 +734,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -865,6 +874,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -96,10 +96,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-mixedinstances-examp
     id      = aws_launch_template.master-us-test-1a-masters-mixedinstances-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-mixedinstances-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.mixedinstances.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.mixedinstances.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -159,10 +160,11 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-mixedinstances-examp
     id      = aws_launch_template.master-us-test-1b-masters-mixedinstances-example-com.id
     version = aws_launch_template.master-us-test-1b-masters-mixedinstances-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1b.masters.mixedinstances.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1b.masters.mixedinstances.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -222,10 +224,11 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-mixedinstances-examp
     id      = aws_launch_template.master-us-test-1c-masters-mixedinstances-example-com.id
     version = aws_launch_template.master-us-test-1c-masters-mixedinstances-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1c.masters.mixedinstances.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1c.masters.mixedinstances.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -542,6 +545,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -622,6 +628,9 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1b.masters.mixedinstances.example.com"
   network_interfaces {
@@ -704,6 +713,9 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1c.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -780,6 +792,9 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.mixedinstances.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -445,6 +445,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -586,6 +589,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {
@@ -729,6 +735,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -866,6 +875,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -96,10 +96,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-mixedinstances-examp
     id      = aws_launch_template.master-us-test-1a-masters-mixedinstances-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-mixedinstances-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.mixedinstances.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.mixedinstances.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -159,10 +160,11 @@ resource "aws_autoscaling_group" "master-us-test-1b-masters-mixedinstances-examp
     id      = aws_launch_template.master-us-test-1b-masters-mixedinstances-example-com.id
     version = aws_launch_template.master-us-test-1b-masters-mixedinstances-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1b.masters.mixedinstances.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1b.masters.mixedinstances.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -222,10 +224,11 @@ resource "aws_autoscaling_group" "master-us-test-1c-masters-mixedinstances-examp
     id      = aws_launch_template.master-us-test-1c-masters-mixedinstances-example-com.id
     version = aws_launch_template.master-us-test-1c-masters-mixedinstances-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1c.masters.mixedinstances.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1c.masters.mixedinstances.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -306,7 +309,8 @@ resource "aws_autoscaling_group" "nodes-mixedinstances-example-com" {
       }
     }
   }
-  name = "nodes.mixedinstances.example.com"
+  name                  = "nodes.mixedinstances.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -542,6 +546,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -622,6 +629,9 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1b.masters.mixedinstances.example.com"
   network_interfaces {
@@ -704,6 +714,9 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1c.masters.mixedinstances.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -780,6 +793,9 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.mixedinstances.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
@@ -277,6 +277,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -422,6 +425,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
+++ b/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
@@ -86,10 +86,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-nthsqsresources-exam
     id      = aws_launch_template.master-us-test-1a-masters-nthsqsresources-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-nthsqsresources-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.nthsqsresources.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.nthsqsresources.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -154,10 +155,11 @@ resource "aws_autoscaling_group" "nodes-nthsqsresources-example-com" {
     id      = aws_launch_template.nodes-nthsqsresources-example-com.id
     version = aws_launch_template.nodes-nthsqsresources-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.nthsqsresources.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.nthsqsresources.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -395,6 +397,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-nthsqsresources-exampl
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.nthsqsresources.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -474,6 +479,9 @@ resource "aws_launch_template" "nodes-nthsqsresources-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.nthsqsresources.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -283,6 +283,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -400,6 +403,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {
@@ -538,6 +544,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -111,11 +111,12 @@ resource "aws_autoscaling_group" "bastion-private-shared-ip-example-com" {
     id      = aws_launch_template.bastion-private-shared-ip-example-com.id
     version = aws_launch_template.bastion-private-shared-ip-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-private-shared-ip-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.private-shared-ip.example.com"
+  load_balancers        = [aws_elb.bastion-private-shared-ip-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.private-shared-ip.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -160,11 +161,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-private-shared-ip-ex
     id      = aws_launch_template.master-us-test-1a-masters-private-shared-ip-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-private-shared-ip-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-private-shared-ip-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.private-shared-ip.example.com"
+  load_balancers        = [aws_elb.api-private-shared-ip-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.private-shared-ip.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -224,10 +226,11 @@ resource "aws_autoscaling_group" "nodes-private-shared-ip-example-com" {
     id      = aws_launch_template.nodes-private-shared-ip-example-com.id
     version = aws_launch_template.nodes-private-shared-ip-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.private-shared-ip.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.private-shared-ip.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -463,6 +466,9 @@ resource "aws_launch_template" "bastion-private-shared-ip-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.private-shared-ip.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -533,6 +539,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-ip-exam
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.private-shared-ip.example.com"
   network_interfaces {
@@ -610,6 +619,9 @@ resource "aws_launch_template" "nodes-private-shared-ip-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.private-shared-ip.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -106,11 +106,12 @@ resource "aws_autoscaling_group" "bastion-private-shared-subnet-example-com" {
     id      = aws_launch_template.bastion-private-shared-subnet-example-com.id
     version = aws_launch_template.bastion-private-shared-subnet-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-private-shared-subnet-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.private-shared-subnet.example.com"
+  load_balancers        = [aws_elb.bastion-private-shared-subnet-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.private-shared-subnet.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -155,11 +156,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-private-shared-subne
     id      = aws_launch_template.master-us-test-1a-masters-private-shared-subnet-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-private-shared-subnet-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-private-shared-subnet-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.private-shared-subnet.example.com"
+  load_balancers        = [aws_elb.api-private-shared-subnet-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.private-shared-subnet.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -219,10 +221,11 @@ resource "aws_autoscaling_group" "nodes-private-shared-subnet-example-com" {
     id      = aws_launch_template.nodes-private-shared-subnet-example-com.id
     version = aws_launch_template.nodes-private-shared-subnet-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.private-shared-subnet.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.private-shared-subnet.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -458,6 +461,9 @@ resource "aws_launch_template" "bastion-private-shared-subnet-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.private-shared-subnet.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -528,6 +534,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.private-shared-subnet.example.com"
   network_interfaces {
@@ -605,6 +614,9 @@ resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.private-shared-subnet.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -345,6 +345,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -462,6 +465,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {
@@ -600,6 +606,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -116,11 +116,12 @@ resource "aws_autoscaling_group" "bastion-privatecalico-example-com" {
     id      = aws_launch_template.bastion-privatecalico-example-com.id
     version = aws_launch_template.bastion-privatecalico-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privatecalico-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privatecalico.example.com"
+  load_balancers        = [aws_elb.bastion-privatecalico-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privatecalico.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -165,11 +166,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecalico-exampl
     id      = aws_launch_template.master-us-test-1a-masters-privatecalico-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privatecalico-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privatecalico-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privatecalico.example.com"
+  load_balancers        = [aws_elb.api-privatecalico-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privatecalico.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -229,10 +231,11 @@ resource "aws_autoscaling_group" "nodes-privatecalico-example-com" {
     id      = aws_launch_template.nodes-privatecalico-example-com.id
     version = aws_launch_template.nodes-privatecalico-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privatecalico.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privatecalico.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -486,6 +489,9 @@ resource "aws_launch_template" "bastion-privatecalico-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privatecalico.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -556,6 +562,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privatecalico.example.com"
   network_interfaces {
@@ -633,6 +642,9 @@ resource "aws_launch_template" "nodes-privatecalico-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privatecalico.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -116,11 +116,12 @@ resource "aws_autoscaling_group" "bastion-privatecanal-example-com" {
     id      = aws_launch_template.bastion-privatecanal-example-com.id
     version = aws_launch_template.bastion-privatecanal-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privatecanal-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privatecanal.example.com"
+  load_balancers        = [aws_elb.bastion-privatecanal-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privatecanal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -165,11 +166,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecanal-example
     id      = aws_launch_template.master-us-test-1a-masters-privatecanal-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privatecanal-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privatecanal-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privatecanal.example.com"
+  load_balancers        = [aws_elb.api-privatecanal-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privatecanal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -229,10 +231,11 @@ resource "aws_autoscaling_group" "nodes-privatecanal-example-com" {
     id      = aws_launch_template.nodes-privatecanal-example-com.id
     version = aws_launch_template.nodes-privatecanal-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privatecanal.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privatecanal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -486,6 +489,9 @@ resource "aws_launch_template" "bastion-privatecanal-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privatecanal.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -556,6 +562,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-c
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privatecanal.example.com"
   network_interfaces {
@@ -633,6 +642,9 @@ resource "aws_launch_template" "nodes-privatecanal-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privatecanal.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -345,6 +345,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -462,6 +465,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {
@@ -600,6 +606,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -116,11 +116,12 @@ resource "aws_autoscaling_group" "bastion-privatecilium-example-com" {
     id      = aws_launch_template.bastion-privatecilium-example-com.id
     version = aws_launch_template.bastion-privatecilium-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privatecilium-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privatecilium.example.com"
+  load_balancers        = [aws_elb.bastion-privatecilium-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privatecilium.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -165,11 +166,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecilium-exampl
     id      = aws_launch_template.master-us-test-1a-masters-privatecilium-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privatecilium-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privatecilium-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privatecilium.example.com"
+  load_balancers        = [aws_elb.api-privatecilium-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privatecilium.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -229,10 +231,11 @@ resource "aws_autoscaling_group" "nodes-privatecilium-example-com" {
     id      = aws_launch_template.nodes-privatecilium-example-com.id
     version = aws_launch_template.nodes-privatecilium-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privatecilium.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privatecilium.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -486,6 +489,9 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privatecilium.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -556,6 +562,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privatecilium.example.com"
   network_interfaces {
@@ -633,6 +642,9 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privatecilium.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -345,6 +345,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -462,6 +465,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {
@@ -600,6 +606,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -116,11 +116,12 @@ resource "aws_autoscaling_group" "bastion-privatecilium-example-com" {
     id      = aws_launch_template.bastion-privatecilium-example-com.id
     version = aws_launch_template.bastion-privatecilium-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privatecilium-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privatecilium.example.com"
+  load_balancers        = [aws_elb.bastion-privatecilium-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privatecilium.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -165,11 +166,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatecilium-exampl
     id      = aws_launch_template.master-us-test-1a-masters-privatecilium-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privatecilium-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privatecilium-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privatecilium.example.com"
+  load_balancers        = [aws_elb.api-privatecilium-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privatecilium.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -229,10 +231,11 @@ resource "aws_autoscaling_group" "nodes-privatecilium-example-com" {
     id      = aws_launch_template.nodes-privatecilium-example-com.id
     version = aws_launch_template.nodes-privatecilium-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privatecilium.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privatecilium.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -486,6 +489,9 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privatecilium.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -556,6 +562,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privatecilium.example.com"
   network_interfaces {
@@ -633,6 +642,9 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privatecilium.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -345,6 +345,9 @@
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
           },
+          "Monitoring": {
+            "Enabled": false
+          },
           "NetworkInterfaces": [
             {
               "AssociatePublicIpAddress": true,
@@ -462,6 +465,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {
@@ -600,6 +606,9 @@
           "MetadataOptions": {
             "HttpPutResponseHopLimit": 1,
             "HttpTokens": "optional"
+          },
+          "Monitoring": {
+            "Enabled": false
           },
           "NetworkInterfaces": [
             {

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -116,11 +116,12 @@ resource "aws_autoscaling_group" "bastion-privateciliumadvanced-example-com" {
     id      = aws_launch_template.bastion-privateciliumadvanced-example-com.id
     version = aws_launch_template.bastion-privateciliumadvanced-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privateciliumadvanced-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privateciliumadvanced.example.com"
+  load_balancers        = [aws_elb.bastion-privateciliumadvanced-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privateciliumadvanced.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -165,11 +166,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privateciliumadvance
     id      = aws_launch_template.master-us-test-1a-masters-privateciliumadvanced-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privateciliumadvanced-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privateciliumadvanced-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privateciliumadvanced.example.com"
+  load_balancers        = [aws_elb.api-privateciliumadvanced-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privateciliumadvanced.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -229,10 +231,11 @@ resource "aws_autoscaling_group" "nodes-privateciliumadvanced-example-com" {
     id      = aws_launch_template.nodes-privateciliumadvanced-example-com.id
     version = aws_launch_template.nodes-privateciliumadvanced-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privateciliumadvanced.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privateciliumadvanced.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -502,6 +505,9 @@ resource "aws_launch_template" "bastion-privateciliumadvanced-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privateciliumadvanced.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -572,6 +578,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privateciliumadvanced.example.com"
   network_interfaces {
@@ -649,6 +658,9 @@ resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privateciliumadvanced.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -116,11 +116,12 @@ resource "aws_autoscaling_group" "bastion-privatedns1-example-com" {
     id      = aws_launch_template.bastion-privatedns1-example-com.id
     version = aws_launch_template.bastion-privatedns1-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privatedns1-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privatedns1.example.com"
+  load_balancers        = [aws_elb.bastion-privatedns1-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privatedns1.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -175,11 +176,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatedns1-example-
     id      = aws_launch_template.master-us-test-1a-masters-privatedns1-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privatedns1-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privatedns1-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privatedns1.example.com"
+  load_balancers        = [aws_elb.api-privatedns1-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privatedns1.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -249,10 +251,11 @@ resource "aws_autoscaling_group" "nodes-privatedns1-example-com" {
     id      = aws_launch_template.nodes-privatedns1-example-com.id
     version = aws_launch_template.nodes-privatedns1-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privatedns1.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privatedns1.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -542,6 +545,9 @@ resource "aws_launch_template" "bastion-privatedns1-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privatedns1.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -618,6 +624,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privatedns1.example.com"
   network_interfaces {
@@ -701,6 +710,9 @@ resource "aws_launch_template" "nodes-privatedns1-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privatedns1.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -111,11 +111,12 @@ resource "aws_autoscaling_group" "bastion-privatedns2-example-com" {
     id      = aws_launch_template.bastion-privatedns2-example-com.id
     version = aws_launch_template.bastion-privatedns2-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privatedns2-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privatedns2.example.com"
+  load_balancers        = [aws_elb.bastion-privatedns2-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privatedns2.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -160,11 +161,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatedns2-example-
     id      = aws_launch_template.master-us-test-1a-masters-privatedns2-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privatedns2-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privatedns2-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privatedns2.example.com"
+  load_balancers        = [aws_elb.api-privatedns2-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privatedns2.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -224,10 +226,11 @@ resource "aws_autoscaling_group" "nodes-privatedns2-example-com" {
     id      = aws_launch_template.nodes-privatedns2-example-com.id
     version = aws_launch_template.nodes-privatedns2-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privatedns2.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privatedns2.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -472,6 +475,9 @@ resource "aws_launch_template" "bastion-privatedns2-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privatedns2.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -542,6 +548,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privatedns2.example.com"
   network_interfaces {
@@ -619,6 +628,9 @@ resource "aws_launch_template" "nodes-privatedns2-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privatedns2.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -116,11 +116,12 @@ resource "aws_autoscaling_group" "bastion-privateflannel-example-com" {
     id      = aws_launch_template.bastion-privateflannel-example-com.id
     version = aws_launch_template.bastion-privateflannel-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privateflannel-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privateflannel.example.com"
+  load_balancers        = [aws_elb.bastion-privateflannel-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privateflannel.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -165,11 +166,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privateflannel-examp
     id      = aws_launch_template.master-us-test-1a-masters-privateflannel-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privateflannel-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privateflannel-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privateflannel.example.com"
+  load_balancers        = [aws_elb.api-privateflannel-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privateflannel.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -229,10 +231,11 @@ resource "aws_autoscaling_group" "nodes-privateflannel-example-com" {
     id      = aws_launch_template.nodes-privateflannel-example-com.id
     version = aws_launch_template.nodes-privateflannel-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privateflannel.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privateflannel.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -486,6 +489,9 @@ resource "aws_launch_template" "bastion-privateflannel-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privateflannel.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -556,6 +562,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privateflannel.example.com"
   network_interfaces {
@@ -633,6 +642,9 @@ resource "aws_launch_template" "nodes-privateflannel-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privateflannel.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -131,11 +131,12 @@ resource "aws_autoscaling_group" "bastion-privatekopeio-example-com" {
     id      = aws_launch_template.bastion-privatekopeio-example-com.id
     version = aws_launch_template.bastion-privatekopeio-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privatekopeio-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privatekopeio.example.com"
+  load_balancers        = [aws_elb.bastion-privatekopeio-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privatekopeio.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -180,11 +181,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privatekopeio-exampl
     id      = aws_launch_template.master-us-test-1a-masters-privatekopeio-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privatekopeio-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privatekopeio-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privatekopeio.example.com"
+  load_balancers        = [aws_elb.api-privatekopeio-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privatekopeio.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -244,10 +246,11 @@ resource "aws_autoscaling_group" "nodes-privatekopeio-example-com" {
     id      = aws_launch_template.nodes-privatekopeio-example-com.id
     version = aws_launch_template.nodes-privatekopeio-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privatekopeio.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privatekopeio.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -492,6 +495,9 @@ resource "aws_launch_template" "bastion-privatekopeio-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privatekopeio.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -562,6 +568,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privatekopeio.example.com"
   network_interfaces {
@@ -639,6 +648,9 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privatekopeio.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -116,11 +116,12 @@ resource "aws_autoscaling_group" "bastion-privateweave-example-com" {
     id      = aws_launch_template.bastion-privateweave-example-com.id
     version = aws_launch_template.bastion-privateweave-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-privateweave-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.privateweave.example.com"
+  load_balancers        = [aws_elb.bastion-privateweave-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.privateweave.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -165,11 +166,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-privateweave-example
     id      = aws_launch_template.master-us-test-1a-masters-privateweave-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-privateweave-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-privateweave-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.privateweave.example.com"
+  load_balancers        = [aws_elb.api-privateweave-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.privateweave.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -229,10 +231,11 @@ resource "aws_autoscaling_group" "nodes-privateweave-example-com" {
     id      = aws_launch_template.nodes-privateweave-example-com.id
     version = aws_launch_template.nodes-privateweave-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.privateweave.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.privateweave.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -486,6 +489,9 @@ resource "aws_launch_template" "bastion-privateweave-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.privateweave.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -556,6 +562,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-c
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.privateweave.example.com"
   network_interfaces {
@@ -633,6 +642,9 @@ resource "aws_launch_template" "nodes-privateweave-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.privateweave.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -96,10 +96,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     id      = aws_launch_template.master-us-test-1a-masters-minimal-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-minimal-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.minimal.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -159,10 +160,11 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
     id      = aws_launch_template.nodes-minimal-example-com.id
     version = aws_launch_template.nodes-minimal-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.minimal.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -361,6 +363,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -437,6 +442,9 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.minimal.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -81,10 +81,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedsubnet-example
     id      = aws_launch_template.master-us-test-1a-masters-sharedsubnet-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-sharedsubnet-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.sharedsubnet.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.sharedsubnet.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -144,10 +145,11 @@ resource "aws_autoscaling_group" "nodes-sharedsubnet-example-com" {
     id      = aws_launch_template.nodes-sharedsubnet-example-com.id
     version = aws_launch_template.nodes-sharedsubnet-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.sharedsubnet.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.sharedsubnet.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -310,6 +312,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.sharedsubnet.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -386,6 +391,9 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.sharedsubnet.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -81,10 +81,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedvpc-example-co
     id      = aws_launch_template.master-us-test-1a-masters-sharedvpc-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-sharedvpc-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.sharedvpc.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.sharedvpc.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -144,10 +145,11 @@ resource "aws_autoscaling_group" "nodes-sharedvpc-example-com" {
     id      = aws_launch_template.nodes-sharedvpc-example-com.id
     version = aws_launch_template.nodes-sharedvpc-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.sharedvpc.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.sharedvpc.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -310,6 +312,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.sharedvpc.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -386,6 +391,9 @@ resource "aws_launch_template" "nodes-sharedvpc-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.sharedvpc.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -111,11 +111,12 @@ resource "aws_autoscaling_group" "bastion-unmanaged-example-com" {
     id      = aws_launch_template.bastion-unmanaged-example-com.id
     version = aws_launch_template.bastion-unmanaged-example-com.latest_version
   }
-  load_balancers      = [aws_elb.bastion-unmanaged-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "bastion.unmanaged.example.com"
+  load_balancers        = [aws_elb.bastion-unmanaged-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "bastion.unmanaged.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -160,11 +161,12 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-unmanaged-example-co
     id      = aws_launch_template.master-us-test-1a-masters-unmanaged-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-unmanaged-example-com.latest_version
   }
-  load_balancers      = [aws_elb.api-unmanaged-example-com.id]
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.unmanaged.example.com"
+  load_balancers        = [aws_elb.api-unmanaged-example-com.id]
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.unmanaged.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -224,10 +226,11 @@ resource "aws_autoscaling_group" "nodes-unmanaged-example-com" {
     id      = aws_launch_template.nodes-unmanaged-example-com.id
     version = aws_launch_template.nodes-unmanaged-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.unmanaged.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.unmanaged.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -463,6 +466,9 @@ resource "aws_launch_template" "bastion-unmanaged-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "bastion.unmanaged.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -533,6 +539,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "master-us-test-1a.masters.unmanaged.example.com"
   network_interfaces {
@@ -610,6 +619,9 @@ resource "aws_launch_template" "nodes-unmanaged-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.unmanaged.example.com"
   network_interfaces {

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -86,10 +86,11 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     id      = aws_launch_template.master-us-test-1a-masters-minimal-example-com.id
     version = aws_launch_template.master-us-test-1a-masters-minimal-example-com.latest_version
   }
-  max_size            = 1
-  metrics_granularity = "1Minute"
-  min_size            = 1
-  name                = "master-us-test-1a.masters.minimal.example.com"
+  max_size              = 1
+  metrics_granularity   = "1Minute"
+  min_size              = 1
+  name                  = "master-us-test-1a.masters.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -149,10 +150,11 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
     id      = aws_launch_template.nodes-minimal-example-com.id
     version = aws_launch_template.nodes-minimal-example-com.latest_version
   }
-  max_size            = 2
-  metrics_granularity = "1Minute"
-  min_size            = 2
-  name                = "nodes.minimal.example.com"
+  max_size              = 2
+  metrics_granularity   = "1Minute"
+  min_size              = 2
+  name                  = "nodes.minimal.example.com"
+  protect_from_scale_in = false
   tag {
     key                 = "KubernetesCluster"
     propagate_at_launch = true
@@ -335,6 +337,9 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
+  monitoring {
+    enabled = false
+  }
   name = "master-us-test-1a.masters.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
@@ -411,6 +416,9 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     http_endpoint               = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
   }
   name = "nodes.minimal.example.com"
   network_interfaces {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -326,11 +326,12 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 		klog.V(2).Infof("Creating autoscaling group with name: %s", fi.StringValue(e.Name))
 
 		request := &autoscaling.CreateAutoScalingGroupInput{
-			AutoScalingGroupName: e.Name,
-			MinSize:              e.MinSize,
-			MaxSize:              e.MaxSize,
-			Tags:                 v.AutoscalingGroupTags(),
-			VPCZoneIdentifier:    fi.String(strings.Join(e.AutoscalingGroupSubnets(), ",")),
+			AutoScalingGroupName:             e.Name,
+			MinSize:                          e.MinSize,
+			MaxSize:                          e.MaxSize,
+			NewInstancesProtectedFromScaleIn: e.InstanceProtection,
+			Tags:                             v.AutoscalingGroupTags(),
+			VPCZoneIdentifier:                fi.String(strings.Join(e.AutoscalingGroupSubnets(), ",")),
 		}
 
 		for _, k := range e.LoadBalancers {
@@ -419,9 +420,6 @@ func (v *AutoscalingGroup) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Autos
 			}
 		}
 
-		if e.InstanceProtection != nil {
-			request.NewInstancesProtectedFromScaleIn = e.InstanceProtection
-		}
 	} else {
 		// @logic: else we have found a autoscaling group and we need to evaluate the difference
 		request := &autoscaling.UpdateAutoScalingGroupInput{


### PR DESCRIPTION
Cherry pick of #11873 on release-1.21.

#11873: Avoid spurious changes for ASG InstanceProtection and LT

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.