### PR TITLE
Automated cherry pick of #12177: Hardcode Flatcar containerd exec command

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -248,8 +248,10 @@ func (b *ContainerdBuilder) buildSystemdServiceOverrideContainerOS(c *fi.ModelBu
 func (b *ContainerdBuilder) buildSystemdServiceOverrideFlatcar(c *fi.ModelBuilderContext) {
 	lines := []string{
 		"[Service]",
-		"Environment=CONTAINERD_CONFIG=" + b.containerdConfigFilePath(),
 		"EnvironmentFile=/etc/environment",
+		"Environment=CONTAINERD_CONFIG=" + b.containerdConfigFilePath(),
+		"ExecStart=",
+		"ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}",
 	}
 	contents := strings.Join(lines, "\n")
 

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -28,8 +28,10 @@ afterFiles:
 - /etc/containerd/config-kops.toml
 contents: |-
   [Service]
-  Environment=CONTAINERD_CONFIG=/etc/containerd/config-kops.toml
   EnvironmentFile=/etc/environment
+  Environment=CONTAINERD_CONFIG=/etc/containerd/config-kops.toml
+  ExecStart=
+  ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}
 onChangeExecute:
 - - systemctl
   - daemon-reload


### PR DESCRIPTION
Cherry pick of #12177 on release-1.21.

#12177: Hardcode Flatcar containerd exec command

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.