### PR TITLE
Automated cherry pick of #12229: Bump cert-manager to 1.5.3

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 31dab244744d2d87e0cea88f5c482a3c952f4ced324a32a5b5df9779046ba32e
+    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
     name: certmanager.io
     selector: null
   - id: k8s-1.9

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: certificaterequests.cert-manager.io
 spec:
   conversion:
@@ -953,7 +953,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: certificates.cert-manager.io
 spec:
   conversion:
@@ -2803,7 +2803,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: challenges.acme.cert-manager.io
 spec:
   conversion:
@@ -10264,7 +10264,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: clusterissuers.cert-manager.io
 spec:
   conversion:
@@ -19982,7 +19982,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: issuers.cert-manager.io
 spec:
   conversion:
@@ -29696,7 +29696,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: orders.acme.cert-manager.io
 spec:
   conversion:
@@ -30631,7 +30631,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -30649,7 +30649,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 
@@ -30667,7 +30667,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -30684,7 +30684,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -30763,7 +30763,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -30813,7 +30813,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -30863,7 +30863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -30935,7 +30935,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -31005,7 +31005,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -31114,7 +31114,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -31188,7 +31188,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -31227,7 +31227,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -31269,7 +31269,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -31295,7 +31295,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -31342,7 +31342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -31365,7 +31365,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31389,7 +31389,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31413,7 +31413,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31437,7 +31437,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31461,7 +31461,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31485,7 +31485,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31509,7 +31509,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31533,7 +31533,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31557,7 +31557,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31581,7 +31581,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31606,7 +31606,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -31658,7 +31658,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -31708,7 +31708,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -31743,7 +31743,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -31768,7 +31768,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -31794,7 +31794,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -31820,7 +31820,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 spec:
@@ -31848,7 +31848,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -31876,7 +31876,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -31893,7 +31893,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -31904,7 +31904,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.5.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.5.3
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -31931,7 +31931,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 spec:
@@ -31952,7 +31952,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -31965,7 +31965,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.5.2
+        image: quay.io/jetstack/cert-manager-controller:v1.5.3
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -31995,7 +31995,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32012,7 +32012,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -32026,7 +32026,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.5.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -32079,7 +32079,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -32122,7 +32122,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: cluster-autoscaler.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 31dab244744d2d87e0cea88f5c482a3c952f4ced324a32a5b5df9779046ba32e
+    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
     name: certmanager.io
     selector: null
   - id: k8s-1.11

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: certificaterequests.cert-manager.io
 spec:
   conversion:
@@ -953,7 +953,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: certificates.cert-manager.io
 spec:
   conversion:
@@ -2803,7 +2803,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: challenges.acme.cert-manager.io
 spec:
   conversion:
@@ -10264,7 +10264,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: clusterissuers.cert-manager.io
 spec:
   conversion:
@@ -19982,7 +19982,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: issuers.cert-manager.io
 spec:
   conversion:
@@ -29696,7 +29696,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: orders.acme.cert-manager.io
 spec:
   conversion:
@@ -30631,7 +30631,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -30649,7 +30649,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 
@@ -30667,7 +30667,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -30684,7 +30684,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -30763,7 +30763,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -30813,7 +30813,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -30863,7 +30863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -30935,7 +30935,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -31005,7 +31005,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -31114,7 +31114,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -31188,7 +31188,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -31227,7 +31227,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -31269,7 +31269,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -31295,7 +31295,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -31342,7 +31342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -31365,7 +31365,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31389,7 +31389,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31413,7 +31413,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31437,7 +31437,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31461,7 +31461,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31485,7 +31485,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31509,7 +31509,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31533,7 +31533,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31557,7 +31557,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31581,7 +31581,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31606,7 +31606,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -31658,7 +31658,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -31708,7 +31708,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -31743,7 +31743,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -31768,7 +31768,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -31794,7 +31794,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -31820,7 +31820,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 spec:
@@ -31848,7 +31848,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -31876,7 +31876,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -31893,7 +31893,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -31904,7 +31904,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.5.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.5.3
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -31931,7 +31931,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 spec:
@@ -31952,7 +31952,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -31965,7 +31965,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.5.2
+        image: quay.io/jetstack/cert-manager-controller:v1.5.3
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -31995,7 +31995,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32012,7 +32012,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -32026,7 +32026,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.5.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -32079,7 +32079,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -32122,7 +32122,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: cluster-autoscaler.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 31dab244744d2d87e0cea88f5c482a3c952f4ced324a32a5b5df9779046ba32e
+    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
     name: certmanager.io
     selector: null
   - id: k8s-1.11

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: certificaterequests.cert-manager.io
 spec:
   conversion:
