### PR TITLE
Automated cherry pick of #12232: check does iface has associations

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -2100,7 +2100,7 @@ func GetInstanceCertificateNames(instances *ec2.DescribeInstancesOutput) (addrs 
 		if iface.Ipv6Addresses != nil && len(iface.Ipv6Addresses) > 0 {
 			addrs = append(addrs, *iface.Ipv6Addresses[0].Ipv6Address)
 		}
-		if iface.Association.PublicIp != nil {
+		if iface.Association != nil && iface.Association.PublicIp != nil {
 			addrs = append(addrs, *iface.Association.PublicIp)
 		}
 	}


### PR DESCRIPTION
Cherry pick of #12232 on release-1.22.

#12232: check does iface has associations

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.