### PR TITLE
Bump cloudbuild images to latest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 steps:
 # Push the images
-- name: 'gcr.io/k8s-testimages/kubekins-e2e:v20210330-fadf59c-experimental'
+- name: 'gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-experimental'
   id: images
   entrypoint: make
   env:
@@ -20,7 +20,7 @@ steps:
   - dns-controller-push
   - kube-apiserver-healthcheck-push
 # Push the artifacts
-- name: 'gcr.io/k8s-testimages/kubekins-e2e:v20210330-fadf59c-experimental'
+- name: 'gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-experimental'
   id: artifacts
   entrypoint: make
   env:
@@ -35,7 +35,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Push the manifests
-- name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+- name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930'
   id: manifests
   waitFor: [images]
   entrypoint: make
@@ -50,7 +50,7 @@ steps:
   - dns-controller-manifest
   - kube-apiserver-healthcheck-manifest
 # Build cloudbuild artifacts (for attestation)
-- name: 'gcr.io/k8s-testimages/kubekins-e2e:v20210330-fadf59c-experimental'
+- name: 'gcr.io/k8s-testimages/kubekins-e2e:v20210825-f1955d1-experimental'
   id: cloudbuild-artifacts
   entrypoint: make
   env:


### PR DESCRIPTION
We were likely releases kops builds with outdated go patch versions before this. This should get cherry-picked to release-1.22