### PR TITLE
Add podPidsLimit / --pod-max-pids support

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -686,6 +686,18 @@ spec:
     housekeepingInterval: 30s
 ```
 
+### Pod PIDs Limit
+{{ kops_feature_table(kops_added_default='1.22', k8s_min='1.20') }}
+
+`podPidsLimit` allows to configure the maximum number of pids (process ids) in any pod.
+[Read more](https://kubernetes.io/docs/concepts/policy/pid-limiting/) in Kubernetes documentation.
+
+```yaml
+spec:
+  kubelet:
+    podPidsLimit: 1024
+```
+
 ### Event QPS
 {{ kops_feature_table(kops_added_default='1.19') }}
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -2572,6 +2572,11 @@ spec:
                     description: config is the path to the config file or directory
                       of files
                     type: string
+                  podPidsLimit:
+                    description: PodPidsLimit is the maximum number of pids in any
+                      pod.
+                    format: int64
+                    type: integer
                   protectKernelDefaults:
                     description: 'Default kubelet behaviour for kernel tuning. If
                       set, kubelet errors if any of kernel tunables is different than
@@ -2982,6 +2987,11 @@ spec:
                     description: config is the path to the config file or directory
                       of files
                     type: string
+                  podPidsLimit:
+                    description: PodPidsLimit is the maximum number of pids in any
+                      pod.
+                    format: int64
+                    type: integer
                   protectKernelDefaults:
                     description: 'Default kubelet behaviour for kernel tuning. If
                       set, kubelet errors if any of kernel tunables is different than

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -526,6 +526,11 @@ spec:
                     description: config is the path to the config file or directory
                       of files
                     type: string
+                  podPidsLimit:
+                    description: PodPidsLimit is the maximum number of pids in any
+                      pod.
+                    format: int64
+                    type: integer
                   protectKernelDefaults:
                     description: 'Default kubelet behaviour for kernel tuning. If
                       set, kubelet errors if any of kernel tunables is different than

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -221,6 +221,8 @@ type KubeletConfigSpec struct {
 	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty" flag:"container-log-max-files"`
 	// EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
 	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
+	// PodPidsLimit is the maximum number of pids in any pod.
+	PodPidsLimit *int64 `json:"podPidsLimit,omitempty" flag:"pod-max-pids"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -221,6 +221,8 @@ type KubeletConfigSpec struct {
 	ContainerLogMaxFiles *int32 `json:"containerLogMaxFiles,omitempty" flag:"container-log-max-files"`
 	// EnableCadvisorJsonEndpoints enables cAdvisor json `/spec` and `/stats/*` endpoints. Defaults to False.
 	EnableCadvisorJsonEndpoints *bool `json:"enableCadvisorJsonEndpoints,omitempty" flag:"enable-cadvisor-json-endpoints"`
+	// PodPidsLimit is the maximum number of pids in any pod.
+	PodPidsLimit *int64 `json:"podPidsLimit,omitempty" flag:"pod-max-pids"`
 }
 
 // KubeProxyConfig defines the configuration for a proxy

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5217,6 +5217,7 @@ func autoConvert_v1alpha2_KubeletConfigSpec_To_kops_KubeletConfigSpec(in *Kubele
 	out.ContainerLogMaxSize = in.ContainerLogMaxSize
 	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
 	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
+	out.PodPidsLimit = in.PodPidsLimit
 	return nil
 }
 
@@ -5312,6 +5313,7 @@ func autoConvert_kops_KubeletConfigSpec_To_v1alpha2_KubeletConfigSpec(in *kops.K
 	out.ContainerLogMaxSize = in.ContainerLogMaxSize
 	out.ContainerLogMaxFiles = in.ContainerLogMaxFiles
 	out.EnableCadvisorJsonEndpoints = in.EnableCadvisorJsonEndpoints
+	out.PodPidsLimit = in.PodPidsLimit
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -3467,6 +3467,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PodPidsLimit != nil {
+		in, out := &in.PodPidsLimit, &out.PodPidsLimit
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3633,6 +3633,11 @@ func (in *KubeletConfigSpec) DeepCopyInto(out *KubeletConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PodPidsLimit != nil {
+		in, out := &in.PodPidsLimit, &out.PodPidsLimit
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Decided to use the same name as in [Kubelet config](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/config/types.go#L260-L261)

This will allow user to configure the PID limit per pod.