### PR TITLE
GCE: TargetPool should ignore Lifecycle field

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/targetpool.go
+++ b/upup/pkg/fi/cloudup/gcetasks/targetpool.go
@@ -55,6 +55,9 @@ func (e *TargetPool) Find(c *fi.Context) (*TargetPool, error) {
 	actual := &TargetPool{}
 	actual.Name = fi.String(r.Name)
 
+	// Avoid spurious changes
+	actual.Lifecycle = e.Lifecycle
+
 	return actual, nil
 }
 


### PR DESCRIPTION
It's an internal field, it shouldn't be detected as a change to apply.
