### PR TITLE
Automated cherry pick of #11901: Include GCP Project in terraform HCL2 output

### DIFF
--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -17,7 +17,8 @@ output "region" {
 }
 
 provider "google" {
-  region = "us-test1"
+  project = "testproject"
+  region  = "us-test1"
 }
 
 resource "google_compute_disk" "d1-etcd-events-ha-gce-example-com" {

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -17,7 +17,8 @@ output "region" {
 }
 
 provider "google" {
-  region = "us-test1"
+  project = "testproject"
+  region  = "us-test1"
 }
 
 resource "google_compute_disk" "d1-etcd-events-minimal-gce-example-com" {

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -17,7 +17,8 @@ output "region" {
 }
 
 provider "google" {
-  region = "us-test1"
+  project = "testproject"
+  region  = "us-test1"
 }
 
 resource "google_compute_disk" "d1-etcd-events-minimal-gce-private-example-com" {

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -45,6 +45,9 @@ func (t *TerraformTarget) finishHCL2(taskMap map[string]fi.Task) error {
 	}
 	providerBlock := rootBody.AppendNewBlock("provider", []string{providerName})
 	providerBody := providerBlock.Body()
+	if t.Cloud.ProviderID() == kops.CloudProviderGCE {
+		providerBody.SetAttributeValue("project", cty.StringVal(t.Project))
+	}
 	providerBody.SetAttributeValue("region", cty.StringVal(t.Cloud.Region()))
 	for k, v := range tfGetProviderExtraConfig(t.clusterSpecTarget) {
 		providerBody.SetAttributeValue(k, cty.StringVal(v))


### PR DESCRIPTION
Cherry pick of #11901 on release-1.21.

#11901: Include GCP Project in terraform HCL2 output

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.