### PR TITLE
Mark the cluster autoscaler as cluster-critical

### DIFF
--- a/addons/cluster-autoscaler/v1.10.0.yaml
+++ b/addons/cluster-autoscaler/v1.10.0.yaml
@@ -134,6 +134,7 @@ spec:
       nodeSelector:
         kubernetes.io/role: master
       serviceAccountName: cluster-autoscaler
+      priorityClassName: system-cluster-critical
       containers:
         - image: {{IMAGE}}
           name: cluster-autoscaler


### PR DESCRIPTION
Currently, it is possible to end up in a broken cluster where the cluster-autoscaler
pod has been bumped out of the masters (for example, because `kube-dns` or other
system critical pods expanded due to large number of nodes). This requires manual 
intervention to fix, since the master instancegroup can not scale up to add enough
capacity for the autoscaler to run.

By marking the pod as [`cluster-system-critical`](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/),
we tell the cluster scheduler to not evict this pod as much as it can, decreasing the chances
of a cluster being broken in this way.