@@ -953,7 +953,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: certificates.cert-manager.io
 spec:
   conversion:
@@ -2803,7 +2803,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: challenges.acme.cert-manager.io
 spec:
   conversion:
@@ -10264,7 +10264,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: clusterissuers.cert-manager.io
 spec:
   conversion:
@@ -19982,7 +19982,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: issuers.cert-manager.io
 spec:
   conversion:
@@ -29696,7 +29696,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: orders.acme.cert-manager.io
 spec:
   conversion:
@@ -30631,7 +30631,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -30649,7 +30649,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 
@@ -30667,7 +30667,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -30684,7 +30684,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -30763,7 +30763,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -30813,7 +30813,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -30863,7 +30863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -30935,7 +30935,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -31005,7 +31005,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -31114,7 +31114,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -31188,7 +31188,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -31227,7 +31227,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -31269,7 +31269,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -31295,7 +31295,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -31342,7 +31342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -31365,7 +31365,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31389,7 +31389,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31413,7 +31413,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31437,7 +31437,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31461,7 +31461,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31485,7 +31485,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31509,7 +31509,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31533,7 +31533,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31557,7 +31557,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31581,7 +31581,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31606,7 +31606,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -31658,7 +31658,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -31708,7 +31708,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -31743,7 +31743,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -31768,7 +31768,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -31794,7 +31794,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -31820,7 +31820,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 spec:
@@ -31848,7 +31848,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -31876,7 +31876,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -31893,7 +31893,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -31904,7 +31904,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.5.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.5.3
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -31931,7 +31931,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 spec:
@@ -31952,7 +31952,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -31965,7 +31965,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.5.2
+        image: quay.io/jetstack/cert-manager-controller:v1.5.3
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -31995,7 +31995,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32012,7 +32012,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -32026,7 +32026,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.5.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -32079,7 +32079,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -32122,7 +32122,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: cluster-autoscaler.addons.k8s.io
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 31dab244744d2d87e0cea88f5c482a3c952f4ced324a32a5b5df9779046ba32e
+    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
     name: certmanager.io
     selector: null
   - id: k8s-1.11

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: certificaterequests.cert-manager.io
 spec:
   conversion:
@@ -953,7 +953,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: certificates.cert-manager.io
 spec:
   conversion:
@@ -2803,7 +2803,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: challenges.acme.cert-manager.io
 spec:
   conversion:
@@ -10264,7 +10264,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: clusterissuers.cert-manager.io
 spec:
   conversion:
@@ -19982,7 +19982,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: issuers.cert-manager.io
 spec:
   conversion:
@@ -29696,7 +29696,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: orders.acme.cert-manager.io
 spec:
   conversion:
@@ -30631,7 +30631,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -30649,7 +30649,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 
@@ -30667,7 +30667,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -30684,7 +30684,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -30763,7 +30763,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -30813,7 +30813,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -30863,7 +30863,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -30935,7 +30935,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -31005,7 +31005,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -31114,7 +31114,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -31188,7 +31188,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -31227,7 +31227,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -31269,7 +31269,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -31295,7 +31295,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -31342,7 +31342,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -31365,7 +31365,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31389,7 +31389,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31413,7 +31413,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31437,7 +31437,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31461,7 +31461,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31485,7 +31485,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31509,7 +31509,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31533,7 +31533,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31557,7 +31557,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31581,7 +31581,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31606,7 +31606,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -31658,7 +31658,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -31708,7 +31708,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -31743,7 +31743,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -31768,7 +31768,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -31794,7 +31794,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -31820,7 +31820,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 spec:
@@ -31848,7 +31848,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -31876,7 +31876,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -31893,7 +31893,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -31904,7 +31904,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.5.2
+        image: quay.io/jetstack/cert-manager-cainjector:v1.5.3
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -31931,7 +31931,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager
   namespace: kube-system
 spec:
