### PR TITLE
check if the instance is under an asg

### DIFF
--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -762,6 +762,10 @@ func getAWSConfigurationMode(c *model.NodeupModelContext) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error describing instances: %v", err)
 	}
+	// If the instance is not a part of an ASG, it won't be in a warm pool either.
+	if len(result.AutoScalingInstances) < 1 {
+		return "", nil
+	}
 	lifecycle := fi.StringValue(result.AutoScalingInstances[0].LifecycleState)
 	if strings.HasPrefix(lifecycle, "Warmed:") {
 		klog.Info("instance is entering warm pool")


### PR DESCRIPTION
Nodeup crash when an instance is not created by an AWS Auto-Scaling Group.

Check if the instance is under an ASG before trying to get the lifeCycle value from the ASG.

Related bug: https://github.com/kubernetes/kops/issues/11949

