### PR TITLE
Cilium etcd fixes

### DIFF
--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -44,6 +44,7 @@ kops create cluster \
 
 For existing clusters, add the following to `spec.etcdClusters`:
 Make sure `instanceGroup` match the other etcd clusters.
+You should also enable auto compaction.
 
 ```yaml
   - etcdMembers:
@@ -53,6 +54,12 @@ Make sure `instanceGroup` match the other etcd clusters.
       name: b
     - instanceGroup: master-az-1c
       name: c
+    manager:
+      env:
+      - name: ETCD_AUTO_COMPACTION_MODE
+        value: revision
+      - name: ETCD_AUTO_COMPACTION_RETENTION
+        value: "2500"
     name: cilium
 ```
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 10397ee38d39d9c66afcc23279540e421c9b984f
+    manifestHash: 518a28569023ee7f179b319581ef56cefcba2504
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -46,6 +46,7 @@ data:
   enable-endpoint-routes: "true"
   enable-ipv4: "true"
   enable-ipv6: "false"
+  enable-k8s-event-handover: "true"
   enable-l7-proxy: "true"
   enable-node-port: "true"
   enable-remote-node-identity: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -49,6 +49,8 @@ data:
     trusted-ca-file: '/var/lib/etcd-secrets/etcd-ca.crt'
     key-file: '/var/lib/etcd-secrets/etcd-client-cilium.key'
     cert-file: '/var/lib/etcd-secrets/etcd-client-cilium.crt'
+
+  enable-k8s-event-handover: "true"
 {{ end }}
 
   # Identity allocation mode selects how identities are shared between cilium

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1173,6 +1173,19 @@ func createEtcdCluster(etcdCluster string, masters []*api.InstanceGroup, encrypt
 		m.InstanceGroup = fi.String(ig.ObjectMeta.Name)
 		etcd.Members = append(etcd.Members, m)
 	}
+
+	// Cilium etcd server is not compacted by the k8s API server.
+	if etcd.Name == "cilium" {
+		if etcd.Manager == nil {
+			etcd.Manager = &api.EtcdManagerSpec{
+				Env: []api.EnvVar{
+					{Name: "ETCD_AUTO_COMPACTION_MODE", Value: "revision"},
+					{Name: "ETCD_AUTO_COMPACTION_RETENTION", Value: "2500"},
+				},
+			}
+		}
+	}
+
 	return etcd
 
 }


### PR DESCRIPTION
First commit fixes an issue where the status object of the CNP becomes too large to write to etcd. Also enables "scalability"
Second fixes #10663