### PR TITLE
Automated cherry pick of #12259: Set ipv6 nameservers on aws

### DIFF
--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -75,6 +75,12 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.KubeDNS.MemoryLimit = &defaultMemoryLimit
 	}
 
+	if clusterSpec.IsIPv6Only() && kops.CloudProviderID(clusterSpec.CloudProvider) == kops.CloudProviderAWS {
+		if len(clusterSpec.KubeDNS.UpstreamNameservers) == 0 {
+			clusterSpec.KubeDNS.UpstreamNameservers = []string{"fd00:ec2::253"}
+		}
+	}
+
 	nodeLocalDNS := clusterSpec.KubeDNS.NodeLocalDNS
 	if nodeLocalDNS == nil {
 		nodeLocalDNS = &kops.NodeLocalDNSConfig{}


### PR DESCRIPTION
Cherry pick of #12259 on release-1.22.

#12259: Set ipv6 nameservers on aws

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.