@@ -31952,7 +31952,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -31965,7 +31965,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.5.2
+        image: quay.io/jetstack/cert-manager-controller:v1.5.3
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -31995,7 +31995,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32012,7 +32012,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.5.2
+        app.kubernetes.io/version: v1.5.3
     spec:
       containers:
       - args:
@@ -32026,7 +32026,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.5.2
+        image: quay.io/jetstack/cert-manager-webhook:v1.5.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -32079,7 +32079,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -32122,7 +32122,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.2
+    app.kubernetes.io/version: v1.5.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   group: cert-manager.io
   names:
@@ -753,7 +753,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   group: cert-manager.io
   names:
@@ -2074,7 +2074,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   group: acme.cert-manager.io
   names:
@@ -5956,7 +5956,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   group: cert-manager.io
   names:
@@ -10687,7 +10687,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   group: cert-manager.io
   names:
@@ -15418,7 +15418,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   group: acme.cert-manager.io
   names:
@@ -16105,7 +16105,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -16119,7 +16119,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -16133,7 +16133,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 ---
 # Source: cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16145,7 +16145,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -16180,7 +16180,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -16206,7 +16206,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -16232,7 +16232,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -16267,7 +16267,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -16305,7 +16305,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -16365,7 +16365,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -16402,7 +16402,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -16424,7 +16424,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -16446,7 +16446,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -16466,7 +16466,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -16492,7 +16492,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -16508,7 +16508,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16528,7 +16528,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16548,7 +16548,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16568,7 +16568,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16588,7 +16588,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16608,7 +16608,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16628,7 +16628,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16648,7 +16648,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16668,7 +16668,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16688,7 +16688,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16711,7 +16711,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -16745,7 +16745,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
   # Used for leader election by the controller
   # See also: https://github.com/kubernetes-sigs/controller-runtime/pull/1144#discussion_r480173688
@@ -16775,7 +16775,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -16800,7 +16800,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16823,7 +16823,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16845,7 +16845,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16867,7 +16867,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   type: ClusterIP
   ports:
@@ -16891,7 +16891,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   type: ClusterIP
   ports:
@@ -16915,7 +16915,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   replicas: 1
   selector:
@@ -16930,7 +16930,7 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.5.2"
+        app.kubernetes.io/version: "v1.5.3"
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -16943,7 +16943,7 @@ spec:
         operator: Exists
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.5.2"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.5.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -16967,7 +16967,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   replicas: 1
   selector:
@@ -16982,7 +16982,7 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.5.2"
+        app.kubernetes.io/version: "v1.5.3"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -16999,7 +16999,7 @@ spec:
         operator: Exists
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v1.5.2"
+          image: "quay.io/jetstack/cert-manager-controller:v1.5.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -17033,7 +17033,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
 spec:
   replicas: 1
   selector:
@@ -17048,7 +17048,7 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.5.2"
+        app.kubernetes.io/version: "v1.5.3"
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -17061,7 +17061,7 @@ spec:
         operator: Exists
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-webhook:v1.5.2"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.5.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -17111,7 +17111,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
   annotations:
     cert-manager.io/inject-ca-from-secret: "kube-system/cert-manager-webhook-ca"
 webhooks:
@@ -17160,7 +17160,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.5.2"
+    app.kubernetes.io/version: "v1.5.3"
   annotations:
     cert-manager.io/inject-ca-from-secret: "kube-system/cert-manager-webhook-ca"
 webhooks:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -54,7 +54,7 @@ spec:
       k8s-app: metrics-server
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 31dab244744d2d87e0cea88f5c482a3c952f4ced324a32a5b5df9779046ba32e
+    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
     name: certmanager.io
     selector: null
   - id: v1.15.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -48,7 +48,7 @@ spec:
       k8s-app: metrics-server
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 31dab244744d2d87e0cea88f5c482a3c952f4ced324a32a5b5df9779046ba32e
+    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
     name: certmanager.io
     selector: null
   - id: v1.15.0


### PR DESCRIPTION
Cherry pick of #12229 on release-1.22.

#12229: Bump cert-manager to 1.5.3

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.