### PR TITLE
Fix MetricsGrabber skip regex condition

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -57,9 +57,10 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|Services.*affinity"
 	}
 
-	if strings.Contains(cluster.Spec.KubernetesVersion, "v1.22.") {
-		// TODO(rifelpet): Remove once k8s tags has been created that include
-		// https://github.com/kubernetes/kubernetes/pull/104061
+	if strings.HasSuffix(cluster.Spec.KubernetesVersion, "v1.23.0-alpha.0") {
+		// This matches `k8s_version='latest'` in build_jobs.py
+		// TODO(rifelpet): Remove once the next 1.23 pre-release tag has been created
+		// ref: https://github.com/kubernetes/kubernetes/pull/104061
 		skipRegex += "|MetricsGrabber.should.grab.all.metrics.from.a.ControllerManager"
 	}
 


### PR DESCRIPTION
The release/latest version marker will stay on 1.23.0-alpha.0 until another 1.23 pre-release is tagged which isn't for a while.
This will skip the MetricsGrabber test for that tag which has been fixed in master ([example failing job](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-grid-scenario-arm64/1427307647635296256#1:build-log.txt%3A140)). This won't match CI builds since they have a [commit hash suffix](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-misc-arm64-ci/1427457851500007424#1:build-log.txt%3A142)


Once a new 1.23 pre-release has been tagged we can remove this.

Alternatively we migrate all jobs off of the release/latest version marker since it isn't particularly valuable.

/hold until 1.22.1 is tagged on Wednesday which includes the cherry-picked fix (https://github.com/kubernetes/kubernetes/pull/104154) so we'll no longer need to skip the test on k8s 1.22 jobs.