### PR TITLE
Continue if a single addon fails to be applied

### DIFF
--- a/channels/pkg/cmd/apply_channel.go
+++ b/channels/pkg/cmd/apply_channel.go
@@ -194,10 +194,8 @@ func RunApplyChannel(ctx context.Context, f Factory, out io.Writer, options *App
 	for _, needUpdate := range needUpdates {
 		update, err := needUpdate.EnsureUpdated(ctx, k8sClient, cmClient)
 		if err != nil {
-			return fmt.Errorf("error updating %q: %v", needUpdate.Name, err)
-		}
-		// Could have been a concurrent request
-		if update != nil {
+			fmt.Printf("error updating %q: %v", needUpdate.Name, err)
+		} else if update != nil {
 			fmt.Printf("Updated %q\n", update.Name)
 		}
 	}


### PR DESCRIPTION
If a single addon fails, channels will just give up on the rest. This PR makes channels just print an error when an addon fails and continue with the next one.

Skipping on first addon failure is especially problematic with addons depending on cert-manager. These will always fail due to the missing CRDs and if these are executed before cert-manager, channels will exit and we have to hope cert-manager is executed earlier in the next iteration.