### PR TITLE
Set ipv6 nameservers on aws

### DIFF
--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -75,6 +75,12 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.KubeDNS.MemoryLimit = &defaultMemoryLimit
 	}
 
+	if clusterSpec.IsIPv6Only() && kops.CloudProviderID(clusterSpec.CloudProvider) == kops.CloudProviderAWS {
+		if len(clusterSpec.KubeDNS.UpstreamNameservers) == 0 {
+			clusterSpec.KubeDNS.UpstreamNameservers = []string{"fd00:ec2::253"}
+		}
+	}
+
 	nodeLocalDNS := clusterSpec.KubeDNS.NodeLocalDNS
 	if nodeLocalDNS == nil {
 		nodeLocalDNS = &kops.NodeLocalDNSConfig{}


### PR DESCRIPTION
AWS now provides ipv6 DNS server endpoint at a fixed address (rather than ipv4, which depends on the VPC CIDR block). This isn't provided in dhcp, and anyways we want to ensure we use this endpoint in ipv6 mode and not have ipv4 in the mix.