### PR TITLE
Provision TLS server certs for controller-manager and scheduler

### DIFF
--- a/docs/releases/1.22-NOTES.md
+++ b/docs/releases/1.22-NOTES.md
@@ -93,6 +93,10 @@ spec:
 * There is a new command `kops get assets` for listing image and file assets used by a cluster.
   It also includes a `--copy` flag to copy the assets to local repositories.
   See the documentation on [Using local asset repositories](../operations/asset-repository.md) for more information.
+  
+* kOps now provisions TLS server certificates signed by the Kubernetes general CA to kube-controller-manager and kube-scheduler.
+  The previous behavior of using self-signed certs may be restored by setting `kubeControllerManager.tlsCertFile` and/or
+  `kubeScheduler.tlsCertFile` to `""` in the cluster spec.
 
 # Full change list since 1.21.0 release
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1973,6 +1973,10 @@ spec:
                       garbage collector is disabled.
                     format: int32
                     type: integer
+                  tlsCertFile:
+                    description: TLSCertFile is the file containing the TLS server
+                      certificate.
+                    type: string
                   tlsCipherSuites:
                     description: TLSCipherSuites indicates the allowed TLS cipher
                       suite
@@ -1981,6 +1985,10 @@ spec:
                     type: array
                   tlsMinVersion:
                     description: TLSMinVersion indicates the minimum TLS version allowed
+                    type: string
+                  tlsPrivateKeyFile:
+                    description: TLSPrivateKeyFile is the file containing the private
+                      key for the TLS server certificate.
                     type: string
                   useServiceAccountCredentials:
                     description: UseServiceAccountCredentials controls whether we
@@ -2295,6 +2303,14 @@ spec:
                       the burst quota is exhausted
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  tlsCertFile:
+                    description: TLSCertFile is the file containing the TLS server
+                      certificate.
+                    type: string
+                  tlsPrivateKeyFile:
+                    description: TLSPrivateKeyFile is the file containing the private
+                      key for the TLS server certificate.
+                    type: string
                   usePolicyConfigMap:
                     description: UsePolicyConfigMap enable setting the scheduler policy
                       from a configmap

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
@@ -28,6 +28,8 @@ contents: |
       - --leader-elect=true
       - --root-ca-file=/srv/kubernetes/ca.crt
       - --service-account-private-key-file=/srv/kubernetes/kube-controller-manager/service-account.key
+      - --tls-cert-file=/srv/kubernetes/kube-controller-manager/server.crt
+      - --tls-private-key-file=/srv/kubernetes/kube-controller-manager/server.key
       - --use-service-account-credentials=true
       - --v=2
       - --logtostderr=false
@@ -147,6 +149,10 @@ contents: |
 path: /etc/kubernetes/manifests/kube-controller-manager.manifest
 type: file
 ---
+mode: "0755"
+path: /srv/kubernetes/kube-controller-manager
+type: directory
+---
 contents: |
   -----BEGIN CERTIFICATE-----
   MIIC2DCCAcCgAwIBAgIRALJXAkVj964tq67wMSI8oJQwDQYJKoZIhvcNAQELBQAw
@@ -200,6 +206,34 @@ contents: |
   -----END RSA PRIVATE KEY-----
 mode: "0600"
 path: /srv/kubernetes/kube-controller-manager/ca.key
+type: file
+---
+contents:
+  task:
+    Name: kube-controller-manager-server
+    alternateNames:
+    - kube-controller-manager.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-controller-manager
+    type: server
+mode: "0644"
+path: /srv/kubernetes/kube-controller-manager/server.crt
+type: file
+---
+contents:
+  task:
+    Name: kube-controller-manager-server
+    alternateNames:
+    - kube-controller-manager.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-controller-manager
+    type: server
+mode: "0600"
+path: /srv/kubernetes/kube-controller-manager/server.key
 type: file
 ---
 contents: |
@@ -260,6 +294,15 @@ signer: kubernetes-ca
 subject:
   CommonName: system:kube-controller-manager
 type: client
+---
+Name: kube-controller-manager-server
+alternateNames:
+- kube-controller-manager.kube-system.svc.cluster.local
+keypairID: "3"
+signer: kubernetes-ca
+subject:
+  CommonName: kube-controller-manager
+type: server
 ---
 CA:
   task:

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
@@ -16,6 +16,8 @@ contents: |
       - --authorization-kubeconfig=/var/lib/kube-scheduler/kubeconfig
       - --config=/var/lib/kube-scheduler/config.yaml
       - --leader-elect=true
