### PR TITLE
Fix bullet point rendering in state doc

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -9,6 +9,7 @@ though we have to copy the data from the state store to a file where components 
 
 The state store uses kOps's VFS implementation, so can in theory be stored anywhere.
 As of now the following state stores are supported:
+
 * Amazon AWS S3 (`s3://`)
 * local filesystem (`file://`) (only for dry-run purposes, see [note](#local-filesystem-state-stores) below)
 * Digital Ocean (`do://`)


### PR DESCRIPTION
Needs a line break or it combines bullet points with the previous paragraph.

Current page at https://kops.sigs.k8s.io/state/looks like this

![image](https://user-images.githubusercontent.com/371796/124839317-6d9df680-df3d-11eb-9016-ee330249b4f2.png)
