### PR TITLE
Add ability to yaml-encode unstructured

### DIFF
--- a/pkg/kopscodecs/BUILD.bazel
+++ b/pkg/kopscodecs/BUILD.bazel
@@ -10,10 +10,10 @@ go_library(
         "//pkg/apis/kops/install:go_default_library",
         "//pkg/apis/kops/v1alpha2:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
-        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This is not only cleaner (eliminate a function that panics), but adds
the ability to marshal unstructured.
