### PR TITLE
Support GSFS Terraform Managed Files

### DIFF
--- a/util/pkg/vfs/tests/BUILD.bazel
+++ b/util/pkg/vfs/tests/BUILD.bazel
@@ -2,11 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    srcs = ["s3fs_test.go"],
+    srcs = [
+        "gsfs_test.go",
+        "s3fs_test.go",
+    ],
     deps = [
+        "//cloudmock/gce:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
         "//util/pkg/vfs:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/google.golang.org/api/storage/v1:go_default_library",
     ],
 )

--- a/util/pkg/vfs/tests/BUILD.bazel
+++ b/util/pkg/vfs/tests/BUILD.bazel
@@ -6,6 +6,9 @@ go_test(
         "gsfs_test.go",
         "s3fs_test.go",
     ],
+    data = [
+        "//util/pkg/vfs/tests:mock_gcp_credentials",  # keep
+    ],
     deps = [
         "//cloudmock/gce:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
@@ -14,4 +17,10 @@ go_test(
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/google.golang.org/api/storage/v1:go_default_library",
     ],
+)
+
+filegroup(
+    name = "mock_gcp_credentials",
+    srcs = ["mock_gcp_credentials.json"],
+    visibility = ["//visibility:public"],
 )

--- a/util/pkg/vfs/tests/BUILD.bazel
+++ b/util/pkg/vfs/tests/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["s3fs_test.go"],
+    deps = [
+        "//upup/pkg/fi/cloudup/awsup:go_default_library",
+        "//upup/pkg/fi/cloudup/terraform:go_default_library",
+        "//util/pkg/vfs:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+    ],
+)

--- a/util/pkg/vfs/tests/gsfs_test.go
+++ b/util/pkg/vfs/tests/gsfs_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/storage/v1"
+	"k8s.io/kops/cloudmock/gce"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/util/pkg/vfs"
+)
+
+func TestGSRenderTerraform(t *testing.T) {
+	content := "hello world"
+	grid := []struct {
+		expectedPath       string
+		gsPath             string
+		gsObject           string
+		serviceAcct        string
+		expectedObjectJSON string
+		expectedACLJSON    string
+	}{
+		{
+			gsPath:      "gs://foo/bar",
+			gsObject:    "bar",
+			serviceAcct: "foo-123@project.iam.gserviceaccount.com",
+			expectedObjectJSON: `
+			{
+				"bucket": "foo",
+				"name": "bar",
+				"source": "\"${path.module}/data/google_storage_bucket_object_bar_content\""
+			}
+			`,
+			expectedACLJSON: `
+			{
+				"bucket": "foo",
+				"object": "${google_storage_bucket_object.bar.output_name}",
+				"role_entity": [
+					"READER:user-foo-123@project.iam.gserviceaccount.com"
+				]
+			}
+			`,
+		},
+	}
+	for _, tc := range grid {
+
+		t.Run(tc.gsPath, func(t *testing.T) {
+			cloud := gce.InstallMockGCECloud("us-central1", "project")
+			path, err := vfs.Context.BuildVfsPath(tc.gsPath)
+			if err != nil {
+				t.Fatalf("error building VFS path: %v", err)
+				t.FailNow()
+			}
+
+			vfsProvider, err := path.(vfs.TerraformPath).TerraformProvider()
+			if err != nil {
+				t.Fatalf("error building VFS Terraform provider: %v", err)
+				t.FailNow()
+			}
+			target := terraform.NewTerraformTarget(cloud, "", vfsProvider, "/dev/null", nil)
+
+			acl := vfs.GSAcl{
+				Acl: []*storage.ObjectAccessControl{
+					{
+						Entity: fmt.Sprintf("user-%v", tc.serviceAcct),
+						Role:   "READER",
+					},
+				},
+			}
+			err = path.(*vfs.GSPath).RenderTerraform(
+				&target.TerraformWriter, tc.gsObject, strings.NewReader(content), acl,
+			)
+			if err != nil {
+				t.Fatalf("error rendering terraform %v", err)
+				t.FailNow()
+			}
+			res, err := target.GetResourcesByType()
+			if err != nil {
+				t.Fatalf("error fetching terraform resources: %v", err)
+				t.FailNow()
+			}
+			if objs := res["google_storage_bucket_object"]; objs == nil {
+				t.Fatalf("google_storage_bucket_object resources not found: %v", res)
+				t.FailNow()
+			}
+			if obj := res["google_storage_bucket_object"][tc.gsObject]; obj == nil {
+				t.Fatalf("google_storage_bucket_object object not found: %v", res["google_storage_bucket_object"])
+				t.FailNow()
+			}
+			obj, err := json.Marshal(res["google_storage_bucket_object"][tc.gsObject])
+			if err != nil {
+				t.Fatalf("error marshaling gs object: %v", err)
+				t.FailNow()
+			}
+			if !assert.JSONEq(t, tc.expectedObjectJSON, string(obj), "JSON representation of terraform resource did not match") {
+				t.FailNow()
+			}
+			if objs := target.TerraformWriter.Files[fmt.Sprintf("data/google_storage_bucket_object_%v_content", tc.gsObject)]; objs == nil {
+				t.Fatalf("google_storage_bucket_object content file not found: %v", target.TerraformWriter.Files)
+				t.FailNow()
+			}
+			actualContent := string(target.TerraformWriter.Files[fmt.Sprintf("data/google_storage_bucket_object_%v_content", tc.gsObject)])
+			if !assert.Equal(t, content, actualContent, "google_storage_bucket_object content did not match") {
+				t.FailNow()
+			}
+
+			if objs := res["google_storage_object_access_control"]; objs == nil {
+				t.Fatalf("google_storage_object_access_control resources not found: %v", res)
+				t.FailNow()
+			}
+			if obj := res["google_storage_object_access_control"][tc.gsObject]; obj == nil {
+				t.Fatalf("google_storage_object_access_control object not found: %v", res["google_storage_object_access_control"])
+				t.FailNow()
+			}
+			actualACL, err := json.Marshal(res["google_storage_object_access_control"][tc.gsObject])
+			if err != nil {
+				t.Fatalf("error marshaling gs ACL: %v", err)
+				t.FailNow()
+			}
+			if !assert.JSONEq(t, tc.expectedACLJSON, string(actualACL), "JSON representation of terraform resource did not match") {
+				t.FailNow()
+			}
+
+		})
+	}
+}

