### PR TITLE
Cleanup various references to LaunchConfigurations

### DIFF
--- a/docs/boot-sequence.md
+++ b/docs/boot-sequence.md
@@ -11,7 +11,7 @@ of all flags that will be passed to all components. All decisions about how to i
 cluster are made at this stage, and thus every decision can in theory be changed if the user
 specifies a value in the spec.
 
-This complete specification is set in the launch configuration for the AutoScaling Group (on AWS),
+This complete specification is set in the LaunchTemplate for the AutoScaling Group (on AWS),
 or the Managed Instance Group (on GCE).
 
 On both AWS & GCE, everything (nodes & masters) runs in an ASG/MIG; this means that failures

--- a/docs/contributing/adding_a_feature.md
+++ b/docs/contributing/adding_a_feature.md
@@ -279,7 +279,7 @@ Users would simply `kops edit cluster`, and add a value like:
 ```
 
 Then `kops update cluster --yes` would create the new NodeUpConfig, which is included in the instance startup script
-and thus requires a new LaunchConfiguration, and thus a `kops-rolling update`.  We're working on changing settings
+and thus requires a new LaunchTemplate version, and thus a `kops-rolling update`.  We're working on changing settings
 without requiring a reboot, but likely for this particular setting it isn't the sort of thing you need to change
 very often.
 

--- a/docs/security_groups.md
+++ b/docs/security_groups.md
@@ -41,7 +41,7 @@ spec:
 
 ```
 
-Now run a cluster update to create the new launch configuration, using [lifecycle overrides](./cli/kops_update_cluster.md#options) to prevent Security Group resources from being created:
+Now run a cluster update to create the new LaunchTemplateVersion, using [lifecycle overrides](./cli/kops_update_cluster.md#options) to prevent Security Group resources from being created:
 
 ```shell
 kops update cluster ${CLUSTER_NAME} --yes --lifecycle-overrides SecurityGroup=ExistsAndWarnIfChanges,SecurityGroupRule=ExistsAndWarnIfChanges
@@ -49,7 +49,7 @@ kops update cluster ${CLUSTER_NAME} --yes --lifecycle-overrides SecurityGroup=Ex
 
 *Every time `kops update cluster` is run, it must include the above `--lifecycle-overrides`.*
 
-Then perform a rolling update in order to replace EC2 instances in the ASG with the new launch configuration:
+Then perform a rolling update in order to replace EC2 instances in the ASG with the new LaunchTemplateVersion:
 
 ```shell
 kops rolling-update cluster ${CLUSTER_NAME} --yes

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -134,7 +134,7 @@ Ps: You don't have to `kops delete cluster` if you just want to recreate from sc
 
 #### `kops rolling-update` might be needed after editing the cluster
 
-Changes made with `kops edit` (like enabling RBAC and / or feature gates) will result in changes to the launch configuration of your cluster nodes. After a `terraform apply`, they won't be applied right away since terraform will not launch new instances as part of that.
+Changes made with `kops edit` (like enabling RBAC and / or feature gates) will result in changes to the LaunchTemplate of your cluster nodes. After a `terraform apply`, they won't be applied right away since terraform will not launch new instances as part of that.
 
 To see your changes applied to the cluster you'll also need to run `kops rolling-update` after running `terraform apply`. This will ensure that all nodes' changes have the desired settings configured with `kops edit`.
 

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -875,11 +875,9 @@ spec:
                     attached to the instance group
                   properties:
                     deleteOnTermination:
-                      description: 'DeleteOnTermination configures volume retention
+                      description: DeleteOnTermination configures volume retention
                         policy upon instance termination. The volume is deleted by
                         default. Cluster deletion does not remove retained volumes.
-                        NOTE: This setting applies only to the Launch Configuration
-                        and does not affect Launch Templates.'
                       type: boolean
                     device:
                       description: Device is an optional device name of the block

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -245,7 +245,6 @@ type UserData struct {
 type VolumeSpec struct {
 	// DeleteOnTermination configures volume retention policy upon instance termination.
 	// The volume is deleted by default. Cluster deletion does not remove retained volumes.
-	// NOTE: This setting applies only to the Launch Configuration and does not affect Launch Templates.
 	DeleteOnTermination *bool `json:"deleteOnTermination,omitempty"`
 	// Device is an optional device name of the block device
 	Device string `json:"device,omitempty"`

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -199,7 +199,6 @@ type UserData struct {
 type VolumeSpec struct {
 	// DeleteOnTermination configures volume retention policy upon instance termination.
 	// The volume is deleted by default. Cluster deletion does not remove retained volumes.
-	// NOTE: This setting applies only to the Launch Configuration and does not affect Launch Templates.
 	DeleteOnTermination *bool `json:"deleteOnTermination,omitempty"`
 	// Device is an optional device name of the block device
 	Device string `json:"device,omitempty"`

--- a/pkg/model/awsmodel/autoscalinggroup_test.go
+++ b/pkg/model/awsmodel/autoscalinggroup_test.go
@@ -132,7 +132,7 @@ func TestAPIServerAdditionalSecurityGroupsWithNLB(t *testing.T) {
 		_roleCount
 	)
 	igs := make([]*kops.InstanceGroup, _roleCount)
-	// NB: (*AutoscalingGroupModelBuilder).buildLaunchConfigurationTask expects there to be at least
+	// NB: (*AutoscalingGroupModelBuilder).buildLaunchTemplateTask expects there to be at least
 	// one subnet specified in each InstanceGroup.
 	subnets := []string{cluster.Spec.Subnets[0].Name}
 	igs[roleBastion] = &kops.InstanceGroup{


### PR DESCRIPTION
The note in the API documentation is incorrect, the field _is_ used in LaunchTemplates:

https://github.com/kubernetes/kops/blob/a0a6e3c9741df4d647018aa7072be5f2e2640bd2/pkg/model/awsmodel/autoscalinggroup.go#L250-L253