### PR TITLE
Fix cluster list action

### DIFF
--- a/cmd/kops/get_cluster.go
+++ b/cmd/kops/get_cluster.go
@@ -100,8 +100,8 @@ func NewCmdGetCluster(f *util.Factory, out io.Writer, getOptions *GetOptions) *c
 					return fmt.Errorf("cannot mix --name for cluster with positional arguments")
 				}
 				options.ClusterNames = append(options.ClusterNames, args...)
-			} else {
-				options.ClusterNames = append(options.ClusterNames, rootCommand.ClusterName(true))
+			} else if rootCommand.clusterName != "" {
+				options.ClusterNames = append(options.ClusterNames, rootCommand.clusterName)
 			}
 
 			return nil


### PR DESCRIPTION
Restoring the behaviour of `kops get cluster`, where it lists clusters
even if one is configured in kubeconfig.
