### PR TITLE
Kubetest2 scenarios - provide absolute path to kops binary

### DIFF
--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -107,7 +107,7 @@ function kops-acquire-latest() {
             KOPS_BASE_URL=""
          fi
          $KUBETEST2 --build
-         KOPS=".bazelbuild/dist/linux/amd64/kops"
+         KOPS="${REPO_ROOT}/.bazelbuild/dist/linux/amd64/kops"
     fi
 }
 


### PR DESCRIPTION
This allows the rest of the scenario to change directories and the "down" step still uses the correct location of the kops binary

This should fix https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-kops-e2e-aws-ebs-csi-driver/1413601399341584384

I confirmed all scenario scripts set REPO_ROOT.

/cc @olemarkus I'm curious why that job is building kops from source given that it is a periodic test. I would expect this `kops-acquire-latest()` function to be downloading it from a kops version marker, any idea why that is?