### PR TITLE
Support Debian 11 Bullseye

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -42,6 +42,7 @@ The following table provides the support status for various distros with regards
 | Debian 8 | - | 1.5 | 1.17 | 1.18 |
 | [Debian 9](#debian-9-stretch) | 1.8 | 1.10 | 1.21 | - |
 | [Debian 10](#debian-10-buster) | 1.13 | 1.17 | - | - |
+| [Debian 11](#debian-11-bullseye) | 1.22 | - | - | - |
 | [Flatcar](#flatcar) | 1.15.1 | 1.17 | - | - |
 | [Kope.io](#kopeio) | - | - | 1.18 | - |
 | [RHEL 7](#rhel-7) | - | 1.5 | 1.21 | - |
@@ -92,6 +93,19 @@ aws ec2 describe-images --region us-east-1 --output table \
   --owners 136693071363 \
   --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
   --filters "Name=name,Values=debian-10-amd64-*"
+```
+
+### Debian 11 (Bullseye)
+
+Debian 11 is based on Kernel version **5.10** which has no known major Kernel bugs and fully supports all Cilium features.
+
+Available images can be listed using:
+
+```bash
+aws ec2 describe-images --region us-east-1 --output table \
+  --owners 903794441882 \
+  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
+  --filters "Name=name,Values=debian-11-amd64-*"
 ```
 
 ### Flatcar
@@ -235,6 +249,7 @@ kOps supports owner aliases for the official accounts of supported distros:
 * `centos` => `125523088429`
 * `debian9` => `379101102735`
 * `debian10` => `136693071363`
+* `debian11` => `903794441882`
 * `flatcar` => `075585003325`
 * `redhat` => `309956199498`
 * `ubuntu` => `099720109477`

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -498,7 +498,7 @@ func guessSSHUser(image *ec2.Image) string {
 		return "ec2-user"
 	case awsup.WellKnownAccountCentOS:
 		return "centos"
-	case awsup.WellKnownAccountDebian9, awsup.WellKnownAccountDebian10, awsup.WellKnownAccountKopeio:
+	case awsup.WellKnownAccountDebian9, awsup.WellKnownAccountDebian10, awsup.WellKnownAccountDebian11, awsup.WellKnownAccountKopeio:
 		return "admin"
 	case awsup.WellKnownAccountUbuntu:
 		return "ubuntu"

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -101,6 +101,7 @@ const (
 	WellKnownAccountCoreOS       = "595879546273"
 	WellKnownAccountDebian9      = "379101102735"
 	WellKnownAccountDebian10     = "136693071363"
+	WellKnownAccountDebian11     = "903794441882"
 	WellKnownAccountFlatcar      = "075585003325"
 	WellKnownAccountKopeio       = "383156758163"
 	WellKnownAccountRedhat       = "309956199498"
@@ -1716,6 +1717,8 @@ func resolveImage(ec2Client ec2iface.EC2API, name string) (*ec2.Image, error) {
 				owner = WellKnownAccountDebian9
 			case "debian10":
 				owner = WellKnownAccountDebian10
+			case "debian11":
+				owner = WellKnownAccountDebian11
 			case "flatcar":
 				owner = WellKnownAccountFlatcar
 			case "kopeio", "kope.io":

--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -39,6 +39,7 @@ type Distribution struct {
 var (
 	DistributionDebian9      = Distribution{packageFormat: "deb", project: "debian", id: "stretch", version: 9}
 	DistributionDebian10     = Distribution{packageFormat: "deb", project: "debian", id: "buster", version: 10}
+	DistributionDebian11     = Distribution{packageFormat: "deb", project: "debian", id: "bullseye", version: 11}
 	DistributionUbuntu1604   = Distribution{packageFormat: "deb", project: "ubuntu", id: "xenial", version: 16.04}
 	DistributionUbuntu1804   = Distribution{packageFormat: "deb", project: "ubuntu", id: "bionic", version: 18.04}
 	DistributionUbuntu2004   = Distribution{packageFormat: "deb", project: "ubuntu", id: "focal", version: 20.04}

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -58,6 +58,8 @@ func FindDistribution(rootfs string) (Distribution, error) {
 		return DistributionDebian9, nil
 	case "debian-10":
 		return DistributionDebian10, nil
+	case "debian-11":
+		return DistributionDebian11, nil
 	case "ubuntu-16.04":
 		return DistributionUbuntu1604, nil
 	case "ubuntu-18.04":

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -70,6 +70,11 @@ func TestFindDistribution(t *testing.T) {
 			expected: DistributionDebian10,
 		},
 		{
+			rootfs:   "debian11",
+			err:      nil,
+			expected: DistributionDebian11,
+		},
+		{
 			rootfs:   "flatcar",
 			err:      nil,
 			expected: DistributionFlatcar,

--- a/util/pkg/distributions/tests/debian11/etc/os-release
+++ b/util/pkg/distributions/tests/debian11/etc/os-release
@@ -1,0 +1,9 @@
+PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
+NAME="Debian GNU/Linux"
+VERSION_ID="11"
+VERSION="11 (bullseye)"
+VERSION_CODENAME=bullseye
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"


### PR DESCRIPTION
Add support for Debian 11 ahead of the impending release on August 14th. 

Tested by creating a cluster with the `debian-11-amd64-daily-20210805-725` image and verifying that both the cluster came up and that node logs did not contain any errors. Tested kubenet and cilium networking and both containerd and docker runtimes. 