### PR TITLE
Fix parse channels error

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -124,8 +124,8 @@ spec:
     recommendedVersion: 1.11.10
     requiredVersion: 1.11.10
   kopsVersions:
-  - range: ">=v1.22.0-alpha.1"
-    recommendedVersion: "v1.22.0-alpha.2"
+  - range: ">=1.22.0-alpha.1"
+    recommendedVersion: "1.22.0-alpha.2"
     #requiredVersion: 1.22.0
     kubernetesVersion: 1.22.0
   - range: ">=1.21.0-alpha.1"


### PR DESCRIPTION
Currently running into this on our alpha fleet:
```
W0817 16:17:58.105635    4764 channel.go:239] unable to parse range in channel version spec: ">=v1.22.0-alpha.1"
```

Unless I missed something with versioning changes, I believe this should fix the issue.