--- a/util/pkg/vfs/tests/gsfs_test.go
+++ b/util/pkg/vfs/tests/gsfs_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -29,7 +30,16 @@ import (
 	"k8s.io/kops/util/pkg/vfs"
 )
 
+var credsFile = "./mock_gcp_credentials.json"
+
 func TestGSRenderTerraform(t *testing.T) {
+	creds, err := filepath.Abs(credsFile)
+	if err != nil {
+		t.Fatalf("failed to prepare mock gcp credentials: %v", err)
+		t.FailNow()
+	}
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", creds)
+
 	content := "hello world"
 	grid := []struct {
 		expectedPath       string

--- a/util/pkg/vfs/tests/gsfs_test.go
+++ b/util/pkg/vfs/tests/gsfs_test.go
@@ -47,6 +47,7 @@ func TestGSRenderTerraform(t *testing.T) {
 			{
 				"bucket": "foo",
 				"name": "bar",
+				"provider": "${google.files}",
 				"source": "\"${path.module}/data/google_storage_bucket_object_bar_content\""
 			}
 			`,
@@ -54,6 +55,7 @@ func TestGSRenderTerraform(t *testing.T) {
 			{
 				"bucket": "foo",
 				"object": "${google_storage_bucket_object.bar.output_name}",
+				"provider": "${google.files}",
 				"role_entity": [
 					"READER:user-foo-123@project.iam.gserviceaccount.com"
 				]

--- a/util/pkg/vfs/tests/mock_gcp_credentials.json
+++ b/util/pkg/vfs/tests/mock_gcp_credentials.json
@@ -1,0 +1,14 @@
+{
+  "installed": {
+    "client_id": "foo.apps.googleusercontent.com",
+    "project_id": "foo",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_secret": "foo",
+    "redirect_uris": [
+      "urn:ietf:wg:oauth:2.0:oob",
+      "http://localhost"
+    ]
+  }
+}

--- a/util/pkg/vfs/tests/s3fs_test.go
+++ b/util/pkg/vfs/tests/s3fs_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/terraform"
+	"k8s.io/kops/util/pkg/vfs"
+)
+
+func TestS3RenderTerraform(t *testing.T) {
+	content := "hello world"
+	grid := []struct {
+		expectedPath string
+		s3Path       string
+		s3Object     string
+		expectedJSON string
+	}{
+		{
+			s3Path:   "s3://foo/bar",
+			s3Object: "bar",
+			expectedJSON: `
+			{
+				"acl": "bucket-owner-full-control",
+				"bucket": "foo",
+				"content": "${file(\"${path.module}/data/aws_s3_bucket_object_bar_content\")}",
+				"key": "bar",
+				"provider": "${aws.files}",
+				"server_side_encryption": "AES256"
+			}
+			`,
+		},
+	}
+	origEndpoint := os.Getenv("S3_ENDPOINT")
+	os.Setenv("S3_ENDPOINT", "foo.s3.amazonaws.com")
+	defer os.Setenv("S3_ENDPOINT", origEndpoint)
+
+	origACL := os.Getenv("KOPS_STATE_S3_ACL")
+	os.Setenv("KOPS_STATE_S3_ACL", "bucket-owner-full-control")
+	defer os.Setenv("KOPS_STATE_S3_ACL", origACL)
+	for _, tc := range grid {
+
+		t.Run(tc.s3Path, func(t *testing.T) {
+			cloud := awsup.BuildMockAWSCloud("us-east-1", "a")
+			path, err := vfs.Context.BuildVfsPath(tc.s3Path)
+			if err != nil {
+				t.Fatalf("error building VFS path: %v", err)
+				t.FailNow()
+			}
+
+			vfsProvider, err := path.(vfs.TerraformPath).TerraformProvider()
+			if err != nil {
+				t.Fatalf("error building VFS Terraform provider: %v", err)
+				t.FailNow()
+			}
+			target := terraform.NewTerraformTarget(cloud, "", vfsProvider, "/dev/null", nil)
+
+			err = path.(*vfs.S3Path).RenderTerraform(
+				&target.TerraformWriter, tc.s3Object, strings.NewReader(content), vfs.S3Acl{},
+			)
+			if err != nil {
+				t.Fatalf("error rendering terraform %v", err)
+				t.FailNow()
+			}
+			res, err := target.GetResourcesByType()
+			if err != nil {
+				t.Fatalf("error fetching terraform resources: %v", err)
+				t.FailNow()
+			}
+			if objs := res["aws_s3_bucket_object"]; objs == nil {
+				t.Fatalf("aws_s3_bucket_object resources not found: %v", res)
+				t.FailNow()
+			}
+			if obj := res["aws_s3_bucket_object"][tc.s3Object]; obj == nil {
+				t.Fatalf("aws_s3_bucket_object object not found: %v", res["aws_s3_bucket_object"])
+				t.FailNow()
+			}
+			obj, err := json.Marshal(res["aws_s3_bucket_object"][tc.s3Object])
+			if err != nil {
+				t.Fatalf("error marshaling s3 object: %v", err)
+				t.FailNow()
+			}
+			if !assert.JSONEq(t, tc.expectedJSON, string(obj), "JSON representation of terraform resource did not match") {
+				t.FailNow()
+			}
+			if objs := target.TerraformWriter.Files[fmt.Sprintf("data/aws_s3_bucket_object_%v_content", tc.s3Object)]; objs == nil {
+				t.Fatalf("aws_s3_bucket_object content file not found: %v", target.TerraformWriter.Files)
+				t.FailNow()
+			}
+			actualContent := string(target.TerraformWriter.Files[fmt.Sprintf("data/aws_s3_bucket_object_%v_content", tc.s3Object)])
+			if !assert.Equal(t, content, actualContent, "aws_s3_bucket_object content did not match") {
+				t.FailNow()
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds support for google storage objects rendered in Terraform.

I also added unit tests for both GS and S3. Ideally we could generate their HCL representations and save them to their own .tf files that could be checked by ./hack/verify-terraform.sh but our terraform target would require significant refactoring to be usable in isolated tests like this. Instead we just marshal the resources to JSON.

closes https://github.com/kubernetes/kops/issues/11929

WIP until I get around to testing a `terraform apply` with this.