### PR TITLE
Hardcode Flatcar containerd exec command

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -249,8 +249,10 @@ func (b *ContainerdBuilder) buildSystemdServiceOverrideContainerOS(c *fi.ModelBu
 func (b *ContainerdBuilder) buildSystemdServiceOverrideFlatcar(c *fi.ModelBuilderContext) {
 	lines := []string{
 		"[Service]",
-		"Environment=CONTAINERD_CONFIG=" + b.containerdConfigFilePath(),
 		"EnvironmentFile=/etc/environment",
+		"Environment=CONTAINERD_CONFIG=" + b.containerdConfigFilePath(),
+		"ExecStart=",
+		"ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}",
 	}
 	contents := strings.Join(lines, "\n")
 

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -46,8 +46,10 @@ afterFiles:
 - /etc/containerd/config-kops.toml
 contents: |-
   [Service]
-  Environment=CONTAINERD_CONFIG=/etc/containerd/config-kops.toml
   EnvironmentFile=/etc/environment
+  Environment=CONTAINERD_CONFIG=/etc/containerd/config-kops.toml
+  ExecStart=
+  ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}
 onChangeExecute:
 - - systemctl
   - daemon-reload


### PR DESCRIPTION
As part of https://github.com/kinvolk/coreos-overlay/pull/931 and https://github.com/kinvolk/update_engine/pull/13, Flatcar decided to change the containerd exec command and not allow an easy override of the config file.
https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/customizing-docker/#use-a-custom-containerd-configuration

/cc @rifelpet 