### PR TITLE
Use node internal IP for metrics-server

### DIFF
--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -132,6 +132,7 @@ spec:
           - --secure-port=443
           - --kubelet-use-node-status-port
           - --metric-resolution=15s
+          - --kubelet-preferred-address-types=InternalIP
 {{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
           - --tls-cert-file=/srv/tls.crt
           - --tls-private-key-file=/srv/tls.key

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -47,7 +47,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: ce871ef1bf53baa9443848ba5f32936f8682383c787b1433da2d75734958a953
+    manifestHash: 4dff6f6241cb58b551453522219441ea26a49878bec473702d2812aae4331c86
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -168,6 +168,7 @@ spec:
         - --secure-port=443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
+        - --kubelet-preferred-address-types=InternalIP
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -41,7 +41,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: ce871ef1bf53baa9443848ba5f32936f8682383c787b1433da2d75734958a953
+    manifestHash: 4dff6f6241cb58b551453522219441ea26a49878bec473702d2812aae4331c86
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -168,6 +168,7 @@ spec:
         - --secure-port=443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
+        - --kubelet-preferred-address-types=InternalIP
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -47,7 +47,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: fb11ac1e25afb1687b3019675ca72e7f4baaceb4faec7424a26b4900d2e0f4bb
+    manifestHash: 9731b5082d21212b47d01fef745c867bb7ae07ba5e67d313ff052c1f2ab41c64
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -168,6 +168,7 @@ spec:
         - --secure-port=443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
+        - --kubelet-preferred-address-types=InternalIP
         - --tls-cert-file=/srv/tls.crt
         - --tls-private-key-file=/srv/tls.key
         - --kubelet-insecure-tls

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -41,7 +41,7 @@ spec:
       k8s-addon: dns-controller.addons.k8s.io
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 6c433dec3ce69175b4079d75a89726ee0bd4237c94c1297903922561b06cec68
+    manifestHash: ee0475eb7db9ad2892bb0a41ee55c94c312c528af4205326b93df84180e63034
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -168,6 +168,7 @@ spec:
         - --secure-port=443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
+        - --kubelet-preferred-address-types=InternalIP
         - --tls-cert-file=/srv/tls.crt
         - --tls-private-key-file=/srv/tls.key
         image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0


### PR DESCRIPTION
Now that kubelet certs contains node IPs, metrics-server can use InternalIP. This makes metrics-server work with ipv6.