### PR TITLE
Update alpha channel with July k8s releases and bump Ubuntu EC2 AMI version

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -58,11 +58,11 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210503
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210518
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210503
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210518
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0"
@@ -88,13 +88,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.21.0"
-    recommendedVersion: 1.21.2
+    recommendedVersion: 1.21.3
     requiredVersion: 1.21.0
   - range: ">=1.20.0"
-    recommendedVersion: 1.20.8
+    recommendedVersion: 1.20.9
     requiredVersion: 1.20.0
   - range: ">=1.19.0"
-    recommendedVersion: 1.19.12
+    recommendedVersion: 1.19.13
     requiredVersion: 1.19.0
   - range: ">=1.18.0"
     recommendedVersion: 1.18.20
@@ -127,15 +127,15 @@ spec:
   - range: ">=1.21.0-alpha.1"
     #recommendedVersion: "1.21.0-beta.1"
     #requiredVersion: 1.21.0
-    kubernetesVersion: 1.21.2
+    kubernetesVersion: 1.21.3
   - range: ">=1.20.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.20.0
-    kubernetesVersion: 1.20.8
+    kubernetesVersion: 1.20.9
   - range: ">=1.19.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.19.0
-    kubernetesVersion: 1.19.12
+    kubernetesVersion: 1.19.13
   - range: ">=1.18.0-alpha.1"
     recommendedVersion: "1.20.0"
     #requiredVersion: 1.18.0


### PR DESCRIPTION
* https://github.com/kubernetes/kubernetes/releases/tag/v1.19.13
* https://github.com/kubernetes/kubernetes/releases/tag/v1.20.9
* https://github.com/kubernetes/kubernetes/releases/tag/v1.21.3

The newest globally available [Ubuntu AMI release on EC2](https://cloud-images.ubuntu.com/locator/ec2/) for `focal` is `20210518` (the stragglers are `cn-north` and `cn-northwest`. Thus, I went with that one for now.