### PR TITLE
Automated cherry pick of #12270: Try to bootstrap when at least one IP is available

### DIFF
--- a/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
@@ -168,7 +168,9 @@ func (b *KopsBootstrapClient) QueryBootstrap(ctx context.Context, req *nodeup.Bo
 		return nil, err
 	} else {
 		for _, ip := range ips {
-			if ip.String() == cloudup.PlaceholderIP {
+			if ip.String() != cloudup.PlaceholderIP {
+				break
+			} else {
 				return nil, fi.NewTryAgainLaterError(fmt.Sprintf("kops-controller DNS not setup yet (placeholder IP found: %v)", ips))
 			}
 		}


### PR DESCRIPTION
Cherry pick of #12270 on release-1.22.

#12270: Try to bootstrap when at least one IP is available

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.