### PR TITLE
Cleanup unused TerraformFmt feature flag

### DIFF
--- a/docs/advanced/experimental.md
+++ b/docs/advanced/experimental.md
@@ -8,7 +8,6 @@ The following experimental features are currently available:
 
 * `+EnableExternalDNS` - Enable external-dns with default settings (ingress sources only).
 * `+VPCSkipEnableDNSSupport` - Enables creation of a VPC that does not need DNSSupport enabled.
-* `+SkipTerraformFormat` - Do not `terraform fmt` the generated terraform files.
 * `+EnableSeparateConfigBase` - Allow a config-base that is different from the state store.
 * `+SpecOverrideFlag` - Allow setting spec values on `kops create`.
 * `+ExperimentalClusterDNS` - Turns off validation of the kubelet cluster dns flag.

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -62,11 +62,6 @@ var (
 	GoogleCloudBucketACL = new("GoogleCloudBucketAcl", Bool(false))
 	// KeepLaunchConfigurations can be set to prevent garbage collection of old launch configurations
 	KeepLaunchConfigurations = new("KeepLaunchConfigurations", Bool(false))
-	// SkipTerraformFormat if set means we will not `tf fmt` the generated terraform.
-	// However we should no longer need it, with the keyset.yaml fix
-	// In particular, this is the only (?) way to grant the bucket.list permission
-	// It allows for experiments with alternative DNS configurations - in particular local proxies.
-	SkipTerraformFormat = new("SkipTerraformFormat", Bool(false))
 	// SpecOverrideFlag allows setting spec values on create
 	SpecOverrideFlag = new("SpecOverrideFlag", Bool(false))
 	// Spotinst toggles the use of Spotinst integration.


### PR DESCRIPTION
Since dropping support for terraform <0.12, this feature flag is no longer used. The generated HCL2 is always formatted