### PR TITLE
Fix various CCM issues

### DIFF
--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -29,6 +29,7 @@ spec:
       containers:
         - name: aws-cloud-controller-manager
           image: {{ if .ExternalCloudControllerManager.Image }}{{ .ExternalCloudControllerManager.Image }}{{ else }}gcr.io/k8s-staging-provider-aws/cloud-controller-manager:{{AWSCCMTag}}{{ end }}
+          imagePullPolicy: IfNotPresent
           args:
 {{- range $arg := CloudControllerConfigArgv }}
             - {{ $arg }}

--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -25,7 +25,7 @@ spec:
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
-      serviceAccountName: cloud-controller-manager
+      serviceAccountName: aws-cloud-controller-manager
       containers:
         - name: aws-cloud-controller-manager
           image: {{ if .ExternalCloudControllerManager.Image }}{{ .ExternalCloudControllerManager.Image }}{{ else }}gcr.io/k8s-staging-provider-aws/cloud-controller-manager:{{AWSCCMTag}}{{ end }}
@@ -42,7 +42,7 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cloud-controller-manager
+  name: aws-cloud-controller-manager
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,7 +57,7 @@ roleRef:
 subjects:
 - apiGroup: ""
   kind: ServiceAccount
-  name: cloud-controller-manager
+  name: aws-cloud-controller-manager
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -168,6 +168,6 @@ roleRef:
 subjects:
 - apiGroup: ""
   kind: ServiceAccount
-  name: cloud-controller-manager
+  name: aws-cloud-controller-manager
   namespace: kube-system
 

--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -27,16 +27,19 @@ spec:
         effect: NoSchedule
       serviceAccountName: aws-cloud-controller-manager
       containers:
-        - name: aws-cloud-controller-manager
-          image: {{ if .ExternalCloudControllerManager.Image }}{{ .ExternalCloudControllerManager.Image }}{{ else }}gcr.io/k8s-staging-provider-aws/cloud-controller-manager:{{AWSCCMTag}}{{ end }}
-          imagePullPolicy: IfNotPresent
-          args:
+      - name: aws-cloud-controller-manager
+        image: {{ if .ExternalCloudControllerManager.Image }}{{ .ExternalCloudControllerManager.Image }}{{ else }}gcr.io/k8s-staging-provider-aws/cloud-controller-manager:{{AWSCCMTag}}{{ end }}
+        imagePullPolicy: IfNotPresent
+        args:
 {{- range $arg := CloudControllerConfigArgv }}
-            - {{ $arg }}
+          - {{ $arg }}
 {{- end }}
-          resources:
-            requests:
-              cpu: 200m
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+        resources:
+          requests:
+            cpu: 200m
       hostNetwork: true
       priorityClassName: system-cluster-critical
 ---

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -27,6 +27,9 @@ spec:
         - --allocate-node-cidrs=true
         - --configure-cloud-routes=false
         - --use-service-account-credentials=true
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
         image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -28,6 +28,7 @@ spec:
         - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest
+        imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -36,7 +36,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
-      serviceAccountName: cloud-controller-manager
+      serviceAccountName: aws-cloud-controller-manager
       tolerations:
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
@@ -56,7 +56,7 @@ metadata:
     addon.kops.k8s.io/name: aws-cloud-controller.addons.k8s.io
     app.kubernetes.io/managed-by: kops
     k8s-addon: aws-cloud-controller.addons.k8s.io
-  name: cloud-controller-manager
+  name: aws-cloud-controller-manager
   namespace: kube-system
 
 ---
@@ -78,7 +78,7 @@ roleRef:
 subjects:
 - apiGroup: ""
   kind: ServiceAccount
-  name: cloud-controller-manager
+  name: aws-cloud-controller-manager
   namespace: kube-system
 
 ---
@@ -203,5 +203,5 @@ roleRef:
 subjects:
 - apiGroup: ""
   kind: ServiceAccount
-  name: cloud-controller-manager
+  name: aws-cloud-controller-manager
   namespace: kube-system

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 44f4c35583b89ca3dce92aad96c06095bc0ead28
+    manifestHash: 262dc72788b283088815442c33e4609e75769f7f
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 9ca4820e2d12cabdb9b2d32c2f8f9b00e3e75a7f
+    manifestHash: ef74ee3b557b92e6e6944329c81e4f1925e2f3df
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 262dc72788b283088815442c33e4609e75769f7f
+    manifestHash: 9ca4820e2d12cabdb9b2d32c2f8f9b00e3e75a7f
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
* CCM is crashing on startup because it cannot talk to k8s api using the default k8s service address
* When CCM crashes, we download image again, which takes a long time (some rate limit at play here?)
* Prefix the CCM SA to avoid conflicts (kOps IRSA assumes unique SAs across all addons)