### PR TITLE
Automated cherry pick of #11958: check if the instance is under an asg

### DIFF
--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -722,6 +722,10 @@ func getAWSConfigurationMode(c *model.NodeupModelContext) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error describing instances: %v", err)
 	}
+	// If the instance is not a part of an ASG, it won't be in a warm pool either.
+	if len(result.AutoScalingInstances) < 1 {
+		return "", nil
+	}
 	lifecycle := fi.StringValue(result.AutoScalingInstances[0].LifecycleState)
 	if strings.HasPrefix(lifecycle, "Warmed:") {
 		klog.Info("instance is entering warm pool")


### PR DESCRIPTION
Cherry pick of #11958 on release-1.21.

#11958: check if the instance is under an asg

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.