### PR TITLE
Initial IPv6 support for GCE

### DIFF
--- a/pkg/model/gcemodel/api_loadbalancer.go
+++ b/pkg/model/gcemodel/api_loadbalancer.go
@@ -84,16 +84,13 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	// Allow traffic into the API (port 443) from KubernetesAPIAccess CIDRs
 	{
-		t := &gcetasks.FirewallRule{
-			Name:         s(b.NameForFirewallRule("https-api")),
+		b.AddFirewallRulesTasks(c, "https-api", &gcetasks.FirewallRule{
 			Lifecycle:    b.Lifecycle,
 			Network:      b.LinkToNetwork(),
 			SourceRanges: b.Cluster.Spec.KubernetesAPIAccess,
 			TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
 			Allowed:      []string{"tcp:443"},
-		}
-		c.AddTask(t)
+		})
 	}
 	return nil
-
 }

--- a/pkg/model/gcemodel/external_access.go
+++ b/pkg/model/gcemodel/external_access.go
@@ -49,8 +49,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		// But I think we can always add more permissions in this case later, but we can't easily take them away
 		klog.V(2).Infof("bastion is in use; won't configure SSH access to master / node instances")
 	} else {
-		c.AddTask(&gcetasks.FirewallRule{
-			Name:         s(b.SafeObjectName("ssh-external-to-master")),
+		b.AddFirewallRulesTasks(c, "ssh-external-to-master", &gcetasks.FirewallRule{
 			Lifecycle:    b.Lifecycle,
 			TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
 			Allowed:      []string{"tcp:22"},
@@ -58,8 +57,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Network:      b.LinkToNetwork(),
 		})
 
-		c.AddTask(&gcetasks.FirewallRule{
-			Name:         s(b.SafeObjectName("ssh-external-to-node")),
+		b.AddFirewallRulesTasks(c, "ssh-external-to-node", &gcetasks.FirewallRule{
 			Lifecycle:    b.Lifecycle,
 			TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
 			Allowed:      []string{"tcp:22"},
@@ -74,9 +72,9 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		if err != nil {
 			return err
 		}
+
 		nodePortRangeString := nodePortRange.String()
-		t := &gcetasks.FirewallRule{
-			Name:       s(b.SafeObjectName("nodeport-external-to-node")),
+		b.AddFirewallRulesTasks(c, "nodeport-external-to-node", &gcetasks.FirewallRule{
 			Lifecycle:  b.Lifecycle,
 			TargetTags: []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
 			Allowed: []string{
@@ -85,13 +83,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			},
 			SourceRanges: b.Cluster.Spec.NodePortAccess,
 			Network:      b.LinkToNetwork(),
-		}
-		if len(t.SourceRanges) == 0 {
-			// Empty SourceRanges is interpreted as 0.0.0.0/0 if tags are empty, so we set a SourceTag
-			// This is already covered by the normal node-to-node rules, but avoids opening the NodePort range
-			t.SourceTags = []string{b.GCETagForRole(kops.InstanceGroupRoleNode)}
-		}
-		c.AddTask(t)
+		})
 	}
 
 	if !b.UseLoadBalancerForAPI() {
@@ -100,8 +92,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		// We need to open security groups directly to the master nodes (instead of via the ELB)
 
 		// HTTPS to the master is allowed (for API access)
-		c.AddTask(&gcetasks.FirewallRule{
-			Name:         s(b.SafeObjectName("kubernetes-master-https")),
+		b.AddFirewallRulesTasks(c, "kubernetes-master-https", &gcetasks.FirewallRule{
 			Lifecycle:    b.Lifecycle,
 			TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
 			Allowed:      []string{"tcp:443"},

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -49,7 +49,8 @@ const (
 )
 
 // Maximum number of `-` separated tokens in a name
-const maxPrefixTokens = 4
+// Example: nodeport-external-to-node-ipv6
+const maxPrefixTokens = 5
 
 func ListResourcesGCE(gceCloud gce.GCECloud, clusterName string, region string) (map[string]*resources.Resource, error) {
 	if region == "" {

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -153,6 +153,7 @@ spec:
     podManifestPath: /etc/kubernetes/manifests
   kubernetesApiAccess:
   - 0.0.0.0/0
+  - ::/0
   kubernetesVersion: 1.21.0
   masterInternalName: api.internal.ha-gce.example.com
   masterKubelet:
@@ -182,6 +183,7 @@ spec:
   serviceClusterIPRange: 100.64.0.0/13
   sshAccess:
   - 0.0.0.0/0
+  - ::/0
   subnets:
   - name: us-test1
     region: us-test1

--- a/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/ha_gce/in-v1alpha2.yaml
@@ -35,6 +35,7 @@ spec:
     anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
+  - ::/0
   kubernetesVersion: v1.21.0
   masterPublicName: api.ha-gce.example.com
   networking:
@@ -43,6 +44,7 @@ spec:
   project: testproject
   sshAccess:
   - 0.0.0.0/0
+  - ::/0
   subnets:
   - name: us-test1
     region: us-test1

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -249,10 +249,26 @@ resource "google_compute_firewall" "cidr-to-master-ha-gce-example-com" {
     ports    = ["4194"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "cidr-to-master-ha-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["100.64.0.0/10"]
   target_tags   = ["ha-gce-example-com-k8s-io-role-master"]
+}
+
+resource "google_compute_firewall" "cidr-to-master-ipv6-ha-gce-example-com" {
+  allow {
+    ports    = ["443"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["4194"]
+    protocol = "tcp"
+  }
+  disabled    = true
+  name        = "cidr-to-master-ipv6-ha-gce-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["ha-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "cidr-to-node-ha-gce-example-com" {
@@ -274,10 +290,36 @@ resource "google_compute_firewall" "cidr-to-node-ha-gce-example-com" {
   allow {
     protocol = "sctp"
   }
+  disabled      = false
   name          = "cidr-to-node-ha-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["100.64.0.0/10"]
   target_tags   = ["ha-gce-example-com-k8s-io-role-node"]
+}
+
+resource "google_compute_firewall" "cidr-to-node-ipv6-ha-gce-example-com" {
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
+  }
+  allow {
+    protocol = "icmp"
+  }
+  allow {
+    protocol = "esp"
+  }
+  allow {
+    protocol = "ah"
+  }
+  allow {
+    protocol = "sctp"
+  }
+  disabled    = true
+  name        = "cidr-to-node-ipv6-ha-gce-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["ha-gce-example-com-k8s-io-role-node"]
 }
 
 resource "google_compute_firewall" "kubernetes-master-https-ha-gce-example-com" {
@@ -285,9 +327,22 @@ resource "google_compute_firewall" "kubernetes-master-https-ha-gce-example-com" 
     ports    = ["443"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "kubernetes-master-https-ha-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["ha-gce-example-com-k8s-io-role-master"]
+}
+
+resource "google_compute_firewall" "kubernetes-master-https-ipv6-ha-gce-example-com" {
+  allow {
+    ports    = ["443"]
+    protocol = "tcp"
+  }
+  disabled      = false
+  name          = "kubernetes-master-https-ipv6-ha-gce-example-com"
+  network       = google_compute_network.default.name
+  source_ranges = ["::/0"]
   target_tags   = ["ha-gce-example-com-k8s-io-role-master"]
 }
 
@@ -310,6 +365,7 @@ resource "google_compute_firewall" "master-to-master-ha-gce-example-com" {
   allow {
     protocol = "sctp"
   }
+  disabled    = false
   name        = "master-to-master-ha-gce-example-com"
   network     = google_compute_network.default.name
   source_tags = ["ha-gce-example-com-k8s-io-role-master"]
@@ -335,6 +391,7 @@ resource "google_compute_firewall" "master-to-node-ha-gce-example-com" {
   allow {
     protocol = "sctp"
   }
+  disabled    = false
   name        = "master-to-node-ha-gce-example-com"
   network     = google_compute_network.default.name
   source_tags = ["ha-gce-example-com-k8s-io-role-master"]
@@ -350,6 +407,7 @@ resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
     ports    = ["4194"]
     protocol = "tcp"
   }
+  disabled    = false
   name        = "node-to-master-ha-gce-example-com"
   network     = google_compute_network.default.name
   source_tags = ["ha-gce-example-com-k8s-io-role-node"]
@@ -375,6 +433,7 @@ resource "google_compute_firewall" "node-to-node-ha-gce-example-com" {
   allow {
     protocol = "sctp"
   }
+  disabled    = false
   name        = "node-to-node-ha-gce-example-com"
   network     = google_compute_network.default.name
   source_tags = ["ha-gce-example-com-k8s-io-role-node"]
@@ -390,9 +449,24 @@ resource "google_compute_firewall" "nodeport-external-to-node-ha-gce-example-com
     ports    = ["30000-32767"]
     protocol = "udp"
   }
+  disabled    = true
   name        = "nodeport-external-to-node-ha-gce-example-com"
   network     = google_compute_network.default.name
-  source_tags = ["ha-gce-example-com-k8s-io-role-node"]
+  target_tags = ["ha-gce-example-com-k8s-io-role-node"]
+}
+
+resource "google_compute_firewall" "nodeport-external-to-node-ipv6-ha-gce-example-com" {
+  allow {
+    ports    = ["30000-32767"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["30000-32767"]
+    protocol = "udp"
+  }
+  disabled    = true
+  name        = "nodeport-external-to-node-ipv6-ha-gce-example-com"
+  network     = google_compute_network.default.name
   target_tags = ["ha-gce-example-com-k8s-io-role-node"]
 }
 
@@ -401,9 +475,22 @@ resource "google_compute_firewall" "ssh-external-to-master-ha-gce-example-com" {
     ports    = ["22"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "ssh-external-to-master-ha-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["ha-gce-example-com-k8s-io-role-master"]
+}
+
+resource "google_compute_firewall" "ssh-external-to-master-ipv6-ha-gce-example-com" {
+  allow {
+    ports    = ["22"]
+    protocol = "tcp"
+  }
+  disabled      = false
+  name          = "ssh-external-to-master-ipv6-ha-gce-example-com"
+  network       = google_compute_network.default.name
+  source_ranges = ["::/0"]
   target_tags   = ["ha-gce-example-com-k8s-io-role-master"]
 }
 
@@ -412,9 +499,22 @@ resource "google_compute_firewall" "ssh-external-to-node-ha-gce-example-com" {
     ports    = ["22"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "ssh-external-to-node-ha-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["ha-gce-example-com-k8s-io-role-node"]
+}
+
+resource "google_compute_firewall" "ssh-external-to-node-ipv6-ha-gce-example-com" {
+  allow {
+    ports    = ["22"]
+    protocol = "tcp"
+  }
+  disabled      = false
+  name          = "ssh-external-to-node-ipv6-ha-gce-example-com"
+  network       = google_compute_network.default.name
+  source_ranges = ["::/0"]
   target_tags   = ["ha-gce-example-com-k8s-io-role-node"]
 }
 

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -178,6 +178,21 @@ resource "google_compute_disk" "d1-etcd-main-minimal-gce-example-com" {
   zone = "us-test1-a"
 }
 
+resource "google_compute_firewall" "cidr-to-master-ipv6-minimal-gce-example-com" {
+  allow {
+    ports    = ["443"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["4194"]
+    protocol = "tcp"
+  }
+  disabled    = true
+  name        = "cidr-to-master-ipv6-minimal-gce-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-example-com-k8s-io-role-master"]
+}
+
 resource "google_compute_firewall" "cidr-to-master-minimal-gce-example-com" {
   allow {
     ports    = ["443"]
@@ -187,10 +202,36 @@ resource "google_compute_firewall" "cidr-to-master-minimal-gce-example-com" {
     ports    = ["4194"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "cidr-to-master-minimal-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["100.64.0.0/10"]
   target_tags   = ["minimal-gce-example-com-k8s-io-role-master"]
+}
+
+resource "google_compute_firewall" "cidr-to-node-ipv6-minimal-gce-example-com" {
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
+  }
+  allow {
+    protocol = "icmp"
+  }
+  allow {
+    protocol = "esp"
+  }
+  allow {
+    protocol = "ah"
+  }
+  allow {
+    protocol = "sctp"
+  }
+  disabled    = true
+  name        = "cidr-to-node-ipv6-minimal-gce-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-example-com-k8s-io-role-node"]
 }
 
 resource "google_compute_firewall" "cidr-to-node-minimal-gce-example-com" {
@@ -212,10 +253,22 @@ resource "google_compute_firewall" "cidr-to-node-minimal-gce-example-com" {
   allow {
     protocol = "sctp"
   }
+  disabled      = false
   name          = "cidr-to-node-minimal-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["100.64.0.0/10"]
   target_tags   = ["minimal-gce-example-com-k8s-io-role-node"]
+}
+
+resource "google_compute_firewall" "kubernetes-master-https-ipv6-minimal-gce-example-com" {
+  allow {
+    ports    = ["443"]
+    protocol = "tcp"
+  }
+  disabled    = true
+  name        = "kubernetes-master-https-ipv6-minimal-gce-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "kubernetes-master-https-minimal-gce-example-com" {
@@ -223,6 +276,7 @@ resource "google_compute_firewall" "kubernetes-master-https-minimal-gce-example-
     ports    = ["443"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "kubernetes-master-https-minimal-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["0.0.0.0/0"]
@@ -248,6 +302,7 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-example-com" {
   allow {
     protocol = "sctp"
   }
+  disabled    = false
   name        = "master-to-master-minimal-gce-example-com"
   network     = google_compute_network.default.name
   source_tags = ["minimal-gce-example-com-k8s-io-role-master"]
@@ -273,6 +328,7 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-example-com" {
   allow {
     protocol = "sctp"
   }
+  disabled    = false
   name        = "master-to-node-minimal-gce-example-com"
   network     = google_compute_network.default.name
   source_tags = ["minimal-gce-example-com-k8s-io-role-master"]
@@ -288,6 +344,7 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
     ports    = ["4194"]
     protocol = "tcp"
   }
+  disabled    = false
   name        = "node-to-master-minimal-gce-example-com"
   network     = google_compute_network.default.name
   source_tags = ["minimal-gce-example-com-k8s-io-role-node"]
@@ -313,9 +370,25 @@ resource "google_compute_firewall" "node-to-node-minimal-gce-example-com" {
   allow {
     protocol = "sctp"
   }
+  disabled    = false
   name        = "node-to-node-minimal-gce-example-com"
   network     = google_compute_network.default.name
   source_tags = ["minimal-gce-example-com-k8s-io-role-node"]
+  target_tags = ["minimal-gce-example-com-k8s-io-role-node"]
+}
+
+resource "google_compute_firewall" "nodeport-external-to-node-ipv6-minimal-gce-example-com" {
+  allow {
+    ports    = ["30000-32767"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["30000-32767"]
+    protocol = "udp"
+  }
+  disabled    = true
+  name        = "nodeport-external-to-node-ipv6-minimal-gce-example-com"
+  network     = google_compute_network.default.name
   target_tags = ["minimal-gce-example-com-k8s-io-role-node"]
 }
 
@@ -328,10 +401,21 @@ resource "google_compute_firewall" "nodeport-external-to-node-minimal-gce-exampl
     ports    = ["30000-32767"]
     protocol = "udp"
   }
+  disabled    = true
   name        = "nodeport-external-to-node-minimal-gce-example-com"
   network     = google_compute_network.default.name
-  source_tags = ["minimal-gce-example-com-k8s-io-role-node"]
   target_tags = ["minimal-gce-example-com-k8s-io-role-node"]
+}
+
+resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-example-com" {
+  allow {
+    ports    = ["22"]
+    protocol = "tcp"
+  }
+  disabled    = true
+  name        = "ssh-external-to-master-ipv6-minimal-gce-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-example-com" {
@@ -339,10 +423,22 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-example-c
     ports    = ["22"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "ssh-external-to-master-minimal-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["minimal-gce-example-com-k8s-io-role-master"]
+}
+
+resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-example-com" {
+  allow {
+    ports    = ["22"]
+    protocol = "tcp"
+  }
+  disabled    = true
+  name        = "ssh-external-to-node-ipv6-minimal-gce-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-example-com-k8s-io-role-node"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-example-com" {
@@ -350,6 +446,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-example-com
     ports    = ["22"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "ssh-external-to-node-minimal-gce-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["0.0.0.0/0"]

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -178,6 +178,21 @@ resource "google_compute_disk" "d1-etcd-main-minimal-gce-private-example-com" {
   zone = "us-test1-a"
 }
 
+resource "google_compute_firewall" "cidr-to-master-ipv6-minimal-gce-private-example-com" {
+  allow {
+    ports    = ["443"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["4194"]
+    protocol = "tcp"
+  }
+  disabled    = true
+  name        = "cidr-to-master-ipv6-minimal-gce-private-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-private-example-com-k8s-io-role-master"]
+}
+
 resource "google_compute_firewall" "cidr-to-master-minimal-gce-private-example-com" {
   allow {
     ports    = ["443"]
@@ -187,10 +202,36 @@ resource "google_compute_firewall" "cidr-to-master-minimal-gce-private-example-c
     ports    = ["4194"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "cidr-to-master-minimal-gce-private-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["100.64.0.0/10"]
   target_tags   = ["minimal-gce-private-example-com-k8s-io-role-master"]
+}
+
+resource "google_compute_firewall" "cidr-to-node-ipv6-minimal-gce-private-example-com" {
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
+  }
+  allow {
+    protocol = "icmp"
+  }
+  allow {
+    protocol = "esp"
+  }
+  allow {
+    protocol = "ah"
+  }
+  allow {
+    protocol = "sctp"
+  }
+  disabled    = true
+  name        = "cidr-to-node-ipv6-minimal-gce-private-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-private-example-com-k8s-io-role-node"]
 }
 
 resource "google_compute_firewall" "cidr-to-node-minimal-gce-private-example-com" {
@@ -212,10 +253,22 @@ resource "google_compute_firewall" "cidr-to-node-minimal-gce-private-example-com
   allow {
     protocol = "sctp"
   }
+  disabled      = false
   name          = "cidr-to-node-minimal-gce-private-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["100.64.0.0/10"]
   target_tags   = ["minimal-gce-private-example-com-k8s-io-role-node"]
+}
+
+resource "google_compute_firewall" "kubernetes-master-https-ipv6-minimal-gce-private-example-com" {
+  allow {
+    ports    = ["443"]
+    protocol = "tcp"
+  }
+  disabled    = true
+  name        = "kubernetes-master-https-ipv6-minimal-gce-private-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-private-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "kubernetes-master-https-minimal-gce-private-example-com" {
@@ -223,6 +276,7 @@ resource "google_compute_firewall" "kubernetes-master-https-minimal-gce-private-
     ports    = ["443"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "kubernetes-master-https-minimal-gce-private-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["0.0.0.0/0"]
@@ -248,6 +302,7 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-private-example
   allow {
     protocol = "sctp"
   }
+  disabled    = false
   name        = "master-to-master-minimal-gce-private-example-com"
   network     = google_compute_network.default.name
   source_tags = ["minimal-gce-private-example-com-k8s-io-role-master"]
@@ -273,6 +328,7 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-private-example-c
   allow {
     protocol = "sctp"
   }
+  disabled    = false
   name        = "master-to-node-minimal-gce-private-example-com"
   network     = google_compute_network.default.name
   source_tags = ["minimal-gce-private-example-com-k8s-io-role-master"]
@@ -288,6 +344,7 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-private-example-c
     ports    = ["4194"]
     protocol = "tcp"
   }
+  disabled    = false
   name        = "node-to-master-minimal-gce-private-example-com"
   network     = google_compute_network.default.name
   source_tags = ["minimal-gce-private-example-com-k8s-io-role-node"]
@@ -313,9 +370,25 @@ resource "google_compute_firewall" "node-to-node-minimal-gce-private-example-com
   allow {
     protocol = "sctp"
   }
+  disabled    = false
   name        = "node-to-node-minimal-gce-private-example-com"
   network     = google_compute_network.default.name
   source_tags = ["minimal-gce-private-example-com-k8s-io-role-node"]
+  target_tags = ["minimal-gce-private-example-com-k8s-io-role-node"]
+}
+
+resource "google_compute_firewall" "nodeport-external-to-node-ipv6-minimal-gce-private-example-com" {
+  allow {
+    ports    = ["30000-32767"]
+    protocol = "tcp"
+  }
+  allow {
+    ports    = ["30000-32767"]
+    protocol = "udp"
+  }
+  disabled    = true
+  name        = "nodeport-external-to-node-ipv6-minimal-gce-private-example-com"
+  network     = google_compute_network.default.name
   target_tags = ["minimal-gce-private-example-com-k8s-io-role-node"]
 }
 
@@ -328,10 +401,21 @@ resource "google_compute_firewall" "nodeport-external-to-node-minimal-gce-privat
     ports    = ["30000-32767"]
     protocol = "udp"
   }
+  disabled    = true
   name        = "nodeport-external-to-node-minimal-gce-private-example-com"
   network     = google_compute_network.default.name
-  source_tags = ["minimal-gce-private-example-com-k8s-io-role-node"]
   target_tags = ["minimal-gce-private-example-com-k8s-io-role-node"]
+}
+
+resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-private-example-com" {
+  allow {
+    ports    = ["22"]
+    protocol = "tcp"
+  }
+  disabled    = true
+  name        = "ssh-external-to-master-ipv6-minimal-gce-private-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-private-example-com-k8s-io-role-master"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-private-example-com" {
@@ -339,10 +423,22 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-private-e
     ports    = ["22"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "ssh-external-to-master-minimal-gce-private-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["minimal-gce-private-example-com-k8s-io-role-master"]
+}
+
+resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-private-example-com" {
+  allow {
+    ports    = ["22"]
+    protocol = "tcp"
+  }
+  disabled    = true
+  name        = "ssh-external-to-node-ipv6-minimal-gce-private-example-com"
+  network     = google_compute_network.default.name
+  target_tags = ["minimal-gce-private-example-com-k8s-io-role-node"]
 }
 
 resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-private-example-com" {
@@ -350,6 +446,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-private-exa
     ports    = ["22"]
     protocol = "tcp"
   }
+  disabled      = false
   name          = "ssh-external-to-node-minimal-gce-private-example-com"
   network       = google_compute_network.default.name
   source_ranges = ["0.0.0.0/0"]


### PR DESCRIPTION
Supporting IPv6 values where they can be set by the user, and ensuring
that IPv4 and IPv6 firewall rules are split because on GCP they cannot
be in the same rule.
