### PR TITLE
Spotinst: Update `spotinst/ocean-controller` to v1.0.77

### DIFF
--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -205,7 +205,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: gcr.io/spotinst-artifacts/kubernetes-cluster-controller:1.0.76
+        image: gcr.io/spotinst-artifacts/kubernetes-cluster-controller:1.0.77
         livenessProbe:
           httpGet:
             path: /healthcheck


### PR DESCRIPTION
This PR upgrades `spotinst/ocean-controller` to v1.0.77.