### PR TITLE
Fix keypair rotation scenario kops binary

### DIFF
--- a/tests/e2e/scenarios/keypair-rotation/run-test.sh
+++ b/tests/e2e/scenarios/keypair-rotation/run-test.sh
@@ -17,7 +17,7 @@
 REPO_ROOT=$(git rev-parse --show-toplevel);
 source "${REPO_ROOT}"/tests/e2e/scenarios/lib/common.sh
 
-KOPS=$(kops-acquire-latest)
+kops-acquire-latest
 
 kops-up
 


### PR DESCRIPTION
fixes https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-keypair-rotation

this shell function assigns a value to KOPS, rather than echoing to stdout like some of the other functions:

https://github.com/kubernetes/kops/blob/4048d0caf19c09419b34d35a8850a1cf7ac86eae/tests/e2e/scenarios/lib/common.sh#L104