### PR TITLE
Update metrics-server tag used in e2e scenario

### DIFF
--- a/tests/e2e/scenarios/metrics-server/run-test.sh
+++ b/tests/e2e/scenarios/metrics-server/run-test.sh
@@ -27,7 +27,7 @@ kops-up
 # shellcheck disable=SC2164
 cd "$(mktemp -dt kops.XXXXXXXXX)"
 
-git clone --branch v0.4.4 https://github.com/kubernetes-sigs/metrics-server.git .
+git clone --branch v0.5.0 https://github.com/kubernetes-sigs/metrics-server.git .
 
 # The prometheus test expects to have only one metrics-server pod, but we use two
 # We scale down to meet test expectation


### PR DESCRIPTION
ref: https://github.com/kubernetes/kops/pull/12198

fixes these test failures due to the port change: https://testgrid.k8s.io/kops-misc#kops-aws-metrics-server