### PR TITLE
Azure - support VMSS availability zones

### DIFF
--- a/pkg/model/azuremodel/vmscaleset.go
+++ b/pkg/model/azuremodel/vmscaleset.go
@@ -78,6 +78,7 @@ func (b *VMScaleSetModelBuilder) buildVMScaleSetTask(
 		SKUName:            fi.String(ig.Spec.MachineType),
 		ComputerNamePrefix: fi.String(ig.Name),
 		AdminUser:          fi.String(b.Cluster.Spec.CloudConfig.Azure.AdminUser),
+		Zones:              ig.Spec.Zones,
 	}
 
 	var err error

--- a/pkg/model/azuremodel/vmscaleset.go
+++ b/pkg/model/azuremodel/vmscaleset.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/defaults"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azuretasks"
 )
 
@@ -70,6 +71,14 @@ func (b *VMScaleSetModelBuilder) buildVMScaleSetTask(
 	name string,
 	ig *kops.InstanceGroup,
 ) (*azuretasks.VMScaleSet, error) {
+	var azNumbers []string
+	for _, zone := range ig.Spec.Zones {
+		az, err := azure.ZoneToAvailabilityZoneNumber(zone)
+		if err != nil {
+			return nil, err
+		}
+		azNumbers = append(azNumbers, az)
+	}
 	t := &azuretasks.VMScaleSet{
 		Name:               fi.String(name),
 		Lifecycle:          b.Lifecycle,
@@ -78,7 +87,7 @@ func (b *VMScaleSetModelBuilder) buildVMScaleSetTask(
 		SKUName:            fi.String(ig.Spec.MachineType),
 		ComputerNamePrefix: fi.String(ig.Name),
 		AdminUser:          fi.String(b.Cluster.Spec.CloudConfig.Azure.AdminUser),
-		Zones:              ig.Spec.Zones,
+		Zones:              azNumbers,
 	}
 
 	var err error

--- a/upup/pkg/fi/cloudup/azure/azure_utils.go
+++ b/upup/pkg/fi/cloudup/azure/azure_utils.go
@@ -30,3 +30,13 @@ func ZoneToLocation(zone string) (string, error) {
 	}
 	return l[0], nil
 }
+
+// ZoneToAvailabilityZoneNumber extracts the availability zone number from a zone of the
+// form <location>-<available-zone-number>..
+func ZoneToAvailabilityZoneNumber(zone string) (string, error) {
+	l := strings.Split(zone, "-")
+	if len(l) != 2 {
+		return "", fmt.Errorf("invalid Azure zone: %q ", zone)
+	}
+	return l[1], nil
+}

--- a/upup/pkg/fi/cloudup/azure/azure_utils_test.go
+++ b/upup/pkg/fi/cloudup/azure/azure_utils_test.go
@@ -61,3 +61,44 @@ func TestZoneToLocation(t *testing.T) {
 		})
 	}
 }
+
+func TestZoneToAvailabilityZoneNumber(t *testing.T) {
+	testCases := []struct {
+		zone     string
+		success  bool
+		azNumber string
+	}{
+		{
+			zone:     "eastus-1",
+			success:  true,
+			azNumber: "1",
+		},
+		{
+			zone:    "eastus",
+			success: false,
+		},
+		{
+			zone:    "eastus-1-2",
+			success: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			azNum, err := ZoneToAvailabilityZoneNumber(tc.zone)
+			if !tc.success {
+				if err == nil {
+					t.Fatalf("unexpected success")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if azNum != tc.azNumber {
+				t.Errorf("expected %s but got %s", tc.azNumber, azNum)
+			}
+		})
+	}
+}

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset.go
@@ -116,6 +116,7 @@ type VMScaleSet struct {
 	// CustomData is the user data configuration
 	CustomData  fi.Resource
 	Tags        map[string]*string
+	Zones       []string
 	PrincipalID *string
 }
 
@@ -230,6 +231,9 @@ func (s *VMScaleSet) Find(c *fi.Context) (*VMScaleSet, error) {
 		vmss.LoadBalancer = &LoadBalancer{
 			Name: to.StringPtr(loadBalancerID.LoadBalancerName),
 		}
+	}
+	if found.Zones != nil {
+		vmss.Zones = *found.Zones
 	}
 	return vmss, nil
 }
@@ -367,7 +371,8 @@ func (s *VMScaleSet) RenderAzure(t *azure.AzureAPITarget, a, e, changes *VMScale
 		Identity: &compute.VirtualMachineScaleSetIdentity{
 			Type: compute.ResourceIdentityTypeSystemAssigned,
 		},
-		Tags: e.Tags,
+		Tags:  e.Tags,
+		Zones: &e.Zones,
 	}
 
 	result, err := t.Cloud.VMScaleSet().CreateOrUpdate(

--- a/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
+++ b/upup/pkg/fi/cloudup/azuretasks/vmscaleset_test.go
@@ -86,6 +86,7 @@ func newTestVMScaleSet() *VMScaleSet {
 		SSHPublicKey:       to.StringPtr("ssh"),
 		CustomData:         fi.NewStringResource("custom"),
 		Tags:               map[string]*string{},
+		Zones:              []string{"zone1"},
 	}
 }
 
@@ -127,6 +128,10 @@ func TestVMScaleSetRenderAzure(t *testing.T) {
 
 	if expected.PrincipalID == nil {
 		t.Errorf("unexpected nil principalID")
+	}
+
+	if a, e := *actual.Zones, expected.Zones; !reflect.DeepEqual(a, e) {
+		t.Errorf("unexpected Zone: expected %s, but got %s", e, a)
 	}
 }
 
@@ -253,6 +258,7 @@ func TestVMScaleSetFind(t *testing.T) {
 		Identity: &compute.VirtualMachineScaleSetIdentity{
 			Type: compute.ResourceIdentityTypeSystemAssigned,
 		},
+		Zones: &[]string{"zone1"},
 	}
 	if _, err := cloud.VMScaleSet().CreateOrUpdate(context.Background(), *rg.Name, *vmss.Name, vmssParameters); err != nil {
 		t.Fatalf("failed to create: %s", err)
@@ -287,6 +293,9 @@ func TestVMScaleSetFind(t *testing.T) {
 	}
 	if !*actual.RequirePublicIP {
 		t.Errorf("unexpected require public IP")
+	}
+	if a, e := actual.Zones, *vmssParameters.Zones; !reflect.DeepEqual(a, e) {
+		t.Errorf("unexpected Zone: expected %s, but got %s", e, a)
 	}
 }
 


### PR DESCRIPTION
Azure's subnets are regional so we use similar functionality to GCE where we reference the InstanceGroup's zones rather than a subnet's zone.
IG Zones are already populated from `--zones` and `--master-zones` at cluster creation time here:

https://github.com/kubernetes/kops/blob/b35803789627345f58eb979cf53fa87bfe422f28/upup/pkg/fi/cloudup/new_cluster.go#L682-L684

fixes #11955