### PR TITLE
Set SilenceUsage on root so we don't print usage

### DIFF
--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -86,6 +86,7 @@ var rootCommand = RootCmd{
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
 		},
+		SilenceUsage: true,
 	},
 }
 


### PR DESCRIPTION
As we're removing exitWithError, we can use this option instead.
