### PR TITLE
Keypair rotation scenario - create report directory

### DIFF
--- a/tests/e2e/scenarios/keypair-rotation/run-test.sh
+++ b/tests/e2e/scenarios/keypair-rotation/run-test.sh
@@ -21,7 +21,8 @@ kops-acquire-latest
 
 kops-up
 
-REPORT_DIR="${ARTIFACTS:-$(pwd)/_artifacts}/keypair-rotation/"
+REPORT_DIR="${ARTIFACTS:-$(pwd)/_artifacts}/keypair-rotation"
+mkdir -p "${REPORT_DIR}"
 
 ${KOPS} create keypair all
 ${KOPS} update cluster --yes


### PR DESCRIPTION
Fixes https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-keypair-rotation/1416714756152102912/build-log.txt

```
./tests/e2e/scenarios/keypair-rotation/run-test.sh: line 32: /logs/artifacts/keypair-rotation//create.kubeconfig: No such file or directory
```