### PR TITLE
Always enable IPv4 forwarding

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -145,15 +145,14 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
+	sysctls = append(sysctls,
+		"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
+		"net.ipv4.ip_forward=1",
+		"")
 	if b.Cluster.Spec.IsIPv6Only() {
 		sysctls = append(sysctls,
 			"net.ipv6.ip_forward=1",
 			"net.ipv6.conf.all.accept_ra=2",
-			"")
-	} else {
-		sysctls = append(sysctls,
-			"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
-			"net.ipv4.ip_forward=1",
 			"")
 	}
 


### PR DESCRIPTION
... event if cluster is "IPv6 only", IPv6 only is just at k8s level.

/cc @olemarkus 