### PR TITLE
Schedule certmanager webhook on control plane

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: c43bfe56ee1820480ed7ddbe1a13e66a679286d0
+    manifestHash: 487c047d774b1368a74463202aaf5790c186ae6f
     name: certmanager.io
     selector: null
   - id: k8s-1.9

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -26994,8 +26994,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-webhook
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: cluster-autoscaler.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: c43bfe56ee1820480ed7ddbe1a13e66a679286d0
+    manifestHash: 487c047d774b1368a74463202aaf5790c186ae6f
     name: certmanager.io
     selector: null
   - id: k8s-1.11

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -26994,8 +26994,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-webhook
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -26815,8 +26815,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-webhook
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration


### PR DESCRIPTION
This PR allows the cert-manager webhook to run on CP nodes so that certificate resources within addons can be applied before worker nodes have joined the cluster.