### PR TITLE
Verify CA keypair IDs for kops-controller-issued certs

### DIFF
--- a/cmd/kops-controller/pkg/server/BUILD.bazel
+++ b/cmd/kops-controller/pkg/server/BUILD.bazel
@@ -19,5 +19,6 @@ go_library(
         "//util/pkg/vfs:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/nodeup/pkg/model/bootstrap_client.go
+++ b/nodeup/pkg/model/bootstrap_client.go
@@ -64,8 +64,9 @@ func (b BootstrapClientBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	bootstrapClientTask := &nodetasks.BootstrapClientTask{
-		Client: bootstrapClient,
-		Certs:  b.bootstrapCerts,
+		Client:     bootstrapClient,
+		Certs:      b.bootstrapCerts,
+		KeypairIDs: b.bootstrapKeypairIDs,
 	}
 
 	for _, cert := range b.bootstrapCerts {

--- a/nodeup/pkg/model/kops_controller.go
+++ b/nodeup/pkg/model/kops_controller.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kops/pkg/wellknownusers"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
+	"sigs.k8s.io/yaml"
 )
 
 // KopsControllerBuilder installs the keys for a kops-controller.
@@ -90,6 +91,18 @@ func (b *KopsControllerBuilder) Build(c *fi.ModelBuilderContext) error {
 			return err
 		}
 	}
+
+	keypairIDs, err := yaml.Marshal(b.NodeupConfig.KeypairIDs)
+	if err != nil {
+		return err
+	}
+	c.AddTask(&nodetasks.File{
+		Path:     filepath.Join(pkiDir, "keypair-ids.yaml"),
+		Contents: fi.NewBytesResource(keypairIDs),
+		Type:     nodetasks.FileType_File,
+		Mode:     s("0600"),
+		Owner:    s(wellknownusers.KopsControllerName),
+	})
 
 	return nil
 }

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -559,7 +559,10 @@ func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.ModelBuilderContex
 		}
 
 		if !b.HasAPIServer {
-			cert, key := b.GetBootstrapCert(name)
+			cert, key, err := b.GetBootstrapCert(name, fi.CertificateIDCA)
+			if err != nil {
+				return err
+			}
 
 			c.AddTask(&nodetasks.File{
 				Path:           filepath.Join(dir, name+".crt"),

--- a/nodeup/pkg/model/networking/cilium.go
+++ b/nodeup/pkg/model/networking/cilium.go
@@ -123,7 +123,10 @@ func (b *CiliumBuilder) buildCiliumEtcdSecrets(c *fi.ModelBuilderContext) error 
 		return issueCert.AddFileTasks(c, dir, name, "", nil)
 	} else {
 		if b.UseKopsControllerForNodeBootstrap() {
-			cert, key := b.GetBootstrapCert(name)
+			cert, key, err := b.GetBootstrapCert(name, signer)
+			if err != nil {
+				return err
+			}
 
 			c.AddTask(&nodetasks.File{
 				Path:           filepath.Join(dir, name+".crt"),

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kops-controller.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kops-controller.yaml
@@ -2,6 +2,14 @@ mode: "0755"
 path: /etc/kubernetes/kops-controller
 type: directory
 ---
+contents: |
+  kubernetes-ca: "3"
+  service-account: "2"
+mode: "0600"
+owner: kops-controller
+path: /etc/kubernetes/kops-controller/keypair-ids.yaml
+type: file
+---
 contents:
   task:
     Name: kops-controller

--- a/pkg/apis/nodeup/bootstrap.go
+++ b/pkg/apis/nodeup/bootstrap.go
@@ -24,6 +24,8 @@ type BootstrapRequest struct {
 	APIVersion string `json:"apiVersion"`
 	// Certs are the requested certificates and their respective public keys.
 	Certs map[string]string `json:"certs"`
+	// KeypairIDs are the keypair IDs of the CAs to use for issuing certificates.
+	KeypairIDs map[string]string `json:"keypairIDs"`
 
 	// IncludeNodeConfig controls whether the cluster & instance group configuration should be returned.
 	// This allows for nodes without access to the kops state store.

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
@@ -163,7 +163,7 @@ Resources.AWSEC2LaunchTemplateapiserverapiserversminimalexamplecom.Properties.La
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: apiserver
   InstanceGroupRole: APIServer
-  NodeupConfigHash: m42Jgc8PoZhVAC89vuntMvXrH++DSM8mwoTImuyRjzc=
+  NodeupConfigHash: iWrD5bIyJd86oWdSRDFwjcezKpalA0SeCY3CTvmTQjM=
 
   __EOF_KUBE_ENV
 
@@ -587,7 +587,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: tkKsjnWeOxwXl+xmlcu9fg6LL9i/1GpYYZbbNEUSOgk=
+  NodeupConfigHash: A0AyiJo03pbqluaXrVtbacjofP1NmBexAl0w2y4oS5o=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: tkKsjnWeOxwXl+xmlcu9fg6LL9i/1GpYYZbbNEUSOgk=
+NodeupConfigHash: A0AyiJo03pbqluaXrVtbacjofP1NmBexAl0w2y4oS5o=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: minimal.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
@@ -171,7 +171,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/bastionuserdata.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: v3vAGhTxpuP2+WEcyx3spjODFbRipxYbiD0PoMfW/1c=
+NodeupConfigHash: XE9IpKZd9oCrCv/x+HIIxysnlj82y2WpjG3iuknb0Mk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_nodeupconfig-bastion_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_nodeupconfig-bastion_content
@@ -35,7 +35,8 @@ ClusterName: bastionuserdata.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: bastionuserdata.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -451,7 +451,7 @@ Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateDa
   ConfigBase: memfs://clusters.example.com/complex.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: W/7jMLzECfR0XTWLf7Hg6HMBQwKn1xRYsr0w3UsEUoY=
+  NodeupConfigHash: YhMDAtYXeVayMfXL+lAMRKJ5B1N2nmXjIEp3zx2O3SY=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
@@ -171,7 +171,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: W/7jMLzECfR0XTWLf7Hg6HMBQwKn1xRYsr0w3UsEUoY=
+NodeupConfigHash: YhMDAtYXeVayMfXL+lAMRKJ5B1N2nmXjIEp3zx2O3SY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: complex.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/compress/data/aws_launch_template_nodes.compress.example.com_user_data
+++ b/tests/integration/update_cluster/compress/data/aws_launch_template_nodes.compress.example.com_user_data
@@ -133,7 +133,7 @@ ensure-install-dir
 
 echo "H4sIAAAAAAAA/3yS0W7bPAyF7/0UvCl601+2i/7BJvRiW7KhAZYuSJ6AsRhXiEymouQsbz/YTZplA3Zl+Bzah/zIJkh2U+Gtb20BgAf9+mU9Xc9n0fcUBwmAGDeBnIUtBqUCoEPGltZJIrY0DahKaiHFTEUjnNAzxVXm5Duy8K64i+mGHwdpv1NPwYLnrRQAPUX1whZq82AmhZNm99aC7vx+zpowhFPMLm9oGeXncbCbkDVRnM5nKwt1VZmPE1OZqqzrwdznFb1m0jR6XQHwIpoYO/rRU4zekYXbT3jQ2wLAd9iShd0HNW0TjZdySPpvP0b1tbmvTXXV+v3YSqA00mPhYydZP+f0csHVtFHy/kQU9KiJOveur0SShXKcQ7JbRum9GwrxoJfhZs/rt9kmD6YydfWbIx16tudXE6TBUJy3NqNNblvP7ROyCxTPewKg3jfJCz9hdBY66iQeDfbow/DdY11VC3/H4mirV/LNWfTDU79Fosf/b+5Gcn+VntWr2n+vYODZjAe5xIFi2WMsg9+UJ9DlpeCPTQAwpYPE3TLk1vMzjufHfjCEF6ivmSI6uhzKCLMqR5x7cQtkvyVNp2BKzRgWmRJp2Z1cLX4BAAD//wEAAP//GWuHvzUDAAA=" | base64 -d | gzip -d > conf/cluster_spec.yaml
 
-echo "H4sIAAAAAAAA/1SNwU6EMBQA7/2KfgEoJkiaeBCMiiZI1JC9Nu1jYWn7mj5K+fzNZk9c5jBzmMZg1H3AbdYQBJeJWINunM+1JBDcgh1J5LkykVYIlMEurTeQKbS5QusD0EGy1tEqnYKPgNF30oLgDjXQMfyiAcE71MBuiP4+/ZQ0CV49PG3FV5re96TK6vsU3Pi8LPXj5W94bfe3/7Ie+mJb3fKTXtgVAAD//wEAAP//5xLuGcEAAAA=" | base64 -d | gzip -d > conf/kube_env.yaml
+echo "H4sIAAAAAAAA/1SNwUrEMBQA7/mK3IUGxSIGvFiktWKVghWPIXmt3SZ52bykW/brl2VPvcxh5jCVxWy+I66zgSi5OhGr0I/z9KoIJHfgRpJCaJspQaQCNuWChUKjExpdiEA7yd49JeU11BFz6JQDyT0aoH3o0YLkHRpgV+RwmzaK/iV/m5qtPD/V83N32I5N36ZyEHf+cfn6yOn351Mv93lYH3Ir/l7YBQAA//8BAAD//w/PoYLBAAAA" | base64 -d | gzip -d > conf/kube_env.yaml
 
 download-release
 echo "== nodeup node config done =="

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: compress.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json.extracted.yaml
@@ -432,7 +432,7 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
   ConfigBase: memfs://clusters.example.com/containerd.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: mQ3AvnQERQ6PiYxBIkJ2VkeEAL1WvRLVxQeb5hi5WBc=
+  NodeupConfigHash: ZYCe88bkLCotK0J/VSldr8XpzuA7qmdkQKAw8+Lxqt0=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/containerd/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd/cloudformation.json.extracted.yaml
@@ -416,7 +416,7 @@ Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplat
   ConfigBase: memfs://clusters.example.com/containerd.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: LfIjYwhZ+QZeIe1EaAfPaVAJEXDldauEfoRDqJ376L8=
+  NodeupConfigHash: yNDHI151rlG9u+g2DApXbUdjHi3Ko/2WgbLZcK5oyP0=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json.extracted.yaml
@@ -451,7 +451,7 @@ Resources.AWSEC2LaunchTemplatenodesdockerexamplecom.Properties.LaunchTemplateDat
   ConfigBase: memfs://clusters.example.com/docker.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: dn0AX7sK+3cBMEdv2c5OI6iocGx8FIsx6XJP6tU58uo=
+  NodeupConfigHash: IUUmgKRx8/87kspoEHjZ9Q2XsW04SJhfvsctLdfPywA=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/existing-iam.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: I6SvbzNi8x8vsZvatJwokYmc0zJry/3TeQktzRJREpU=
+NodeupConfigHash: s7LyXyLYgQ6KZvt2Wye3i5GJgAGHX7h1kk9+Bi+GDXg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: existing-iam.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -416,7 +416,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: tkKsjnWeOxwXl+xmlcu9fg6LL9i/1GpYYZbbNEUSOgk=
+  NodeupConfigHash: A0AyiJo03pbqluaXrVtbacjofP1NmBexAl0w2y4oS5o=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/existingsg.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 8Z+i4jo2TtNgYCXc2VcN6nIRl7Ok32gghvtSH+aJUvY=
+NodeupConfigHash: 6bY/YXtoKWx9A+emWACwbxUIT9KhmDtAxDcCfd8eeJA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: existingsg.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -416,7 +416,7 @@ Resources.AWSEC2LaunchTemplatenodesexternallbexamplecom.Properties.LaunchTemplat
   ConfigBase: memfs://clusters.example.com/externallb.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: FzEzx/o0MsD4+1xVGe75bmIsb4TbSm3ZgB3HI6UGMYM=
+  NodeupConfigHash: bdjSOGEceYhBOW9P2HSJNSoQH3jEvW12Hag/2hr1e6E=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
+++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/externallb.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: FzEzx/o0MsD4+1xVGe75bmIsb4TbSm3ZgB3HI6UGMYM=
+NodeupConfigHash: bdjSOGEceYhBOW9P2HSJNSoQH3jEvW12Hag/2hr1e6E=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: externallb.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/externalpolicies.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: PNYBDlpKEoP1QjCOxO7ZGpkNtaEti1zDxLRS2nOvBzg=
+NodeupConfigHash: XgwNnyqHBUSXCDvQ5csUiuiVDlTyrItmRWHAmyQqCfI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: externalpolicies.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/ha.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: TDt530JMA90sQnDv0CcQnQbH4Nfzz3XWMvC6P7891vk=
+NodeupConfigHash: +UE1BbfLcWfM7SXw54BSAqA9UKzf2/XlBZiZCLfPMWU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: ha.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -37,7 +37,8 @@ ClusterName: ha-gce.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
@@ -162,7 +162,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/ha-gce.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: cMQLIcI7lFqgACWxQPSBbUfaI8fZLhMk7tvZkN2AVIE=
+NodeupConfigHash: KjcIhj3Z1G5c3A+/QV9HTJTWk4JeSiCaTX3I91Q97ZY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: iOXf4O4Nytl0ULpILcqhcOLlhL17H1XN14npubipb0E=
+NodeupConfigHash: FHBXR/nZvBftgS8f9ASwir6J1ubIxIOyUj5weAiJkMQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: minimal.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -165,7 +165,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 75mRrq7GTeR2o1ef9tjGJ8uf1Z2sGyAG6n5l0bQFulE=
+NodeupConfigHash: m9RoefjqnssINNuqti1CvJ5+nM9+qA3yWOJvkfgFKnc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -36,7 +36,8 @@ DefaultMachineType: t2.medium
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/minimal-etcd/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-etcd/cloudformation.json.extracted.yaml
@@ -432,7 +432,7 @@ Resources.AWSEC2LaunchTemplatenodesminimaletcdexamplecom.Properties.LaunchTempla
   ConfigBase: memfs://clusters.example.com/minimal-etcd.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: 0iYBTE1qSb9CYeRIeXSmG9rdUezNsUe2pRjMbE8RbG8=
+  NodeupConfigHash: LDevpa8cfuLNHz9S4syHz3JhFCuU5OppDWbYVPzPrWY=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json.extracted.yaml
@@ -422,7 +422,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: tkKsjnWeOxwXl+xmlcu9fg6LL9i/1GpYYZbbNEUSOgk=
+  NodeupConfigHash: A0AyiJo03pbqluaXrVtbacjofP1NmBexAl0w2y4oS5o=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: tkKsjnWeOxwXl+xmlcu9fg6LL9i/1GpYYZbbNEUSOgk=
+NodeupConfigHash: A0AyiJo03pbqluaXrVtbacjofP1NmBexAl0w2y4oS5o=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: minimal.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/minimal-ipv6/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-ipv6/cloudformation.json.extracted.yaml
@@ -416,7 +416,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTempla
   ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: B000Wthm726uqhkkbzEq8F035YOJyeFQx2LgnTvSXsM=
+  NodeupConfigHash: 9TjWKlz9epkWB6OUxdBlnNn7bMXxCHk7y16oWDUVYLk=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: B000Wthm726uqhkkbzEq8F035YOJyeFQx2LgnTvSXsM=
+NodeupConfigHash: 9TjWKlz9epkWB6OUxdBlnNn7bMXxCHk7y16oWDUVYLk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: minimal-ipv6.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/minimal-json/data/aws_launch_template_nodes.minimal-json.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-json/data/aws_launch_template_nodes.minimal-json.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-json.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: z5k9twrrZsc5pjqG/T1s/T08Maa40iZzERDaK6yYp3U=
+NodeupConfigHash: fDrRmSIF+gluyzsbHJTYSQKg1PguiQ7IPAL227vKl8A=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-json/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-json/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: minimal-json.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: HHZXWMo3x4f4EMBM3R/sXk9sKUvlTLTGr9P4vFGwWd8=
+NodeupConfigHash: Y13x1Iql1eNPYAs3Ynsh1Y8q3Zqslmxl6KARj6Ys+90=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: minimal-warmpool.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/minimal/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal/cloudformation.json.extracted.yaml
@@ -416,7 +416,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: tkKsjnWeOxwXl+xmlcu9fg6LL9i/1GpYYZbbNEUSOgk=
+  NodeupConfigHash: A0AyiJo03pbqluaXrVtbacjofP1NmBexAl0w2y4oS5o=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: tkKsjnWeOxwXl+xmlcu9fg6LL9i/1GpYYZbbNEUSOgk=
+NodeupConfigHash: A0AyiJo03pbqluaXrVtbacjofP1NmBexAl0w2y4oS5o=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: minimal.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -37,7 +37,8 @@ ClusterName: minimal-gce.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -162,7 +162,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: An7JIMOwl1blxERRyNnbNGIRjcQGlwhiNCyi5zPqsTQ=
+NodeupConfigHash: oVXw5XN4cMP2Teqe3ZUv7TO/81lePlNiur1Ge1NhVrA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -37,7 +37,8 @@ ClusterName: minimal-gce-private.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_startup-script
@@ -162,7 +162,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce-private.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: xkYatSBwom9QO9DBj+Tnz+NnFeRp8GnPDJokiN8DZT4=
+NodeupConfigHash: l7fPJ5CpjpaBcyQTiKOjrDgN03hDD+vff1Ut1carYEc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: wqkDigZCCGDaRHpqvUR6rfLOlt0Cin2CKydfErRr7Ds=
+NodeupConfigHash: 2Fo4nPBO0R7diEUzoI1iTETi6ZRhyZQwhmUt4i3XcGs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -39,7 +39,8 @@ ClusterName: minimal.k8s.local
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -922,7 +922,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: Z6ruP2QBZKY/CWpan8kL/iVGVxh3jBaxSSqQCLNmG+4=
+  NodeupConfigHash: RsLEJr46Xcyh5F+aw+mv0cdok9gUDJHGcyoBzcorJd0=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: Z6ruP2QBZKY/CWpan8kL/iVGVxh3jBaxSSqQCLNmG+4=
+NodeupConfigHash: RsLEJr46Xcyh5F+aw+mv0cdok9gUDJHGcyoBzcorJd0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: mixedinstances.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -922,7 +922,7 @@ Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTem
   ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: Z6ruP2QBZKY/CWpan8kL/iVGVxh3jBaxSSqQCLNmG+4=
+  NodeupConfigHash: RsLEJr46Xcyh5F+aw+mv0cdok9gUDJHGcyoBzcorJd0=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: Z6ruP2QBZKY/CWpan8kL/iVGVxh3jBaxSSqQCLNmG+4=
+NodeupConfigHash: RsLEJr46Xcyh5F+aw+mv0cdok9gUDJHGcyoBzcorJd0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: mixedinstances.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
@@ -416,7 +416,7 @@ Resources.AWSEC2LaunchTemplatenodesnthsqsresourcesexamplecom.Properties.LaunchTe
   ConfigBase: memfs://clusters.example.com/nthsqsresources.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: RHYxFKnk5Hvv4XubFyLlP/sxrRCWwz0Vc4Gs82v4t2M=
+  NodeupConfigHash: 2CPy/IUGbQipsUVs54c828IDu9GI5k0LwHH5XOOgcMU=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.example.com_user_data
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/nthsqsresources.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: RHYxFKnk5Hvv4XubFyLlP/sxrRCWwz0Vc4Gs82v4t2M=
+NodeupConfigHash: 2CPy/IUGbQipsUVs54c828IDu9GI5k0LwHH5XOOgcMU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: nthsqsresources.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json.extracted.yaml
@@ -417,7 +417,7 @@ Resources.AWSEC2LaunchTemplatenodesprivatesharedipexamplecom.Properties.LaunchTe
   ConfigBase: memfs://clusters.example.com/private-shared-ip.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: mbey+gINFWJmkPWdjwWulcFL38lshpBp4i9hS/YU9MA=
+  NodeupConfigHash: /5uEbdyeKsSyACGPnL3AcWr9dDFCMTIo6TsKFtZfQY8=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/private-shared-ip.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: mbey+gINFWJmkPWdjwWulcFL38lshpBp4i9hS/YU9MA=
+NodeupConfigHash: /5uEbdyeKsSyACGPnL3AcWr9dDFCMTIo6TsKFtZfQY8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: private-shared-ip.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/private-shared-subnet.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: uk/OnkIYw7D9JDB0bapsDsrKEXImTiLPIyOZK/y+DrU=
+NodeupConfigHash: YP3rs2Jt5ILuaCSX/nL4br+lJl3BkEt+mvo9S+CaqTM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: private-shared-subnet.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -417,7 +417,7 @@ Resources.AWSEC2LaunchTemplatenodesprivatecalicoexamplecom.Properties.LaunchTemp
   ConfigBase: memfs://clusters.example.com/privatecalico.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: IYWQLOccFqNCuhLbNBotGynsWACCa0BFXNxrQwDldDk=
+  NodeupConfigHash: /dVlBvSuPvaoTwJ1PQ4cH6r34yiqW7f0yqymzKljbm0=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecalico.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: IYWQLOccFqNCuhLbNBotGynsWACCa0BFXNxrQwDldDk=
+NodeupConfigHash: /dVlBvSuPvaoTwJ1PQ4cH6r34yiqW7f0yqymzKljbm0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: privatecalico.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecanal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: SYNxK8NV6KoZOF6/eLVZDKF+4O6zjRNLeWKXUkKuorI=
+NodeupConfigHash: o0QdJcl3FAZgJ3ZCQSGFMBOgpkBYKRjLl1wMCSQ9ptA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: privatecanal.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
@@ -417,7 +417,7 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
   ConfigBase: memfs://clusters.example.com/privatecilium.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: JNy6CJ9R/90CCImseZqoKFV3lArtwCQb9wcUE5A3HV0=
+  NodeupConfigHash: +A3ynJBC/SEqeXU3Mzrq9NrWNYkoYI7qFtSbcymftlU=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: JNy6CJ9R/90CCImseZqoKFV3lArtwCQb9wcUE5A3HV0=
+NodeupConfigHash: +A3ynJBC/SEqeXU3Mzrq9NrWNYkoYI7qFtSbcymftlU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: privatecilium.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
@@ -431,7 +431,7 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
   ConfigBase: memfs://clusters.example.com/privatecilium.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: bldYPsujFX/fAiUObweFc8J2JfDYE9FbFXezOIunKaA=
+  NodeupConfigHash: cRVyEga1NwlrdI+7931ppAijC4EcmfTUBfaprxlwZgk=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -171,7 +171,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: bldYPsujFX/fAiUObweFc8J2JfDYE9FbFXezOIunKaA=
+NodeupConfigHash: cRVyEga1NwlrdI+7931ppAijC4EcmfTUBfaprxlwZgk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: privatecilium.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupRoot: /

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
@@ -421,7 +421,7 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumadvancedexamplecom.Properties.La
   ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: b9wVmNTeZeEe4dGlCda8S194XJxL9lBrnEG5XHwQ3yw=
+  NodeupConfigHash: czTpqSQ5bmpp+T8VX/aNnI8P8VbGG6QFdeuJBgmkW+s=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
@@ -163,7 +163,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: b9wVmNTeZeEe4dGlCda8S194XJxL9lBrnEG5XHwQ3yw=
+NodeupConfigHash: czTpqSQ5bmpp+T8VX/aNnI8P8VbGG6QFdeuJBgmkW+s=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -58,7 +58,9 @@ ClusterName: privateciliumadvanced.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  etcd-clients-ca-cilium: "6977087239278090025924899436"
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatedns1.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: z5Z2Y09jVxkhq7c9amrzfspgQzR8jwaV7Bckal49YYQ=
+NodeupConfigHash: l9fVqJeL3CDNZLBv62ahm8dguMFHhsnA+R5rSX1/VXk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: privatedns1.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatedns2.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: t4mggxzOAlu9w8SDd0c4XHwJ+DQRz1hysOkLbYjBQ+0=
+NodeupConfigHash: szYwTm1enDV0ChP01yU1/V5mWnuT0wunImpNM+ifstk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: privatedns2.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privateflannel.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 6x4qWYQ36yAN6BgJysNVgdn2ufPN4ZDtptCEJePwSf4=
+NodeupConfigHash: u6ZXQYhqRIXxxYcJ5XXoraXg+ZoMrjvrxtMT0HOUveY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: privateflannel.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatekopeio.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: zAmcy+2MrD7RfY+YHQu/k6CAaYD02Bu29NQ0CdHQZHU=
+NodeupConfigHash: yAFSdXLM+7m6ucG2sHmraf17wE2PKyh5zvy61ZBmT2Y=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: privatekopeio.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/privateweave/data/aws_launch_template_nodes.privateweave.example.com_user_data
+++ b/tests/integration/update_cluster/privateweave/data/aws_launch_template_nodes.privateweave.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privateweave.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: n4yAEF5KBx5KC7fCKntkd15tfGbRtbxeLD7aiHXEj3c=
+NodeupConfigHash: jrZ6kGuXzL2l7Ef5ebcuHNJU0QhGKTEwQYHa0teZrcE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: privateweave.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -171,7 +171,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: tYAllzf7IZ+fKbvdeG0zyqXLwVudUFeMAIftgqNIXR4=
+NodeupConfigHash: JMivLNdXnURUuRMQAE3OmbRJtADb/bT+NPz+jKPMGi0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: minimal.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupRoot: /

--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/sharedsubnet.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: wW+BrM+6SIAlp7xHMNmPclXvRUv9HNW3Vost/MAWDr8=
+NodeupConfigHash: aPWxlCRqf8wihVV20ZoFJOIsWvduBEOLJkxnBOhH7X0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: sharedsubnet.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/sharedvpc.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: R/zXiPbN576jx9+tm7w01As1c3o6puktRbSarvYqmAU=
+NodeupConfigHash: qNrBFJAwMHFXNb+sdtcrH13LD/Nl6ZCUjk0mLkIaLqw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: sharedvpc.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
+++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/unmanaged.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: yac99w2gNqgUuOPQ2NLFNpctg5MusRah0+BMUw3Np84=
+NodeupConfigHash: hsQqx6uw6JmtLJmhz2c5qDfOi52GGdMJNbByR9JYEnI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: unmanaged.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -162,7 +162,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: tkKsjnWeOxwXl+xmlcu9fg6LL9i/1GpYYZbbNEUSOgk=
+NodeupConfigHash: A0AyiJo03pbqluaXrVtbacjofP1NmBexAl0w2y4oS5o=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -35,7 +35,8 @@ ClusterName: minimal.example.com
 Hooks:
 - null
 - null
-KeypairIDs: {}
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
   anonymousAuth: false
   cgroupDriver: systemd

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/klog/v2"
 	kopsbase "k8s.io/kops"
 	"k8s.io/kops/pkg/apis/kops"
+	apiModel "k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/apis/kops/validation"
@@ -1295,17 +1296,16 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 		}
 	}
 
-	if err := getTasksCertificate(caTasks, fi.CertificateIDCA, config, false); err != nil {
+	if err := getTasksCertificate(caTasks, fi.CertificateIDCA, config, true); err != nil {
 		return nil, nil, err
 	}
 	if caTasks["etcd-clients-ca-cilium"] != nil {
-		if err := getTasksCertificate(caTasks, "etcd-clients-ca-cilium", config, hasAPIServer); err != nil {
+		if err := getTasksCertificate(caTasks, "etcd-clients-ca-cilium", config, hasAPIServer || apiModel.UseKopsControllerForNodeBootstrap(n.cluster)); err != nil {
 			return nil, nil, err
 		}
 	}
 
 	if isMaster {
-		config.KeypairIDs[fi.CertificateIDCA] = caTasks[fi.CertificateIDCA].Keyset().Primary.Id
 		if err := getTasksCertificate(caTasks, "etcd-clients-ca", config, true); err != nil {
 			return nil, nil, err
 		}

--- a/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
@@ -41,6 +41,8 @@ import (
 type BootstrapClientTask struct {
 	// Certs are the requested certificates.
 	Certs map[string]*BootstrapCert
+	// KeypairIDs are the keypair IDs of the CAs to use for issuing certificates.
+	KeypairIDs map[string]string
 
 	// Client holds the client wrapper for the kops-bootstrap protocol
 	Client *KopsBootstrapClient
@@ -83,6 +85,7 @@ func (b *BootstrapClientTask) Run(c *fi.Context) error {
 	req := nodeup.BootstrapRequest{
 		APIVersion: nodeup.BootstrapAPIVersion,
 		Certs:      map[string]string{},
+		KeypairIDs: b.KeypairIDs,
 	}
 
 	if b.keys == nil {


### PR DESCRIPTION
This ensures that nodes that have kops-controller-issued certs from a demoted CA will be selected by rolling-update as needing update. If a bootstrapping node requests certs from a kops-controller that has a different idea of what the primary keypair is for one of the relevant CAs, the request will fail. This will happen after the apply_cluster following the promotion of one of the CA's keypairs. The failure will continue until whichever node (kops-controller or worker) is out of date is replaced by rolling-update.

The other possible way to do this would be to give kops-controller direct access to the secret store and allow the client node to select whichever CA keypair it wants the certs issued from.
