### PR TITLE
Add azure support for specifying a shared vpc

### DIFF
--- a/upup/pkg/fi/cloudup/azuretasks/testing.go
+++ b/upup/pkg/fi/cloudup/azuretasks/testing.go
@@ -122,6 +122,10 @@ func (c *MockAzureCloud) FindVPCInfo(id string) (*fi.VPCInfo, error) {
 	return nil, errors.New("FindVPCInfo not implemented on azureCloud")
 }
 
+func (c *MockAzureCloud) FindVNetInfo(id, resourceGroup string) (*fi.VPCInfo, error) {
+	return nil, errors.New("FindVNetInfo not implemented on azureCloud")
+}
+
 // DeleteInstance deletes the instance.
 func (c *MockAzureCloud) DeleteInstance(i *cloudinstances.CloudInstance) error {
 	return errors.New("DeleteInstance not implemented on azureCloud")


### PR DESCRIPTION
This allows the `create cluster --vpc` flag to specify the vnet ID for using shared vnets.

This makes an assumption that the cluster will use the first address prefix in the vnet. If that's not the case, the user should specify the address prefix with `--network-cidr`.

This is mostly untested, I may get a chance to at least confirm API behavior sometime this week.

Fixes #11950

/cc @kenji-cloudnatix 