### PR TITLE
Automated cherry pick of #12246: Set kube-apiserver as default logs container

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -739,6 +739,7 @@ func (b *KubeAPIServerBuilder) buildPod(kubeAPIServer *kops.KubeAPIServerConfig)
 
 func (b *KubeAPIServerBuilder) buildAnnotations() map[string]string {
 	annotations := make(map[string]string)
+	annotations["kubectl.kubernetes.io/default-container"] = "kube-apiserver"
 
 	if b.Cluster.Spec.API != nil {
 		if b.Cluster.Spec.API.LoadBalancer == nil || !b.Cluster.Spec.API.LoadBalancer.UseForInternalApi {

--- a/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
@@ -26,6 +26,7 @@ contents: |
     annotations:
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
+      kubectl.kubernetes.io/default-container: kube-apiserver
       scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:

--- a/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
@@ -5,6 +5,7 @@ contents: |
     annotations:
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
+      kubectl.kubernetes.io/default-container: kube-apiserver
       scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
@@ -5,6 +5,7 @@ contents: |
     annotations:
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
+      kubectl.kubernetes.io/default-container: kube-apiserver
       scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
@@ -5,6 +5,7 @@ contents: |
     annotations:
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
+      kubectl.kubernetes.io/default-container: kube-apiserver
       scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
@@ -5,6 +5,7 @@ contents: |
     annotations:
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
+      kubectl.kubernetes.io/default-container: kube-apiserver
       scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:

--- a/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
@@ -5,6 +5,7 @@ contents: |
     annotations:
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
+      kubectl.kubernetes.io/default-container: kube-apiserver
       scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:


### PR DESCRIPTION
Cherry pick of #12246 on release-1.22.

#12246: Set kube-apiserver as default logs container

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.