### PR TITLE
Stop skipping MetricsGrabber tests on CI k8s versions

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -57,7 +57,7 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|Services.*affinity"
 	}
 
-	if strings.Contains(cluster.Spec.KubernetesVersion, "v1.22.") || strings.Contains(cluster.Spec.KubernetesVersion, "v1.23.") {
+	if strings.Contains(cluster.Spec.KubernetesVersion, "v1.22.") {
 		// TODO(rifelpet): Remove once k8s tags has been created that include
 		// https://github.com/kubernetes/kubernetes/pull/104061
 		skipRegex += "|MetricsGrabber.should.grab.all.metrics.from.a.ControllerManager"


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/104061 has been merged, so CI builds should now pass these tests. Once it is backported to 1.22 we'll remove it from there as well.