### PR TITLE
Automated cherry pick of #12161: Debian 11: Release AMIs use same AWS Owner ID as Buster

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -152,7 +152,7 @@ Available images can be listed using:
 
 ```bash
 aws ec2 describe-images --region us-east-1 --output table \
-  --owners 903794441882 \
+  --owners 136693071363 \
   --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
   --filters "Name=name,Values=debian-11-amd64-*"
 ```
@@ -261,7 +261,7 @@ kOps supports owner aliases for the official accounts of supported distros:
 * `centos` => `125523088429`
 * `debian9` => `379101102735`
 * `debian10` => `136693071363`
-* `debian11` => `903794441882`
+* `debian11` => `136693071363`
 * `flatcar` => `075585003325`
 * `redhat` => `309956199498`
 * `ubuntu` => `099720109477`

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -524,7 +524,7 @@ func guessSSHUser(image *ec2.Image) string {
 		return "ec2-user"
 	case awsup.WellKnownAccountCentOS:
 		return "centos"
-	case awsup.WellKnownAccountDebian9, awsup.WellKnownAccountDebian10, awsup.WellKnownAccountDebian11, awsup.WellKnownAccountKopeio:
+	case awsup.WellKnownAccountDebian, awsup.WellKnownAccountDebian9, awsup.WellKnownAccountKopeio:
 		return "admin"
 	case awsup.WellKnownAccountUbuntu:
 		return "ubuntu"

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -99,9 +99,8 @@ const (
 	WellKnownAccountAmazonLinux2 = "137112412989"
 	WellKnownAccountCentOS       = "125523088429"
 	WellKnownAccountCoreOS       = "595879546273"
+	WellKnownAccountDebian       = "136693071363"
 	WellKnownAccountDebian9      = "379101102735"
-	WellKnownAccountDebian10     = "136693071363"
-	WellKnownAccountDebian11     = "903794441882"
 	WellKnownAccountFlatcar      = "075585003325"
 	WellKnownAccountKopeio       = "383156758163"
 	WellKnownAccountRedhat       = "309956199498"
@@ -1507,9 +1506,9 @@ func resolveImage(ec2Client ec2iface.EC2API, name string) (*ec2.Image, error) {
 			case "debian9":
 				owner = WellKnownAccountDebian9
 			case "debian10":
-				owner = WellKnownAccountDebian10
+				owner = WellKnownAccountDebian
 			case "debian11":
-				owner = WellKnownAccountDebian11
+				owner = WellKnownAccountDebian
 			case "flatcar":
 				owner = WellKnownAccountFlatcar
 			case "kopeio", "kope.io":


### PR DESCRIPTION
Cherry pick of #12161 on release-1.21.

#12161: Debian 11: Release AMIs use same AWS Owner ID as Buster

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.