### PR TITLE
Add Option to Specify OpenStack Octavia Provider

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -1057,8 +1057,17 @@ func completeOpenstackLBSubnet(cmd *cobra.Command, args []string, toComplete str
 }
 
 func completeOpenstackOctaviaProvider(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	// TODO call into cloud provider to get list of Octavia providers
-	return nil, cobra.ShellCompDirectiveNoFileComp
+	providers := []string{
+		"a10",
+		"amphora",
+		"amphorav2",
+		"f5",
+		"octavia",
+		"ovn",
+		"radware",
+		"vmwareedge",
+	}
+	return providers, cobra.ShellCompDirectiveNoFileComp
 }
 
 func completeOpenstackDNSServers(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -419,6 +419,8 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	cmd.RegisterFlagCompletionFunc("os-lb-floating-subnet", completeOpenstackLBSubnet)
 	cmd.Flags().BoolVar(&options.OpenstackStorageIgnoreAZ, "os-kubelet-ignore-az", options.OpenstackStorageIgnoreAZ, "Attach volumes across availability zones")
 	cmd.Flags().BoolVar(&options.OpenstackLBOctavia, "os-octavia", options.OpenstackLBOctavia, "Use octavia loadbalancer API")
+	cmd.Flags().StringVar(&options.OpenstackOctaviaProvider, "os-octavia-provider", options.OpenstackOctaviaProvider, "Octavia provider to use")
+	cmd.RegisterFlagCompletionFunc("os-octavia-provider", completeOpenstackOctaviaProvider)
 	cmd.Flags().StringVar(&options.OpenstackDNSServers, "os-dns-servers", options.OpenstackDNSServers, "comma separated list of DNS Servers which is used in network")
 	cmd.RegisterFlagCompletionFunc("os-dns-servers", completeOpenstackDNSServers)
 	cmd.Flags().StringVar(&options.OpenstackNetworkID, "os-network", options.OpenstackNetworkID, "ID of the existing OpenStack network to use")
@@ -1051,6 +1053,11 @@ func completeOpenstackExternalSubnet(cmd *cobra.Command, args []string, toComple
 
 func completeOpenstackLBSubnet(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// TODO call into cloud provider to get list of external subnets
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeOpenstackOctaviaProvider(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// TODO call into cloud provider to get list of Octavia providers
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -109,6 +109,7 @@ kops create cluster [CLUSTER] [flags]
       --os-lb-floating-subnet string     External subnet to use with the kubernetes api
       --os-network string                ID of the existing OpenStack network to use
       --os-octavia                       Use octavia loadbalancer API
+      --os-octavia-provider string       Octavia provider to use
       --out string                       Path to write any local output
   -o, --output string                    Output format. One of json or yaml. Used with the --dry-run flag.
       --project string                   Project to use (must be set on GCE)

--- a/docs/getting_started/openstack.md
+++ b/docs/getting_started/openstack.md
@@ -80,6 +80,7 @@ kops delete cluster my-cluster.k8s.local --yes
 * `--os-kubelet-ignore-az=true` Nova and Cinder have different availability zones, more information [Kubernetes docs](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#block-storage)
 * `--os-octavia=true` If Octavia Loadbalancer api should be used instead of old lbaas v2 api.
 * `--os-dns-servers=8.8.8.8,8.8.4.4` You can define dns servers to be used in your cluster if your openstack setup does not have working dnssetup by default
+* `--os-octavia-provider` You can define the Octavia Loadbalancer provider to use. To get the list of providers available in your environment, run `openstack loadbalancer provider list`. Default: octavia.
 
 
 ## Compute and volume zone names does not match

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -101,7 +101,8 @@ type NewClusterOptions struct {
 	OpenstackDNSServers      string
 	OpenstackLBSubnet        string
 	// OpenstackLBOctavia is whether to use use octavia instead of haproxy.
-	OpenstackLBOctavia bool
+	OpenstackLBOctavia       bool
+	OpenstackOctaviaProvider string
 
 	AzureSubscriptionID    string
 	AzureTenantID          string
@@ -1115,7 +1116,11 @@ func initializeOpenstackAPI(opt *NewClusterOptions, cluster *api.Cluster) {
 		cluster.Spec.API.LoadBalancer = &api.LoadBalancerAccessSpec{}
 		provider := "haproxy"
 		if opt.OpenstackLBOctavia {
-			provider = "octavia"
+			if opt.OpenstackOctaviaProvider != "" {
+				provider = opt.OpenstackOctaviaProvider
+			} else {
+				provider = "octavia"
+			}
 		}
 
 		cluster.Spec.CloudConfig.Openstack.Loadbalancer = &api.OpenstackLoadbalancerConfig{


### PR DESCRIPTION
In newer version of OpenStack, there are multiple octavia provider to
choose from instead of only "octavia" as provider. This commit added a
command line option "os-octavia-provider", enabling user to specify the
octavia provider that will be use to create load balancers.