### PR TITLE
[Documentation update] Note for the metrics configuration for etcd

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -224,6 +224,8 @@ etcdClusters:
       value: basic
 ```
 
+*Note:* If you are running multiple etcd clusters you need to expose the metrics on different ports for each cluster as etcd is running as a service on the master nodes.
+
 ### etcd backups retention
 {{ kops_feature_table(kops_added_default='1.18') }}
 


### PR DESCRIPTION
As etcd is running directly as a service on the master nodes it is easy to overlook that different ports are needed to expose metrics for multiple etcd clusters on the master nodes. It can be easy to forget this if you otherwise just deal with containers and pods... 😅  A reminder and clarification doesn't hurt.