### PR TITLE
Add possibility to prepend additional user data scripts

### DIFF
--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -72,6 +72,10 @@ spec:
                 items:
                   description: UserData defines a user-data section
                   properties:
+                    before:
+                      description: Before indicated whether this user data script
+                        should be executed before or after the default user data scripts
+                      type: boolean
                     content:
                       description: Content is the user-data content
                       type: string

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -239,6 +239,8 @@ type UserData struct {
 	Type string `json:"type,omitempty"`
 	// Content is the user-data content
 	Content string `json:"content,omitempty"`
+	// Before indicated whether this user data script should be executed before or after the default user data scripts
+	Before bool `json:"before,omitempty"`
 }
 
 // VolumeSpec defined the spec for an additional volume attached to the instance group

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -193,6 +193,8 @@ type UserData struct {
 	Type string `json:"type,omitempty"`
 	// Content is the user-data content
 	Content string `json:"content,omitempty"`
+	// Before indicated whether this user data script should be executed before or after the default user data scripts
+	Before bool `json:"before,omitempty"`
 }
 
 // VolumeSpec defined the spec for an additional volume attached to the instance group

--- a/pkg/model/resources/BUILD.bazel
+++ b/pkg/model/resources/BUILD.bazel
@@ -12,4 +12,5 @@ go_test(
     name = "go_default_test",
     srcs = ["nodeup_test.go"],
     embed = [":go_default_library"],
+    deps = ["//pkg/apis/kops:go_default_library"],
 )

--- a/pkg/model/resources/nodeup_test.go
+++ b/pkg/model/resources/nodeup_test.go
@@ -35,7 +35,7 @@ func Test_AWSNodeUpTemplate(t *testing.T) {
 	beforeScriptName := "some_script_required_to_run_before_nodeup.sh"
 	afterScriptName := "some_script.sh"
 
-    ig := &kops.InstanceGroup{
+	ig := &kops.InstanceGroup{
 		Spec: kops.InstanceGroupSpec{
 			AdditionalUserData: []kops.UserData{
 				{
@@ -52,14 +52,14 @@ echo "I run after nodeup.sh to setup some other stuff"
 
 echo "I run before nodeup.sh to fix some stuff"
 `,
-					Type: "text/x-shellscript",
+					Type:   "text/x-shellscript",
 					Before: true,
 				},
 			},
 		},
 	}
 
-    actual, err := AWSNodeUpTemplate(ig)
+	actual, err := AWSNodeUpTemplate(ig)
 	if err != nil {
 		t.Fatalf("got unexpected error: %v", err)
 	}


### PR DESCRIPTION
Before this patch, AdditionalUserData scripts will only be placed
after `nodeup.sh`.
We needed to have a script running before to workaround issues that are inherent to `nodeup.sh`, such as https://github.com/kubernetes/kops/issues/12041