### PR TITLE
Fix cases when the VPC doesn't exist yet for vpccidrblocks in 1.21

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpccidrblock.go
@@ -44,6 +44,11 @@ func (e *VPCCIDRBlock) Find(c *fi.Context) (*VPCCIDRBlock, error) {
 
 	vpcID := e.VPC.ID
 
+	// If the VPC doesn't (yet) exist, there is no association
+	if vpcID == nil {
+		return nil, nil
+	}
+
 	vpc, err := cloud.DescribeVPC(*vpcID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Backported version of https://github.com/kubernetes/kops/pull/12124.  