### PR TITLE
Fix cases when the VPC doesn't exist yet

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
@@ -44,6 +44,12 @@ func (e *VPCCIDRBlock) Find(c *fi.Context) (*VPCCIDRBlock, error) {
 	cloud := c.Cloud.(awsup.AWSCloud)
 
 	vpcID := aws.StringValue(e.VPC.ID)
+
+	// If the VPC doesn't (yet) exist, there is no association
+	if vpcID == "" {
+		return nil, nil
+	}
+
 	vpc, err := cloud.DescribeVPC(vpcID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Similarly to the code here, we should catch cases when the VPC doesn't exist yet.  

This is similar to: https://github.com/kubernetes/kops/blob/e7b52981abd9c510106ab4e43a5fa7ae19f80fec/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go#L44-L48