### PR TITLE
Disallow the use of legacy addons

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -1,3 +1,5 @@
 ## Addons
 
-Read on [addons](../docs/addons.md)
+**Legacy addons are deprecated and unmaintained!!!**
+
+Use [managed addons](../docs/addons.md) instead.

--- a/channels/pkg/cmd/BUILD.bazel
+++ b/channels/pkg/cmd/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//channels/pkg/channels:go_default_library",
+        "//pkg/apis/kops/util:go_default_library",
         "//util/pkg/tables:go_default_library",
         "//vendor/github.com/blang/semver/v4:go_default_library",
         "//vendor/github.com/jetstack/cert-manager/pkg/client/clientset/versioned:go_default_library",
@@ -25,5 +26,6 @@ go_library(
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/docs/releases/1.22-NOTES.md
+++ b/docs/releases/1.22-NOTES.md
@@ -40,6 +40,8 @@ spec:
 
 * Support for Kubernetes versions 1.15 and 1.16 has been removed.
 
+* The legacy addons from `https://github.com/kubernetes/kops/tree/master/addons` have been deprecated and will not be available in Kubernetes 1.23+. Use [managed addons](https://kops.sigs.k8s.io/addons) instead.
+
 * The legacy location for downloads `s3://https://kubeupv2.s3.amazonaws.com/kops/` has been deprecated and will not be used for new releases. The new canonical downloads location is `https://artifacts.k8s.io/binaries/kops/`.
 
 * The `assets` phase of `kops update cluster` has been removed. It is replaced by the new `kops get assets --copy` command.
@@ -76,9 +78,7 @@ spec:
 
 * Support for Ubuntu 18.04 (Bionic) is deprecated and will be removed in future versions of kOps.
 
-* The [manifest based metrics server addon](https://github.com/kubernetes/kops/tree/master/addons/metrics-server) has been deprecated in favour of a configurable addon.
-
-* The [manifest based cluster autoscaler addon](https://github.com/kubernetes/kops/tree/master/addons/cluster-autoscaler) has been deprecated in favour of a configurable addon.
+* All legacy addons are deprecated in favor of managed addons, including the [metrics server addon](https://github.com/kubernetes/kops/tree/master/addons/metrics-server) and the [autoscaler addon](https://github.com/kubernetes/kops/tree/master/addons/cluster-autoscaler).
 
 * The `node-role.kubernetes.io/master` and `kubernetes.io/role` labels are deprecated and might be removed from control plane nodes in kOps 1.23.
 


### PR DESCRIPTION
These are no longer maintained and kept around to not break very old versions of kOps.

/cc @olemarkus @johngmyers @rifelpet 