### PR TITLE
Assert the correct number of kubeconfig CAs during keypair rotation

### DIFF
--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -118,8 +118,8 @@ function kops-up() {
         create_args="${create_args} --zones=${ZONES}"
     fi
     ${KUBETEST2} \
-		--up \
-		--kops-binary-path="${KOPS}" \
-		--kubernetes-version="1.21.0" \
-		--create-args="${create_args}"
+        --up \
+        --kops-binary-path="${KOPS}" \
+        --kubernetes-version="1.21.0" \
+        --create-args="${create_args}"
 }


### PR DESCRIPTION
The keypair rotation test is failing because there are two CAs where we expected 1: https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-keypair-rotation/1417258356002787328/build-log.txt 

After reviewing the steps, I think it _should_ have 2 CAs at that point, and then one CA after the distrust command. This updates the scenario to reflect that.