### PR TITLE
Automated cherry pick of #11049: cluster validation - allow flapping of validation errors

### DIFF
--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -217,8 +217,9 @@ func RunValidateCluster(ctx context.Context, f *util.Factory, cmd *cobra.Command
 				return result, nil
 			}
 		} else {
-			if options.wait > 0 && consecutive == 0 {
+			if options.wait > 0 {
 				klog.Warningf("(will retry): cluster not yet healthy")
+				consecutive = 0
 				time.Sleep(pollInterval)
 				continue
 			} else {


### PR DESCRIPTION
Cherry pick of #11049 on release-1.20.

#11049: cluster validation - allow flapping of validation errors

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Fixes #11920