### PR TITLE
keypair rotation - export new credentials between promote and distruts

### DIFF
--- a/tests/e2e/scenarios/keypair-rotation/run-test.sh
+++ b/tests/e2e/scenarios/keypair-rotation/run-test.sh
@@ -40,6 +40,11 @@ ${KOPS} promote keypair all
 ${KOPS} update cluster --yes
 ${KOPS} rolling-update cluster --yes --validate-count=10
 
+KUBECFG_PROMOTE=$(mktemp -t kubeconfig.XXXXXXXXX)
+${KOPS} export kubecfg --admin --kubeconfig="${KUBECFG_PROMOTE}"
+kubectl --kubeconfig="${KUBECFG_PROMOTE}" config view > "${REPORT_DIR}/promote.kubeconfig"
+
+export KUBECONFIG="${KUBECFG_PROMOTE}"
 ${KOPS} validate cluster --wait=10m --count=3
 
 ${KOPS} distrust keypair all


### PR DESCRIPTION
The test is now failing during the third `rolling-update` (after `distrust`) with unauthorized errors:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-keypair-rotation/1417620742954029056

`I0721 00:38:31.819943    4501 instancegroups.go:513] Cluster did not validate within deadline: error listing nodes: Unauthorized.`

Rereading [the docs](https://kops.sigs.k8s.io/operations/rotate-secrets/#export-and-distribute-new-kubeconfig-admin-credentials), it seems like we _do_ need to export new credentials after promoting the new CA and before distrusting the old CA, that way the credentials will be signed from the new CA.

followup to https://github.com/kubernetes/kops/pull/12029