### PR TITLE
Enable protect-kernel-defaults by default and set the correct sysctls in nodeup

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -115,6 +115,11 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"# e.g. uses of inotify: nginx ingress controller, kubectl logs -f",
 			"fs.inotify.max_user_instances = 8192",
 			"fs.inotify.max_user_watches = 524288",
+
+			"# Additional sysctl flags that kubelet expects",
+			"vm.overcommit_memory = 1",
+			"kernel.panic = 10",
+			"kernel.panic_on_oops = 1",
 			"",
 		)
 	}

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -225,5 +225,9 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.CgroupDriver = "systemd"
 	}
 
+	if b.IsKubernetesGTE("1.22") && clusterSpec.Kubelet.ProtectKernelDefaults == nil {
+		clusterSpec.Kubelet.ProtectKernelDefaults = fi.Bool(true)
+	}
+
 	return nil
 }


### PR DESCRIPTION
I think enabling protectKernelDefaults by default as of 1.22 is a good thing.

We either way need to set these sysctls in nodeup.

ref #12192