### PR TITLE
Automated cherry pick of #12280: Set explicit fsType to be able to mount volumes

### DIFF
--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -280,6 +280,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--extra-create-metadata"
+            - "--default-fstype=ext4"
 {{ if WithDefaultBool .CloudConfig.Openstack.BlockStorage.CSITopologySupport false }}
             - --feature-gates=Topology=true
 {{ end }}


### PR DESCRIPTION
Cherry pick of #12280 on release-1.22.

#12280: Set explicit fsType to be able to mount volumes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```