### PR TITLE
Automated cherry pick of #12286: use ipip Always by default in OpenStack

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -171,6 +171,9 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			if c.IPIPMode != "" {
 				return c.IPIPMode
 			}
+			if kops.CloudProviderID(cluster.Spec.CloudProvider) == kops.CloudProviderOpenstack {
+				return "Always"
+			}
 			return "CrossSubnet"
 		}
 		dest["CalicoIPv4PoolVXLANMode"] = func() string {


### PR DESCRIPTION
Cherry pick of #12286 on release-1.22.

#12286: use ipip Always by default in OpenStack

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.