### PR TITLE
Temporarily skip MetricsGrabber test

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -18,6 +18,7 @@ package tester
 
 import (
 	"regexp"
+	"strings"
 )
 
 const (
@@ -54,6 +55,12 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|load-balancer|hairpin|affinity\\stimeout|service\\.kubernetes\\.io|CLOSE_WAIT"
 	} else if networking.Kubenet != nil {
 		skipRegex += "|Services.*affinity"
+	}
+
+	if strings.Contains(cluster.Spec.KubernetesVersion, "v1.22.") {
+		// TODO(rifelpet): Remove once k8s tags has been created that include
+		// https://github.com/kubernetes/kubernetes/pull/104061
+		skipRegex += "|MetricsGrabber.should.grab.all.metrics.from.a.ControllerManager"
 	}
 
 	// Ensure it is valid regex


### PR DESCRIPTION
The fix won't make it into 1.22.0, instead slated for 1.22.1.

https://kubernetes.slack.com/archives/CJH2GBF7Y/p1627938879019800

To avoid additional jobs failing (those that use the `release/stable` k8s version marker) we can ignore the test now that the issue is known and the fix is ready to be merged.