+      - --tls-cert-file=/srv/kubernetes/kube-scheduler/server.crt
+      - --tls-private-key-file=/srv/kubernetes/kube-scheduler/server.key
       - --v=2
       - --logtostderr=false
       - --alsologtostderr
@@ -38,6 +40,9 @@ contents: |
       - mountPath: /var/lib/kube-scheduler
         name: varlibkubescheduler
         readOnly: true
+      - mountPath: /srv/kubernetes/kube-scheduler
+        name: srvscheduler
+        readOnly: true
       - mountPath: /var/log/kube-scheduler.log
         name: logfile
     hostNetwork: true
@@ -50,10 +55,45 @@ contents: |
         path: /var/lib/kube-scheduler
       name: varlibkubescheduler
     - hostPath:
+        path: /srv/kubernetes/kube-scheduler
+      name: srvscheduler
+    - hostPath:
         path: /var/log/kube-scheduler.log
       name: logfile
   status: {}
 path: /etc/kubernetes/manifests/kube-scheduler.manifest
+type: file
+---
+mode: "0755"
+path: /srv/kubernetes/kube-scheduler
+type: directory
+---
+contents:
+  task:
+    Name: kube-scheduler-server
+    alternateNames:
+    - kube-scheduler.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-scheduler
+    type: server
+mode: "0644"
+path: /srv/kubernetes/kube-scheduler/server.crt
+type: file
+---
+contents:
+  task:
+    Name: kube-scheduler-server
+    alternateNames:
+    - kube-scheduler.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-scheduler
+    type: server
+mode: "0600"
+path: /srv/kubernetes/kube-scheduler/server.key
 type: file
 ---
 contents: |
@@ -109,6 +149,15 @@ signer: kubernetes-ca
 subject:
   CommonName: system:kube-scheduler
 type: client
+---
+Name: kube-scheduler-server
+alternateNames:
+- kube-scheduler.kube-system.svc.cluster.local
+keypairID: "3"
+signer: kubernetes-ca
+subject:
+  CommonName: kube-scheduler
+type: server
 ---
 CA:
   task:

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
@@ -28,6 +28,8 @@ contents: |
       - --leader-elect=true
       - --root-ca-file=/srv/kubernetes/ca.crt
       - --service-account-private-key-file=/srv/kubernetes/kube-controller-manager/service-account.key
+      - --tls-cert-file=/srv/kubernetes/kube-controller-manager/server.crt
+      - --tls-private-key-file=/srv/kubernetes/kube-controller-manager/server.key
       - --use-service-account-credentials=true
       - --v=2
       - --logtostderr=false
@@ -147,6 +149,10 @@ contents: |
 path: /etc/kubernetes/manifests/kube-controller-manager.manifest
 type: file
 ---
+mode: "0755"
+path: /srv/kubernetes/kube-controller-manager
+type: directory
+---
 contents: |
   -----BEGIN CERTIFICATE-----
   MIIC2DCCAcCgAwIBAgIRALJXAkVj964tq67wMSI8oJQwDQYJKoZIhvcNAQELBQAw
@@ -200,6 +206,34 @@ contents: |
   -----END RSA PRIVATE KEY-----
 mode: "0600"
 path: /srv/kubernetes/kube-controller-manager/ca.key
+type: file
+---
+contents:
+  task:
+    Name: kube-controller-manager-server
+    alternateNames:
+    - kube-controller-manager.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-controller-manager
+    type: server
+mode: "0644"
+path: /srv/kubernetes/kube-controller-manager/server.crt
+type: file
+---
+contents:
+  task:
+    Name: kube-controller-manager-server
+    alternateNames:
+    - kube-controller-manager.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-controller-manager
+    type: server
+mode: "0600"
+path: /srv/kubernetes/kube-controller-manager/server.key
 type: file
 ---
 contents: |
@@ -260,6 +294,15 @@ signer: kubernetes-ca
 subject:
   CommonName: system:kube-controller-manager
 type: client
+---
+Name: kube-controller-manager-server
+alternateNames:
+- kube-controller-manager.kube-system.svc.cluster.local
+keypairID: "3"
+signer: kubernetes-ca
+subject:
+  CommonName: kube-controller-manager
+type: server
 ---
 CA:
   task:

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
@@ -28,6 +28,8 @@ contents: |
       - --leader-elect=true
       - --root-ca-file=/srv/kubernetes/ca.crt
       - --service-account-private-key-file=/srv/kubernetes/kube-controller-manager/service-account.key
