### PR TITLE
WIP: Update containerd to 1.5.2 for kubernetes >= 1.22

### DIFF
--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -46,7 +46,9 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 	if clusterSpec.ContainerRuntime == "containerd" {
 		// Set version based on Kubernetes version
 		if fi.StringValue(containerd.Version) == "" {
-			if b.IsKubernetesGTE("1.19") {
+			if b.IsKubernetesGTE("1.22") {
+				containerd.Version = fi.String("1.5.2")
+			} else if b.IsKubernetesGTE("1.19") {
 				containerd.Version = fi.String("1.4.6")
 			} else {
 				containerd.Version = fi.String("1.3.10")


### PR DESCRIPTION
Aiming to address some flakiness observed with static pods.