### PR TITLE
Automated cherry pick of #12114: Make metrics-server insecure if insecure is true

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -51,6 +51,10 @@ func TestBootstrapChannelBuilder_BuildTasks(t *testing.T) {
 	runChannelBuilderTest(t, "amazonvpc", []string{"networking.amazon-vpc-routed-eni-k8s-1.12", "networking.amazon-vpc-routed-eni-k8s-1.16"})
 	runChannelBuilderTest(t, "amazonvpc-containerd", []string{"networking.amazon-vpc-routed-eni-k8s-1.12", "networking.amazon-vpc-routed-eni-k8s-1.16"})
 	runChannelBuilderTest(t, "awsiamauthenticator", []string{"authentication.aws-k8s-1.12"})
+	runChannelBuilderTest(t, "metrics-server/insecure-1.18", []string{"metrics-server.addons.k8s.io-k8s-1.11"})
+	runChannelBuilderTest(t, "metrics-server/insecure-1.19", []string{"metrics-server.addons.k8s.io-k8s-1.11"})
+	runChannelBuilderTest(t, "metrics-server/secure-1.18", []string{"metrics-server.addons.k8s.io-k8s-1.11"})
+	runChannelBuilderTest(t, "metrics-server/secure-1.19", []string{"metrics-server.addons.k8s.io-k8s-1.11"})
 }
 
 func TestBootstrapChannelBuilder_ServiceAccountIAM(t *testing.T) {

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/cluster.yaml
@@ -1,0 +1,47 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  addons:
+    - manifest: s3://somebucket/example.yaml
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    version: 3.1.12
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    version: 3.1.12
+    name: events
+  iam: {}
+  kubernetesVersion: 1.18.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  metricsServer:
+    enabled: true
+    insecure: true
+  additionalSans:
+  - proxy.api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    cilium: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -1,0 +1,86 @@
+kind: Addons
+metadata:
+  creationTimestamp: null
+  name: bootstrap
+spec:
+  addons:
+  - id: k8s-1.16
+    kubernetesVersion: '>=1.16.0-alpha.0'
+    manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
+    manifestHash: f2e7f05885491169783402bfc59ba2b7db9654dd
+    name: kops-controller.addons.k8s.io
+    needsRollingUpdate: control-plane
+    selector:
+      k8s-addon: kops-controller.addons.k8s.io
+    version: 1.21.0
+  - manifest: core.addons.k8s.io/v1.4.0.yaml
+    manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
+    name: core.addons.k8s.io
+    selector:
+      k8s-addon: core.addons.k8s.io
+    version: 1.4.0
+  - id: k8s-1.12
+    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: 9115bb04f06321decd39b1588a93e31e48a40c06
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.15.13-kops.3
+  - id: k8s-1.8
+    manifest: rbac.addons.k8s.io/k8s-1.8.yaml
+    manifestHash: a9ebd499f4d73dfa12cd6f0f762d3b143aecada6
+    name: rbac.addons.k8s.io
+    selector:
+      k8s-addon: rbac.addons.k8s.io
+    version: 1.8.0
+  - id: k8s-1.9
+    manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
+    manifestHash: 1dbad74e01965afc2c32ca822d16c204d015db82
+    name: kubelet-api.rbac.addons.k8s.io
+    selector:
+      k8s-addon: kubelet-api.rbac.addons.k8s.io
+    version: v0.0.1
+  - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
+    manifestHash: 18871595294c46105ef2570f11b1b2318aecfb57
+    name: limit-range.addons.k8s.io
+    selector:
+      k8s-addon: limit-range.addons.k8s.io
+    version: 1.5.0
+  - id: k8s-1.12
+    manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: c8f2a03ebfabcdbf89a49f3848eaa90c0e8cd2b8
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.21.0
+  - id: k8s-1.11
+    manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
+    manifestHash: a760a68f4d76cfddb5a2cd9afa9afdb0b301d187
+    name: metrics-server.addons.k8s.io
+    selector:
+      k8s-app: metrics-server
+    version: 0.4.4
+  - id: v1.15.0
+    kubernetesVersion: '>=1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.17.0
+  - id: v1.7.0
+    kubernetesVersion: <1.15.0
+    manifest: storage-aws.addons.k8s.io/v1.7.0.yaml
+    manifestHash: 0a699ecad09b62fd94da8b97d1c2204c716c2b8f
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.17.0
+  - id: k8s-1.12
+    manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
+    manifestHash: 57f434b35f81299083798cce92cfbf9dd3629cd0
+    name: networking.cilium.io
+    needsRollingUpdate: all
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 1.9.4-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -1,17 +1,25 @@
-# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.4/components.yaml
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -27,11 +35,17 @@ rules:
   - get
   - list
   - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: system:metrics-server
 rules:
@@ -47,11 +61,17 @@ rules:
   - get
   - list
   - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server-auth-reader
   namespace: kube-system
@@ -63,11 +83,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server:system:auth-delegator
 roleRef:
@@ -78,11 +104,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: system:metrics-server
 roleRef:
@@ -93,11 +125,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: v1
 kind: Service
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
@@ -109,11 +147,17 @@ spec:
     targetPort: https
   selector:
     k8s-app: metrics-server
+
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
@@ -129,18 +173,11 @@ spec:
     spec:
       containers:
       - args:
-          - --secure-port=4443
-          - --kubelet-use-node-status-port
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-          - --tls-cert-file=/srv/tls.crt
-          - --tls-private-key-file=/srv/tls.key
-{{ else }}
-          - --cert-dir=/tmp
-{{ end }}
-{{ if or (not UseKopsControllerForNodeBootstrap) (WithDefaultBool .MetricsServer.Insecure true) }}
-          - --kubelet-insecure-tls
-{{ end }}
-        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.4" }}
+        - --secure-port=4443
+        - --kubelet-use-node-status-port
+        - --cert-dir=/tmp
+        - --kubelet-insecure-tls
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.4.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -161,84 +198,62 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
         volumeMounts:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-        - name: certs
-          mountPath: /srv
-{{ end }}
         - mountPath: /tmp
           name: tmp-dir
-        resources:
-          requests:
-            cpu: 50m
-            memory: 128Mi
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
       volumes:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-      - name: certs
-        secret:
-          secretName: metrics-server-tls
-{{ end }}
       - emptyDir: {}
         name: tmp-dir
+
 ---
+
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-  annotations:
-    cert-manager.io/inject-ca-from: kube-system/metrics-server
-{{ end }}
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io
   groupPriorityMinimum: 100
-{{ if WithDefaultBool .MetricsServer.Insecure true }}
   insecureSkipTLSVerify: true
-{{ end }}
   service:
     name: metrics-server
     namespace: kube-system
   version: v1beta1
   versionPriority: 100
+
 ---
+
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
+    k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
-  labels:
-    k8s-app: metrics-server
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       k8s-app: metrics-server
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: metrics-server
-  namespace: kube-system
-spec:
-  secretName: metrics-server-tls
-  duration: 2160h
-  renewBefore: 360h
-  usages:
-    - server auth
-  dnsNames:
-  - metrics-server.kube-system.svc
-  issuerRef:
-    name: metrics-server.addons.k8s.io
-    kind: Issuer
-{{ end }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/cluster.yaml
@@ -1,0 +1,47 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  addons:
+    - manifest: s3://somebucket/example.yaml
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    version: 3.1.12
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    version: 3.1.12
+    name: events
+  iam: {}
+  kubernetesVersion: 1.19.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  metricsServer:
+    enabled: true
+    insecure: true
+  additionalSans:
+  - proxy.api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    cilium: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -1,0 +1,79 @@
+kind: Addons
+metadata:
+  creationTimestamp: null
+  name: bootstrap
+spec:
+  addons:
+  - id: k8s-1.16
+    kubernetesVersion: '>=1.16.0-alpha.0'
+    manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
+    manifestHash: 8219a09076d2245d21fa55d8d1308e16d7eebc60
+    name: kops-controller.addons.k8s.io
+    needsRollingUpdate: control-plane
+    selector:
+      k8s-addon: kops-controller.addons.k8s.io
+    version: 1.21.0
+  - manifest: core.addons.k8s.io/v1.4.0.yaml
+    manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
+    name: core.addons.k8s.io
+    selector:
+      k8s-addon: core.addons.k8s.io
+    version: 1.4.0
+  - id: k8s-1.12
+    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: 9115bb04f06321decd39b1588a93e31e48a40c06
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.15.13-kops.3
+  - id: k8s-1.9
+    manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
+    manifestHash: 1dbad74e01965afc2c32ca822d16c204d015db82
+    name: kubelet-api.rbac.addons.k8s.io
+    selector:
+      k8s-addon: kubelet-api.rbac.addons.k8s.io
+    version: v0.0.1
+  - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
+    manifestHash: 18871595294c46105ef2570f11b1b2318aecfb57
+    name: limit-range.addons.k8s.io
+    selector:
+      k8s-addon: limit-range.addons.k8s.io
+    version: 1.5.0
+  - id: k8s-1.12
+    manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: c8f2a03ebfabcdbf89a49f3848eaa90c0e8cd2b8
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.21.0
+  - id: k8s-1.11
+    manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
+    manifestHash: a760a68f4d76cfddb5a2cd9afa9afdb0b301d187
+    name: metrics-server.addons.k8s.io
+    selector:
+      k8s-app: metrics-server
+    version: 0.4.4
+  - id: v1.15.0
+    kubernetesVersion: '>=1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.17.0
+  - id: v1.7.0
+    kubernetesVersion: <1.15.0
+    manifest: storage-aws.addons.k8s.io/v1.7.0.yaml
+    manifestHash: 0a699ecad09b62fd94da8b97d1c2204c716c2b8f
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.17.0
+  - id: k8s-1.12
+    manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
+    manifestHash: 57f434b35f81299083798cce92cfbf9dd3629cd0
+    name: networking.cilium.io
+    needsRollingUpdate: all
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 1.9.4-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -1,17 +1,25 @@
-# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.4/components.yaml
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -27,11 +35,17 @@ rules:
   - get
   - list
   - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: system:metrics-server
 rules:
@@ -47,11 +61,17 @@ rules:
   - get
   - list
   - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server-auth-reader
   namespace: kube-system
@@ -63,11 +83,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server:system:auth-delegator
 roleRef:
@@ -78,11 +104,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: system:metrics-server
 roleRef:
@@ -93,11 +125,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: v1
 kind: Service
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
@@ -109,11 +147,17 @@ spec:
     targetPort: https
   selector:
     k8s-app: metrics-server
+
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
@@ -129,18 +173,11 @@ spec:
     spec:
       containers:
       - args:
-          - --secure-port=4443
-          - --kubelet-use-node-status-port
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-          - --tls-cert-file=/srv/tls.crt
-          - --tls-private-key-file=/srv/tls.key
-{{ else }}
-          - --cert-dir=/tmp
-{{ end }}
-{{ if or (not UseKopsControllerForNodeBootstrap) (WithDefaultBool .MetricsServer.Insecure true) }}
-          - --kubelet-insecure-tls
-{{ end }}
-        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.4" }}
+        - --secure-port=4443
+        - --kubelet-use-node-status-port
+        - --cert-dir=/tmp
+        - --kubelet-insecure-tls
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.4.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -161,84 +198,62 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
         volumeMounts:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-        - name: certs
-          mountPath: /srv
-{{ end }}
         - mountPath: /tmp
           name: tmp-dir
-        resources:
-          requests:
-            cpu: 50m
-            memory: 128Mi
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
       volumes:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-      - name: certs
-        secret:
-          secretName: metrics-server-tls
-{{ end }}
       - emptyDir: {}
         name: tmp-dir
+
 ---
+
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-  annotations:
-    cert-manager.io/inject-ca-from: kube-system/metrics-server
-{{ end }}
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io
   groupPriorityMinimum: 100
-{{ if WithDefaultBool .MetricsServer.Insecure true }}
   insecureSkipTLSVerify: true
-{{ end }}
   service:
     name: metrics-server
     namespace: kube-system
   version: v1beta1
   versionPriority: 100
+
 ---
+
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
+    k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
-  labels:
-    k8s-app: metrics-server
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       k8s-app: metrics-server
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: metrics-server
-  namespace: kube-system
-spec:
-  secretName: metrics-server-tls
-  duration: 2160h
-  renewBefore: 360h
-  usages:
-    - server auth
-  dnsNames:
-  - metrics-server.kube-system.svc
-  issuerRef:
-    name: metrics-server.addons.k8s.io
-    kind: Issuer
-{{ end }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/cluster.yaml
@@ -1,0 +1,49 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  addons:
+    - manifest: s3://somebucket/example.yaml
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  certManager:
+    enabled: true
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    version: 3.1.12
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    version: 3.1.12
+    name: events
+  iam: {}
+  kubernetesVersion: 1.18.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  metricsServer:
+    enabled: true
+    insecure: false
+  additionalSans:
+  - proxy.api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    cilium: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -1,0 +1,93 @@
+kind: Addons
+metadata:
+  creationTimestamp: null
+  name: bootstrap
+spec:
+  addons:
+  - id: k8s-1.16
+    kubernetesVersion: '>=1.16.0-alpha.0'
+    manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
+    manifestHash: f2e7f05885491169783402bfc59ba2b7db9654dd
+    name: kops-controller.addons.k8s.io
+    needsRollingUpdate: control-plane
+    selector:
+      k8s-addon: kops-controller.addons.k8s.io
+    version: 1.21.0
+  - manifest: core.addons.k8s.io/v1.4.0.yaml
+    manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
+    name: core.addons.k8s.io
+    selector:
+      k8s-addon: core.addons.k8s.io
+    version: 1.4.0
+  - id: k8s-1.12
+    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: 9115bb04f06321decd39b1588a93e31e48a40c06
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.15.13-kops.3
+  - id: k8s-1.8
+    manifest: rbac.addons.k8s.io/k8s-1.8.yaml
+    manifestHash: a9ebd499f4d73dfa12cd6f0f762d3b143aecada6
+    name: rbac.addons.k8s.io
+    selector:
+      k8s-addon: rbac.addons.k8s.io
+    version: 1.8.0
+  - id: k8s-1.9
+    manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
+    manifestHash: 1dbad74e01965afc2c32ca822d16c204d015db82
+    name: kubelet-api.rbac.addons.k8s.io
+    selector:
+      k8s-addon: kubelet-api.rbac.addons.k8s.io
+    version: v0.0.1
+  - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
+    manifestHash: 18871595294c46105ef2570f11b1b2318aecfb57
+    name: limit-range.addons.k8s.io
+    selector:
+      k8s-addon: limit-range.addons.k8s.io
+    version: 1.5.0
+  - id: k8s-1.12
+    manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: c8f2a03ebfabcdbf89a49f3848eaa90c0e8cd2b8
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.21.0
+  - id: k8s-1.11
+    manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
+    manifestHash: d4a188bdcd03921d7852fa12f4dbb7d996b7edb5
+    name: metrics-server.addons.k8s.io
+    needsPKI: true
+    selector:
+      k8s-app: metrics-server
+    version: 0.4.4
+  - id: k8s-1.16
+    manifest: certmanager.io/k8s-1.16.yaml
+    manifestHash: e0d7966ae9d077de6344323d78ae6c899a17cb3d
+    name: certmanager.io
+    selector: null
+    version: 1.1.0
+  - id: v1.15.0
+    kubernetesVersion: '>=1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.17.0
+  - id: v1.7.0
+    kubernetesVersion: <1.15.0
+    manifest: storage-aws.addons.k8s.io/v1.7.0.yaml
+    manifestHash: 0a699ecad09b62fd94da8b97d1c2204c716c2b8f
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.17.0
+  - id: k8s-1.12
+    manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
+    manifestHash: 57f434b35f81299083798cce92cfbf9dd3629cd0
+    name: networking.cilium.io
+    needsRollingUpdate: all
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 1.9.4-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -1,17 +1,25 @@
-# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.4/components.yaml
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -27,11 +35,17 @@ rules:
   - get
   - list
   - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: system:metrics-server
 rules:
@@ -47,11 +61,17 @@ rules:
   - get
   - list
   - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server-auth-reader
   namespace: kube-system
@@ -63,11 +83,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server:system:auth-delegator
 roleRef:
@@ -78,11 +104,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: system:metrics-server
 roleRef:
@@ -93,11 +125,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: v1
 kind: Service
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
@@ -109,11 +147,17 @@ spec:
     targetPort: https
   selector:
     k8s-app: metrics-server
+
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
@@ -129,18 +173,12 @@ spec:
     spec:
       containers:
       - args:
-          - --secure-port=4443
-          - --kubelet-use-node-status-port
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-          - --tls-cert-file=/srv/tls.crt
-          - --tls-private-key-file=/srv/tls.key
-{{ else }}
-          - --cert-dir=/tmp
-{{ end }}
-{{ if or (not UseKopsControllerForNodeBootstrap) (WithDefaultBool .MetricsServer.Insecure true) }}
-          - --kubelet-insecure-tls
-{{ end }}
-        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.4" }}
+        - --secure-port=4443
+        - --kubelet-use-node-status-port
+        - --tls-cert-file=/srv/tls.crt
+        - --tls-private-key-file=/srv/tls.key
+        - --kubelet-insecure-tls
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.4.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -161,84 +199,93 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
         volumeMounts:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-        - name: certs
-          mountPath: /srv
-{{ end }}
+        - mountPath: /srv
+          name: certs
         - mountPath: /tmp
           name: tmp-dir
-        resources:
-          requests:
-            cpu: 50m
-            memory: 128Mi
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
       volumes:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
       - name: certs
         secret:
           secretName: metrics-server-tls
-{{ end }}
       - emptyDir: {}
         name: tmp-dir
+
 ---
+
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
   annotations:
     cert-manager.io/inject-ca-from: kube-system/metrics-server
-{{ end }}
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io
   groupPriorityMinimum: 100
-{{ if WithDefaultBool .MetricsServer.Insecure true }}
-  insecureSkipTLSVerify: true
-{{ end }}
   service:
     name: metrics-server
     namespace: kube-system
   version: v1beta1
   versionPriority: 100
+
 ---
+
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
+    k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
-  labels:
-    k8s-app: metrics-server
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       k8s-app: metrics-server
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
+
 ---
+
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
+    k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
 spec:
-  secretName: metrics-server-tls
-  duration: 2160h
-  renewBefore: 360h
-  usages:
-    - server auth
   dnsNames:
   - metrics-server.kube-system.svc
+  duration: 2160h
   issuerRef:
-    name: metrics-server.addons.k8s.io
     kind: Issuer
-{{ end }}
+    name: metrics-server.addons.k8s.io
+  renewBefore: 360h
+  secretName: metrics-server-tls
+  usages:
+  - server auth

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/cluster.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/cluster.yaml
@@ -1,0 +1,49 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  addons:
+    - manifest: s3://somebucket/example.yaml
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  certManager:
+    enabled: true
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    version: 3.1.12
+    name: main
+  - etcdMembers:
+    - instanceGroup: master-us-test-1a
+      name: master-us-test-1a
+    version: 3.1.12
+    name: events
+  iam: {}
+  kubernetesVersion: 1.19.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  metricsServer:
+    enabled: true
+    insecure: false
+  additionalSans:
+  - proxy.api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    cilium: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -1,0 +1,86 @@
+kind: Addons
+metadata:
+  creationTimestamp: null
+  name: bootstrap
+spec:
+  addons:
+  - id: k8s-1.16
+    kubernetesVersion: '>=1.16.0-alpha.0'
+    manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
+    manifestHash: 8219a09076d2245d21fa55d8d1308e16d7eebc60
+    name: kops-controller.addons.k8s.io
+    needsRollingUpdate: control-plane
+    selector:
+      k8s-addon: kops-controller.addons.k8s.io
+    version: 1.21.0
+  - manifest: core.addons.k8s.io/v1.4.0.yaml
+    manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
+    name: core.addons.k8s.io
+    selector:
+      k8s-addon: core.addons.k8s.io
+    version: 1.4.0
+  - id: k8s-1.12
+    manifest: kube-dns.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: 9115bb04f06321decd39b1588a93e31e48a40c06
+    name: kube-dns.addons.k8s.io
+    selector:
+      k8s-addon: kube-dns.addons.k8s.io
+    version: 1.15.13-kops.3
+  - id: k8s-1.9
+    manifest: kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml
+    manifestHash: 1dbad74e01965afc2c32ca822d16c204d015db82
+    name: kubelet-api.rbac.addons.k8s.io
+    selector:
+      k8s-addon: kubelet-api.rbac.addons.k8s.io
+    version: v0.0.1
+  - manifest: limit-range.addons.k8s.io/v1.5.0.yaml
+    manifestHash: 18871595294c46105ef2570f11b1b2318aecfb57
+    name: limit-range.addons.k8s.io
+    selector:
+      k8s-addon: limit-range.addons.k8s.io
+    version: 1.5.0
+  - id: k8s-1.12
+    manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
+    manifestHash: c8f2a03ebfabcdbf89a49f3848eaa90c0e8cd2b8
+    name: dns-controller.addons.k8s.io
+    selector:
+      k8s-addon: dns-controller.addons.k8s.io
+    version: 1.21.0
+  - id: k8s-1.11
+    manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
+    manifestHash: 3795901da096a90916f4258aec1dc656f16d2b8f
+    name: metrics-server.addons.k8s.io
+    needsPKI: true
+    selector:
+      k8s-app: metrics-server
+    version: 0.4.4
+  - id: k8s-1.16
+    manifest: certmanager.io/k8s-1.16.yaml
+    manifestHash: e0d7966ae9d077de6344323d78ae6c899a17cb3d
+    name: certmanager.io
+    selector: null
+    version: 1.1.0
+  - id: v1.15.0
+    kubernetesVersion: '>=1.15.0'
+    manifest: storage-aws.addons.k8s.io/v1.15.0.yaml
+    manifestHash: cc7393f22cb59dc4e23b9220ee962243334f47f1
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.17.0
+  - id: v1.7.0
+    kubernetesVersion: <1.15.0
+    manifest: storage-aws.addons.k8s.io/v1.7.0.yaml
+    manifestHash: 0a699ecad09b62fd94da8b97d1c2204c716c2b8f
+    name: storage-aws.addons.k8s.io
+    selector:
+      k8s-addon: storage-aws.addons.k8s.io
+    version: 1.17.0
+  - id: k8s-1.12
+    manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
+    manifestHash: 57f434b35f81299083798cce92cfbf9dd3629cd0
+    name: networking.cilium.io
+    needsRollingUpdate: all
+    selector:
+      role.kubernetes.io/networking: "1"
+    version: 1.9.4-kops.1

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -1,17 +1,25 @@
-# sourced from https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.4/components.yaml
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -27,11 +35,17 @@ rules:
   - get
   - list
   - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: system:metrics-server
 rules:
@@ -47,11 +61,17 @@ rules:
   - get
   - list
   - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server-auth-reader
   namespace: kube-system
@@ -63,11 +83,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server:system:auth-delegator
 roleRef:
@@ -78,11 +104,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: system:metrics-server
 roleRef:
@@ -93,11 +125,17 @@ subjects:
 - kind: ServiceAccount
   name: metrics-server
   namespace: kube-system
+
 ---
+
 apiVersion: v1
 kind: Service
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
@@ -109,11 +147,17 @@ spec:
     targetPort: https
   selector:
     k8s-app: metrics-server
+
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
@@ -129,18 +173,11 @@ spec:
     spec:
       containers:
       - args:
-          - --secure-port=4443
-          - --kubelet-use-node-status-port
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-          - --tls-cert-file=/srv/tls.crt
-          - --tls-private-key-file=/srv/tls.key
-{{ else }}
-          - --cert-dir=/tmp
-{{ end }}
-{{ if or (not UseKopsControllerForNodeBootstrap) (WithDefaultBool .MetricsServer.Insecure true) }}
-          - --kubelet-insecure-tls
-{{ end }}
-        image: {{ or .MetricsServer.Image "k8s.gcr.io/metrics-server/metrics-server:v0.4.4" }}
+        - --secure-port=4443
+        - --kubelet-use-node-status-port
+        - --tls-cert-file=/srv/tls.crt
+        - --tls-private-key-file=/srv/tls.key
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.4.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -161,84 +198,93 @@ spec:
             port: https
             scheme: HTTPS
           periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000
         volumeMounts:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
-        - name: certs
-          mountPath: /srv
-{{ end }}
+        - mountPath: /srv
+          name: certs
         - mountPath: /tmp
           name: tmp-dir
-        resources:
-          requests:
-            cpu: 50m
-            memory: 128Mi
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
       volumes:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
       - name: certs
         secret:
           secretName: metrics-server-tls
-{{ end }}
       - emptyDir: {}
         name: tmp-dir
+
 ---
+
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
   annotations:
     cert-manager.io/inject-ca-from: kube-system/metrics-server
-{{ end }}
+  creationTimestamp: null
   labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
     k8s-app: metrics-server
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io
   groupPriorityMinimum: 100
-{{ if WithDefaultBool .MetricsServer.Insecure true }}
-  insecureSkipTLSVerify: true
-{{ end }}
   service:
     name: metrics-server
     namespace: kube-system
   version: v1beta1
   versionPriority: 100
+
 ---
+
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
+    k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
-  labels:
-    k8s-app: metrics-server
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       k8s-app: metrics-server
-{{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
+
 ---
+
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: metrics-server.addons.k8s.io
+    addon.kops.k8s.io/version: 0.4.4
+    app.kubernetes.io/managed-by: kops
+    k8s-app: metrics-server
   name: metrics-server
   namespace: kube-system
 spec:
-  secretName: metrics-server-tls
-  duration: 2160h
-  renewBefore: 360h
-  usages:
-    - server auth
   dnsNames:
   - metrics-server.kube-system.svc
+  duration: 2160h
   issuerRef:
-    name: metrics-server.addons.k8s.io
     kind: Issuer
-{{ end }}
+    name: metrics-server.addons.k8s.io
+  renewBefore: 360h
+  secretName: metrics-server-tls
+  usages:
+  - server auth


### PR DESCRIPTION
Cherry pick of #12114 on release-1.21.

#12114: Make metrics-server insecure if insecure is true

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.