### PR TITLE
Fix unbound variable in metrics server scenario

### DIFF
--- a/tests/e2e/scenarios/metrics-server/run-test.sh
+++ b/tests/e2e/scenarios/metrics-server/run-test.sh
@@ -19,7 +19,7 @@ source "${REPO_ROOT}"/tests/e2e/scenarios/lib/common.sh
 
 kops-acquire-latest
 
-OVERRIDES="$OVERRIDES --override=cluster.spec.metricsServer.enabled=true"
+OVERRIDES="${OVERRIDES-} --override=cluster.spec.metricsServer.enabled=true"
 OVERRIDES="$OVERRIDES --override=cluster.spec.certManager.enabled=true"
 
 kops-up


### PR DESCRIPTION
following the pattern here:

https://github.com/kubernetes/kops/blob/51b22f062f5250c7a0e525362059c598fb493605/tests/e2e/scenarios/aws-ebs-csi/run-test.sh#L22-L24

ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-metrics-server/1427460871503745024#1:build-log.txt%3A160