+      - --tls-cert-file=/srv/kubernetes/kube-controller-manager/server.crt
+      - --tls-private-key-file=/srv/kubernetes/kube-controller-manager/server.key
       - --use-service-account-credentials=true
       - --v=2
       - --logtostderr=false
@@ -147,6 +149,10 @@ contents: |
 path: /etc/kubernetes/manifests/kube-controller-manager.manifest
 type: file
 ---
+mode: "0755"
+path: /srv/kubernetes/kube-controller-manager
+type: directory
+---
 contents: |
   -----BEGIN CERTIFICATE-----
   MIIC2DCCAcCgAwIBAgIRALJXAkVj964tq67wMSI8oJQwDQYJKoZIhvcNAQELBQAw
@@ -200,6 +206,34 @@ contents: |
   -----END RSA PRIVATE KEY-----
 mode: "0600"
 path: /srv/kubernetes/kube-controller-manager/ca.key
+type: file
+---
+contents:
+  task:
+    Name: kube-controller-manager-server
+    alternateNames:
+    - kube-controller-manager.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-controller-manager
+    type: server
+mode: "0644"
+path: /srv/kubernetes/kube-controller-manager/server.crt
+type: file
+---
+contents:
+  task:
+    Name: kube-controller-manager-server
+    alternateNames:
+    - kube-controller-manager.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-controller-manager
+    type: server
+mode: "0600"
+path: /srv/kubernetes/kube-controller-manager/server.key
 type: file
 ---
 contents: |
@@ -260,6 +294,15 @@ signer: kubernetes-ca
 subject:
   CommonName: system:kube-controller-manager
 type: client
+---
+Name: kube-controller-manager-server
+alternateNames:
+- kube-controller-manager.kube-system.svc.cluster.local
+keypairID: "3"
+signer: kubernetes-ca
+subject:
+  CommonName: kube-controller-manager
+type: server
 ---
 CA:
   task:

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
@@ -16,6 +16,8 @@ contents: |
       - --authorization-kubeconfig=/var/lib/kube-scheduler/kubeconfig
       - --config=/var/lib/kube-scheduler/config.yaml
       - --leader-elect=true
+      - --tls-cert-file=/srv/kubernetes/kube-scheduler/server.crt
+      - --tls-private-key-file=/srv/kubernetes/kube-scheduler/server.key
       - --v=2
       - --logtostderr=false
       - --alsologtostderr
@@ -38,6 +40,9 @@ contents: |
       - mountPath: /var/lib/kube-scheduler
         name: varlibkubescheduler
         readOnly: true
+      - mountPath: /srv/kubernetes/kube-scheduler
+        name: srvscheduler
+        readOnly: true
       - mountPath: /var/log/kube-scheduler.log
         name: logfile
     hostNetwork: true
@@ -50,10 +55,45 @@ contents: |
         path: /var/lib/kube-scheduler
       name: varlibkubescheduler
     - hostPath:
+        path: /srv/kubernetes/kube-scheduler
+      name: srvscheduler
+    - hostPath:
         path: /var/log/kube-scheduler.log
       name: logfile
   status: {}
 path: /etc/kubernetes/manifests/kube-scheduler.manifest
+type: file
+---
+mode: "0755"
+path: /srv/kubernetes/kube-scheduler
+type: directory
+---
+contents:
+  task:
+    Name: kube-scheduler-server
+    alternateNames:
+    - kube-scheduler.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-scheduler
+    type: server
+mode: "0644"
+path: /srv/kubernetes/kube-scheduler/server.crt
+type: file
+---
+contents:
+  task:
+    Name: kube-scheduler-server
+    alternateNames:
+    - kube-scheduler.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-scheduler
+    type: server
+mode: "0600"
+path: /srv/kubernetes/kube-scheduler/server.key
 type: file
 ---
 contents: |
@@ -109,6 +149,15 @@ signer: kubernetes-ca
 subject:
   CommonName: system:kube-scheduler
 type: client
+---
+Name: kube-scheduler-server
+alternateNames:
+- kube-scheduler.kube-system.svc.cluster.local
+keypairID: "3"
+signer: kubernetes-ca
+subject:
+  CommonName: kube-scheduler
+type: server
 ---
 CA:
   task:

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
@@ -16,6 +16,8 @@ contents: |
       - --authorization-kubeconfig=/var/lib/kube-scheduler/kubeconfig
       - --config=/var/lib/kube-scheduler/config.yaml
       - --leader-elect=true
