### PR TITLE
Use SHA-256 for manifest hashes

### DIFF
--- a/channels/pkg/api/channel.go
+++ b/channels/pkg/api/channel.go
@@ -46,7 +46,7 @@ type AddonSpec struct {
 	// Manifest is the URL to the manifest that should be applied
 	Manifest *string `json:"manifest,omitempty"`
 
-	// Manifesthash is the sha1 hash of our manifest
+	// Manifesthash is the sha256 hash of our manifest
 	ManifestHash string `json:"manifestHash,omitempty"`
 
 	// KubernetesVersion is a semver version range on which this version of the addon can be applied

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,54 +6,54 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 886d0565bb011313ee94e8497700550b415eea75
+    manifestHash: ad4c88257aa1b1d05c38bfee630eb6cad07b3e258932dafc37b76d7328f3a8ff
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6129cb5aee3fefdb46667a555c8acd3135be692d
+    manifestHash: 8859d71bf831e87ed1be393a4ca9ff595194086d6734c650f80a53ba45657534
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 59b5f2a0fd6f5fb558c6bb85a38f0236f4ef840f
+    manifestHash: b6aff592b9959ae8c1c41a269230eaf8fe5102eb0e4218400884d5864a059e12
     name: certmanager.io
     selector: null
   - id: k8s-1.9
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 6ae4f2302a6405b54ecf5750cb2576f7bd82a585
+    manifestHash: cbb9621daaefe9546a21d36c0d3408e79ef944f0fb04c9dbb422c3f4a5149523
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:
       k8s-addon: aws-load-balancer-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dedbce90310c5fecae0f9d7d65e538c1a26533a9
+    manifestHash: ee2aa1a739e11b25bd26c2f7e98e26e56ddef656407e776133a728237065ec6b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 374ba0d0c6ffc9b03f2660c8bf4f4adb9106c3ee
+    manifestHash: a7d364ac4af7dec1a4e282872231dc777aaaa50e07722da7dbcdff944f3a7206
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: da9adc29a2de02b2b8fb874d5bbba4b71b219636
+    manifestHash: d60f4d78ab846a1003f9436566717d8349adbc449c12e82aada17ccac0b3ef18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 77a257dadddae9f7cd65122b8c6291336b83e455
+    manifestHash: ba1f83d5a45e9ac12a4aa8691b77cc07524de0bcac9e679a83e873a79714d8ae
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7405cb34ded003feb5a3e26e530a0ca0fa152c4a
+    manifestHash: d43eeca6e4ac74ee186e55e3bb4b8e97042a8b8c8862002f8473a9a6cff5bbfa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4bf70265918e2ac449da4f3de79af9dc0b792a1e
+    manifestHash: 3f19bf292e40f09c3b53b3dff034e423ee68e4ee2536b8daa0f8b2bd3847727d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8de345f2fbe441e8a2565558cdc661c5a75af34e
+    manifestHash: 0cf9dd275a28bbb2981d8006841dd222e0bb9a240c906e764583204aff7d39cd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 240b25a70a95b64be8ee35146b2be50627beb6f9
+    manifestHash: 94e66a4cff79f947df52dbd45258f2700668ad456ebb7c4ba0d89a6279e1fdd6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,54 +6,54 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e45a6ae2df1f26dae1266beb9f1fbfd27982e2de
+    manifestHash: 991c0f6ee88480c5bfcad256a7406bc6322a21a02c2e80299c79ed4e678972ee
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
-    manifestHash: 38ba4e0078bb1225421114f76f121c2277ca92ac
+    manifestHash: f81bd7c57bc1902ca342635d7ad7d01b82dfeaff01a1192b076e66907d87871e
     name: rbac.addons.k8s.io
     selector:
       k8s-addon: rbac.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 0ef78f6df3e5eff8d2461615b2631489c27f1053
+    manifestHash: af41a97afb5a5b3c2c35046c634309400d43d3e1e8b57a691c63e45a9349ed38
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.7.0
     manifest: storage-gce.addons.k8s.io/v1.7.0.yaml
-    manifestHash: f3c1d70f1152e3443a46b33a4d18ce0593ad7d9d
+    manifestHash: 101aceff3d82b4d7066f75fdf537f272eccec6da767d508e2a72bff5e11b0b6d
     name: storage-gce.addons.k8s.io
     selector:
       k8s-addon: storage-gce.addons.k8s.io
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 56ca6de90de20ab5c1ef498b2e85915c3401fdf2
+    manifestHash: 29c78a908980393b0707da7501f2b00025cd24cc62d2605083f9d77e8f3eb40f
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 886d0565bb011313ee94e8497700550b415eea75
+    manifestHash: ad4c88257aa1b1d05c38bfee630eb6cad07b3e258932dafc37b76d7328f3a8ff
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,85 +6,85 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 886d0565bb011313ee94e8497700550b415eea75
+    manifestHash: ad4c88257aa1b1d05c38bfee630eb6cad07b3e258932dafc37b76d7328f3a8ff
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8ed1f809a67af62d540a6fc8b79024f9edeeb9fd
+    manifestHash: 76d9f2ce68086d6287714e810e4fa93f544bc6cb2ef69f25662341b879e96a16
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: e3090416f2a4311b5232a7bea5227160026203fc
+    manifestHash: d3af566737e6e887aae943c29292e5bc033efb0b77bccca3c027c72f66883fda
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 59b5f2a0fd6f5fb558c6bb85a38f0236f4ef840f
+    manifestHash: b6aff592b9959ae8c1c41a269230eaf8fe5102eb0e4218400884d5864a059e12
     name: certmanager.io
     selector: null
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: f999ebfa0df933d11efa7ba5f837b164d75202b1
+    manifestHash: 74c5be2d69091521e7dca1fbadeef7548ce4277791ae161a6097400a57fcd889
     name: node-termination-handler.aws
     selector:
       k8s-addon: node-termination-handler.aws
   - id: k8s-1.9
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 6d8592fb6cd8148af794e0b6203135958a3479ce
+    manifestHash: 23333feb49854bd64d0dfffb155828765419d1d770d0251f733851d27ced7b11
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:
       k8s-addon: aws-load-balancer-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5c1fbf80ac8c9448b050707ddbdf4aa4dd145182
+    manifestHash: 4e2cda50cd5048133aad1b5e28becb60f4629d3f9e09c514a2757c27998b4200
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 7e7e8107d1a8cf34add80b9c026aad6e21e0e144
+    manifestHash: 3f10cffef443c2f18c3cab72a44e64ca4342fde13a88a5ffcff4291e35450b25
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: dacfe709fa608b7952a7a3cac3941c09fab495c2
+    manifestHash: 3cb088c84aaa49afed34e8dc0d2a97cf013a173f719b8cfa5e14f367306f6d92
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: 6a301ca721d26b7fa971c00dc8b8770bf6ca3cfd
+    manifestHash: a4c05a02f8f82706827a71f5aa034dcc21915affe51ecda0498689a2884f4542
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 886d0565bb011313ee94e8497700550b415eea75
+    manifestHash: ad4c88257aa1b1d05c38bfee630eb6cad07b3e258932dafc37b76d7328f3a8ff
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0e41ecd94fcefc9dfabde7b958cf260094dde1ac
+    manifestHash: ca94735a98ab073f6d9248e0d0dfccbb953c8a7b46870719b71515fe52d85775
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-json/data/aws_s3_bucket_object_minimal-json.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-json/data/aws_s3_bucket_object_minimal-json.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 03067811a6653ced8d79103e9bc2ace9e8d3f899
+    manifestHash: 3e027c505af6993b6847c5bb209e472ced1e180515ba66a8034845f236896f2e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,55 +6,55 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fd583edec44148369140b1f326647db0feaffb44
+    manifestHash: bf997379666e6c9e6551eca29d56df79b437a476a5abe6c24b4f0483db5b6ca4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5c1fbf80ac8c9448b050707ddbdf4aa4dd145182
+    manifestHash: 4e2cda50cd5048133aad1b5e28becb60f4629d3f9e09c514a2757c27998b4200
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: b610216c1cb455dd41cd42d95c357c4ff99db4dd
+    manifestHash: 04fd75ba7cc8558332aa3239b430e119ea66f21d7c269afb077c6a5e17dfcf8f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 81765d0e2851b59f1741ed40c8bae7336224536e
+    manifestHash: bbb091c525f691a78ce4d470a1cf7fa4d657f5c005b2238fc187a081e1b81864
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 886d0565bb011313ee94e8497700550b415eea75
+    manifestHash: ad4c88257aa1b1d05c38bfee630eb6cad07b3e258932dafc37b76d7328f3a8ff
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,54 +6,54 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bc3596c636e5d51608fb8e2d3d21597ab8c4d89f
+    manifestHash: 06c670a03cd6454a180bd37944e9aadc9e8fd6da16cbbcacd842e5072d263f17
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
-    manifestHash: 38ba4e0078bb1225421114f76f121c2277ca92ac
+    manifestHash: f81bd7c57bc1902ca342635d7ad7d01b82dfeaff01a1192b076e66907d87871e
     name: rbac.addons.k8s.io
     selector:
       k8s-addon: rbac.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 0ef78f6df3e5eff8d2461615b2631489c27f1053
+    manifestHash: af41a97afb5a5b3c2c35046c634309400d43d3e1e8b57a691c63e45a9349ed38
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.7.0
     manifest: storage-gce.addons.k8s.io/v1.7.0.yaml
-    manifestHash: f3c1d70f1152e3443a46b33a4d18ce0593ad7d9d
+    manifestHash: 101aceff3d82b4d7066f75fdf537f272eccec6da767d508e2a72bff5e11b0b6d
     name: storage-gce.addons.k8s.io
     selector:
       k8s-addon: storage-gce.addons.k8s.io
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 56ca6de90de20ab5c1ef498b2e85915c3401fdf2
+    manifestHash: 29c78a908980393b0707da7501f2b00025cd24cc62d2605083f9d77e8f3eb40f
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,54 +6,54 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 83134476c186a4dc815ce05c9556a1e49ed86e03
+    manifestHash: aedba4516c0b5853ca5c7957854980aca30e25347f2eaed1b2cc7260281db7a8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
-    manifestHash: 38ba4e0078bb1225421114f76f121c2277ca92ac
+    manifestHash: f81bd7c57bc1902ca342635d7ad7d01b82dfeaff01a1192b076e66907d87871e
     name: rbac.addons.k8s.io
     selector:
       k8s-addon: rbac.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 0ef78f6df3e5eff8d2461615b2631489c27f1053
+    manifestHash: af41a97afb5a5b3c2c35046c634309400d43d3e1e8b57a691c63e45a9349ed38
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.7.0
     manifest: storage-gce.addons.k8s.io/v1.7.0.yaml
-    manifestHash: f3c1d70f1152e3443a46b33a4d18ce0593ad7d9d
+    manifestHash: 101aceff3d82b4d7066f75fdf537f272eccec6da767d508e2a72bff5e11b0b6d
     name: storage-gce.addons.k8s.io
     selector:
       k8s-addon: storage-gce.addons.k8s.io
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 56ca6de90de20ab5c1ef498b2e85915c3401fdf2
+    manifestHash: 29c78a908980393b0707da7501f2b00025cd24cc62d2605083f9d77e8f3eb40f
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7ff6f92b7f559554a96b75a57828dc9d46f4f287
+    manifestHash: 75e9ab488690e8a63e97bf3b89296d6c98b75f055d9b0aad850266530d650e45
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 352734471d8de02cfa07dc346454d4cdd57db0e9
+    manifestHash: 23f5cbf35dd1a39376bb87b888b142d768fa108bd608417b98d4280b410c5e8e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 20370bdb982724d0c6a8849c02457407f189dfa1
+    manifestHash: 01b84e11ed5e3a2d9976f68823ce8520bb4a52745fca86b0b505a49b1e2533dc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 20370bdb982724d0c6a8849c02457407f189dfa1
+    manifestHash: 01b84e11ed5e3a2d9976f68823ce8520bb4a52745fca86b0b505a49b1e2533dc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-bootstrap_content
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7fdc6e5ba7da930bab2cd5a766a1cd2df8831302
+    manifestHash: 48733192bcfefc881c51f6aa953348270cf3ec51bbbce294b17980025f63294b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: 4959667b24bdb70ded01a59a2c502ef197b0d8f4
+    manifestHash: 60d44ad0227aad24f8d35242da335e7b2c046de3936597a744cba0e55a579fec
     name: node-termination-handler.aws
     selector:
       k8s-addon: node-termination-handler.aws
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 67d84e42d1d7c1a762f7c2cae61bf1c02afdfa39
+    manifestHash: 734c2c19f8aac3a179cbd5a571f8c6d124a337fe45df2b9ce62139e1d5794fd8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8507c029438ab13738e1c9005a8d37fce804dece
+    manifestHash: 7a60e0e243657f3cd438b1bb313830abad4e2c8af536d2cb779b8e8124b0c054
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 621970bdb4c61961c1097c2b37b0c87714a72959
+    manifestHash: 3120730cb8e90c0274cd56524a64156101147381184d38ea35fddffac5cd6bb7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.projectcalico.org/k8s-1.16.yaml
-    manifestHash: 840a1a95f1bfd15a79bee24cbdc0723063148691
+    manifestHash: fd80f641a123f65d1c4a5c807648951e8dc1b3cfc684e959377036f9af8b2e4f
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 40245cec338f42d70a90618012debd1aca6e5012
+    manifestHash: 57777bc2a01242d70c48a2982b6e0d9bc07039d3b94f291cecdcdafc4ed0fc76
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.projectcalico.org.canal/k8s-1.16.yaml
-    manifestHash: 73de5bf6031757038b0ae6abc34b3d589e7ea394
+    manifestHash: 95eac57e6511368d555dde5c7e50ed95f5b6e9bec9c65c4e846fe8b0437edeef
     name: networking.projectcalico.org.canal
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9f6271b814b9b3e45bb110c3c07abd793d55f2a9
+    manifestHash: 44a5f10bebbc0128fa6a0172601a4cc3a185b8687bf429a124bec0ae9970ffdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: d801eb85019c902dca6d25866b52f77ec79aa2db
+    manifestHash: aac64a032ef26caf615abc009b87d039a70737428e35410d9de57b95507bf891
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,54 +6,54 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 405d355d10ff00ded5d9f1868bebcee19cb38a24
+    manifestHash: 31d7e99a93caf1ddb7f8837680113c275dd5220aba7b1640a20f078c02e89e91
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 470684b80af41aa53c25bc5ac1a78b259c93336b
+    manifestHash: 0325578894a58aa80552729f3f2077360f8211b64e650c6603efbf0a8b8fddfd
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
-    manifestHash: 38ba4e0078bb1225421114f76f121c2277ca92ac
+    manifestHash: f81bd7c57bc1902ca342635d7ad7d01b82dfeaff01a1192b076e66907d87871e
     name: rbac.addons.k8s.io
     selector:
       k8s-addon: rbac.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: networking.cilium.io/k8s-1.12-v1.8.yaml
-    manifestHash: 89773466c5bff25483956f2c479b928234585ed0
+    manifestHash: f4eb8cc3bc5a8c402c357bec19bb3668edc2d9b65f29c5afd3d62a42dbaf9786
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 33475ed81f9917f3b9304066ba5f9b42eb419ff7
+    manifestHash: 05260aa4d7f0635ec25669974d236f7aa410b70ca2f06440fdf77b05a8005c32
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 518a28569023ee7f179b319581ef56cefcba2504
+    manifestHash: 5e5bd5f13fedc1a8b9edfd0f7e81d1c411452442151896cb8e8f9ef49a932b23
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d4e2336ffa617497b1b8c2995f52c56554593bd7
+    manifestHash: 5776f85e5aaba08d6b5e52b3a963ccde9ad7402f36a11ff7ed7cbdcd59824693
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 66bab5f68aa6916bc02172095333f37961cf429d
+    manifestHash: dd054f335676beae5671a437a90aa69209e32791df00bd9dc9e75d05cf3366ab
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 029ade650920ee77d6d4205fefe9c78852a81b99
+    manifestHash: 3f14f8869934001778849837c28217709bf4f1c593d3acdbde9cdf1d97ac47f3
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: eaa19bce7d8fa95f04b25c6bf72b355ff0cd3724
+    manifestHash: 7d61e209dc174119f3bbea8288d6ca46fa22a77bd4597f032b74b5cdddb6626c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 574c94baaa31a75ea83f10565572e9d66944f260
+    manifestHash: 4691a86a2a04e84df92dfe85f91ed626e7750bbeac57e23b8f62addfef375931
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8b3f7bc0eb97d290b7dfa5cab5fd3295a65faf63
+    manifestHash: e4539d56e182e4eafb66bb5f9fc4b50642d39a509459cbb6b0e0e05848ae61cb
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: networking.flannel/k8s-1.12.yaml
-    manifestHash: 9f1c852ae7a7dcc55c9f8de3f1dba18cdb208b5f
+    manifestHash: b273910fdf8ea76680ee0fe5d204774157a4362e1da4082cff57b9d15e516373
     name: networking.flannel
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 95b7ed90347083b7fa03c5887548877680c91d5d
+    manifestHash: 7704b00aad28d18c71c269fc8b444a21a72051ac10b7aa4e48cc68dd48e7e8bc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 029ade650920ee77d6d4205fefe9c78852a81b99
+    manifestHash: 3f14f8869934001778849837c28217709bf4f1c593d3acdbde9cdf1d97ac47f3
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 891d3e2dde8b74e2ce7db8118e1b5ce447d5dd26
+    manifestHash: c92ddbd54cfb1437631ab4019055dbdac486686ac03ee867e0405c836783d862
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 029ade650920ee77d6d4205fefe9c78852a81b99
+    manifestHash: 3f14f8869934001778849837c28217709bf4f1c593d3acdbde9cdf1d97ac47f3
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 886d0565bb011313ee94e8497700550b415eea75
+    manifestHash: ad4c88257aa1b1d05c38bfee630eb6cad07b3e258932dafc37b76d7328f3a8ff
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 470684b80af41aa53c25bc5ac1a78b259c93336b
+    manifestHash: 0325578894a58aa80552729f3f2077360f8211b64e650c6603efbf0a8b8fddfd
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6129cb5aee3fefdb46667a555c8acd3135be692d
+    manifestHash: 8859d71bf831e87ed1be393a4ca9ff595194086d6734c650f80a53ba45657534
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 928b7a5f9a4e8a1b15dee78af62553d28705e938
+    manifestHash: f8910f55b37687de21c683954c61bfa9b70ecc8a88c2364ebdcd93114f39db89
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b82e2e95ebe045ef12e10a3ce8d53f9611a15c3e
+    manifestHash: 791a88dded805e8a39152f4217c8b5c16ca5ef815f000f790c6a117c53d21082
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ab32e48f85abb639e473b88f2d7de51da3a2859e
+    manifestHash: f632e5be332470d8e600d9851cbf778a857fe7c94dbbcef15bc508f379a577ff
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 886d0565bb011313ee94e8497700550b415eea75
+    manifestHash: ad4c88257aa1b1d05c38bfee630eb6cad07b3e258932dafc37b76d7328f3a8ff
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 65724beac22bba4b212a558d2d0d22d9561e8f13
+    manifestHash: a970a3d16c4299fbe17ff5aa7fc1f69d4b13791d3fd21cd057360a1f5b29a370
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 27896afb4023ea5dc4081806a3bdb17821982da4
+    manifestHash: 43248639361134d8a3bd94098b9b0bb8a9209088c2b85dbb2af9594a236ea83c
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 65724beac22bba4b212a558d2d0d22d9561e8f13
+    manifestHash: a970a3d16c4299fbe17ff5aa7fc1f69d4b13791d3fd21cd057360a1f5b29a370
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 27896afb4023ea5dc4081806a3bdb17821982da4
+    manifestHash: 43248639361134d8a3bd94098b9b0bb8a9209088c2b85dbb2af9594a236ea83c
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,54 +6,54 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 65724beac22bba4b212a558d2d0d22d9561e8f13
+    manifestHash: a970a3d16c4299fbe17ff5aa7fc1f69d4b13791d3fd21cd057360a1f5b29a370
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: 5c1fbf80ac8c9448b050707ddbdf4aa4dd145182
+    manifestHash: 4e2cda50cd5048133aad1b5e28becb60f4629d3f9e09c514a2757c27998b4200
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ef74ee3b557b92e6e6944329c81e4f1925e2f3df
+    manifestHash: c2b208761561c8596a3cb60ada550760756f85d1973a55510ce0df044c0f680d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: dacfe709fa608b7952a7a3cac3941c09fab495c2
+    manifestHash: 3cb088c84aaa49afed34e8dc0d2a97cf013a173f719b8cfa5e14f367306f6d92
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 65724beac22bba4b212a558d2d0d22d9561e8f13
+    manifestHash: a970a3d16c4299fbe17ff5aa7fc1f69d4b13791d3fd21cd057360a1f5b29a370
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 1ce76cfd2180815252c11cc79e946d75b277b41a
+    manifestHash: b2da910792c8a9282f4e9076d6090b9bd47b7cb11bf22da39dd91e40f64bbd66
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,54 +6,54 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7688677b30291a6c60a21259b0a6397b2a4c9d4d
+    manifestHash: d32d56c2650bdd6ab90a3e8e170785cda87c06214316e3f5938beed71868b9d1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 470684b80af41aa53c25bc5ac1a78b259c93336b
+    manifestHash: 0325578894a58aa80552729f3f2077360f8211b64e650c6603efbf0a8b8fddfd
     name: kube-dns.addons.k8s.io
     selector:
       k8s-addon: kube-dns.addons.k8s.io
   - id: k8s-1.8
     manifest: rbac.addons.k8s.io/k8s-1.8.yaml
-    manifestHash: 38ba4e0078bb1225421114f76f121c2277ca92ac
+    manifestHash: f81bd7c57bc1902ca342635d7ad7d01b82dfeaff01a1192b076e66907d87871e
     name: rbac.addons.k8s.io
     selector:
       k8s-addon: rbac.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 70ed5b105e2515222f6286ba4c1cf9e95d89b7b6
+    manifestHash: 60da1ee7e51ce39ddedcf7db008205c0b466e41d1b9d6ac865d9aeabbbf0ee81
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 65724beac22bba4b212a558d2d0d22d9561e8f13
+    manifestHash: a970a3d16c4299fbe17ff5aa7fc1f69d4b13791d3fd21cd057360a1f5b29a370
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6129cb5aee3fefdb46667a555c8acd3135be692d
+    manifestHash: 8859d71bf831e87ed1be393a4ca9ff595194086d6734c650f80a53ba45657534
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,42 +6,42 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 65724beac22bba4b212a558d2d0d22d9561e8f13
+    manifestHash: a970a3d16c4299fbe17ff5aa7fc1f69d4b13791d3fd21cd057360a1f5b29a370
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,48 +6,48 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 65724beac22bba4b212a558d2d0d22d9561e8f13
+    manifestHash: a970a3d16c4299fbe17ff5aa7fc1f69d4b13791d3fd21cd057360a1f5b29a370
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
   - manifest: core.addons.k8s.io/v1.4.0.yaml
-    manifestHash: 9283cd74e74b10e441d3f1807c49c1bef8fac8c8
+    manifestHash: 90f8d3bd227dc1f4fdd46b561ac6bfc9355392477a7eedd6c3e2318614c375d8
     name: core.addons.k8s.io
     selector:
       k8s-addon: core.addons.k8s.io
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 73f83ad2e946a81bba6a45b8bd353eb227f932b4
+    manifestHash: 3bf8c29c45f0f7dbbb1671b577f302a19418b55d214f6847ff586f1ee9d1ba71
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io
   - id: k8s-1.9
     manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
-    manifestHash: 8ee090e41be5e8bcd29ee799b1608edcd2dd8b65
+    manifestHash: 01c120e887bd98d82ef57983ad58a0b22bc85efb48108092a24c4b82e4c9ea81
     name: kubelet-api.rbac.addons.k8s.io
     selector:
       k8s-addon: kubelet-api.rbac.addons.k8s.io
   - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
-    manifestHash: 6ed889ae6a8d83dd6e5b511f831b3ac65950cf9d
+    manifestHash: 2d55c3bc5e354e84a3730a65b42f39aba630a59dc8d32b30859fcce3d3178bc2
     name: limit-range.addons.k8s.io
     selector:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2096284cd9a5115cb2ea85c8f952d2a9a0cd2d7e
+    manifestHash: e78d86189b6860dbfd96fe566d989c4dc1026d8e993ed4a02389f4b66d1d9506
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
   - id: v1.15.0
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
-    manifestHash: d474dbcc9b9c5cd2e87b41a7755851811f5f48aa
+    manifestHash: 065ae832ddac8d0931e9992d6a76f43a33a36975a38003b34f4c5d86a7d42780
     name: storage-aws.addons.k8s.io
     selector:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 0e181c0897c670e16e772f1182cb84c03ed12879
+    manifestHash: 69f0d274728153aa9f250564a7704762b2b74684ef35ef3bb4bf21489aaef21f
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"

--- a/upup/pkg/fi/utils/hash.go
+++ b/upup/pkg/fi/utils/hash.go
@@ -17,13 +17,13 @@ limitations under the License.
 package utils
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 )
 
