### PR TITLE
Add helper to convert kubemanifest.Object to unstructured

### DIFF
--- a/pkg/kubemanifest/BUILD.bazel
+++ b/pkg/kubemanifest/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//util/pkg/text:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/pkg/kubemanifest/manifest.go
+++ b/pkg/kubemanifest/manifest.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/util/pkg/text"
 	"sigs.k8s.io/yaml"
@@ -34,6 +35,11 @@ type Object struct {
 // NewObject returns an Object wrapping the provided data
 func NewObject(data map[string]interface{}) *Object {
 	return &Object{data: data}
+}
+
+// ToUnstructured converts the object to an unstructured.Unstructured
+func (o *Object) ToUnstructured() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: o.data}
 }
 
 // ObjectList describes a list of objects, allowing us to add bulk-methods


### PR DESCRIPTION
This allows the object to be treated as a runtime.Object
