### PR TITLE
Also skip MetricsGrabber tests on 1.23 version marker

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -57,7 +57,7 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|Services.*affinity"
 	}
 
-	if strings.Contains(cluster.Spec.KubernetesVersion, "v1.22.") {
+	if strings.Contains(cluster.Spec.KubernetesVersion, "v1.22.") || strings.Contains(cluster.Spec.KubernetesVersion, "v1.23.") {
 		// TODO(rifelpet): Remove once k8s tags has been created that include
 		// https://github.com/kubernetes/kubernetes/pull/104061
 		skipRegex += "|MetricsGrabber.should.grab.all.metrics.from.a.ControllerManager"


### PR DESCRIPTION
ci/latest is already using 1.23 alpha tags so we need to skip these tests for 1.23 until the PR is merged.

Example job not yet skipping the test: https://testgrid.k8s.io/kops-misc#kops-aws-misc-arm64-ci