### PR TITLE
Set explicit fsType to be able to mount volumes

### DIFF
--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -280,6 +280,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--extra-create-metadata"
+            - "--default-fstype=ext4"
 {{ if WithDefaultBool .CloudConfig.Openstack.BlockStorage.CSITopologySupport false }}
             - --feature-gates=Topology=true
 {{ end }}


### PR DESCRIPTION
Issue https://github.com/kubernetes/cloud-provider-openstack/issues/1362 mentioned that after csi-provisioner update fstype on provisioned PVs no longer defaults to "ext4". Therefore it has to be set explicitly for volumes to work correctly.