### PR TITLE
Pass AZURE_ENVIRONMENT to nodeup

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -204,6 +204,10 @@ func (b *BootstrapScript) buildEnvironmentVariables(cluster *kops.Cluster) (map[
 
 	if kops.CloudProviderID(cluster.Spec.CloudProvider) == kops.CloudProviderAzure {
 		env["AZURE_STORAGE_ACCOUNT"] = os.Getenv("AZURE_STORAGE_ACCOUNT")
+		azureEnv := os.Getenv("AZURE_ENVIRONMENT")
+		if azureEnv != "" {
+			env["AZURE_ENVIRONMENT"] = os.Getenv("AZURE_ENVIRONMENT")
+		}
 	}
 
 	return env, nil


### PR DESCRIPTION
This allows nodeup to use the same azure environment as the kops cli, working towards support for azure government.

https://github.com/kubernetes/kops/blob/b858297fa4f34148374c882c64ebd3025ed59d5a/vendor/github.com/Azure/go-autorest/autorest/azure/auth/auth.go#L48

https://github.com/kubernetes/kops/blob/b858297fa4f34148374c882c64ebd3025ed59d5a/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go#L34-L39