+      - --tls-cert-file=/srv/kubernetes/kube-scheduler/server.crt
+      - --tls-private-key-file=/srv/kubernetes/kube-scheduler/server.key
       - --v=2
       - --logtostderr=false
       - --alsologtostderr
@@ -38,6 +40,9 @@ contents: |
       - mountPath: /var/lib/kube-scheduler
         name: varlibkubescheduler
         readOnly: true
+      - mountPath: /srv/kubernetes/kube-scheduler
+        name: srvscheduler
+        readOnly: true
       - mountPath: /var/log/kube-scheduler.log
         name: logfile
     hostNetwork: true
@@ -50,10 +55,45 @@ contents: |
         path: /var/lib/kube-scheduler
       name: varlibkubescheduler
     - hostPath:
+        path: /srv/kubernetes/kube-scheduler
+      name: srvscheduler
+    - hostPath:
         path: /var/log/kube-scheduler.log
       name: logfile
   status: {}
 path: /etc/kubernetes/manifests/kube-scheduler.manifest
+type: file
+---
+mode: "0755"
+path: /srv/kubernetes/kube-scheduler
+type: directory
+---
+contents:
+  task:
+    Name: kube-scheduler-server
+    alternateNames:
+    - kube-scheduler.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-scheduler
+    type: server
+mode: "0644"
+path: /srv/kubernetes/kube-scheduler/server.crt
+type: file
+---
+contents:
+  task:
+    Name: kube-scheduler-server
+    alternateNames:
+    - kube-scheduler.kube-system.svc.cluster.local
+    keypairID: "3"
+    signer: kubernetes-ca
+    subject:
+      CommonName: kube-scheduler
+    type: server
+mode: "0600"
+path: /srv/kubernetes/kube-scheduler/server.key
 type: file
 ---
 contents: |
@@ -109,6 +149,15 @@ signer: kubernetes-ca
 subject:
   CommonName: system:kube-scheduler
 type: client
