### PR TITLE
[Digital Ocean] Remove PrivateNetworking option in droplet since it's deprecated

### DIFF
--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -145,14 +145,13 @@ func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {
 
 	for i := 0; i < newDropletCount; i++ {
 		_, _, err = t.Cloud.DropletsService().Create(context.TODO(), &godo.DropletCreateRequest{
-			Name:              fi.StringValue(e.Name),
-			Region:            fi.StringValue(e.Region),
-			Size:              fi.StringValue(e.Size),
-			Image:             godo.DropletCreateImage{Slug: fi.StringValue(e.Image)},
-			PrivateNetworking: true,
-			Tags:              e.Tags,
-			UserData:          userData,
-			SSHKeys:           []godo.DropletCreateSSHKey{{Fingerprint: fi.StringValue(e.SSHKey)}},
+			Name:     fi.StringValue(e.Name),
+			Region:   fi.StringValue(e.Region),
+			Size:     fi.StringValue(e.Size),
+			Image:    godo.DropletCreateImage{Slug: fi.StringValue(e.Image)},
+			Tags:     e.Tags,
+			UserData: userData,
+			SSHKeys:  []godo.DropletCreateSSHKey{{Fingerprint: fi.StringValue(e.SSHKey)}},
 		})
 
 		if err != nil {


### PR DESCRIPTION
Per [DO Documetation here](https://docs.digitalocean.com/reference/api/api-reference/#operation/create_droplet) PrivateNetworking option is deprecated and will be eventually replaced by `vpc_uuid`. 
If `private_networking` is not specified, the droplets will be assigned to the account's default VPC, which is the default behavior.

PR to include support for `--vpc` flag will follow soon.

FYI - @timoreimann 