### PR TITLE
Add .log suffix to dumped pod logs

### DIFF
--- a/pkg/dump/dumper.go
+++ b/pkg/dump/dumper.go
@@ -278,8 +278,8 @@ func (n *logDumperNode) dump(ctx context.Context) []error {
 
 	for _, selector := range n.dumper.podSelectors {
 		kv := strings.Split(selector, "=")
-		app := kv[len(kv)-1]
-		if err := n.shellToFile(ctx, "if command -v kubectl &> /dev/null; then kubectl logs -n kube-system --all-containers -l \""+selector+"\"; fi", filepath.Join(n.dir, app)); err != nil {
+		logFile := fmt.Sprintf("%v.log", kv[len(kv)-1])
+		if err := n.shellToFile(ctx, "if command -v kubectl &> /dev/null; then kubectl logs -n kube-system --all-containers -l \""+selector+"\"; fi", filepath.Join(n.dir, logFile)); err != nil {
 			errors = append(errors, err)
 		}
 	}


### PR DESCRIPTION
to be consistent with the other log files: https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/kops/12104/pull-kops-e2e-aws-cloud-controller-manager/1434530384313323520/artifacts/34.220.14.111/