+---
+Name: kube-scheduler-server
+alternateNames:
+- kube-scheduler.kube-system.svc.cluster.local
+keypairID: "3"
+signer: kubernetes-ca
+subject:
+  CommonName: kube-scheduler
+type: server
 ---
 CA:
   task:

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -604,10 +604,14 @@ type KubeControllerManagerConfig struct {
 	ExperimentalClusterSigningDuration *metav1.Duration `json:"experimentalClusterSigningDuration,omitempty" flag:"experimental-cluster-signing-duration"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// TLSCertFile is the file containing the TLS server certificate.
+	TLSCertFile *string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
 	// TLSCipherSuites indicates the allowed TLS cipher suite
 	TLSCipherSuites []string `json:"tlsCipherSuites,omitempty" flag:"tls-cipher-suites"`
 	// TLSMinVersion indicates the minimum TLS version allowed
 	TLSMinVersion string `json:"tlsMinVersion,omitempty" flag:"tls-min-version"`
+	// TLSPrivateKeyFile is the file containing the private key for the TLS server certificate.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 	// MinResyncPeriod indicates the resync period in reflectors.
 	// The resync period will be random between MinResyncPeriod and 2*MinResyncPeriod. (default 12h0m0s)
 	MinResyncPeriod string `json:"minResyncPeriod,omitempty" flag:"min-resync-period"`
@@ -709,6 +713,10 @@ type KubeSchedulerConfig struct {
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
+	// TLSCertFile is the file containing the TLS server certificate.
+	TLSCertFile *string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
+	// TLSPrivateKeyFile is the file containing the private key for the TLS server certificate.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -604,10 +604,14 @@ type KubeControllerManagerConfig struct {
 	ExperimentalClusterSigningDuration *metav1.Duration `json:"experimentalClusterSigningDuration,omitempty" flag:"experimental-cluster-signing-duration"`
 	// FeatureGates is set of key=value pairs that describe feature gates for alpha/experimental features.
 	FeatureGates map[string]string `json:"featureGates,omitempty" flag:"feature-gates"`
+	// TLSCertFile is the file containing the TLS server certificate.
+	TLSCertFile *string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
 	// TLSCipherSuites indicates the allowed TLS cipher suite
 	TLSCipherSuites []string `json:"tlsCipherSuites,omitempty" flag:"tls-cipher-suites"`
 	// TLSMinVersion indicates the minimum TLS version allowed
 	TLSMinVersion string `json:"tlsMinVersion,omitempty" flag:"tls-min-version"`
+	// TLSPrivateKeyFile is the file containing the private key for the TLS server certificate.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 	// MinResyncPeriod indicates the resync period in reflectors.
 	// The resync period will be random between MinResyncPeriod and 2*MinResyncPeriod. (default 12h0m0s)
 	MinResyncPeriod string `json:"minResyncPeriod,omitempty" flag:"min-resync-period"`
@@ -708,6 +712,10 @@ type KubeSchedulerConfig struct {
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
+	// TLSCertFile is the file containing the TLS server certificate.
+	TLSCertFile *string `json:"tlsCertFile,omitempty" flag:"tls-cert-file"`
+	// TLSPrivateKeyFile is the file containing the private key for the TLS server certificate.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty" flag:"tls-private-key-file"`
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4851,8 +4851,10 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.ExperimentalClusterSigningDuration = in.ExperimentalClusterSigningDuration
 	out.FeatureGates = in.FeatureGates
+	out.TLSCertFile = in.TLSCertFile
 	out.TLSCipherSuites = in.TLSCipherSuites
 	out.TLSMinVersion = in.TLSMinVersion
+	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.MinResyncPeriod = in.MinResyncPeriod
 	out.KubeAPIQPS = in.KubeAPIQPS
 	out.KubeAPIBurst = in.KubeAPIBurst
@@ -4918,8 +4920,10 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.HorizontalPodAutoscalerUseRestClients = in.HorizontalPodAutoscalerUseRestClients
 	out.ExperimentalClusterSigningDuration = in.ExperimentalClusterSigningDuration
 	out.FeatureGates = in.FeatureGates
+	out.TLSCertFile = in.TLSCertFile
 	out.TLSCipherSuites = in.TLSCipherSuites
 	out.TLSMinVersion = in.TLSMinVersion
+	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.MinResyncPeriod = in.MinResyncPeriod
 	out.KubeAPIQPS = in.KubeAPIQPS
 	out.KubeAPIBurst = in.KubeAPIBurst
@@ -5091,6 +5095,8 @@ func autoConvert_v1alpha2_KubeSchedulerConfig_To_kops_KubeSchedulerConfig(in *Ku
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.EnableProfiling = in.EnableProfiling
+	out.TLSCertFile = in.TLSCertFile
+	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	return nil
 }
 
@@ -5122,6 +5128,8 @@ func autoConvert_kops_KubeSchedulerConfig_To_v1alpha2_KubeSchedulerConfig(in *ko
 	out.AuthorizationKubeconfig = in.AuthorizationKubeconfig
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.EnableProfiling = in.EnableProfiling
+	out.TLSCertFile = in.TLSCertFile
+	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2961,6 +2961,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 			(*out)[key] = val
 		}
 	}
+	if in.TLSCertFile != nil {
+		in, out := &in.TLSCertFile, &out.TLSCertFile
+		*out = new(string)
+		**out = **in
+	}
 	if in.TLSCipherSuites != nil {
 		in, out := &in.TLSCipherSuites, &out.TLSCipherSuites
 		*out = make([]string, len(*in))
@@ -3196,6 +3201,11 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 	if in.EnableProfiling != nil {
 		in, out := &in.EnableProfiling, &out.EnableProfiling
 		*out = new(bool)
+		**out = **in
+	}
+	if in.TLSCertFile != nil {
+		in, out := &in.TLSCertFile, &out.TLSCertFile
+		*out = new(string)
 		**out = **in
 	}
 	return

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -3127,6 +3127,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 			(*out)[key] = val
 		}
 	}
+	if in.TLSCertFile != nil {
+		in, out := &in.TLSCertFile, &out.TLSCertFile
+		*out = new(string)
+		**out = **in
+	}
 	if in.TLSCipherSuites != nil {
 		in, out := &in.TLSCipherSuites, &out.TLSCipherSuites
 		*out = make([]string, len(*in))
@@ -3362,6 +3367,11 @@ func (in *KubeSchedulerConfig) DeepCopyInto(out *KubeSchedulerConfig) {
 	if in.EnableProfiling != nil {
 		in, out := &in.EnableProfiling, &out.EnableProfiling
 		*out = new(bool)
+		**out = **in
+	}
+	if in.TLSCertFile != nil {
+		in, out := &in.TLSCertFile, &out.TLSCertFile
+		*out = new(string)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
Fixes #12016 

I put in an escape hatch: setting `tlsCertFile: ""` in the respective componentconfig will revert to the previous behavior of using a self-signed cert.