### PR TITLE
Fix broken link to contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [Releases and versioning](https://kops.sigs.k8s.io/welcome/releases/)
 
 ## Getting Involved and Contributing
 
-See [Contributing](https://kops.sigs.k8s.io/welcome/contributing/)
+See [Contributing](https://kops.sigs.k8s.io/contributing/)
 
 ### Office Hours
 


### PR DESCRIPTION
Related to [this](https://github.com/kubernetes/kops/issues/11959#issuecomment-876950002) comment on #11959 
The link to `contributing` page is broken in the main `README.md` file. This PR fixes the broken link