### PR TITLE
Automated cherry pick of #12141: Bump cilium to 1.10.3

### DIFF
--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.9.7"
+		c.Version = "v1.9.9"
 	}
 
 	version, _ := semver.ParseTolerant(c.Version)

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -188,6 +188,8 @@ data:
   {{ end }}
   {{ end }}
 
+  cgroup-root: /sys/fs/cgroup/unified
+
   {{ if WithDefaultBool .Hubble.Enabled false }}
   # Enable Hubble gRPC service.
   enable-hubble: "true"
@@ -714,6 +716,10 @@ spec:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
           mountPropagation: HostToContainer
+        # Required to mount cgroup filesystem from the host to cilium agent pod
+        - mountPath: /sys/fs/cgroup/unified
+          name: cilium-cgroup
+          mountPropagation: HostToContainer
         - mountPath: /var/run/cilium
           name: cilium-run
         resources:
@@ -745,7 +751,12 @@ spec:
           path:  /opt/cni/bin
           type: DirectoryOrCreate
         name: cni-path
-        # To install cilium cni configuration in the host
+      # To keep state between restarts / upgrades for cgroup2 filesystem
+      - hostPath:
+          path: /sys/fs/cgroup/unified
+          type: DirectoryOrCreate
+        name: cilium-cgroup
+      # To install cilium cni configuration in the host
       - hostPath:
           path: /etc/cni/net.d
           type: DirectoryOrCreate

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -190,6 +190,8 @@ data:
   {{ end }}
   {{ end }}
 
+  cgroup-root: /sys/fs/cgroup/unified
+
   {{ if WithDefaultBool .Hubble.Enabled false }}
   # Enable Hubble gRPC service.
   enable-hubble: "true"
@@ -563,7 +565,7 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
-          failureThreshold: 24
+          failureThreshold: 105
           periodSeconds: 2
           successThreshold: 
         livenessProbe:
@@ -737,6 +739,10 @@ spec:
         - mountPath: /sys/fs/bpf
           name: bpf-maps
           mountPropagation: HostToContainer
+         # Required to mount cgroup filesystem from the host to cilium agent pod
+        - mountPath: /sys/fs/cgroup/unified
+          name: cilium-cgroup
+          mountPropagation: HostToContainer
         - mountPath: /var/run/cilium
           name: cilium-run
         resources:
@@ -758,7 +764,7 @@ spec:
           path: /var/run/cilium
           type: DirectoryOrCreate
         name: cilium-run
-        # To keep state between restarts / upgrades for bpf maps
+      # To keep state between restarts / upgrades for bpf maps
       - hostPath:
           path: /sys/fs/bpf
           type: DirectoryOrCreate
@@ -768,6 +774,11 @@ spec:
           path:  /opt/cni/bin
           type: DirectoryOrCreate
         name: cni-path
+      # To keep state between restarts / upgrades for cgroup2 filesystem
+      - hostPath:
+          path: /sys/fs/cgroup/unified
+          type: DirectoryOrCreate
+        name: cilium-cgroup
         # To install cilium cni configuration in the host
       - hostPath:
           path: /etc/cni/net.d

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -71,7 +71,7 @@ spec:
     version: 1.17.0
   - id: k8s-1.12
     manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
-    manifestHash: 57f434b35f81299083798cce92cfbf9dd3629cd0
+    manifestHash: 74bcd38f360fd2c9e843b718b666d2994be56052
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -78,7 +78,7 @@ spec:
     version: 1.17.0
   - id: k8s-1.12
     manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
-    manifestHash: 57f434b35f81299083798cce92cfbf9dd3629cd0
+    manifestHash: 74bcd38f360fd2c9e843b718b666d2994be56052
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -71,7 +71,7 @@ spec:
     version: 1.17.0
   - id: k8s-1.12
     manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
-    manifestHash: 57f434b35f81299083798cce92cfbf9dd3629cd0
+    manifestHash: 74bcd38f360fd2c9e843b718b666d2994be56052
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -85,7 +85,7 @@ spec:
     version: 1.17.0
   - id: k8s-1.12
     manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
-    manifestHash: 57f434b35f81299083798cce92cfbf9dd3629cd0
+    manifestHash: 74bcd38f360fd2c9e843b718b666d2994be56052
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -78,7 +78,7 @@ spec:
     version: 1.17.0
   - id: k8s-1.12
     manifest: networking.cilium.io/k8s-1.12-v1.9.yaml
-    manifestHash: 57f434b35f81299083798cce92cfbf9dd3629cd0
+    manifestHash: 74bcd38f360fd2c9e843b718b666d2994be56052
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #12141 on release-1.21.

#12141: Bump cilium to 1.10.3

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.