### PR TITLE
Try to bootstrap when at least one IP is available

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
@@ -168,7 +168,9 @@ func (b *KopsBootstrapClient) QueryBootstrap(ctx context.Context, req *nodeup.Bo
 		return nil, err
 	} else {
 		for _, ip := range ips {
-			if ip.String() == cloudup.PlaceholderIP {
+			if ip.String() != cloudup.PlaceholderIP {
+				break
+			} else {
 				return nil, fi.NewTryAgainLaterError(fmt.Sprintf("kops-controller DNS not setup yet (placeholder IP found: %v)", ips))
 			}
 		}


### PR DESCRIPTION
Should make things faster when there is at least one non-placeholder IP is available:
https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-grid-scenario-ipv6-cilium/1434126561480544256/artifacts/18.119.163.204/kops-configuration.log
```
Task "BootstrapClientTask/BootstrapClient" not ready: kops-controller DNS not setup yet (placeholder IP found: [2600:1f16:caa:f601:f747:6351:1a1a:8af3 203.0.113.123])
```