### PR TITLE
Automated cherry pick of #12227: fix parse semver

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -690,7 +690,7 @@ func useLoadBalancerVIPACL(c OpenstackCloud) (bool, error) {
 		return false, err
 	}
 	// https://github.com/kubernetes/cloud-provider-openstack/blob/721615aa256bbddbd481cfb4a887c3ab180c5563/pkg/util/openstack/loadbalancer.go#L108
-	return ver.Compare(semver.MustParse("2.12")) > 0, nil
+	return ver.Compare(semver.MustParse("2.12.0")) > 0, nil
 }
 
 type Address struct {


### PR DESCRIPTION
Cherry pick of #12227 on release-1.22.

#12227: fix parse semver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.