### PR TITLE
Issue kubelet cert on apiserver nodes for k8s before 1.19

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -117,8 +117,15 @@ func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		if b.HasAPIServer || !b.UseBootstrapTokens() {
 			var kubeconfig fi.Resource
-			if b.HasAPIServer && (b.IsKubernetesGTE("1.19") || b.UseBootstrapTokens()) {
-				kubeconfig, err = b.buildMasterKubeletKubeconfig(c)
+			if b.HasAPIServer {
+				if b.IsKubernetesGTE("1.19") || b.UseBootstrapTokens() {
+					kubeconfig, err = b.buildMasterKubeletKubeconfig(c)
+				} else {
+					kubeconfig = b.BuildIssuedKubeconfig("kubelet", nodetasks.PKIXName{
+						CommonName:   "kubelet",
+						Organization: []string{rbac.NodesGroup},
+					}, c)
+				}
 			} else {
 				kubeconfig, err = b.BuildBootstrapKubeconfig("kubelet", c)
 			}


### PR DESCRIPTION
Fixes OpenStack and other non-kops-controller-bootstrap providers with k8s < 1.19.