### PR TITLE
keypair rotation scenario - fix base64 decoding

### DIFF
--- a/tests/e2e/scenarios/keypair-rotation/run-test.sh
+++ b/tests/e2e/scenarios/keypair-rotation/run-test.sh
@@ -44,7 +44,7 @@ KUBECFG_PROMOTE=$(mktemp -t kubeconfig.XXXXXXXXX)
 ${KOPS} export kubecfg --admin --kubeconfig="${KUBECFG_PROMOTE}"
 kubectl --kubeconfig="${KUBECFG_PROMOTE}" config view > "${REPORT_DIR}/promote.kubeconfig"
 
-CA=$(kubectl --kubeconfig="${KUBECFG_PROMOTE}" config view --raw -o jsonpath="{.clusters[0].cluster.certificate-authority-data}" | base64 -D)
+CA=$(kubectl --kubeconfig="${KUBECFG_PROMOTE}" config view --raw -o jsonpath="{.clusters[0].cluster.certificate-authority-data}" | base64 --decode)
 if [ "$(echo "${CA}" | grep -c "BEGIN CERTIFICATE")" != "1" ]; then
   >&2 echo unexpected number of CA certificates in kubeconfig
   exit 1


### PR DESCRIPTION
fixes https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-keypair-rotation/1416956350969155584/build-log.txt

```
+ kubectl --kubeconfig=/tmp/kubeconfig.W8ihK1JYy config view
++ kubectl --kubeconfig=/tmp/kubeconfig.W8ihK1JYy config view --raw -o 'jsonpath={.clusters[0].cluster.certificate-authority-data}'
++ base64 -D
base64: invalid option -- 'D'
```