### PR TITLE
Automated cherry pick of #12043: Use regional STS endpoint

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_authenticator.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_authenticator.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"k8s.io/kops/upup/pkg/fi"
@@ -57,13 +58,16 @@ func RegionFromMetadata(ctx context.Context) (string, error) {
 }
 
 func NewAWSAuthenticator(region string) (fi.Authenticator, error) {
-	config := aws.NewConfig().WithCredentialsChainVerboseErrors(true).WithRegion(region)
+	config := aws.NewConfig().
+		WithCredentialsChainVerboseErrors(true).
+		WithRegion(region).
+		WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)
 	sess, err := session.NewSession(config)
 	if err != nil {
 		return nil, err
 	}
 	return &awsAuthenticator{
-		sts: sts.New(sess),
+		sts: sts.New(sess, config),
 	}, nil
 }
 

--- a/upup/pkg/fi/cloudup/awsup/aws_verifier.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_verifier.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -59,13 +60,16 @@ type awsVerifier struct {
 var _ fi.Verifier = &awsVerifier{}
 
 func NewAWSVerifier(opt *AWSVerifierOptions) (fi.Verifier, error) {
-	config := aws.NewConfig().WithCredentialsChainVerboseErrors(true).WithRegion(opt.Region)
+	config := aws.NewConfig().
+		WithCredentialsChainVerboseErrors(true).
+		WithRegion(opt.Region).
+		WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)
 	sess, err := session.NewSession(config)
 	if err != nil {
 		return nil, err
 	}
 
-	stsClient := sts.New(sess)
+	stsClient := sts.New(sess, config)
 	identity, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry pick of #12043 on release-1.21.

#12043: Use regional STS endpoint

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.