### PR TITLE
Automated cherry pick of #12271: Fix kernel parameter for IPv6 forwarding

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -152,7 +152,7 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	if b.Cluster.Spec.IsIPv6Only() {
 		sysctls = append(sysctls,
-			"net.ipv6.ip_forward=1",
+			"net.ipv6.conf.all.forwarding=1",
 			"net.ipv6.conf.all.accept_ra=2",
 			"")
 	} else {


### PR DESCRIPTION
Cherry pick of #12271 on release-1.22.

#12271: Fix kernel parameter for IPv6 forwarding

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.