### PR TITLE
Automated cherry pick of #11961: Enable k8s event handover when kvstore is used

### DIFF
--- a/docs/networking/cilium.md
+++ b/docs/networking/cilium.md
@@ -44,6 +44,7 @@ kops create cluster \
 
 For existing clusters, add the following to `spec.etcdClusters`:
 Make sure `instanceGroup` match the other etcd clusters.
+You should also enable auto compaction.
 
 ```yaml
   - etcdMembers:
@@ -53,6 +54,12 @@ Make sure `instanceGroup` match the other etcd clusters.
       name: b
     - instanceGroup: master-az-1c
       name: c
+    manager:
+      env:
+      - name: ETCD_AUTO_COMPACTION_MODE
+        value: revision
+      - name: ETCD_AUTO_COMPACTION_RETENTION
+        value: "2500"
     name: cilium
 ```
 

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -49,6 +49,8 @@ data:
     trusted-ca-file: '/var/lib/etcd-secrets/etcd-ca.crt'
     key-file: '/var/lib/etcd-secrets/etcd-client-cilium.key'
     cert-file: '/var/lib/etcd-secrets/etcd-client-cilium.crt'
+
+  enable-k8s-event-handover: "true"
 {{ end }}
 
   # Identity allocation mode selects how identities are shared between cilium

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -1130,6 +1130,19 @@ func createEtcdCluster(etcdCluster string, masters []*api.InstanceGroup, encrypt
 		m.InstanceGroup = fi.String(ig.ObjectMeta.Name)
 		etcd.Members = append(etcd.Members, m)
 	}
+
+	// Cilium etcd server is not compacted by the k8s API server.
+	if etcd.Name == "cilium" {
+		if etcd.Manager == nil {
+			etcd.Manager = &api.EtcdManagerSpec{
+				Env: []api.EnvVar{
+					{Name: "ETCD_AUTO_COMPACTION_MODE", Value: "revision"},
+					{Name: "ETCD_AUTO_COMPACTION_RETENTION", Value: "2500"},
+				},
+			}
+		}
+	}
+
 	return etcd
 
 }


### PR DESCRIPTION
Cherry pick of #11961 on release-1.21.

#11961: Enable k8s event handover when kvstore is used

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.