### PR TITLE
Automated cherry pick of #12193: Enable protect-kernel-defaults by default and set the correct

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -115,6 +115,11 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"# e.g. uses of inotify: nginx ingress controller, kubectl logs -f",
 			"fs.inotify.max_user_instances = 8192",
 			"fs.inotify.max_user_watches = 524288",
+
+			"# Additional sysctl flags that kubelet expects",
+			"vm.overcommit_memory = 1",
+			"kernel.panic = 10",
+			"kernel.panic_on_oops = 1",
 			"",
 		)
 	}

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -225,5 +225,9 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.CgroupDriver = "systemd"
 	}
 
+	if b.IsKubernetesGTE("1.22") && clusterSpec.Kubelet.ProtectKernelDefaults == nil {
+		clusterSpec.Kubelet.ProtectKernelDefaults = fi.Bool(true)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #12193 on release-1.22.

#12193: Enable protect-kernel-defaults by default and set the correct

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.