### PR TITLE
Add terraform outputs for OIDC provider ARN and issuer

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -1,5 +1,7 @@
 locals {
   cluster_name                                       = "minimal.example.com"
+  iam_openid_connect_provider_arn                    = aws_iam_openid_connect_provider.minimal-example-com.arn
+  iam_openid_connect_provider_issuer                 = "discovery.example.com/minimal.example.com"
   kube-system-aws-load-balancer-controller_role_arn  = aws_iam_role.aws-load-balancer-controller-kube-system-sa-minimal-example-com.arn
   kube-system-aws-load-balancer-controller_role_name = aws_iam_role.aws-load-balancer-controller-kube-system-sa-minimal-example-com.name
   kube-system-dns-controller_role_arn                = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.arn
@@ -22,6 +24,14 @@ locals {
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "iam_openid_connect_provider_arn" {
+  value = aws_iam_openid_connect_provider.minimal-example-com.arn
+}
+
+output "iam_openid_connect_provider_issuer" {
+  value = "discovery.example.com/minimal.example.com"
 }
 
 output "kube-system-aws-load-balancer-controller_role_arn" {

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -2,6 +2,8 @@ locals {
   cluster_name                          = "minimal.example.com"
   default-myserviceaccount_role_arn     = aws_iam_role.myserviceaccount-default-sa-minimal-example-com.arn
   default-myserviceaccount_role_name    = aws_iam_role.myserviceaccount-default-sa-minimal-example-com.name
+  iam_openid_connect_provider_arn       = aws_iam_openid_connect_provider.minimal-example-com.arn
+  iam_openid_connect_provider_issuer    = "discovery.example.com/minimal.example.com"
   master_autoscaling_group_ids          = [aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id]
   master_security_group_ids             = [aws_security_group.masters-minimal-example-com.id]
   masters_role_arn                      = aws_iam_role.masters-minimal-example-com.arn
@@ -30,6 +32,14 @@ output "default-myserviceaccount_role_arn" {
 
 output "default-myserviceaccount_role_name" {
   value = aws_iam_role.myserviceaccount-default-sa-minimal-example-com.name
+}
+
+output "iam_openid_connect_provider_arn" {
+  value = aws_iam_openid_connect_provider.minimal-example-com.arn
+}
+
+output "iam_openid_connect_provider_issuer" {
+  value = "discovery.example.com/minimal.example.com"
 }
 
 output "master_autoscaling_group_ids" {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
@@ -1,5 +1,7 @@
 locals {
   cluster_name                                       = "minimal.example.com"
+  iam_openid_connect_provider_arn                    = aws_iam_openid_connect_provider.minimal-example-com.arn
+  iam_openid_connect_provider_issuer                 = "discovery.example.com/minimal.example.com"
   kube-system-aws-cloud-controller-manager_role_arn  = aws_iam_role.aws-cloud-controller-manager-kube-system-sa-minimal-example-com.arn
   kube-system-aws-cloud-controller-manager_role_name = aws_iam_role.aws-cloud-controller-manager-kube-system-sa-minimal-example-com.name
   kube-system-aws-load-balancer-controller_role_arn  = aws_iam_role.aws-load-balancer-controller-kube-system-sa-minimal-example-com.arn
@@ -30,6 +32,14 @@ locals {
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "iam_openid_connect_provider_arn" {
+  value = aws_iam_openid_connect_provider.minimal-example-com.arn
+}
+
+output "iam_openid_connect_provider_issuer" {
+  value = "discovery.example.com/minimal.example.com"
 }
 
 output "kube-system-aws-cloud-controller-manager_role_arn" {

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -1,5 +1,7 @@
 locals {
   cluster_name                         = "minimal.example.com"
+  iam_openid_connect_provider_arn      = aws_iam_openid_connect_provider.minimal-example-com.arn
+  iam_openid_connect_provider_issuer   = "discovery.example.com/minimal.example.com"
   kube-system-dns-controller_role_arn  = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.arn
   kube-system-dns-controller_role_name = aws_iam_role.dns-controller-kube-system-sa-minimal-example-com.name
   master_autoscaling_group_ids         = [aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id]
@@ -20,6 +22,14 @@ locals {
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "iam_openid_connect_provider_arn" {
+  value = aws_iam_openid_connect_provider.minimal-example-com.arn
+}
+
+output "iam_openid_connect_provider_issuer" {
+  value = "discovery.example.com/minimal.example.com"
 }
 
 output "kube-system-dns-controller_role_arn" {

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -1,23 +1,33 @@
 locals {
-  cluster_name                 = "minimal.example.com"
-  master_autoscaling_group_ids = [aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id]
-  master_security_group_ids    = [aws_security_group.masters-minimal-example-com.id]
-  masters_role_arn             = aws_iam_role.masters-minimal-example-com.arn
-  masters_role_name            = aws_iam_role.masters-minimal-example-com.name
-  node_autoscaling_group_ids   = [aws_autoscaling_group.nodes-minimal-example-com.id]
-  node_security_group_ids      = [aws_security_group.nodes-minimal-example-com.id]
-  node_subnet_ids              = [aws_subnet.us-test-1a-minimal-example-com.id]
-  nodes_role_arn               = aws_iam_role.nodes-minimal-example-com.arn
-  nodes_role_name              = aws_iam_role.nodes-minimal-example-com.name
-  region                       = "us-test-1"
-  route_table_public_id        = aws_route_table.minimal-example-com.id
-  subnet_us-test-1a_id         = aws_subnet.us-test-1a-minimal-example-com.id
-  vpc_cidr_block               = aws_vpc.minimal-example-com.cidr_block
-  vpc_id                       = aws_vpc.minimal-example-com.id
+  cluster_name                       = "minimal.example.com"
+  iam_openid_connect_provider_arn    = aws_iam_openid_connect_provider.minimal-example-com.arn
+  iam_openid_connect_provider_issuer = "discovery.example.com/minimal.example.com"
+  master_autoscaling_group_ids       = [aws_autoscaling_group.master-us-test-1a-masters-minimal-example-com.id]
+  master_security_group_ids          = [aws_security_group.masters-minimal-example-com.id]
+  masters_role_arn                   = aws_iam_role.masters-minimal-example-com.arn
+  masters_role_name                  = aws_iam_role.masters-minimal-example-com.name
+  node_autoscaling_group_ids         = [aws_autoscaling_group.nodes-minimal-example-com.id]
+  node_security_group_ids            = [aws_security_group.nodes-minimal-example-com.id]
+  node_subnet_ids                    = [aws_subnet.us-test-1a-minimal-example-com.id]
+  nodes_role_arn                     = aws_iam_role.nodes-minimal-example-com.arn
+  nodes_role_name                    = aws_iam_role.nodes-minimal-example-com.name
+  region                             = "us-test-1"
+  route_table_public_id              = aws_route_table.minimal-example-com.id
+  subnet_us-test-1a_id               = aws_subnet.us-test-1a-minimal-example-com.id
+  vpc_cidr_block                     = aws_vpc.minimal-example-com.cidr_block
+  vpc_id                             = aws_vpc.minimal-example-com.id
 }
 
 output "cluster_name" {
   value = "minimal.example.com"
+}
+
+output "iam_openid_connect_provider_arn" {
+  value = aws_iam_openid_connect_provider.minimal-example-com.arn
+}
+
+output "iam_openid_connect_provider_issuer" {
+  value = "discovery.example.com/minimal.example.com"
 }
 
 output "master_autoscaling_group_ids" {

--- a/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamoidcprovider.go
@@ -192,6 +192,17 @@ type terraformIAMOIDCProvider struct {
 }
 
 func (p *IAMOIDCProvider) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *IAMOIDCProvider) error {
+	err := t.AddOutputVariable("iam_openid_connect_provider_arn", e.TerraformLink())
+	if err != nil {
+		return err
+	}
+
+	issuerSubs := strings.SplitAfter(aws.StringValue(e.URL), "://")
+	issuer := issuerSubs[len(issuerSubs)-1]
+	err = t.AddOutputVariable("iam_openid_connect_provider_issuer", terraformWriter.LiteralFromStringValue(issuer))
+	if err != nil {
+		return err
+	}
 
 	tf := &terraformIAMOIDCProvider{
 		URL:            e.URL,


### PR DESCRIPTION
These fields are valuable because their fields are used in the assume role policies of service account IAM roles, based on the docs [here](https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html#aws-cli). This allows terraform users to pass these directly to their IAM role definitions.

The reason I'm using a hard-coded string for the issuer is because the provider doesn't output the issuer without a protocol (see docs [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider)). The other option would be using a terraform `replace()` function but we don't have support for rendering multi-argument function calls yet.