### PR TITLE
Automated cherry pick of #11943: Add log rotation for etcd-cilium.log

### DIFF
--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/systemd"
 	"k8s.io/kops/upup/pkg/fi"
@@ -63,6 +64,9 @@ func (b *LogrotateBuilder) Build(c *fi.ModelBuilderContext) error {
 	b.addLogRotate(c, "kubelet", "/var/log/kubelet.log", logRotateOptions{})
 	b.addLogRotate(c, "etcd", "/var/log/etcd.log", logRotateOptions{})
 	b.addLogRotate(c, "etcd-events", "/var/log/etcd-events.log", logRotateOptions{})
+	if model.UseCiliumEtcd(b.Cluster) {
+		b.addLogRotate(c, "etcd-cilium", "/var/log/etcd-cilium.log", logRotateOptions{})
+	}
 
 	if err := b.addLogrotateService(c); err != nil {
 		return err

--- a/pkg/dump/dumper.go
+++ b/pkg/dump/dumper.go
@@ -67,6 +67,7 @@ func NewLogDumper(sshConfig *ssh.ClientConfig, artifactsDir string) *logDumper {
 		"kube-controller-manager",
 		"etcd",
 		"etcd-events",
+		"etcd-cilium",
 		"glbc",
 		"cluster-autoscaler",
 		"kube-addon-manager",


### PR DESCRIPTION
Cherry pick of #11943 on release-1.20.

#11943: Add log rotation for etcd-cilium.log

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.