### PR TITLE
remove references to kubernetes-release-dev

### DIFF
--- a/pkg/apis/kops/util/versions_test.go
+++ b/pkg/apis/kops/util/versions_test.go
@@ -64,7 +64,7 @@ func Test_ParseKubernetesVersion(t *testing.T) {
 			},
 		},
 		{
-			version: "https://storage.googleapis.com/kubernetes-release-dev/ci/v1.4.0-alpha.2.677+ea69570f61af8e/",
+			version: "https://storage.googleapis.com/k8s-release-dev/ci/v1.4.0-alpha.2.677+ea69570f61af8e/",
 			expected: &semver.Version{
 				Major: 1,
 				Minor: 4,

--- a/tests/e2e/pkg/version/kubernetes.go
+++ b/tests/e2e/pkg/version/kubernetes.go
@@ -41,8 +41,8 @@ func ParseKubernetesVersion(version string) (string, error) {
 
 		// Replace the last part of the version URL path with the contents of the URL's body
 		// Example:
-		// https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt -> v1.21.0-beta.1.112+576aa2d2470b28%0A
-		// becomes https://storage.googleapis.com/kubernetes-release-dev/ci/v1.21.0-beta.1.112+576aa2d2470b28%0A
+		// https://storage.googleapis.com/k8s-release-dev/ci/latest.txt -> v1.21.0-beta.1.112+576aa2d2470b28%0A
+		// becomes https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.112+576aa2d2470b28%0A
 		pathParts := strings.Split(u.Path, "/")
 		pathParts[len(pathParts)-1] = strings.TrimSpace(b.String())
 		u.Path = strings.Join(pathParts, "/")


### PR DESCRIPTION
this is mostly about getting kubernetes/kops out of search results for a
cs.k8s.io query that's looking for all repos that reference
kubernetes-release-dev in their default branch

if there's no compelling reason to keep the old value, use
k8s-release-dev instead

ref: https://github.com/kubernetes/k8s.io/issues/2318