### PR TITLE
Run cert-manager cainjector on CP nodes as well

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 487c047d774b1368a74463202aaf5790c186ae6f
+    manifestHash: 59b5f2a0fd6f5fb558c6bb85a38f0236f4ef840f
     name: certmanager.io
     selector: null
   - id: k8s-1.9

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -26862,8 +26862,13 @@ spec:
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-cainjector
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: cluster-autoscaler.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 487c047d774b1368a74463202aaf5790c186ae6f
+    manifestHash: 59b5f2a0fd6f5fb558c6bb85a38f0236f4ef840f
     name: certmanager.io
     selector: null
   - id: k8s-1.11

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -26862,8 +26862,13 @@ spec:
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-cainjector
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -26688,8 +26688,13 @@ spec:
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-cainjector
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Looks like that for #11934 to work, we also need to move ca-injector. It is a dependency of the webhook.