### PR TITLE
leverage proxy env variables

### DIFF
--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -83,6 +83,7 @@ func downloadURLAlways(url string, destPath string, dirMode os.FileMode) error {
 	// to avoid idle downloads to hang the program
 	httpClient := &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
 				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,


### PR DESCRIPTION
The default http transport uses the proxy if the proxy environment variables exist.
However, since we are creating a new transport to define our own timeout, we should set that proxy option.

https://pkg.go.dev/net/http#DefaultTransport

Fixes:  https://github.com/kubernetes/kops/issues/12140