-// HashString Takes String and returns a sha1 hash represented as a string
+// HashString Takes String and returns a sha256 hash represented as a string
 func HashString(s string) (string, error) {
-	h := sha1.New()
+	h := sha256.New()
 	_, err := h.Write([]byte(s))
 	if err != nil {
 		return "", err

--- a/upup/pkg/fi/utils/hash_test.go
+++ b/upup/pkg/fi/utils/hash_test.go
@@ -27,19 +27,19 @@ func TestHashString(t *testing.T) {
 	}{
 		{
 			s:           "test",
-			expectedStr: "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+			expectedStr: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 		},
 		{
 			s:           "~!*/?",
-			expectedStr: "783c2ea26549ce90df7cd90a27bf9094c226c406",
+			expectedStr: "2ebef337aebca07992300b61b58f3581a3d0228e9eb17c0340eaa01bcb2abde2",
 		},
 		{
 			s:           "测试1",
-			expectedStr: "6d972f7f1450aba1f7496f685c3c656c4fca9624",
+			expectedStr: "d7d16e0c2747b4dbe70a6f4977cf4f4ebb4a227d7ebc24c3a0e99acaae79b518",
 		},
 		{
 			s:           "-897668",
-			expectedStr: "c8facb588b36948d5da0e3a7e16977a701331b0a",
+			expectedStr: "e6909a82db1ad9349f016624af382f62226e9a1bffbd360f9ccc4ef8aaded232",
 		},
 	}
 


### PR DESCRIPTION
This will cause an otherwise unnecessary manifest update upon upgrade, but will remove a use of SHA-1.