### PR TITLE
Automated cherry pick of #12187: Add option in Cluster Autoscaler AddOn for AWS EC2 Static instance list

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -35,6 +35,7 @@ spec:
     enabled: true
     expander: least-waste
     balanceSimilarNodeGroups: false
+    awsUseStaticInstanceList: false
     scaleDownUtilizationThreshold: 0.5
     skipNodesWithLocalStorage: true
     skipNodesWithSystemPods: true

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -539,6 +539,11 @@ spec:
               clusterAutoscaler:
                 description: ClusterAutoscaler defines the cluaster autoscaler configuration.
                 properties:
+                  awsUseStaticInstanceList:
+                    description: 'AWSUseStaticInstanceList makes cluster autoscaler
+                      to use statically defined set of AWS EC2 Instance List. Default:
+                      false'
+                    type: boolean
                   balanceSimilarNodeGroups:
                     description: 'BalanceSimilarNodeGroups makes cluster autoscaler
                       treat similar node groups as one. Default: false'

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -900,6 +900,9 @@ type ClusterAutoscalerConfig struct {
 	// BalanceSimilarNodeGroups makes cluster autoscaler treat similar node groups as one.
 	// Default: false
 	BalanceSimilarNodeGroups *bool `json:"balanceSimilarNodeGroups,omitempty"`
+	// AWSUseStaticInstanceList makes cluster autoscaler to use statically defined set of AWS EC2 Instance List.
+	// Default: false
+	AWSUseStaticInstanceList *bool `json:"awsUseStaticInstanceList,omitempty"`
 	// ScaleDownUtilizationThreshold determines the utilization threshold for node scale-down.
 	// Default: 0.5
 	ScaleDownUtilizationThreshold *string `json:"scaleDownUtilizationThreshold,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -899,6 +899,9 @@ type ClusterAutoscalerConfig struct {
 	// BalanceSimilarNodeGroups makes cluster autoscaler treat similar node groups as one.
 	// Default: false
 	BalanceSimilarNodeGroups *bool `json:"balanceSimilarNodeGroups,omitempty"`
+	// AWSUseStaticInstanceList makes cluster autoscaler to use statically defined set of AWS EC2 Instance List.
+	// Default: false
+	AWSUseStaticInstanceList *bool `json:"awsUseStaticInstanceList,omitempty"`
 	// ScaleDownUtilizationThreshold determines the utilization threshold for node scale-down.
 	// Default: 0.5
 	ScaleDownUtilizationThreshold *string `json:"scaleDownUtilizationThreshold,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2124,6 +2124,7 @@ func autoConvert_v1alpha2_ClusterAutoscalerConfig_To_kops_ClusterAutoscalerConfi
 	out.Enabled = in.Enabled
 	out.Expander = in.Expander
 	out.BalanceSimilarNodeGroups = in.BalanceSimilarNodeGroups
+	out.AWSUseStaticInstanceList = in.AWSUseStaticInstanceList
 	out.ScaleDownUtilizationThreshold = in.ScaleDownUtilizationThreshold
 	out.SkipNodesWithSystemPods = in.SkipNodesWithSystemPods
 	out.SkipNodesWithLocalStorage = in.SkipNodesWithLocalStorage
@@ -2144,6 +2145,7 @@ func autoConvert_kops_ClusterAutoscalerConfig_To_v1alpha2_ClusterAutoscalerConfi
 	out.Enabled = in.Enabled
 	out.Expander = in.Expander
 	out.BalanceSimilarNodeGroups = in.BalanceSimilarNodeGroups
+	out.AWSUseStaticInstanceList = in.AWSUseStaticInstanceList
 	out.ScaleDownUtilizationThreshold = in.ScaleDownUtilizationThreshold
 	out.SkipNodesWithSystemPods = in.SkipNodesWithSystemPods
 	out.SkipNodesWithLocalStorage = in.SkipNodesWithLocalStorage

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -752,6 +752,11 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AWSUseStaticInstanceList != nil {
+		in, out := &in.AWSUseStaticInstanceList, &out.AWSUseStaticInstanceList
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ScaleDownUtilizationThreshold != nil {
 		in, out := &in.ScaleDownUtilizationThreshold, &out.ScaleDownUtilizationThreshold
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -852,6 +852,11 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AWSUseStaticInstanceList != nil {
+		in, out := &in.AWSUseStaticInstanceList, &out.AWSUseStaticInstanceList
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ScaleDownUtilizationThreshold != nil {
 		in, out := &in.ScaleDownUtilizationThreshold, &out.ScaleDownUtilizationThreshold
 		*out = new(string)

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -78,6 +78,9 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 	if cas.BalanceSimilarNodeGroups == nil {
 		cas.BalanceSimilarNodeGroups = fi.Bool(false)
 	}
+	if cas.AWSUseStaticInstanceList == nil {
+		cas.AWSUseStaticInstanceList = fi.Bool(false)
+	}
 	if cas.NewPodScaleUpDelay == nil {
 		cas.NewPodScaleUpDelay = fi.String("0s")
 	}

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -280,6 +280,9 @@ spec:
             - ./cluster-autoscaler
             - --balance-similar-node-groups={{ .BalanceSimilarNodeGroups }}
             - --cloud-provider={{ $.CloudProvider }}
+            {{ if (eq $.CloudProvider "aws") }}
+            - --aws-use-static-instance-list={{ .AWSUseStaticInstanceList }}
+            {{ end }}
             - --expander={{ .Expander }}
             {{ range $name, $spec := GetNodeInstanceGroups }}
             {{ if WithDefaultBool $spec.Autoscale true }}


### PR DESCRIPTION
Cherry pick of #12187 on release-1.21.

#12187: Add option in Cluster Autoscaler AddOn for AWS EC2 Static instance list

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```