### PR TITLE
Update Ubuntu image

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -58,11 +58,11 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210518
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210720
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210518
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20210720
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0"


### PR DESCRIPTION
It seems 20210518 was deleted from all regions except cn-north-1 and cn-northwest-1.

Ref: https://cloud-images.ubuntu.com/locator/ec2/

Fixes #12069 