### PR TITLE
Enable IMDS IPv6 endpoint

### DIFF
--- a/cloudmock/aws/mockec2/launch_templates.go
+++ b/cloudmock/aws/mockec2/launch_templates.go
@@ -205,6 +205,7 @@ func responseLaunchTemplateData(req *ec2.RequestLaunchTemplateData) *ec2.Respons
 		resp.MetadataOptions = &ec2.LaunchTemplateInstanceMetadataOptions{
 			HttpTokens:              req.MetadataOptions.HttpTokens,
 			HttpPutResponseHopLimit: req.MetadataOptions.HttpPutResponseHopLimit,
+			HttpProtocolIpv6:        req.MetadataOptions.HttpProtocolIpv6,
 		}
 	}
 	if req.Monitoring != nil {

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1059
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/amazon-ec2-instance-selector/v2 v2.0.2
-	github.com/aws/aws-sdk-go v1.40.10
+	github.com/aws/aws-sdk-go v1.40.38
 	github.com/blang/semver/v4 v4.0.0
 	github.com/denverdino/aliyungo v0.0.0-20210425065611-55bee4942cba
 	github.com/digitalocean/godo v1.60.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.31.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.30/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.40.10 h1:h+xUINuuH/9CwxE7O8mAuW7Aj9E5agfE9jQ3DrJsnA8=
-github.com/aws/aws-sdk-go v1.40.10/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.40.38 h1:kl3iIW0h/JEBFjSBcAxDsiRbKMPz4aI5FJIHMCAQ+J0=
+github.com/aws/aws-sdk-go v1.40.38/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -179,6 +179,7 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 		CPUCredits:                   fi.String(fi.StringValue(ig.Spec.CPUCredits)),
 		HTTPPutResponseHopLimit:      fi.Int64(1),
 		HTTPTokens:                   fi.String(ec2.LaunchTemplateHttpTokensStateOptional),
+		HTTPProtocolIPv6:             fi.String(ec2.LaunchTemplateInstanceMetadataProtocolIpv6Disabled),
 		IAMInstanceProfile:           link,
 		ImageID:                      fi.String(ig.Spec.Image),
 		InstanceInterruptionBehavior: ig.Spec.InstanceInterruptionBehavior,
@@ -222,6 +223,7 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 				}
 				if clusterSubnet.IPv6CIDR != "" {
 					lt.IPv6AddressCount = fi.Int64(1)
+					lt.HTTPProtocolIPv6 = fi.String(ec2.LaunchTemplateInstanceMetadataProtocolIpv6Enabled)
 				}
 			}
 		}

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -235,8 +235,8 @@ github.com/aws/aws-sdk-go v1.31.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU
 github.com/aws/aws-sdk-go v1.31.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.30/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
-github.com/aws/aws-sdk-go v1.40.10 h1:h+xUINuuH/9CwxE7O8mAuW7Aj9E5agfE9jQ3DrJsnA8=
-github.com/aws/aws-sdk-go v1.40.10/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.40.38 h1:kl3iIW0h/JEBFjSBcAxDsiRbKMPz4aI5FJIHMCAQ+J0=
+github.com/aws/aws-sdk-go v1.40.38/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/bazelbuild/buildtools v0.0.0-20190917191645-69366ca98f89/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/bazelbuild/rules_go v0.22.1/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -45,6 +45,8 @@ type LaunchTemplate struct {
 	HTTPPutResponseHopLimit *int64
 	// HTTPTokens is the state of token usage for your instance metadata requests.
 	HTTPTokens *string
+	// HTTPProtocolIPv6 enables the IPv6 instance metadata endpoint
+	HTTPProtocolIPv6 *string
 	// IAMInstanceProfile is the IAM profile to assign to the nodes
 	IAMInstanceProfile *IAMInstanceProfile
 	// ImageID is the AMI to use for the instances

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -45,6 +45,7 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 		MetadataOptions: &ec2.LaunchTemplateInstanceMetadataOptionsRequest{
 			HttpPutResponseHopLimit: t.HTTPPutResponseHopLimit,
 			HttpTokens:              t.HTTPTokens,
+			HttpProtocolIpv6:        t.HTTPProtocolIPv6,
 		},
 		NetworkInterfaces: []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{
 			{
@@ -301,9 +302,10 @@ func (t *LaunchTemplate) Find(c *fi.Context) (*LaunchTemplate, error) {
 	}
 
 	// @step: add instance metadata options
-	if lt.LaunchTemplateData.MetadataOptions != nil {
-		actual.HTTPPutResponseHopLimit = lt.LaunchTemplateData.MetadataOptions.HttpPutResponseHopLimit
-		actual.HTTPTokens = lt.LaunchTemplateData.MetadataOptions.HttpTokens
+	if options := lt.LaunchTemplateData.MetadataOptions; options != nil {
+		actual.HTTPPutResponseHopLimit = options.HttpPutResponseHopLimit
+		actual.HTTPTokens = options.HttpTokens
+		actual.HTTPProtocolIPv6 = options.HttpProtocolIpv6
 	}
 
 	// @step: to avoid spurious changes on ImageId

--- a/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/awsutil/prettify.go
@@ -50,9 +50,19 @@ func prettify(v reflect.Value, indent int, buf *bytes.Buffer) {
 
 		for i, n := range names {
 			val := v.FieldByName(n)
+			ft, ok := v.Type().FieldByName(n)
+			if !ok {
+				panic(fmt.Sprintf("expected to find field %v on type %v, but was not found", n, v.Type()))
+			}
+
 			buf.WriteString(strings.Repeat(" ", indent+2))
 			buf.WriteString(n + ": ")
-			prettify(val, indent+2, buf)
+
+			if tag := ft.Tag.Get("sensitive"); tag == "true" {
+				buf.WriteString("<sensitive>")
+			} else {
+				prettify(val, indent+2, buf)
+			}
 
 			if i < len(names)-1 {
 				buf.WriteString(",\n")

--- a/vendor/github.com/aws/aws-sdk-go/aws/awsutil/string_value.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/awsutil/string_value.go
@@ -8,6 +8,8 @@ import (
 )
 
 // StringValue returns the string representation of a value.
+//
+// Deprecated: Use Prettify instead.
 func StringValue(i interface{}) string {
 	var buf bytes.Buffer
 	stringValue(reflect.ValueOf(i), 0, &buf)

--- a/vendor/github.com/aws/aws-sdk-go/aws/context_1_5.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/context_1_5.go
@@ -1,3 +1,4 @@
+//go:build !go1.9
 // +build !go1.9
 
 package aws

--- a/vendor/github.com/aws/aws-sdk-go/aws/context_1_9.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/context_1_9.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 package aws

--- a/vendor/github.com/aws/aws-sdk-go/aws/context_background_1_5.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/context_background_1_5.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package aws

--- a/vendor/github.com/aws/aws-sdk-go/aws/context_background_1_7.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/context_background_1_7.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package aws

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.5.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package credentials

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.7.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_background_go1.7.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package credentials

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.5.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.9
 // +build !go1.9
 
 package credentials

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.9.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/context_go1.9.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 package credentials

--- a/vendor/github.com/aws/aws-sdk-go/aws/credentials/ssocreds/os.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/credentials/ssocreds/os.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package ssocreds

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -355,13 +355,43 @@ var awsPartition = partition{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-north-1":     endpoint{},
 				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"sa-east-1":      endpoint{},
 				"us-east-1":      endpoint{},
 				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
+		"amplify": service{
+
+			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
+				"eu-south-1":     endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"me-south-1":     endpoint{},
+				"sa-east-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-1":      endpoint{},
 				"us-west-2":      endpoint{},
 			},
 		},
@@ -707,6 +737,7 @@ var awsPartition = partition{
 				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-northeast-3": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
@@ -923,6 +954,18 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"aps": service{
+			Defaults: endpoint{
+				Protocols: []string{"https"},
+			},
+			Endpoints: endpoints{
+				"eu-central-1": endpoint{},
+				"eu-west-1":    endpoint{},
+				"us-east-1":    endpoint{},
+				"us-east-2":    endpoint{},
+				"us-west-2":    endpoint{},
+			},
+		},
 		"athena": service{
 
 			Endpoints: endpoints{
@@ -930,6 +973,7 @@ var awsPartition = partition{
 				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-northeast-3": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
@@ -1104,6 +1148,14 @@ var awsPartition = partition{
 				"us-west-2":  endpoint{},
 			},
 		},
+		"braket": service{
+
+			Endpoints: endpoints{
+				"us-east-1": endpoint{},
+				"us-west-1": endpoint{},
+				"us-west-2": endpoint{},
+			},
+		},
 		"budgets": service{
 			PartitionEndpoint: "aws-global",
 			IsRegionalized:    boxedFalse,
@@ -1149,9 +1201,11 @@ var awsPartition = partition{
 		"cloud9": service{
 
 			Endpoints: endpoints{
+				"af-south-1":     endpoint{},
 				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-northeast-3": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
@@ -1862,6 +1916,59 @@ var awsPartition = partition{
 				"us-east-1": endpoint{},
 			},
 		},
+		"data.jobs.iot": service{
+
+			Endpoints: endpoints{
+				"ap-east-1":      endpoint{},
+				"ap-northeast-1": endpoint{},
+				"ap-northeast-2": endpoint{},
+				"ap-south-1":     endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"ca-central-1":   endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
+				"eu-west-1":      endpoint{},
+				"eu-west-2":      endpoint{},
+				"eu-west-3":      endpoint{},
+				"fips-ca-central-1": endpoint{
+					Hostname: "data.jobs.iot-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"fips-us-east-1": endpoint{
+					Hostname: "data.jobs.iot-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "data.jobs.iot-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "data.jobs.iot-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "data.jobs.iot-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
+			},
+		},
 		"data.mediastore": service{
 
 			Endpoints: endpoints{
@@ -1909,6 +2016,7 @@ var awsPartition = partition{
 				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-northeast-3": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
@@ -3295,6 +3403,17 @@ var awsPartition = partition{
 				"us-west-2": endpoint{},
 			},
 		},
+		"frauddetector": service{
+
+			Endpoints: endpoints{
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"fsx": service{
 
 			Endpoints: endpoints{
@@ -3302,6 +3421,7 @@ var awsPartition = partition{
 				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-northeast-3": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
@@ -3634,6 +3754,18 @@ var awsPartition = partition{
 				},
 			},
 		},
+		"identity-chime": service{
+
+			Endpoints: endpoints{
+				"us-east-1": endpoint{},
+				"us-east-1-fips": endpoint{
+					Hostname: "identity-chime-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+			},
+		},
 		"identitystore": service{
 
 			Endpoints: endpoints{
@@ -3727,18 +3859,49 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-ca-central-1": endpoint{
+					Hostname: "iot-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+				},
+				"fips-us-east-1": endpoint{
+					Hostname: "iot-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "iot-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "iot-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "iot-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"iotanalytics": service{
 
 			Endpoints: endpoints{
 				"ap-northeast-1": endpoint{},
+				"ap-south-1":     endpoint{},
 				"ap-southeast-2": endpoint{},
 				"eu-central-1":   endpoint{},
 				"eu-west-1":      endpoint{},
@@ -3842,12 +4005,42 @@ var awsPartition = partition{
 				"eu-west-1":      endpoint{},
 				"eu-west-2":      endpoint{},
 				"eu-west-3":      endpoint{},
-				"me-south-1":     endpoint{},
-				"sa-east-1":      endpoint{},
-				"us-east-1":      endpoint{},
-				"us-east-2":      endpoint{},
-				"us-west-1":      endpoint{},
-				"us-west-2":      endpoint{},
+				"fips-ca-central-1": endpoint{
+					Hostname: "api.tunneling.iot-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "ca-central-1",
+					},
+				},
+				"fips-us-east-1": endpoint{
+					Hostname: "api.tunneling.iot-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+				"fips-us-east-2": endpoint{
+					Hostname: "api.tunneling.iot-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-2",
+					},
+				},
+				"fips-us-west-1": endpoint{
+					Hostname: "api.tunneling.iot-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-1",
+					},
+				},
+				"fips-us-west-2": endpoint{
+					Hostname: "api.tunneling.iot-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+				"me-south-1": endpoint{},
+				"sa-east-1":  endpoint{},
+				"us-east-1":  endpoint{},
+				"us-east-2":  endpoint{},
+				"us-west-1":  endpoint{},
+				"us-west-2":  endpoint{},
 			},
 		},
 		"iotthingsgraph": service{
@@ -3898,6 +4091,14 @@ var awsPartition = partition{
 						Region: "us-west-2",
 					},
 				},
+			},
+		},
+		"ivs": service{
+
+			Endpoints: endpoints{
+				"eu-west-1": endpoint{},
+				"us-east-1": endpoint{},
+				"us-west-2": endpoint{},
 			},
 		},
 		"kafka": service{
@@ -4518,6 +4719,18 @@ var awsPartition = partition{
 				"us-west-2":      endpoint{},
 			},
 		},
+		"messaging-chime": service{
+
+			Endpoints: endpoints{
+				"us-east-1": endpoint{},
+				"us-east-1-fips": endpoint{
+					Hostname: "messaging-chime-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+				},
+			},
+		},
 		"metering.marketplace": service{
 			Defaults: endpoint{
 				CredentialScope: credentialScope{
@@ -5078,6 +5291,7 @@ var awsPartition = partition{
 		"polly": service{
 
 			Endpoints: endpoints{
+				"af-south-1":     endpoint{},
 				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
@@ -5538,6 +5752,17 @@ var awsPartition = partition{
 				},
 			},
 		},
+		"route53-recovery-control-config": service{
+
+			Endpoints: endpoints{
+				"aws-global": endpoint{
+					Hostname: "route53-recovery-control-config.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+				},
+			},
+		},
 		"route53domains": service{
 
 			Endpoints: endpoints{
@@ -5608,6 +5833,7 @@ var awsPartition = partition{
 				"ap-east-1":      endpoint{},
 				"ap-northeast-1": endpoint{},
 				"ap-northeast-2": endpoint{},
+				"ap-northeast-3": endpoint{},
 				"ap-south-1":     endpoint{},
 				"ap-southeast-1": endpoint{},
 				"ap-southeast-2": endpoint{},
@@ -6757,6 +6983,20 @@ var awsPartition = partition{
 				"us-west-2":  endpoint{},
 			},
 		},
+		"ssm-incidents": service{
+
+			Endpoints: endpoints{
+				"ap-northeast-1": endpoint{},
+				"ap-southeast-1": endpoint{},
+				"ap-southeast-2": endpoint{},
+				"eu-central-1":   endpoint{},
+				"eu-north-1":     endpoint{},
+				"eu-west-1":      endpoint{},
+				"us-east-1":      endpoint{},
+				"us-east-2":      endpoint{},
+				"us-west-2":      endpoint{},
+			},
+		},
 		"states": service{
 
 			Endpoints: endpoints{
@@ -7822,9 +8062,17 @@ var awscnPartition = partition{
 				"cn-northwest-1": endpoint{},
 			},
 		},
+		"data.jobs.iot": service{
+
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
 		"dax": service{
 
 			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
 				"cn-northwest-1": endpoint{},
 			},
 		},
@@ -7952,6 +8200,13 @@ var awscnPartition = partition{
 				"cn-northwest-1": endpoint{},
 			},
 		},
+		"emr-containers": service{
+
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
 		"es": service{
 
 			Endpoints: endpoints{
@@ -7973,6 +8228,15 @@ var awscnPartition = partition{
 				"cn-northwest-1": endpoint{},
 			},
 		},
+		"fms": service{
+			Defaults: endpoint{
+				Protocols: []string{"https"},
+			},
+			Endpoints: endpoints{
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
+			},
+		},
 		"fsx": service{
 
 			Endpoints: endpoints{
@@ -7983,7 +8247,8 @@ var awscnPartition = partition{
 		"gamelift": service{
 
 			Endpoints: endpoints{
-				"cn-north-1": endpoint{},
+				"cn-north-1":     endpoint{},
+				"cn-northwest-1": endpoint{},
 			},
 		},
 		"glacier": service{
@@ -9009,6 +9274,25 @@ var awsusgovPartition = partition{
 				"us-gov-west-1": endpoint{},
 			},
 		},
+		"data.jobs.iot": service{
+
+			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "data.jobs.iot-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "data.jobs.iot-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
+				"us-gov-east-1": endpoint{},
+				"us-gov-west-1": endpoint{},
+			},
+		},
 		"datasync": service{
 
 			Endpoints: endpoints{
@@ -9516,6 +9800,18 @@ var awsusgovPartition = partition{
 				},
 			},
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "iot-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "iot-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "execute-api",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -9523,6 +9819,18 @@ var awsusgovPartition = partition{
 		"iotsecuredtunneling": service{
 
 			Endpoints: endpoints{
+				"fips-us-gov-east-1": endpoint{
+					Hostname: "api.tunneling.iot-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+				},
+				"fips-us-gov-west-1": endpoint{
+					Hostname: "api.tunneling.iot-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+				},
 				"us-gov-east-1": endpoint{},
 				"us-gov-west-1": endpoint{},
 			},
@@ -10712,6 +11020,12 @@ var awsisoPartition = partition{
 				"us-iso-east-1": endpoint{},
 			},
 		},
+		"license-manager": service{
+
+			Endpoints: endpoints{
+				"us-iso-east-1": endpoint{},
+			},
+		},
 		"logs": service{
 
 			Endpoints: endpoints{
@@ -10771,6 +11085,12 @@ var awsisoPartition = partition{
 						Region: "us-iso-east-1",
 					},
 				},
+			},
+		},
+		"route53resolver": service{
+
+			Endpoints: endpoints{
+				"us-iso-east-1": endpoint{},
 			},
 		},
 		"runtime.sagemaker": service{
@@ -11219,6 +11539,12 @@ var awsisobPartition = partition{
 			},
 		},
 		"swf": service{
+
+			Endpoints: endpoints{
+				"us-isob-east-1": endpoint{},
+			},
+		},
+		"tagging": service{
 
 			Endpoints: endpoints{
 				"us-isob-east-1": endpoint{},

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model_codegen.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/v3model_codegen.go
@@ -1,3 +1,4 @@
+//go:build codegen
 // +build codegen
 
 package endpoints

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_7.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_7.go
@@ -1,3 +1,4 @@
+//go:build !go1.8
 // +build !go1.8
 
 package request

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_8.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_8.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package request

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_context.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_context.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package request

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_context_1_6.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_context_1_6.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package request

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 package session

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.12.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.12.go
@@ -1,3 +1,4 @@
+//go:build !go1.13 && go1.7
 // +build !go1.13,go1.7
 
 package session

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.5.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.6 && go1.5
 // +build !go1.6,go1.5
 
 package session

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.6.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/custom_transport_go1.6.go
@@ -1,3 +1,4 @@
+//go:build !go1.7 && go1.6
 // +build !go1.7,go1.6
 
 package session

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.5.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package v4

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.7.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/request_context_go1.7.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package v4

--- a/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/uri_path.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/uri_path.go
@@ -1,3 +1,4 @@
+//go:build go1.5
 // +build go1.5
 
 package v4

--- a/vendor/github.com/aws/aws-sdk-go/aws/url.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/url.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package aws

--- a/vendor/github.com/aws/aws-sdk-go/aws/url_1_7.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/url_1_7.go
@@ -1,3 +1,4 @@
+//go:build !go1.8
 // +build !go1.8
 
 package aws

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.40.10"
+const SDKVersion = "1.40.38"

--- a/vendor/github.com/aws/aws-sdk-go/internal/context/background_go1.5.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/context/background_go1.5.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package context

--- a/vendor/github.com/aws/aws-sdk-go/internal/ini/fuzz.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/ini/fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 package ini

--- a/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.6.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.6.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package sdkio

--- a/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.7.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.7.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package sdkio

--- a/vendor/github.com/aws/aws-sdk-go/internal/sdkmath/floor.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sdkmath/floor.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package sdkmath

--- a/vendor/github.com/aws/aws-sdk-go/internal/sdkmath/floor_go1.9.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sdkmath/floor_go1.9.go
@@ -1,3 +1,4 @@
+//go:build !go1.10
 // +build !go1.10
 
 package sdkmath

--- a/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read.go
@@ -1,3 +1,4 @@
+//go:build go1.6
 // +build go1.6
 
 package sdkrand

--- a/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read_1_5.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sdkrand/read_1_5.go
@@ -1,3 +1,4 @@
+//go:build !go1.6
 // +build !go1.6
 
 package sdkrand

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/timestamp.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/timestamp.go
@@ -29,7 +29,8 @@ const (
 	RFC822OutputTimeFormat = "Mon, 02 Jan 2006 15:04:05 GMT"
 
 	// RFC3339 a subset of the ISO8601 timestamp format. e.g 2014-04-29T18:30:38Z
-	ISO8601TimeFormat = "2006-01-02T15:04:05.999999999Z"
+	ISO8601TimeFormat    = "2006-01-02T15:04:05.999999999Z"
+	iso8601TimeFormatNoZ = "2006-01-02T15:04:05.999999999"
 
 	// This format is used for output time with fractional second precision up to milliseconds
 	ISO8601OutputTimeFormat = "2006-01-02T15:04:05.999999999Z"
@@ -82,6 +83,7 @@ func ParseTime(formatName, value string) (time.Time, error) {
 	case ISO8601TimeFormatName: // Smithy DateTime format
 		return tryParse(value,
 			ISO8601TimeFormat,
+			iso8601TimeFormatNoZ,
 			time.RFC3339Nano,
 			time.RFC3339,
 		)

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
@@ -1879,7 +1879,7 @@ func (c *CloudFormation) DescribeStackInstanceRequest(input *DescribeStackInstan
 // DescribeStackInstance API operation for AWS CloudFormation.
 //
 // Returns the stack instance that's associated with the specified stack set,
-// account, and Region.
+// Amazon Web Services account, and Region.
 //
 // For a list of stack instances that are associated with a specific stack set,
 // use ListStackInstances.
@@ -4006,7 +4006,8 @@ func (c *CloudFormation) ListStackInstancesRequest(input *ListStackInstancesInpu
 //
 // Returns summary information about stack instances that are associated with
 // the specified stack set. You can filter for stack instances that are associated
-// with a specific account name or Region, or that have a specific status.
+// with a specific Amazon Web Services account name or Region, or that have
+// a specific status.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4559,8 +4560,8 @@ func (c *CloudFormation) ListStackSetsRequest(input *ListStackSetsInput) (req *r
 // user.
 //
 //    * [Self-managed permissions] If you set the CallAs parameter to SELF while
-//    signed in to your account, ListStackSets returns all self-managed stack
-//    sets in your account.
+//    signed in to your Amazon Web Services account, ListStackSets returns all
+//    self-managed stack sets in your Amazon Web Services account.
 //
 //    * [Service-managed permissions] If you set the CallAs parameter to SELF
 //    while signed in to the organization's management account, ListStackSets
@@ -5421,7 +5422,7 @@ func (c *CloudFormation) RegisterPublisherRequest(input *RegisterPublisherInput)
 //
 // Registers your account as a publisher of public extensions in the CloudFormation
 // registry. Public extensions are available for use by all CloudFormation users.
-// This publisher ID applies to your account in all Regions.
+// This publisher ID applies to your account in all Amazon Web Services Regions.
 //
 // For information on requirements for registering as a public extension publisher,
 // see Registering your account to publish CloudFormation extensions (https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/publish-extension.html#publish-extension-prereqs)
@@ -5505,8 +5506,8 @@ func (c *CloudFormation) RegisterTypeRequest(input *RegisterTypeInput) (req *req
 // RegisterType API operation for AWS CloudFormation.
 //
 // Registers an extension with the CloudFormation service. Registering an extension
-// makes it available for use in CloudFormation templates in your account, and
-// includes:
+// makes it available for use in CloudFormation templates in your Amazon Web
+// Services account, and includes:
 //
 //    * Validating the extension schema
 //
@@ -5560,6 +5561,104 @@ func (c *CloudFormation) RegisterType(input *RegisterTypeInput) (*RegisterTypeOu
 // for more information on using Contexts.
 func (c *CloudFormation) RegisterTypeWithContext(ctx aws.Context, input *RegisterTypeInput, opts ...request.Option) (*RegisterTypeOutput, error) {
 	req, out := c.RegisterTypeRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opRollbackStack = "RollbackStack"
+
+// RollbackStackRequest generates a "aws/request.Request" representing the
+// client's request for the RollbackStack operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See RollbackStack for more information on using the RollbackStack
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the RollbackStackRequest method.
+//    req, resp := client.RollbackStackRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/RollbackStack
+func (c *CloudFormation) RollbackStackRequest(input *RollbackStackInput) (req *request.Request, output *RollbackStackOutput) {
+	op := &request.Operation{
+		Name:       opRollbackStack,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &RollbackStackInput{}
+	}
+
+	output = &RollbackStackOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// RollbackStack API operation for AWS CloudFormation.
+//
+// When specifying RollbackStack, you preserve the state of previously provisioned
+// resources when an operation fails. You can check the status of the stack
+// through the DescribeStacks API.
+//
+// Rolls back the specified stack to the last known stable state from CREATE_FAILED
+// or UPDATE_FAILED stack statuses.
+//
+// This operation will delete a stack if it doesn't contain a last known stable
+// state. A last known stable state includes any status in a *_COMPLETE. This
+// includes the following stack statuses.
+//
+//    * CREATE_COMPLETE
+//
+//    * UPDATE_COMPLETE
+//
+//    * UPDATE_ROLLBACK_COMPLETE
+//
+//    * IMPORT_COMPLETE
+//
+//    * IMPORT_ROLLBACK_COMPLETE
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CloudFormation's
+// API operation RollbackStack for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeTokenAlreadyExistsException "TokenAlreadyExistsException"
+//   A client request token already exists.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/RollbackStack
+func (c *CloudFormation) RollbackStack(input *RollbackStackInput) (*RollbackStackOutput, error) {
+	req, out := c.RollbackStackRequest(input)
+	return out, req.Send()
+}
+
+// RollbackStackWithContext is the same as RollbackStack with the addition of
+// the ability to pass a context and additional request options.
+//
+// See RollbackStack for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *CloudFormation) RollbackStackWithContext(ctx aws.Context, input *RollbackStackInput, opts ...request.Option) (*RollbackStackOutput, error) {
+	req, out := c.RollbackStackRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -7420,14 +7519,14 @@ type CreateChangeSetInput struct {
 	// certain capabilities in order for CloudFormation to create the stack.
 	//
 	//    * CAPABILITY_IAM and CAPABILITY_NAMED_IAM Some stack templates might include
-	//    resources that can affect permissions in your account; for example, by
-	//    creating new Identity and Access Management (IAM) users. For those stacks,
-	//    you must explicitly acknowledge this by specifying one of these capabilities.
-	//    The following IAM resources require you to specify either the CAPABILITY_IAM
-	//    or CAPABILITY_NAMED_IAM capability. If you have IAM resources, you can
-	//    specify either capability. If you have IAM resources with custom names,
-	//    you must specify CAPABILITY_NAMED_IAM. If you don't specify either of
-	//    these capabilities, CloudFormation returns an InsufficientCapabilities
+	//    resources that can affect permissions in your Amazon Web Services account;
+	//    for example, by creating new Identity and Access Management (IAM) users.
+	//    For those stacks, you must explicitly acknowledge this by specifying one
+	//    of these capabilities. The following IAM resources require you to specify
+	//    either the CAPABILITY_IAM or CAPABILITY_NAMED_IAM capability. If you have
+	//    IAM resources, you can specify either capability. If you have IAM resources
+	//    with custom names, you must specify CAPABILITY_NAMED_IAM. If you don't
+	//    specify either of these capabilities, CloudFormation returns an InsufficientCapabilities
 	//    error. If your stack template contains these resources, we recommend that
 	//    you review all permissions associated with them and edit their permissions
 	//    if necessary. AWS::IAM::AccessKey (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
@@ -7787,14 +7886,14 @@ type CreateStackInput struct {
 	// certain capabilities in order for CloudFormation to create the stack.
 	//
 	//    * CAPABILITY_IAM and CAPABILITY_NAMED_IAM Some stack templates might include
-	//    resources that can affect permissions in your account; for example, by
-	//    creating new Identity and Access Management (IAM) users. For those stacks,
-	//    you must explicitly acknowledge this by specifying one of these capabilities.
-	//    The following IAM resources require you to specify either the CAPABILITY_IAM
-	//    or CAPABILITY_NAMED_IAM capability. If you have IAM resources, you can
-	//    specify either capability. If you have IAM resources with custom names,
-	//    you must specify CAPABILITY_NAMED_IAM. If you don't specify either of
-	//    these capabilities, CloudFormation returns an InsufficientCapabilities
+	//    resources that can affect permissions in your Amazon Web Services account;
+	//    for example, by creating new Identity and Access Management (IAM) users.
+	//    For those stacks, you must explicitly acknowledge this by specifying one
+	//    of these capabilities. The following IAM resources require you to specify
+	//    either the CAPABILITY_IAM or CAPABILITY_NAMED_IAM capability. If you have
+	//    IAM resources, you can specify either capability. If you have IAM resources
+	//    with custom names, you must specify CAPABILITY_NAMED_IAM. If you don't
+	//    specify either of these capabilities, CloudFormation returns an InsufficientCapabilities
 	//    error. If your stack template contains these resources, we recommend that
 	//    you review all permissions associated with them and edit their permissions
 	//    if necessary. AWS::IAM::AccessKey (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
@@ -7916,7 +8015,7 @@ type CreateStackInput struct {
 	// Region in which you are creating the stack.
 	//
 	// A stack name can contain only alphanumeric characters (case sensitive) and
-	// hyphens. It must start with an alphabetic character and cannot be longer
+	// hyphens. It must start with an alphabetical character and cannot be longer
 	// than 128 characters.
 	//
 	// StackName is a required field
@@ -8127,8 +8226,8 @@ func (s *CreateStackInput) SetTimeoutInMinutes(v int64) *CreateStackInput {
 type CreateStackInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// [Self-managed permissions] The names of one or more accounts that you want
-	// to create stack instances in the specified Region(s) for.
+	// [Self-managed permissions] The names of one or more Amazon Web Services accounts
+	// that you want to create stack instances in the specified Region(s) for.
 	//
 	// You can specify Accounts or DeploymentTargets, but not both.
 	Accounts []*string `type:"list"`
@@ -8143,9 +8242,9 @@ type CreateStackInstancesInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -8202,7 +8301,7 @@ type CreateStackInstancesInput struct {
 	ParameterOverrides []*Parameter `type:"list"`
 
 	// The names of one or more Regions where you want to create stack instances
-	// using the specified accounts.
+	// using the specified Amazon Web Services accounts.
 	//
 	// Regions is a required field
 	Regions []*string `type:"list" required:"true"`
@@ -8378,8 +8477,9 @@ type CreateStackSetInput struct {
 	//
 	//    * To create a stack set with service-managed permissions while signed
 	//    in to a delegated administrator account, specify DELEGATED_ADMIN. Your
-	//    account must be registered as a delegated admin in the management account.
-	//    For more information, see Register a delegated administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Amazon Web Services account must be registered as a delegated admin in
+	//    the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	//
 	// Stack sets with service-managed permissions are created in the management
@@ -8391,17 +8491,17 @@ type CreateStackSetInput struct {
 	// set and related stack instances.
 	//
 	//    * CAPABILITY_IAM and CAPABILITY_NAMED_IAM Some stack templates might include
-	//    resources that can affect permissions in your account; for example, by
-	//    creating new Identity and Access Management (IAM) users. For those stack
-	//    sets, you must explicitly acknowledge this by specifying one of these
-	//    capabilities. The following IAM resources require you to specify either
-	//    the CAPABILITY_IAM or CAPABILITY_NAMED_IAM capability. If you have IAM
-	//    resources, you can specify either capability. If you have IAM resources
-	//    with custom names, you must specify CAPABILITY_NAMED_IAM. If you don't
-	//    specify either of these capabilities, CloudFormation returns an InsufficientCapabilities
-	//    error. If your stack template contains these resources, we recommend that
-	//    you review all permissions associated with them and edit their permissions
-	//    if necessary. AWS::IAM::AccessKey (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
+	//    resources that can affect permissions in your Amazon Web Services account;
+	//    for example, by creating new Identity and Access Management (IAM) users.
+	//    For those stack sets, you must explicitly acknowledge this by specifying
+	//    one of these capabilities. The following IAM resources require you to
+	//    specify either the CAPABILITY_IAM or CAPABILITY_NAMED_IAM capability.
+	//    If you have IAM resources, you can specify either capability. If you have
+	//    IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM.
+	//    If you don't specify either of these capabilities, CloudFormation returns
+	//    an InsufficientCapabilities error. If your stack template contains these
+	//    resources, we recommend that you review all permissions associated with
+	//    them and edit their permissions if necessary. AWS::IAM::AccessKey (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
 	//    AWS::IAM::Group (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html)
 	//    AWS::IAM::InstanceProfile (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html)
 	//    AWS::IAM::Policy (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html)
@@ -8908,8 +9008,8 @@ func (s *DeleteStackInput) SetStackName(v string) *DeleteStackInput {
 type DeleteStackInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// [Self-managed permissions] The names of the accounts that you want to delete
-	// stack instances for.
+	// [Self-managed permissions] The names of the Amazon Web Services accounts
+	// that you want to delete stack instances for.
 	//
 	// You can specify Accounts or DeploymentTargets, but not both.
 	Accounts []*string `type:"list"`
@@ -8924,9 +9024,9 @@ type DeleteStackInstancesInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -9113,9 +9213,9 @@ type DeleteStackSetInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -9185,8 +9285,8 @@ func (s DeleteStackSetOutput) GoString() string {
 type DeploymentTargets struct {
 	_ struct{} `type:"structure"`
 
-	// The names of one or more accounts for which you want to deploy stack set
-	// updates.
+	// The names of one or more Amazon Web Services accounts for which you want
+	// to deploy stack set updates.
 	Accounts []*string `type:"list"`
 
 	// Returns the value of the AccountsUrl property.
@@ -10025,13 +10125,14 @@ type DescribeStackInstanceInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
-	// The ID of an account that's associated with this stack instance.
+	// The ID of an Amazon Web Services account that's associated with this stack
+	// instance.
 	//
 	// StackInstanceAccount is a required field
 	StackInstanceAccount *string `type:"string" required:"true"`
@@ -10452,9 +10553,9 @@ type DescribeStackSetInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -10512,9 +10613,9 @@ type DescribeStackSetOperationInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -11475,9 +11576,9 @@ type DetectStackSetDriftInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -11690,6 +11791,12 @@ type ExecuteChangeSetInput struct {
 	// received them.
 	ClientRequestToken *string `min:"1" type:"string"`
 
+	// Preserves the state of previously provisioned resources when an operation
+	// fails.
+	//
+	// Default: True
+	DisableRollback *bool `type:"boolean"`
+
 	// If you specified the name of a change set, specify the stack name or ID (ARN)
 	// that is associated with the change set you want to execute.
 	StackName *string `min:"1" type:"string"`
@@ -11736,6 +11843,12 @@ func (s *ExecuteChangeSetInput) SetChangeSetName(v string) *ExecuteChangeSetInpu
 // SetClientRequestToken sets the ClientRequestToken field's value.
 func (s *ExecuteChangeSetInput) SetClientRequestToken(v string) *ExecuteChangeSetInput {
 	s.ClientRequestToken = &v
+	return s
+}
+
+// SetDisableRollback sets the DisableRollback field's value.
+func (s *ExecuteChangeSetInput) SetDisableRollback(v bool) *ExecuteChangeSetInput {
+	s.DisableRollback = &v
 	return s
 }
 
@@ -11996,9 +12109,9 @@ type GetTemplateSummaryInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -12586,9 +12699,9 @@ type ListStackInstancesInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -12608,7 +12721,8 @@ type ListStackInstancesInput struct {
 	// response object's NextToken parameter is set to null.
 	NextToken *string `min:"1" type:"string"`
 
-	// The name of the account that you want to list stack instances for.
+	// The name of the Amazon Web Services account that you want to list stack instances
+	// for.
 	StackInstanceAccount *string `type:"string"`
 
 	// The name of the Region where you want to list stack instances.
@@ -12845,9 +12959,9 @@ type ListStackSetOperationResultsInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -12991,9 +13105,9 @@ type ListStackSetOperationsInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -13119,9 +13233,9 @@ type ListStackSetsInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -14057,7 +14171,7 @@ type ParameterDeclaration struct {
 	Description *string `min:"1" type:"string"`
 
 	// Flag that indicates whether the parameter value is shown as plain text in
-	// logs and in the Management Console.
+	// logs and in the Amazon Web Services Management Console.
 	NoEcho *bool `type:"boolean"`
 
 	// The criteria that CloudFormation uses to validate parameter values.
@@ -15262,6 +15376,95 @@ func (s *RollbackConfiguration) SetRollbackTriggers(v []*RollbackTrigger) *Rollb
 	return s
 }
 
+type RollbackStackInput struct {
+	_ struct{} `type:"structure"`
+
+	// A unique identifier for this RollbackStack request.
+	ClientRequestToken *string `min:"1" type:"string"`
+
+	// The Amazon Resource Name (ARN) of an Identity and Access Management role
+	// that CloudFormation assumes to rollback the stack.
+	RoleARN *string `min:"20" type:"string"`
+
+	// The name that is associated with the stack.
+	//
+	// StackName is a required field
+	StackName *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s RollbackStackInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RollbackStackInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RollbackStackInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RollbackStackInput"}
+	if s.ClientRequestToken != nil && len(*s.ClientRequestToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("ClientRequestToken", 1))
+	}
+	if s.RoleARN != nil && len(*s.RoleARN) < 20 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleARN", 20))
+	}
+	if s.StackName == nil {
+		invalidParams.Add(request.NewErrParamRequired("StackName"))
+	}
+	if s.StackName != nil && len(*s.StackName) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("StackName", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetClientRequestToken sets the ClientRequestToken field's value.
+func (s *RollbackStackInput) SetClientRequestToken(v string) *RollbackStackInput {
+	s.ClientRequestToken = &v
+	return s
+}
+
+// SetRoleARN sets the RoleARN field's value.
+func (s *RollbackStackInput) SetRoleARN(v string) *RollbackStackInput {
+	s.RoleARN = &v
+	return s
+}
+
+// SetStackName sets the StackName field's value.
+func (s *RollbackStackInput) SetStackName(v string) *RollbackStackInput {
+	s.StackName = &v
+	return s
+}
+
+type RollbackStackOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Unique identifier of the stack.
+	StackId *string `type:"string"`
+}
+
+// String returns the string representation
+func (s RollbackStackOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s RollbackStackOutput) GoString() string {
+	return s.String()
+}
+
+// SetStackId sets the StackId field's value.
+func (s *RollbackStackOutput) SetStackId(v string) *RollbackStackOutput {
+	s.StackId = &v
+	return s
+}
+
 // A rollback trigger CloudFormation monitors during creation and updating of
 // stacks. If any of the alarms you specify goes to ALARM state during the stack
 // operation or within the specified monitoring period afterwards, CloudFormation
@@ -16229,8 +16432,8 @@ func (s *StackEvent) SetTimestamp(v time.Time) *StackEvent {
 type StackInstance struct {
 	_ struct{} `type:"structure"`
 
-	// [Self-managed permissions] The name of the account that the stack instance
-	// is associated with.
+	// [Self-managed permissions] The name of the Amazon Web Services account that
+	// the stack instance is associated with.
 	Account *string `type:"string"`
 
 	// Status of the stack instance's actual configuration compared to the expected
@@ -16263,7 +16466,8 @@ type StackInstance struct {
 	// in this stack instance.
 	ParameterOverrides []*Parameter `type:"list"`
 
-	// The name of the Region that the stack instance is associated with.
+	// The name of the Amazon Web Services Region that the stack instance is associated
+	// with.
 	Region *string `type:"string"`
 
 	// The ID of the stack instance.
@@ -16469,8 +16673,8 @@ func (s *StackInstanceFilter) SetValues(v string) *StackInstanceFilter {
 type StackInstanceSummary struct {
 	_ struct{} `type:"structure"`
 
-	// [Self-managed permissions] The name of the account that the stack instance
-	// is associated with.
+	// [Self-managed permissions] The name of the Amazon Web Services account that
+	// the stack instance is associated with.
 	Account *string `type:"string"`
 
 	// Status of the stack instance's actual configuration compared to the expected
@@ -16499,7 +16703,8 @@ type StackInstanceSummary struct {
 	// unit (OU) IDs that you specified for DeploymentTargets (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DeploymentTargets.html).
 	OrganizationalUnitId *string `type:"string"`
 
-	// The name of the Region that the stack instance is associated with.
+	// The name of the Amazon Web Services Region that the stack instance is associated
+	// with.
 	Region *string `type:"string"`
 
 	// The ID of the stack instance.
@@ -17241,9 +17446,10 @@ func (s *StackResourceSummary) SetResourceType(v string) *StackResourceSummary {
 }
 
 // A structure that contains information about a stack set. A stack set enables
-// you to provision stacks into accounts and across Regions by using a single
-// CloudFormation template. In the stack set, you specify the template to use,
-// as well as any parameters and capabilities that the template requires.
+// you to provision stacks into Amazon Web Services accounts and across Regions
+// by using a single CloudFormation template. In the stack set, you specify
+// the template to use, as well as any parameters and capabilities that the
+// template requires.
 type StackSet struct {
 	_ struct{} `type:"structure"`
 
@@ -17262,10 +17468,10 @@ type StackSet struct {
 	AutoDeployment *AutoDeployment `type:"structure"`
 
 	// The capabilities that are allowed in the stack set. Some stack set templates
-	// might include resources that can affect permissions in your account—for
-	// example, by creating new Identity and Access Management (IAM) users. For
-	// more information, see Acknowledging IAM Resources in CloudFormation Templates.
-	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities)
+	// might include resources that can affect permissions in your Amazon Web Services
+	// account—for example, by creating new Identity and Access Management (IAM)
+	// users. For more information, see Acknowledging IAM Resources in CloudFormation
+	// Templates. (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities)
 	Capabilities []*string `type:"list"`
 
 	// A description of the stack set that you specify when the stack set is created
@@ -17878,7 +18084,8 @@ func (s *StackSetOperationPreferences) SetRegionOrder(v []*string) *StackSetOper
 type StackSetOperationResultSummary struct {
 	_ struct{} `type:"structure"`
 
-	// [Self-managed permissions] The name of the account for this operation result.
+	// [Self-managed permissions] The name of the Amazon Web Services account for
+	// this operation result.
 	Account *string `type:"string"`
 
 	// The results of the account gate function CloudFormation invokes, if present,
@@ -17889,7 +18096,7 @@ type StackSetOperationResultSummary struct {
 	// unit (OU) IDs that you specified for DeploymentTargets (https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DeploymentTargets.html).
 	OrganizationalUnitId *string `type:"string"`
 
-	// The name of the Region for this operation result.
+	// The name of the Amazon Web Services Region for this operation result.
 	Region *string `type:"string"`
 
 	// The result status of the stack set operation for the given account in the
@@ -18316,9 +18523,9 @@ type StopStackSetOperationInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -19187,14 +19394,14 @@ type UpdateStackInput struct {
 	// certain capabilities in order for CloudFormation to update the stack.
 	//
 	//    * CAPABILITY_IAM and CAPABILITY_NAMED_IAM Some stack templates might include
-	//    resources that can affect permissions in your account; for example, by
-	//    creating new Identity and Access Management (IAM) users. For those stacks,
-	//    you must explicitly acknowledge this by specifying one of these capabilities.
-	//    The following IAM resources require you to specify either the CAPABILITY_IAM
-	//    or CAPABILITY_NAMED_IAM capability. If you have IAM resources, you can
-	//    specify either capability. If you have IAM resources with custom names,
-	//    you must specify CAPABILITY_NAMED_IAM. If you don't specify either of
-	//    these capabilities, CloudFormation returns an InsufficientCapabilities
+	//    resources that can affect permissions in your Amazon Web Services account;
+	//    for example, by creating new Identity and Access Management (IAM) users.
+	//    For those stacks, you must explicitly acknowledge this by specifying one
+	//    of these capabilities. The following IAM resources require you to specify
+	//    either the CAPABILITY_IAM or CAPABILITY_NAMED_IAM capability. If you have
+	//    IAM resources, you can specify either capability. If you have IAM resources
+	//    with custom names, you must specify CAPABILITY_NAMED_IAM. If you don't
+	//    specify either of these capabilities, CloudFormation returns an InsufficientCapabilities
 	//    error. If your stack template contains these resources, we recommend that
 	//    you review all permissions associated with them and edit their permissions
 	//    if necessary. AWS::IAM::AccessKey (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
@@ -19244,6 +19451,12 @@ type UpdateStackInput struct {
 	// stack operation . For example, if you create a stack using the console, each
 	// stack event would be assigned the same token in the following format: Console-CreateStack-7f59c3cf-00d2-40c7-b2ff-e75db0987002.
 	ClientRequestToken *string `min:"1" type:"string"`
+
+	// Preserve the state of previously provisioned resources when an operation
+	// fails.
+	//
+	// Default: False
+	DisableRollback *bool `type:"boolean"`
 
 	// Amazon Simple Notification Service topic Amazon Resource Names (ARNs) that
 	// CloudFormation associates with the stack. Specify an empty list to remove
@@ -19433,6 +19646,12 @@ func (s *UpdateStackInput) SetClientRequestToken(v string) *UpdateStackInput {
 	return s
 }
 
+// SetDisableRollback sets the DisableRollback field's value.
+func (s *UpdateStackInput) SetDisableRollback(v bool) *UpdateStackInput {
+	s.DisableRollback = &v
+	return s
+}
+
 // SetNotificationARNs sets the NotificationARNs field's value.
 func (s *UpdateStackInput) SetNotificationARNs(v []*string) *UpdateStackInput {
 	s.NotificationARNs = v
@@ -19520,10 +19739,10 @@ func (s *UpdateStackInput) SetUsePreviousTemplate(v bool) *UpdateStackInput {
 type UpdateStackInstancesInput struct {
 	_ struct{} `type:"structure"`
 
-	// [Self-managed permissions] The names of one or more accounts for which you
-	// want to update parameter values for stack instances. The overridden parameter
-	// values will be applied to all stack instances in the specified accounts and
-	// Regions.
+	// [Self-managed permissions] The names of one or more Amazon Web Services accounts
+	// for which you want to update parameter values for stack instances. The overridden
+	// parameter values will be applied to all stack instances in the specified
+	// accounts and Regions.
 	//
 	// You can specify Accounts or DeploymentTargets, but not both.
 	Accounts []*string `type:"list"`
@@ -19538,9 +19757,9 @@ type UpdateStackInstancesInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -19799,9 +20018,9 @@ type UpdateStackSetInput struct {
 	//    * If you are signed in to the management account, specify SELF.
 	//
 	//    * If you are signed in to a delegated administrator account, specify DELEGATED_ADMIN.
-	//    Your account must be registered as a delegated administrator in the management
-	//    account. For more information, see Register a delegated administrator
-	//    (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
+	//    Your Amazon Web Services account must be registered as a delegated administrator
+	//    in the management account. For more information, see Register a delegated
+	//    administrator (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-delegated-admin.html)
 	//    in the CloudFormation User Guide.
 	CallAs *string `type:"string" enum:"CallAs"`
 
@@ -19810,17 +20029,17 @@ type UpdateStackSetInput struct {
 	// and its associated stack instances.
 	//
 	//    * CAPABILITY_IAM and CAPABILITY_NAMED_IAM Some stack templates might include
-	//    resources that can affect permissions in your account; for example, by
-	//    creating new Identity and Access Management (IAM) users. For those stacks
-	//    sets, you must explicitly acknowledge this by specifying one of these
-	//    capabilities. The following IAM resources require you to specify either
-	//    the CAPABILITY_IAM or CAPABILITY_NAMED_IAM capability. If you have IAM
-	//    resources, you can specify either capability. If you have IAM resources
-	//    with custom names, you must specify CAPABILITY_NAMED_IAM. If you don't
-	//    specify either of these capabilities, CloudFormation returns an InsufficientCapabilities
-	//    error. If your stack template contains these resources, we recommend that
-	//    you review all permissions associated with them and edit their permissions
-	//    if necessary. AWS::IAM::AccessKey (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
+	//    resources that can affect permissions in your Amazon Web Services account;
+	//    for example, by creating new Identity and Access Management (IAM) users.
+	//    For those stacks sets, you must explicitly acknowledge this by specifying
+	//    one of these capabilities. The following IAM resources require you to
+	//    specify either the CAPABILITY_IAM or CAPABILITY_NAMED_IAM capability.
+	//    If you have IAM resources, you can specify either capability. If you have
+	//    IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM.
+	//    If you don't specify either of these capabilities, CloudFormation returns
+	//    an InsufficientCapabilities error. If your stack template contains these
+	//    resources, we recommend that you review all permissions associated with
+	//    them and edit their permissions if necessary. AWS::IAM::AccessKey (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html)
 	//    AWS::IAM::Group (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html)
 	//    AWS::IAM::InstanceProfile (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html)
 	//    AWS::IAM::Policy (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html)
@@ -21048,6 +21267,24 @@ const (
 
 	// ResourceStatusImportRollbackComplete is a ResourceStatus enum value
 	ResourceStatusImportRollbackComplete = "IMPORT_ROLLBACK_COMPLETE"
+
+	// ResourceStatusUpdateRollbackInProgress is a ResourceStatus enum value
+	ResourceStatusUpdateRollbackInProgress = "UPDATE_ROLLBACK_IN_PROGRESS"
+
+	// ResourceStatusUpdateRollbackComplete is a ResourceStatus enum value
+	ResourceStatusUpdateRollbackComplete = "UPDATE_ROLLBACK_COMPLETE"
+
+	// ResourceStatusUpdateRollbackFailed is a ResourceStatus enum value
+	ResourceStatusUpdateRollbackFailed = "UPDATE_ROLLBACK_FAILED"
+
+	// ResourceStatusRollbackInProgress is a ResourceStatus enum value
+	ResourceStatusRollbackInProgress = "ROLLBACK_IN_PROGRESS"
+
+	// ResourceStatusRollbackComplete is a ResourceStatus enum value
+	ResourceStatusRollbackComplete = "ROLLBACK_COMPLETE"
+
+	// ResourceStatusRollbackFailed is a ResourceStatus enum value
+	ResourceStatusRollbackFailed = "ROLLBACK_FAILED"
 )
 
 // ResourceStatus_Values returns all elements of the ResourceStatus enum
@@ -21069,6 +21306,12 @@ func ResourceStatus_Values() []string {
 		ResourceStatusImportRollbackInProgress,
 		ResourceStatusImportRollbackFailed,
 		ResourceStatusImportRollbackComplete,
+		ResourceStatusUpdateRollbackInProgress,
+		ResourceStatusUpdateRollbackComplete,
+		ResourceStatusUpdateRollbackFailed,
+		ResourceStatusRollbackInProgress,
+		ResourceStatusRollbackComplete,
+		ResourceStatusRollbackFailed,
 	}
 }
 
@@ -21389,6 +21632,9 @@ const (
 	// StackStatusUpdateComplete is a StackStatus enum value
 	StackStatusUpdateComplete = "UPDATE_COMPLETE"
 
+	// StackStatusUpdateFailed is a StackStatus enum value
+	StackStatusUpdateFailed = "UPDATE_FAILED"
+
 	// StackStatusUpdateRollbackInProgress is a StackStatus enum value
 	StackStatusUpdateRollbackInProgress = "UPDATE_ROLLBACK_IN_PROGRESS"
 
@@ -21435,6 +21681,7 @@ func StackStatus_Values() []string {
 		StackStatusUpdateInProgress,
 		StackStatusUpdateCompleteCleanupInProgress,
 		StackStatusUpdateComplete,
+		StackStatusUpdateFailed,
 		StackStatusUpdateRollbackInProgress,
 		StackStatusUpdateRollbackFailed,
 		StackStatusUpdateRollbackCompleteCleanupInProgress,

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/ec2iface/interface.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/ec2iface/interface.go
@@ -1406,6 +1406,9 @@ type EC2API interface {
 	DescribeTrunkInterfaceAssociationsWithContext(aws.Context, *ec2.DescribeTrunkInterfaceAssociationsInput, ...request.Option) (*ec2.DescribeTrunkInterfaceAssociationsOutput, error)
 	DescribeTrunkInterfaceAssociationsRequest(*ec2.DescribeTrunkInterfaceAssociationsInput) (*request.Request, *ec2.DescribeTrunkInterfaceAssociationsOutput)
 
+	DescribeTrunkInterfaceAssociationsPages(*ec2.DescribeTrunkInterfaceAssociationsInput, func(*ec2.DescribeTrunkInterfaceAssociationsOutput, bool) bool) error
+	DescribeTrunkInterfaceAssociationsPagesWithContext(aws.Context, *ec2.DescribeTrunkInterfaceAssociationsInput, func(*ec2.DescribeTrunkInterfaceAssociationsOutput, bool) bool, ...request.Option) error
+
 	DescribeVolumeAttribute(*ec2.DescribeVolumeAttributeInput) (*ec2.DescribeVolumeAttributeOutput, error)
 	DescribeVolumeAttributeWithContext(aws.Context, *ec2.DescribeVolumeAttributeInput, ...request.Option) (*ec2.DescribeVolumeAttributeOutput, error)
 	DescribeVolumeAttributeRequest(*ec2.DescribeVolumeAttributeInput) (*request.Request, *ec2.DescribeVolumeAttributeOutput)

--- a/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
@@ -6771,20 +6771,27 @@ type LoadBalancerAttribute struct {
 	//    are in OpenSSL format. The possible values for the attribute are true
 	//    and false. The default is false.
 	//
-	//    * routing.http2.enabled - Indicates whether HTTP/2 is enabled. The value
-	//    is true or false. The default is true. Elastic Load Balancing requires
-	//    that message header names contain only alphanumeric characters and hyphens.
+	//    * routing.http.xff_client_port.enabled - Indicates whether the X-Forwarded-For
+	//    header should preserve the source port that the client used to connect
+	//    to the load balancer. The possible values are true and false. The default
+	//    is false.
+	//
+	//    * routing.http2.enabled - Indicates whether HTTP/2 is enabled. The possible
+	//    values are true and false. The default is true. Elastic Load Balancing
+	//    requires that message header names contain only alphanumeric characters
+	//    and hyphens.
 	//
 	//    * waf.fail_open.enabled - Indicates whether to allow a WAF-enabled load
 	//    balancer to route requests to targets if it is unable to forward the request
-	//    to Amazon Web Services WAF. The value is true or false. The default is
-	//    false.
+	//    to Amazon Web Services WAF. The possible values are true and false. The
+	//    default is false.
 	//
 	// The following attribute is supported by Network Load Balancers and Gateway
 	// Load Balancers:
 	//
 	//    * load_balancing.cross_zone.enabled - Indicates whether cross-zone load
-	//    balancing is enabled. The value is true or false. The default is false.
+	//    balancing is enabled. The possible values are true and false. The default
+	//    is false.
 	Key *string `type:"string"`
 
 	// The value of the attribute.

--- a/vendor/github.com/aws/aws-sdk-go/service/eventbridge/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/eventbridge/api.go
@@ -618,30 +618,32 @@ func (c *EventBridge) CreatePartnerEventSourceRequest(input *CreatePartnerEventS
 // CreatePartnerEventSource API operation for Amazon EventBridge.
 //
 // Called by an SaaS partner to create a partner event source. This operation
-// is not used by AWS customers.
+// is not used by Amazon Web Services customers.
 //
-// Each partner event source can be used by one AWS account to create a matching
-// partner event bus in that AWS account. A SaaS partner must create one partner
-// event source for each AWS account that wants to receive those event types.
+// Each partner event source can be used by one Amazon Web Services account
+// to create a matching partner event bus in that Amazon Web Services account.
+// A SaaS partner must create one partner event source for each Amazon Web Services
+// account that wants to receive those event types.
 //
 // A partner event source creates events based on resources within the SaaS
 // partner's service or application.
 //
-// An AWS account that creates a partner event bus that matches the partner
-// event source can use that event bus to receive events from the partner, and
-// then process them using AWS Events rules and targets.
+// An Amazon Web Services account that creates a partner event bus that matches
+// the partner event source can use that event bus to receive events from the
+// partner, and then process them using Amazon Web Services Events rules and
+// targets.
 //
 // Partner event source names follow this format:
 //
 // partner_name/event_namespace/event_name
 //
 // partner_name is determined during partner registration and identifies the
-// partner to AWS customers. event_namespace is determined by the partner and
-// is a way for the partner to categorize their events. event_name is determined
-// by the partner, and should uniquely identify an event-generating resource
-// within the partner system. The combination of event_namespace and event_name
-// should help AWS customers decide whether to create an event bus to receive
-// these events.
+// partner to Amazon Web Services customers. event_namespace is determined by
+// the partner and is a way for the partner to categorize their events. event_name
+// is determined by the partner, and should uniquely identify an event-generating
+// resource within the partner system. The combination of event_namespace and
+// event_name should help Amazon Web Services customers decide whether to create
+// an event bus to receive these events.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -740,7 +742,7 @@ func (c *EventBridge) DeactivateEventSourceRequest(input *DeactivateEventSourceI
 // When you deactivate a partner event source, the source goes into PENDING
 // state. If it remains in PENDING state for more than two weeks, it is deleted.
 //
-// To activate a deactivated partner event source, use ActivateEventSource.
+// To activate a deactivated partner event source, use ActivateEventSource (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ActivateEventSource.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1262,10 +1264,10 @@ func (c *EventBridge) DeletePartnerEventSourceRequest(input *DeletePartnerEventS
 // DeletePartnerEventSource API operation for Amazon EventBridge.
 //
 // This operation is used by SaaS partners to delete a partner event source.
-// This operation is not used by AWS customers.
+// This operation is not used by Amazon Web Services customers.
 //
 // When you delete an event source, the status of the corresponding partner
-// event bus in the AWS customer account becomes DELETED.
+// event bus in the Amazon Web Services customer account becomes DELETED.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1353,7 +1355,8 @@ func (c *EventBridge) DeleteRuleRequest(input *DeleteRuleInput) (req *request.Re
 //
 // Deletes the specified rule.
 //
-// Before you can delete the rule, you must remove all targets, using RemoveTargets.
+// Before you can delete the rule, you must remove all targets, using RemoveTargets
+// (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_RemoveTargets.html).
 //
 // When you delete a rule, incoming events might continue to match to the deleted
 // rule. Allow a short period of time for changes to take effect.
@@ -1362,11 +1365,11 @@ func (c *EventBridge) DeleteRuleRequest(input *DeleteRuleInput) (req *request.Re
 // succeed. When you call delete rule for a non-existent custom eventbus, ResourceNotFoundException
 // is returned.
 //
-// Managed rules are rules created and managed by another AWS service on your
-// behalf. These rules are created by those other AWS services to support functionality
-// in those services. You can delete these rules using the Force option, but
-// you should do so only if you are sure the other service is not still using
-// that rule.
+// Managed rules are rules created and managed by another Amazon Web Services
+// service on your behalf. These rules are created by those other Amazon Web
+// Services services to support functionality in those services. You can delete
+// these rules using the Force option, but you should do so only if you are
+// sure the other service is not still using that rule.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1380,12 +1383,12 @@ func (c *EventBridge) DeleteRuleRequest(input *DeleteRuleInput) (req *request.Re
 //   There is concurrent modification on a rule, target, archive, or replay.
 //
 //   * ManagedRuleException
-//   This rule was created by an AWS service on behalf of your account. It is
-//   managed by that service. If you see this error in response to DeleteRule
-//   or RemoveTargets, you can use the Force parameter in those calls to delete
-//   the rule or remove targets from the rule. You cannot modify these managed
-//   rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-//   or UntagResource.
+//   This rule was created by an Amazon Web Services service on behalf of your
+//   account. It is managed by that service. If you see this error in response
+//   to DeleteRule or RemoveTargets, you can use the Force parameter in those
+//   calls to delete the rule or remove targets from the rule. You cannot modify
+//   these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+//   TagResource, or UntagResource.
 //
 //   * InternalException
 //   This exception occurs due to unexpected causes.
@@ -1709,14 +1712,15 @@ func (c *EventBridge) DescribeEventBusRequest(input *DescribeEventBusInput) (req
 // DescribeEventBus API operation for Amazon EventBridge.
 //
 // Displays details about an event bus in your account. This can include the
-// external AWS accounts that are permitted to write events to your default
-// event bus, and the associated policy. For custom event buses and partner
-// event buses, it displays the name, ARN, policy, state, and creation time.
+// external Amazon Web Services accounts that are permitted to write events
+// to your default event bus, and the associated policy. For custom event buses
+// and partner event buses, it displays the name, ARN, policy, state, and creation
+// time.
 //
 // To enable your account to receive events from other accounts on its default
-// event bus, use PutPermission.
+// event bus, use PutPermission (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutPermission.html).
 //
-// For more information about partner event buses, see CreateEventBus.
+// For more information about partner event buses, see CreateEventBus (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreateEventBus.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1885,9 +1889,10 @@ func (c *EventBridge) DescribePartnerEventSourceRequest(input *DescribePartnerEv
 // DescribePartnerEventSource API operation for Amazon EventBridge.
 //
 // An SaaS partner can use this operation to list details about a partner event
-// source that they have created. AWS customers do not use this operation. Instead,
-// AWS customers can use DescribeEventSource to see details about a partner
-// event source that is shared with them.
+// source that they have created. Amazon Web Services customers do not use this
+// operation. Instead, Amazon Web Services customers can use DescribeEventSource
+// (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeEventSource.html)
+// to see details about a partner event source that is shared with them.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2065,7 +2070,7 @@ func (c *EventBridge) DescribeRuleRequest(input *DescribeRuleInput) (req *reques
 // Describes the specified rule.
 //
 // DescribeRule does not list the targets of a rule. To see the targets associated
-// with a rule, use ListTargetsByRule.
+// with a rule, use ListTargetsByRule (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListTargetsByRule.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2169,12 +2174,12 @@ func (c *EventBridge) DisableRuleRequest(input *DisableRuleInput) (req *request.
 //   There is concurrent modification on a rule, target, archive, or replay.
 //
 //   * ManagedRuleException
-//   This rule was created by an AWS service on behalf of your account. It is
-//   managed by that service. If you see this error in response to DeleteRule
-//   or RemoveTargets, you can use the Force parameter in those calls to delete
-//   the rule or remove targets from the rule. You cannot modify these managed
-//   rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-//   or UntagResource.
+//   This rule was created by an Amazon Web Services service on behalf of your
+//   account. It is managed by that service. If you see this error in response
+//   to DeleteRule or RemoveTargets, you can use the Force parameter in those
+//   calls to delete the rule or remove targets from the rule. You cannot modify
+//   these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+//   TagResource, or UntagResource.
 //
 //   * InternalException
 //   This exception occurs due to unexpected causes.
@@ -2267,12 +2272,12 @@ func (c *EventBridge) EnableRuleRequest(input *EnableRuleInput) (req *request.Re
 //   There is concurrent modification on a rule, target, archive, or replay.
 //
 //   * ManagedRuleException
-//   This rule was created by an AWS service on behalf of your account. It is
-//   managed by that service. If you see this error in response to DeleteRule
-//   or RemoveTargets, you can use the Force parameter in those calls to delete
-//   the rule or remove targets from the rule. You cannot modify these managed
-//   rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-//   or UntagResource.
+//   This rule was created by an Amazon Web Services service on behalf of your
+//   account. It is managed by that service. If you see this error in response
+//   to DeleteRule or RemoveTargets, you can use the Force parameter in those
+//   calls to delete the rule or remove targets from the rule. You cannot modify
+//   these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+//   TagResource, or UntagResource.
 //
 //   * InternalException
 //   This exception occurs due to unexpected causes.
@@ -2665,8 +2670,8 @@ func (c *EventBridge) ListEventSourcesRequest(input *ListEventSourcesInput) (req
 // ListEventSources API operation for Amazon EventBridge.
 //
 // You can use this to see all the partner event sources that have been shared
-// with your AWS account. For more information about partner event sources,
-// see CreateEventBus.
+// with your Amazon Web Services account. For more information about partner
+// event sources, see CreateEventBus (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreateEventBus.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2748,9 +2753,9 @@ func (c *EventBridge) ListPartnerEventSourceAccountsRequest(input *ListPartnerEv
 
 // ListPartnerEventSourceAccounts API operation for Amazon EventBridge.
 //
-// An SaaS partner can use this operation to display the AWS account ID that
-// a particular partner event source name is associated with. This operation
-// is not used by AWS customers.
+// An SaaS partner can use this operation to display the Amazon Web Services
+// account ID that a particular partner event source name is associated with.
+// This operation is not used by Amazon Web Services customers.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2836,7 +2841,8 @@ func (c *EventBridge) ListPartnerEventSourcesRequest(input *ListPartnerEventSour
 // ListPartnerEventSources API operation for Amazon EventBridge.
 //
 // An SaaS partner can use this operation to list all the partner event source
-// names that they have created. This operation is not used by AWS customers.
+// names that they have created. This operation is not used by Amazon Web Services
+// customers.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3085,7 +3091,7 @@ func (c *EventBridge) ListRulesRequest(input *ListRulesInput) (req *request.Requ
 // you can provide a prefix to match to the rule names.
 //
 // ListRules does not list the targets of a rule. To see the targets associated
-// with a rule, use ListTargetsByRule.
+// with a rule, use ListTargetsByRule (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListTargetsByRule.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3413,7 +3419,7 @@ func (c *EventBridge) PutPartnerEventsRequest(input *PutPartnerEventsInput) (req
 // PutPartnerEvents API operation for Amazon EventBridge.
 //
 // This is used by SaaS partners to write events to a customer's partner event
-// bus. AWS customers do not use this operation.
+// bus. Amazon Web Services customers do not use this operation.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3496,27 +3502,27 @@ func (c *EventBridge) PutPermissionRequest(input *PutPermissionInput) (req *requ
 
 // PutPermission API operation for Amazon EventBridge.
 //
-// Running PutPermission permits the specified AWS account or AWS organization
-// to put events to the specified event bus. Amazon EventBridge (CloudWatch
-// Events) rules in your account are triggered by these events arriving to an
-// event bus in your account.
+// Running PutPermission permits the specified Amazon Web Services account or
+// Amazon Web Services organization to put events to the specified event bus.
+// Amazon EventBridge (CloudWatch Events) rules in your account are triggered
+// by these events arriving to an event bus in your account.
 //
 // For another account to send events to your account, that external account
 // must have an EventBridge rule with your account's event bus as a target.
 //
-// To enable multiple AWS accounts to put events to your event bus, run PutPermission
-// once for each of these accounts. Or, if all the accounts are members of the
-// same AWS organization, you can run PutPermission once specifying Principal
-// as "*" and specifying the AWS organization ID in Condition, to grant permissions
-// to all accounts in that organization.
+// To enable multiple Amazon Web Services accounts to put events to your event
+// bus, run PutPermission once for each of these accounts. Or, if all the accounts
+// are members of the same Amazon Web Services organization, you can run PutPermission
+// once specifying Principal as "*" and specifying the Amazon Web Services organization
+// ID in Condition, to grant permissions to all accounts in that organization.
 //
 // If you grant permissions using an organization, then accounts in that organization
 // must specify a RoleArn with proper permissions when they use PutTarget to
 // add your account's event bus as a target. For more information, see Sending
-// and Receiving Events Between AWS Accounts (https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html)
+// and Receiving Events Between Amazon Web Services Accounts (https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html)
 // in the Amazon EventBridge User Guide.
 //
-// The permission policy on the default event bus cannot exceed 10 KB in size.
+// The permission policy on the event bus cannot exceed 10 KB in size.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3608,14 +3614,14 @@ func (c *EventBridge) PutRuleRequest(input *PutRuleInput) (req *request.Request,
 // PutRule API operation for Amazon EventBridge.
 //
 // Creates or updates the specified rule. Rules are enabled by default, or based
-// on value of the state. You can disable a rule using DisableRule.
+// on value of the state. You can disable a rule using DisableRule (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DisableRule.html).
 //
 // A single rule watches for events from a single event bus. Events generated
-// by AWS services go to your account's default event bus. Events generated
-// by SaaS partner services or applications go to the matching partner event
-// bus. If you have custom applications or services, you can specify whether
+// by Amazon Web Services services go to your account's default event bus. Events
+// generated by SaaS partner services or applications go to the matching partner
+// event bus. If you have custom applications or services, you can specify whether
 // their events go to your default event bus or a custom event bus that you
-// have created. For more information, see CreateEventBus.
+// have created. For more information, see CreateEventBus (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreateEventBus.html).
 //
 // If you are updating an existing rule, the rule is replaced with what you
 // specify in this PutRule command. If you omit arguments in PutRule, the old
@@ -3641,12 +3647,14 @@ func (c *EventBridge) PutRuleRequest(input *PutRuleInput) (req *request.Request,
 //
 // If you are updating an existing rule, any tags you specify in the PutRule
 // operation are ignored. To update the tags of an existing rule, use TagResource
-// and UntagResource.
+// (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_TagResource.html)
+// and UntagResource (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_UntagResource.html).
 //
-// Most services in AWS treat : or / as the same character in Amazon Resource
-// Names (ARNs). However, EventBridge uses an exact match in event patterns
-// and rules. Be sure to use the correct ARN characters when creating event
-// patterns so that they match the ARN syntax in the event you want to match.
+// Most services in Amazon Web Services treat : or / as the same character in
+// Amazon Resource Names (ARNs). However, EventBridge uses an exact match in
+// event patterns and rules. Be sure to use the correct ARN characters when
+// creating event patterns so that they match the ARN syntax in the event you
+// want to match.
 //
 // In EventBridge, it is possible to create rules that lead to infinite loops,
 // where a rule is fired repeatedly. For example, a rule might detect that ACLs
@@ -3681,12 +3689,12 @@ func (c *EventBridge) PutRuleRequest(input *PutRuleInput) (req *request.Request,
 //   There is concurrent modification on a rule, target, archive, or replay.
 //
 //   * ManagedRuleException
-//   This rule was created by an AWS service on behalf of your account. It is
-//   managed by that service. If you see this error in response to DeleteRule
-//   or RemoveTargets, you can use the Force parameter in those calls to delete
-//   the rule or remove targets from the rule. You cannot modify these managed
-//   rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-//   or UntagResource.
+//   This rule was created by an Amazon Web Services service on behalf of your
+//   account. It is managed by that service. If you see this error in response
+//   to DeleteRule or RemoveTargets, you can use the Force parameter in those
+//   calls to delete the rule or remove targets from the rule. You cannot modify
+//   these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+//   TagResource, or UntagResource.
 //
 //   * InternalException
 //   This exception occurs due to unexpected causes.
@@ -3773,13 +3781,13 @@ func (c *EventBridge) PutTargetsRequest(input *PutTargetsInput) (req *request.Re
 //
 //    * API Gateway
 //
-//    * AWS Batch job queue
+//    * Batch job queue
 //
 //    * CloudWatch Logs group
 //
 //    * CodeBuild project
 //
-//    * CodePineline
+//    * CodePipeline
 //
 //    * Amazon EC2 CreateSnapshot API call
 //
@@ -3791,9 +3799,9 @@ func (c *EventBridge) PutTargetsRequest(input *PutTargetsInput) (req *request.Re
 //
 //    * Amazon ECS tasks
 //
-//    * Event bus in a different AWS account or Region. You can use an event
-//    bus in the US East (N. Virginia) us-east-1, US West (Oregon) us-west-2,
-//    or Europe (Ireland) eu-west-1 Regions as a target for a rule.
+//    * Event bus in a different Amazon Web Services account or Region. You
+//    can use an event bus in the US East (N. Virginia) us-east-1, US West (Oregon)
+//    us-west-2, or Europe (Ireland) eu-west-1 Regions as a target for a rule.
 //
 //    * Firehose delivery stream (Kinesis Data Firehose)
 //
@@ -3801,7 +3809,7 @@ func (c *EventBridge) PutTargetsRequest(input *PutTargetsInput) (req *request.Re
 //
 //    * Kinesis stream (Kinesis Data Stream)
 //
-//    * AWS Lambda function
+//    * Lambda function
 //
 //    * Redshift clusters (Data API statement execution)
 //
@@ -3817,9 +3825,10 @@ func (c *EventBridge) PutTargetsRequest(input *PutTargetsInput) (req *request.Re
 //
 //    * Step Functions state machines
 //
-// Creating rules with built-in targets is supported only in the AWS Management
-// Console. The built-in targets are EC2 CreateSnapshot API call, EC2 RebootInstances
-// API call, EC2 StopInstances API call, and EC2 TerminateInstances API call.
+// Creating rules with built-in targets is supported only in the Amazon Web
+// Services Management Console. The built-in targets are EC2 CreateSnapshot
+// API call, EC2 RebootInstances API call, EC2 StopInstances API call, and EC2
+// TerminateInstances API call.
 //
 // For some target types, PutTargets provides target-specific parameters. If
 // the target is a Kinesis data stream, you can optionally specify which shard
@@ -3828,35 +3837,35 @@ func (c *EventBridge) PutTargetsRequest(input *PutTargetsInput) (req *request.Re
 // field.
 //
 // To be able to make API calls against the resources that you own, Amazon EventBridge
-// (CloudWatch Events) needs the appropriate permissions. For AWS Lambda and
-// Amazon SNS resources, EventBridge relies on resource-based policies. For
-// EC2 instances, Kinesis data streams, AWS Step Functions state machines and
-// API Gateway REST APIs, EventBridge relies on IAM roles that you specify in
-// the RoleARN argument in PutTargets. For more information, see Authentication
-// and Access Control (https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html)
+// needs the appropriate permissions. For Lambda and Amazon SNS resources, EventBridge
+// relies on resource-based policies. For EC2 instances, Kinesis Data Streams,
+// Step Functions state machines and API Gateway REST APIs, EventBridge relies
+// on IAM roles that you specify in the RoleARN argument in PutTargets. For
+// more information, see Authentication and Access Control (https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html)
 // in the Amazon EventBridge User Guide.
 //
-// If another AWS account is in the same region and has granted you permission
-// (using PutPermission), you can send events to that account. Set that account's
-// event bus as a target of the rules in your account. To send the matched events
-// to the other account, specify that account's event bus as the Arn value when
-// you run PutTargets. If your account sends events to another account, your
-// account is charged for each sent event. Each event sent to another account
-// is charged as a custom event. The account receiving the event is not charged.
-// For more information, see Amazon EventBridge (CloudWatch Events) Pricing
-// (https://aws.amazon.com/eventbridge/pricing/).
+// If another Amazon Web Services account is in the same region and has granted
+// you permission (using PutPermission), you can send events to that account.
+// Set that account's event bus as a target of the rules in your account. To
+// send the matched events to the other account, specify that account's event
+// bus as the Arn value when you run PutTargets. If your account sends events
+// to another account, your account is charged for each sent event. Each event
+// sent to another account is charged as a custom event. The account receiving
+// the event is not charged. For more information, see Amazon EventBridge Pricing
+// (http://aws.amazon.com/eventbridge/pricing/).
 //
 // Input, InputPath, and InputTransformer are not available with PutTarget if
-// the target is an event bus of a different AWS account.
+// the target is an event bus of a different Amazon Web Services account.
 //
 // If you are setting the event bus of another account as the target, and that
 // account granted permission to your account through an organization instead
 // of directly by the account ID, then you must specify a RoleArn with proper
 // permissions in the Target structure. For more information, see Sending and
-// Receiving Events Between AWS Accounts (https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html)
+// Receiving Events Between Amazon Web Services Accounts (https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html)
 // in the Amazon EventBridge User Guide.
 //
-// For more information about enabling cross-account events, see PutPermission.
+// For more information about enabling cross-account events, see PutPermission
+// (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutPermission.html).
 //
 // Input, InputPath, and InputTransformer are mutually exclusive and optional
 // parameters of a target. When a rule is triggered due to a matched event:
@@ -3908,12 +3917,12 @@ func (c *EventBridge) PutTargetsRequest(input *PutTargetsInput) (req *request.Re
 //   service quota.
 //
 //   * ManagedRuleException
-//   This rule was created by an AWS service on behalf of your account. It is
-//   managed by that service. If you see this error in response to DeleteRule
-//   or RemoveTargets, you can use the Force parameter in those calls to delete
-//   the rule or remove targets from the rule. You cannot modify these managed
-//   rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-//   or UntagResource.
+//   This rule was created by an Amazon Web Services service on behalf of your
+//   account. It is managed by that service. If you see this error in response
+//   to DeleteRule or RemoveTargets, you can use the Force parameter in those
+//   calls to delete the rule or remove targets from the rule. You cannot modify
+//   these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+//   TagResource, or UntagResource.
 //
 //   * InternalException
 //   This exception occurs due to unexpected causes.
@@ -3985,10 +3994,11 @@ func (c *EventBridge) RemovePermissionRequest(input *RemovePermissionInput) (req
 
 // RemovePermission API operation for Amazon EventBridge.
 //
-// Revokes the permission of another AWS account to be able to put events to
-// the specified event bus. Specify the account to revoke by the StatementId
-// value that you associated with the account when you granted it permission
-// with PutPermission. You can find the StatementId by using DescribeEventBus.
+// Revokes the permission of another Amazon Web Services account to be able
+// to put events to the specified event bus. Specify the account to revoke by
+// the StatementId value that you associated with the account when you granted
+// it permission with PutPermission. You can find the StatementId by using DescribeEventBus
+// (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeEventBus.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4103,12 +4113,12 @@ func (c *EventBridge) RemoveTargetsRequest(input *RemoveTargetsInput) (req *requ
 //   There is concurrent modification on a rule, target, archive, or replay.
 //
 //   * ManagedRuleException
-//   This rule was created by an AWS service on behalf of your account. It is
-//   managed by that service. If you see this error in response to DeleteRule
-//   or RemoveTargets, you can use the Force parameter in those calls to delete
-//   the rule or remove targets from the rule. You cannot modify these managed
-//   rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-//   or UntagResource.
+//   This rule was created by an Amazon Web Services service on behalf of your
+//   account. It is managed by that service. If you see this error in response
+//   to DeleteRule or RemoveTargets, you can use the Force parameter in those
+//   calls to delete the rule or remove targets from the rule. You cannot modify
+//   these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+//   TagResource, or UntagResource.
 //
 //   * InternalException
 //   This exception occurs due to unexpected causes.
@@ -4286,8 +4296,8 @@ func (c *EventBridge) TagResourceRequest(input *TagResourceInput) (req *request.
 // change only resources with certain tag values. In EventBridge, rules and
 // event buses can be tagged.
 //
-// Tags don't have any semantic meaning to AWS and are interpreted strictly
-// as strings of characters.
+// Tags don't have any semantic meaning to Amazon Web Services and are interpreted
+// strictly as strings of characters.
 //
 // You can use the TagResource action with a resource that already has tags.
 // If you specify a new tag key, this tag is appended to the list of tags associated
@@ -4315,12 +4325,12 @@ func (c *EventBridge) TagResourceRequest(input *TagResourceInput) (req *request.
 //   This exception occurs due to unexpected causes.
 //
 //   * ManagedRuleException
-//   This rule was created by an AWS service on behalf of your account. It is
-//   managed by that service. If you see this error in response to DeleteRule
-//   or RemoveTargets, you can use the Force parameter in those calls to delete
-//   the rule or remove targets from the rule. You cannot modify these managed
-//   rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-//   or UntagResource.
+//   This rule was created by an Amazon Web Services service on behalf of your
+//   account. It is managed by that service. If you see this error in response
+//   to DeleteRule or RemoveTargets, you can use the Force parameter in those
+//   calls to delete the rule or remove targets from the rule. You cannot modify
+//   these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+//   TagResource, or UntagResource.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/TagResource
 func (c *EventBridge) TagResource(input *TagResourceInput) (*TagResourceOutput, error) {
@@ -4390,10 +4400,11 @@ func (c *EventBridge) TestEventPatternRequest(input *TestEventPatternInput) (req
 //
 // Tests whether the specified event pattern matches the provided event.
 //
-// Most services in AWS treat : or / as the same character in Amazon Resource
-// Names (ARNs). However, EventBridge uses an exact match in event patterns
-// and rules. Be sure to use the correct ARN characters when creating event
-// patterns so that they match the ARN syntax in the event you want to match.
+// Most services in Amazon Web Services treat : or / as the same character in
+// Amazon Resource Names (ARNs). However, EventBridge uses an exact match in
+// event patterns and rules. Be sure to use the correct ARN characters when
+// creating event patterns so that they match the ARN syntax in the event you
+// want to match.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4497,12 +4508,12 @@ func (c *EventBridge) UntagResourceRequest(input *UntagResourceInput) (req *requ
 //   There is concurrent modification on a rule, target, archive, or replay.
 //
 //   * ManagedRuleException
-//   This rule was created by an AWS service on behalf of your account. It is
-//   managed by that service. If you see this error in response to DeleteRule
-//   or RemoveTargets, you can use the Force parameter in those calls to delete
-//   the rule or remove targets from the rule. You cannot modify these managed
-//   rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-//   or UntagResource.
+//   This rule was created by an Amazon Web Services service on behalf of your
+//   account. It is managed by that service. If you see this error in response
+//   to DeleteRule or RemoveTargets, you can use the Force parameter in those
+//   calls to delete the rule or remove targets from the rule. You cannot modify
+//   these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+//   TagResource, or UntagResource.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/UntagResource
 func (c *EventBridge) UntagResource(input *UntagResourceInput) (*UntagResourceOutput, error) {
@@ -5103,7 +5114,7 @@ func (s *AwsVpcConfiguration) SetSubnets(v []*string) *AwsVpcConfiguration {
 // The array properties for the submitted job, such as the size of the array.
 // The array size can be between 2 and 10,000. If you specify array properties
 // for a job, it becomes an array job. This parameter is used only if the target
-// is an AWS Batch job.
+// is an Batch job.
 type BatchArrayProperties struct {
 	_ struct{} `type:"structure"`
 
@@ -5128,30 +5139,30 @@ func (s *BatchArrayProperties) SetSize(v int64) *BatchArrayProperties {
 	return s
 }
 
-// The custom parameters to be used when the target is an AWS Batch job.
+// The custom parameters to be used when the target is an Batch job.
 type BatchParameters struct {
 	_ struct{} `type:"structure"`
 
 	// The array properties for the submitted job, such as the size of the array.
 	// The array size can be between 2 and 10,000. If you specify array properties
 	// for a job, it becomes an array job. This parameter is used only if the target
-	// is an AWS Batch job.
+	// is an Batch job.
 	ArrayProperties *BatchArrayProperties `type:"structure"`
 
-	// The ARN or name of the job definition to use if the event target is an AWS
-	// Batch job. This job definition must already exist.
+	// The ARN or name of the job definition to use if the event target is an Batch
+	// job. This job definition must already exist.
 	//
 	// JobDefinition is a required field
 	JobDefinition *string `type:"string" required:"true"`
 
-	// The name to use for this execution of the job, if the target is an AWS Batch
+	// The name to use for this execution of the job, if the target is an Batch
 	// job.
 	//
 	// JobName is a required field
 	JobName *string `type:"string" required:"true"`
 
-	// The retry strategy to use for failed jobs, if the target is an AWS Batch
-	// job. The retry strategy is the number of times to retry the failed job execution.
+	// The retry strategy to use for failed jobs, if the target is an Batch job.
+	// The retry strategy is the number of times to retry the failed job execution.
 	// Valid values are 1–10. When you specify a retry strategy here, it overrides
 	// the retry strategy defined in the job definition.
 	RetryStrategy *BatchRetryStrategy `type:"structure"`
@@ -5207,9 +5218,9 @@ func (s *BatchParameters) SetRetryStrategy(v *BatchRetryStrategy) *BatchParamete
 	return s
 }
 
-// The retry strategy to use for failed jobs, if the target is an AWS Batch
-// job. If you specify a retry strategy here, it overrides the retry strategy
-// defined in the job definition.
+// The retry strategy to use for failed jobs, if the target is an Batch job.
+// If you specify a retry strategy here, it overrides the retry strategy defined
+// in the job definition.
 type BatchRetryStrategy struct {
 	_ struct{} `type:"structure"`
 
@@ -5441,9 +5452,10 @@ func (s *ConcurrentModificationException) RequestID() string {
 
 // A JSON string which you can use to limit the event bus permissions you are
 // granting to only accounts that fulfill the condition. Currently, the only
-// supported condition is membership in a certain AWS organization. The string
-// must contain Type, Key, and Value fields. The Value field specifies the ID
-// of the AWS organization. Following is an example value for Condition:
+// supported condition is membership in a certain Amazon Web Services organization.
+// The string must contain Type, Key, and Value fields. The Value field specifies
+// the ID of the Amazon Web Services organization. Following is an example value
+// for Condition:
 //
 // '{"Type" : "StringEquals", "Key": "aws:PrincipalOrgID", "Value": "o-1234567890"}'
 type Condition struct {
@@ -6129,7 +6141,7 @@ type CreateArchiveInput struct {
 	// An event pattern to use to filter events sent to the archive.
 	EventPattern *string `type:"string"`
 
-	// The ARN of the event source associated with the archive.
+	// The ARN of the event bus that sends events to the archive.
 	//
 	// EventSourceArn is a required field
 	EventSourceArn *string `min:"1" type:"string" required:"true"`
@@ -6838,16 +6850,16 @@ func (s *CreateEventBusOutput) SetEventBusArn(v string) *CreateEventBusOutput {
 type CreatePartnerEventSourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// The AWS account ID that is permitted to create a matching partner event bus
-	// for this partner event source.
+	// The Amazon Web Services account ID that is permitted to create a matching
+	// partner event bus for this partner event source.
 	//
 	// Account is a required field
 	Account *string `min:"12" type:"string" required:"true"`
 
 	// The name of the partner event source. This name must be unique and must be
-	// in the format partner_name/event_namespace/event_name . The AWS account that
-	// wants to use this partner event source must create a partner event bus with
-	// a name that matches the name of the partner event source.
+	// in the format partner_name/event_namespace/event_name . The Amazon Web Services
+	// account that wants to use this partner event source must create a partner
+	// event bus with a name that matches the name of the partner event source.
 	//
 	// Name is a required field
 	Name *string `min:"1" type:"string" required:"true"`
@@ -7383,8 +7395,8 @@ func (s DeleteEventBusOutput) GoString() string {
 type DeletePartnerEventSourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// The AWS account ID of the AWS customer that the event source was created
-	// for.
+	// The Amazon Web Services account ID of the Amazon Web Services customer that
+	// the event source was created for.
 	//
 	// Account is a required field
 	Account *string `min:"12" type:"string" required:"true"`
@@ -7460,11 +7472,11 @@ type DeleteRuleInput struct {
 	// the default event bus is used.
 	EventBusName *string `min:"1" type:"string"`
 
-	// If this is a managed rule, created by an AWS service on your behalf, you
-	// must specify Force as True to delete the rule. This parameter is ignored
-	// for rules that are not managed rules. You can check whether a rule is a managed
-	// rule by using DescribeRule or ListRules and checking the ManagedBy field
-	// of the response.
+	// If this is a managed rule, created by an Amazon Web Services service on your
+	// behalf, you must specify Force as True to delete the rule. This parameter
+	// is ignored for rules that are not managed rules. You can check whether a
+	// rule is a managed rule by using DescribeRule or ListRules and checking the
+	// ManagedBy field of the response.
 	Force *bool `type:"boolean"`
 
 	// The name of the rule.
@@ -8500,8 +8512,9 @@ type DescribeRuleOutput struct {
 	// in the Amazon EventBridge User Guide.
 	EventPattern *string `type:"string"`
 
-	// If this is a managed rule, created by an AWS service on your behalf, this
-	// field displays the principal name of the AWS service that created the rule.
+	// If this is a managed rule, created by an Amazon Web Services service on your
+	// behalf, this field displays the principal name of the Amazon Web Services
+	// service that created the rule.
 	ManagedBy *string `min:"1" type:"string"`
 
 	// The name of the rule.
@@ -8682,15 +8695,16 @@ type EcsParameters struct {
 	// Specifies the launch type on which your task is running. The launch type
 	// that you specify here must match one of the launch type (compatibilities)
 	// of the target task. The FARGATE value is supported only in the Regions where
-	// AWS Fargate with Amazon ECS is supported. For more information, see AWS Fargate
-	// on Amazon ECS (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS-Fargate.html)
+	// Fargate witt Amazon ECS is supported. For more information, see Fargate on
+	// Amazon ECS (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS-Fargate.html)
 	// in the Amazon Elastic Container Service Developer Guide.
 	LaunchType *string `type:"string" enum:"LaunchType"`
 
-	// Use this structure if the ECS task uses the awsvpc network mode. This structure
-	// specifies the VPC subnets and security groups associated with the task, and
-	// whether a public IP address is to be used. This structure is required if
-	// LaunchType is FARGATE because the awsvpc mode is required for Fargate tasks.
+	// Use this structure if the Amazon ECS task uses the awsvpc network mode. This
+	// structure specifies the VPC subnets and security groups associated with the
+	// task, and whether a public IP address is to be used. This structure is required
+	// if LaunchType is FARGATE because the awsvpc mode is required for Fargate
+	// tasks.
 	//
 	// If you specify NetworkConfiguration when the target ECS task does not use
 	// the awsvpc network mode, the task fails.
@@ -8709,7 +8723,7 @@ type EcsParameters struct {
 	// of the platform version, such as 1.1.0.
 	//
 	// This structure is used only if LaunchType is FARGATE. For more information
-	// about valid platform versions, see AWS Fargate Platform Versions (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html)
+	// about valid platform versions, see Fargate Platform Versions (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html)
 	// in the Amazon Elastic Container Service Developer Guide.
 	PlatformVersion *string `type:"string"`
 
@@ -8946,9 +8960,10 @@ func (s EnableRuleOutput) GoString() string {
 
 // An event bus receives events from a source and routes them to rules associated
 // with that event bus. Your account's default event bus receives events from
-// AWS services. A custom event bus can receive events from your custom applications
-// and services. A partner event bus receives events from an event source created
-// by an SaaS partner. These events come from the partners services or applications.
+// Amazon Web Services services. A custom event bus can receive events from
+// your custom applications and services. A partner event bus receives events
+// from an event source created by an SaaS partner. These events come from the
+// partners services or applications.
 type EventBus struct {
 	_ struct{} `type:"structure"`
 
@@ -8958,8 +8973,8 @@ type EventBus struct {
 	// The name of the event bus.
 	Name *string `type:"string"`
 
-	// The permissions policy of the event bus, describing which other AWS accounts
-	// can write events to this event bus.
+	// The permissions policy of the event bus, describing which other Amazon Web
+	// Services accounts can write events to this event bus.
 	Policy *string `type:"string"`
 }
 
@@ -8992,8 +9007,8 @@ func (s *EventBus) SetPolicy(v string) *EventBus {
 }
 
 // A partner event source is created by an SaaS partner. If a customer creates
-// a partner event bus that matches this event source, that AWS account can
-// receive events from the partner's applications or services.
+// a partner event bus that matches this event source, that Amazon Web Services
+// account can receive events from the partner's applications or services.
 type EventSource struct {
 	_ struct{} `type:"structure"`
 
@@ -9006,8 +9021,8 @@ type EventSource struct {
 	// The date and time the event source was created.
 	CreationTime *time.Time `type:"timestamp"`
 
-	// The date and time that the event source will expire, if the AWS account doesn't
-	// create a matching event bus for it.
+	// The date and time that the event source will expire, if the Amazon Web Services
+	// account doesn't create a matching event bus for it.
 	ExpirationTime *time.Time `type:"timestamp"`
 
 	// The name of the event source.
@@ -9185,7 +9200,7 @@ type InputTransformer struct {
 	// path. You can have as many as 100 key-value pairs. You must use JSON dot
 	// notation, not bracket notation.
 	//
-	// The keys cannot start with "AWS."
+	// The keys cannot start with "Amazon Web Services."
 	InputPathsMap map[string]*string `type:"map"`
 
 	// Input template where you specify placeholders that will be filled with the
@@ -10268,7 +10283,7 @@ func (s *ListPartnerEventSourcesOutput) SetPartnerEventSources(v []*PartnerEvent
 type ListReplaysInput struct {
 	_ struct{} `type:"structure"`
 
-	// The ARN of the event source associated with the replay.
+	// The ARN of the archive from which the events are replayed.
 	EventSourceArn *string `min:"1" type:"string"`
 
 	// The maximum number of replays to retrieve.
@@ -10771,12 +10786,12 @@ func (s *ListTargetsByRuleOutput) SetTargets(v []*Target) *ListTargetsByRuleOutp
 	return s
 }
 
-// This rule was created by an AWS service on behalf of your account. It is
-// managed by that service. If you see this error in response to DeleteRule
-// or RemoveTargets, you can use the Force parameter in those calls to delete
-// the rule or remove targets from the rule. You cannot modify these managed
-// rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-// or UntagResource.
+// This rule was created by an Amazon Web Services service on behalf of your
+// account. It is managed by that service. If you see this error in response
+// to DeleteRule or RemoveTargets, you can use the Force parameter in those
+// calls to delete the rule or remove targets from the rule. You cannot modify
+// these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+// TagResource, or UntagResource.
 type ManagedRuleException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -10930,8 +10945,8 @@ func (s *OperationDisabledException) RequestID() string {
 }
 
 // A partner event source is created by an SaaS partner. If a customer creates
-// a partner event bus that matches this event source, that AWS account can
-// receive events from the partner's applications or services.
+// a partner event bus that matches this event source, that Amazon Web Services
+// account can receive events from the partner's applications or services.
 type PartnerEventSource struct {
 	_ struct{} `type:"structure"`
 
@@ -10964,18 +10979,20 @@ func (s *PartnerEventSource) SetName(v string) *PartnerEventSource {
 	return s
 }
 
-// The AWS account that a partner event source has been offered to.
+// The Amazon Web Services account that a partner event source has been offered
+// to.
 type PartnerEventSourceAccount struct {
 	_ struct{} `type:"structure"`
 
-	// The AWS account ID that the partner event source was offered to.
+	// The Amazon Web Services account ID that the partner event source was offered
+	// to.
 	Account *string `min:"12" type:"string"`
 
 	// The date and time the event source was created.
 	CreationTime *time.Time `type:"timestamp"`
 
-	// The date and time that the event source will expire, if the AWS account doesn't
-	// create a matching event bus for it.
+	// The date and time that the event source will expire, if the Amazon Web Services
+	// account doesn't create a matching event bus for it.
 	ExpirationTime *time.Time `type:"timestamp"`
 
 	// The state of the event source. If it is ACTIVE, you have already created
@@ -11062,7 +11079,7 @@ func (s *PlacementConstraint) SetType(v string) *PlacementConstraint {
 
 // The task placement strategy for a task or service. To learn more, see Task
 // Placement Strategies (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html)
-// in the Amazon Elastic Container Service Developer Guide.
+// in the Amazon Elastic Container Service Service Developer Guide.
 type PlacementStrategy struct {
 	_ struct{} `type:"structure"`
 
@@ -11265,22 +11282,23 @@ type PutEventsRequestEntry struct {
 	// this, the default event bus is used.
 	EventBusName *string `min:"1" type:"string"`
 
-	// AWS resources, identified by Amazon Resource Name (ARN), which the event
-	// primarily concerns. Any number, including zero, may be present.
+	// Amazon Web Services resources, identified by Amazon Resource Name (ARN),
+	// which the event primarily concerns. Any number, including zero, may be present.
 	Resources []*string `type:"list"`
 
 	// The source of the event.
 	Source *string `type:"string"`
 
 	// The time stamp of the event, per RFC3339 (https://www.rfc-editor.org/rfc/rfc3339.txt).
-	// If no time stamp is provided, the time stamp of the PutEvents call is used.
+	// If no time stamp is provided, the time stamp of the PutEvents (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html)
+	// call is used.
 	Time *time.Time `type:"timestamp"`
 
-	// An AWS X-Ray trade header, which is an http header (X-Amzn-Trace-Id) that
-	// contains the trace-id associated with the event.
+	// An X-Ray trade header, which is an http header (X-Amzn-Trace-Id) that contains
+	// the trace-id associated with the event.
 	//
 	// To learn more about X-Ray trace headers, see Tracing header (https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)
-	// in the AWS X-Ray Developer Guide.
+	// in the X-Ray Developer Guide.
 	TraceHeader *string `min:"1" type:"string"`
 }
 
@@ -11490,11 +11508,11 @@ type PutPartnerEventsRequestEntry struct {
 	// A free-form string used to decide what fields to expect in the event detail.
 	DetailType *string `type:"string"`
 
-	// AWS resources, identified by Amazon Resource Name (ARN), which the event
-	// primarily concerns. Any number, including zero, may be present.
+	// Amazon Web Services resources, identified by Amazon Resource Name (ARN),
+	// which the event primarily concerns. Any number, including zero, may be present.
 	Resources []*string `type:"list"`
 
-	// The event source that is generating the evntry.
+	// The event source that is generating the entry.
 	Source *string `min:"1" type:"string"`
 
 	// The date and time of the event.
@@ -11599,19 +11617,18 @@ func (s *PutPartnerEventsResultEntry) SetEventId(v string) *PutPartnerEventsResu
 type PutPermissionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The action that you are enabling the other account to perform. Currently,
-	// this must be events:PutEvents.
+	// The action that you are enabling the other account to perform.
 	Action *string `min:"1" type:"string"`
 
 	// This parameter enables you to limit the permission to accounts that fulfill
-	// a certain condition, such as being a member of a certain AWS organization.
-	// For more information about AWS Organizations, see What Is AWS Organizations
-	// (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html)
-	// in the AWS Organizations User Guide.
+	// a certain condition, such as being a member of a certain Amazon Web Services
+	// organization. For more information about Amazon Web Services Organizations,
+	// see What Is Amazon Web Services Organizations (https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html)
+	// in the Amazon Web Services Organizations User Guide.
 	//
-	// If you specify Condition with an AWS organization ID, and specify "*" as
-	// the value for Principal, you grant permission to all the accounts in the
-	// named organization.
+	// If you specify Condition with an Amazon Web Services organization ID, and
+	// specify "*" as the value for Principal, you grant permission to all the accounts
+	// in the named organization.
 	//
 	// The Condition is a JSON string which must contain Type, Key, and Value fields.
 	Condition *Condition `type:"structure"`
@@ -11625,9 +11642,9 @@ type PutPermissionInput struct {
 	// Principal, or Condition parameters.
 	Policy *string `type:"string"`
 
-	// The 12-digit AWS account ID that you are permitting to put events to your
-	// default event bus. Specify "*" to permit any account to put events to your
-	// default event bus.
+	// The 12-digit Amazon Web Services account ID that you are permitting to put
+	// events to your default event bus. Specify "*" to permit any account to put
+	// events to your default event bus.
 	//
 	// If you specify "*" without specifying Condition, avoid creating rules that
 	// may match undesirable events. To create more secure rules, make sure that
@@ -11638,7 +11655,7 @@ type PutPermissionInput struct {
 
 	// An identifier string for the external account that you are granting permissions
 	// to. If you later want to revoke the permission for this external account,
-	// specify this StatementId when you run RemovePermission.
+	// specify this StatementId when you run RemovePermission (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_RemovePermission.html).
 	StatementId *string `min:"1" type:"string"`
 }
 
@@ -11749,6 +11766,11 @@ type PutRuleInput struct {
 	Name *string `min:"1" type:"string" required:"true"`
 
 	// The Amazon Resource Name (ARN) of the IAM role associated with the rule.
+	//
+	// If you're setting an event bus in another account as the target and that
+	// account granted permission to your account through an organization instead
+	// of directly by the account ID, you must specify a RoleArn with proper permissions
+	// in the Target structure, instead of here in this parameter.
 	RoleArn *string `min:"1" type:"string"`
 
 	// The scheduling expression. For example, "cron(0 20 * * ? *)" or "rate(5 minutes)".
@@ -12031,8 +12053,9 @@ func (s *PutTargetsResultEntry) SetTargetId(v string) *PutTargetsResultEntry {
 	return s
 }
 
-// These are custom parameters to be used when the target is a Redshift cluster
-// to invoke the Redshift Data API ExecuteStatement based on EventBridge events.
+// These are custom parameters to be used when the target is a Amazon Redshift
+// cluster to invoke the Amazon Redshift Data API ExecuteStatement based on
+// EventBridge events.
 type RedshiftDataParameters struct {
 	_ struct{} `type:"structure"`
 
@@ -12045,7 +12068,7 @@ type RedshiftDataParameters struct {
 	DbUser *string `min:"1" type:"string"`
 
 	// The name or ARN of the secret that enables access to the database. Required
-	// when authenticating using AWS Secrets Manager.
+	// when authenticating using Amazon Web Services Secrets Manager.
 	SecretManagerArn *string `min:"1" type:"string"`
 
 	// The SQL statement text to run.
@@ -12219,11 +12242,11 @@ type RemoveTargetsInput struct {
 	// the default event bus is used.
 	EventBusName *string `min:"1" type:"string"`
 
-	// If this is a managed rule, created by an AWS service on your behalf, you
-	// must specify Force as True to remove targets. This parameter is ignored for
-	// rules that are not managed rules. You can check whether a rule is a managed
-	// rule by using DescribeRule or ListRules and checking the ManagedBy field
-	// of the response.
+	// If this is a managed rule, created by an Amazon Web Services service on your
+	// behalf, you must specify Force as True to remove targets. This parameter
+	// is ignored for rules that are not managed rules. You can check whether a
+	// rule is a managed rule by using DescribeRule or ListRules and checking the
+	// ManagedBy field of the response.
 	Force *bool `type:"boolean"`
 
 	// The IDs of the targets to remove from the rule.
@@ -12701,17 +12724,25 @@ type Rule struct {
 	// in the Amazon EventBridge User Guide.
 	EventPattern *string `type:"string"`
 
-	// If the rule was created on behalf of your account by an AWS service, this
-	// field displays the principal name of the service that created the rule.
+	// If the rule was created on behalf of your account by an Amazon Web Services
+	// service, this field displays the principal name of the service that created
+	// the rule.
 	ManagedBy *string `min:"1" type:"string"`
 
 	// The name of the rule.
 	Name *string `min:"1" type:"string"`
 
 	// The Amazon Resource Name (ARN) of the role that is used for target invocation.
+	//
+	// If you're setting an event bus in another account as the target and that
+	// account granted permission to your account through an organization instead
+	// of directly by the account ID, you must specify a RoleArn with proper permissions
+	// in the Target structure, instead of here in this parameter.
 	RoleArn *string `min:"1" type:"string"`
 
 	// The scheduling expression. For example, "cron(0 20 * * ? *)", "rate(5 minutes)".
+	// For more information, see Creating an Amazon EventBridge rule that runs on
+	// a schedule (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html).
 	ScheduleExpression *string `type:"string"`
 
 	// The state of the rule.
@@ -13193,8 +13224,8 @@ func (s *StartReplayOutput) SetStateReason(v string) *StartReplayOutput {
 	return s
 }
 
-// A key-value pair associated with an AWS resource. In EventBridge, rules and
-// event buses support tagging.
+// A key-value pair associated with an Amazon Web Services resource. In EventBridge,
+// rules and event buses support tagging.
 type Tag struct {
 	_ struct{} `type:"structure"`
 
@@ -13331,13 +13362,14 @@ func (s TagResourceOutput) GoString() string {
 }
 
 // Targets are the resources to be invoked when a rule is triggered. For a complete
-// list of services and resources that can be set as a target, see PutTargets.
+// list of services and resources that can be set as a target, see PutTargets
+// (https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutTargets.html).
 //
 // If you are setting the event bus of another account as the target, and that
 // account granted permission to your account through an organization instead
 // of directly by the account ID, then you must specify a RoleArn with proper
 // permissions in the Target structure. For more information, see Sending and
-// Receiving Events Between AWS Accounts (https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html)
+// Receiving Events Between Amazon Web Services Accounts (https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html)
 // in the Amazon EventBridge User Guide.
 type Target struct {
 	_ struct{} `type:"structure"`
@@ -13347,9 +13379,9 @@ type Target struct {
 	// Arn is a required field
 	Arn *string `min:"1" type:"string" required:"true"`
 
-	// If the event target is an AWS Batch job, this contains the job definition,
-	// job name, and other parameters. For more information, see Jobs (https://docs.aws.amazon.com/batch/latest/userguide/jobs.html)
-	// in the AWS Batch User Guide.
+	// If the event target is an Batch job, this contains the job definition, job
+	// name, and other parameters. For more information, see Jobs (https://docs.aws.amazon.com/batch/latest/userguide/jobs.html)
+	// in the Batch User Guide.
 	BatchParameters *BatchParameters `type:"structure"`
 
 	// The DeadLetterConfig that defines the target queue to send dead-letter queue
@@ -13373,7 +13405,7 @@ type Target struct {
 	// precedence.
 	HttpParameters *HttpParameters `type:"structure"`
 
-	// The ID of the target.
+	// The ID of the target. We recommend using a memorable and unique string.
 	//
 	// Id is a required field
 	Id *string `min:"1" type:"string" required:"true"`
@@ -13398,12 +13430,12 @@ type Target struct {
 	// default is to use the eventId as the partition key.
 	KinesisParameters *KinesisParameters `type:"structure"`
 
-	// Contains the Redshift Data API parameters to use when the target is a Redshift
-	// cluster.
+	// Contains the Amazon Redshift Data API parameters to use when the target is
+	// a Amazon Redshift cluster.
 	//
-	// If you specify a Redshift Cluster as a Target, you can use this to specify
-	// parameters to invoke the Redshift Data API ExecuteStatement based on EventBridge
-	// events.
+	// If you specify a Amazon Redshift Cluster as a Target, you can use this to
+	// specify parameters to invoke the Amazon Redshift Data API ExecuteStatement
+	// based on EventBridge events.
 	RedshiftDataParameters *RedshiftDataParameters `type:"structure"`
 
 	// The RetryPolicy object that contains the retry policy configuration to use
@@ -13613,7 +13645,7 @@ type TestEventPatternInput struct {
 	_ struct{} `type:"structure"`
 
 	// The event, in JSON format, to test against the event pattern. The JSON must
-	// follow the format specified in AWS Events (https://docs.aws.amazon.com/eventbridge/latest/userguide/aws-events.html),
+	// follow the format specified in Amazon Web Services Events (https://docs.aws.amazon.com/eventbridge/latest/userguide/aws-events.html),
 	// and the following fields are mandatory:
 	//
 	//    * id
@@ -14666,6 +14698,9 @@ const (
 
 	// LaunchTypeFargate is a LaunchType enum value
 	LaunchTypeFargate = "FARGATE"
+
+	// LaunchTypeExternal is a LaunchType enum value
+	LaunchTypeExternal = "EXTERNAL"
 )
 
 // LaunchType_Values returns all elements of the LaunchType enum
@@ -14673,6 +14708,7 @@ func LaunchType_Values() []string {
 	return []string{
 		LaunchTypeEc2,
 		LaunchTypeFargate,
+		LaunchTypeExternal,
 	}
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/eventbridge/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/eventbridge/doc.go
@@ -3,19 +3,18 @@
 // Package eventbridge provides the client and types for making API
 // requests to Amazon EventBridge.
 //
-// Amazon EventBridge helps you to respond to state changes in your AWS resources.
-// When your resources change state, they automatically send events into an
-// event stream. You can create rules that match selected events in the stream
-// and route them to targets to take action. You can also use rules to take
-// action on a predetermined schedule. For example, you can configure rules
-// to:
+// Amazon EventBridge helps you to respond to state changes in your Amazon Web
+// Services resources. When your resources change state, they automatically
+// send events to an event stream. You can create rules that match selected
+// events in the stream and route them to targets to take action. You can also
+// use rules to take action on a predetermined schedule. For example, you can
+// configure rules to:
 //
-//    * Automatically invoke an AWS Lambda function to update DNS entries when
-//    an event notifies you that Amazon EC2 instance enters the running state.
+//    * Automatically invoke an Lambda function to update DNS entries when an
+//    event notifies you that Amazon EC2 instance enters the running state.
 //
-//    * Direct specific API records from AWS CloudTrail to an Amazon Kinesis
-//    data stream for detailed analysis of potential security or availability
-//    risks.
+//    * Direct specific API records from CloudTrail to an Amazon Kinesis data
+//    stream for detailed analysis of potential security or availability risks.
 //
 //    * Periodically invoke a built-in target to create a snapshot of an Amazon
 //    EBS volume.

--- a/vendor/github.com/aws/aws-sdk-go/service/eventbridge/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/eventbridge/errors.go
@@ -49,12 +49,12 @@ const (
 	// ErrCodeManagedRuleException for service response error code
 	// "ManagedRuleException".
 	//
-	// This rule was created by an AWS service on behalf of your account. It is
-	// managed by that service. If you see this error in response to DeleteRule
-	// or RemoveTargets, you can use the Force parameter in those calls to delete
-	// the rule or remove targets from the rule. You cannot modify these managed
-	// rules by using DisableRule, EnableRule, PutTargets, PutRule, TagResource,
-	// or UntagResource.
+	// This rule was created by an Amazon Web Services service on behalf of your
+	// account. It is managed by that service. If you see this error in response
+	// to DeleteRule or RemoveTargets, you can use the Force parameter in those
+	// calls to delete the rule or remove targets from the rule. You cannot modify
+	// these managed rules by using DisableRule, EnableRule, PutTargets, PutRule,
+	// TagResource, or UntagResource.
 	ErrCodeManagedRuleException = "ManagedRuleException"
 
 	// ErrCodeOperationDisabledException for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
@@ -57,19 +57,19 @@ func (c *KMS) CancelKeyDeletionRequest(input *CancelKeyDeletionInput) (req *requ
 
 // CancelKeyDeletion API operation for AWS Key Management Service.
 //
-// Cancels the deletion of a customer master key (CMK). When this operation
-// succeeds, the key state of the CMK is Disabled. To enable the CMK, use EnableKey.
+// Cancels the deletion of a KMS key. When this operation succeeds, the key
+// state of the KMS key is Disabled. To enable the KMS key, use EnableKey.
 //
-// For more information about scheduling and canceling deletion of a CMK, see
-// Deleting Customer Master Keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// For more information about scheduling and canceling deletion of a KMS key,
+// see Deleting KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:CancelKeyDeletion (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -104,9 +104,9 @@ func (c *KMS) CancelKeyDeletionRequest(input *CancelKeyDeletionInput) (req *requ
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CancelKeyDeletion
 func (c *KMS) CancelKeyDeletion(input *CancelKeyDeletionInput) (*CancelKeyDeletionOutput, error) {
@@ -176,19 +176,19 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 // ConnectCustomKeyStore API operation for AWS Key Management Service.
 //
 // Connects or reconnects a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// to its associated AWS CloudHSM cluster.
+// to its associated CloudHSM cluster.
 //
-// The custom key store must be connected before you can create customer master
-// keys (CMKs) in the key store or use the CMKs it contains. You can disconnect
-// and reconnect a custom key store at any time.
+// The custom key store must be connected before you can create KMS keys in
+// the key store or use the KMS keys it contains. You can disconnect and reconnect
+// a custom key store at any time.
 //
-// To connect a custom key store, its associated AWS CloudHSM cluster must have
+// To connect a custom key store, its associated CloudHSM cluster must have
 // at least one active HSM. To get the number of active HSMs in a cluster, use
 // the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
 // operation. To add HSMs to the cluster, use the CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 // operation. Also, the kmsuser crypto user (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
-// (CU) must not be logged into the cluster. This prevents AWS KMS from using
-// this account to log in.
+// (CU) must not be logged into the cluster. This prevents KMS from using this
+// account to log in.
 //
 // The connection process can take an extended amount of time to complete; up
 // to 20 minutes. This operation starts the connection process, but it does
@@ -198,10 +198,10 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 // the connection state of the custom key store, use the DescribeCustomKeyStores
 // operation.
 //
-// During the connection process, AWS KMS finds the AWS CloudHSM cluster that
-// is associated with the custom key store, creates the connection infrastructure,
-// connects to the cluster, logs into the AWS CloudHSM client as the kmsuser
-// CU, and rotates its password.
+// During the connection process, KMS finds the CloudHSM cluster that is associated
+// with the custom key store, creates the connection infrastructure, connects
+// to the cluster, logs into the CloudHSM client as the kmsuser CU, and rotates
+// its password.
 //
 // The ConnectCustomKeyStore operation might fail for various reasons. To find
 // the reason, use the DescribeCustomKeyStores operation and see the ConnectionErrorCode
@@ -213,10 +213,10 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //
 // If you are having trouble connecting or disconnecting a custom key store,
 // see Troubleshooting a Custom Key Store (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:ConnectCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -242,11 +242,11 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //
 // Returned Error Types:
 //   * CloudHsmClusterNotActiveException
-//   The request was rejected because the AWS CloudHSM cluster that is associated
+//   The request was rejected because the CloudHSM cluster that is associated
 //   with the custom key store is not active. Initialize and activate the cluster
 //   and try the command again. For detailed instructions, see Getting Started
 //   (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-//   in the AWS CloudHSM User Guide.
+//   in the CloudHSM User Guide.
 //
 //   * CustomKeyStoreInvalidStateException
 //   The request was rejected because of the ConnectionState of the custom key
@@ -268,7 +268,7 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //      for all other ConnectionState values.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * InternalException
@@ -276,8 +276,8 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //   can be retried.
 //
 //   * CloudHsmClusterInvalidConfigurationException
-//   The request was rejected because the associated AWS CloudHSM cluster did
-//   not meet the configuration requirements for a custom key store.
+//   The request was rejected because the associated CloudHSM cluster did not
+//   meet the configuration requirements for a custom key store.
 //
 //      * The cluster must be configured with private subnets in at least two
 //      different Availability Zones in the Region.
@@ -292,20 +292,19 @@ func (c *KMS) ConnectCustomKeyStoreRequest(input *ConnectCustomKeyStoreInput) (r
 //      operation.
 //
 //      * The cluster must contain at least as many HSMs as the operation requires.
-//      To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//      To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //      operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//      operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//      each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//      the AWS CloudHSM must contain at least one active HSM.
+//      operations, the CloudHSM cluster must have at least two active HSMs, each
+//      in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//      the CloudHSM must contain at least one active HSM.
 //
-//   For information about the requirements for an AWS CloudHSM cluster that is
-//   associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-//   in the AWS Key Management Service Developer Guide. For information about
-//   creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-//   Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-//   in the AWS CloudHSM User Guide. For information about cluster security groups,
+//   For information about the requirements for an CloudHSM cluster that is associated
+//   with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+//   in the Key Management Service Developer Guide. For information about creating
+//   a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+//   in the CloudHSM User Guide. For information about cluster security groups,
 //   see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-//   in the AWS CloudHSM User Guide .
+//   in the CloudHSM User Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ConnectCustomKeyStore
 func (c *KMS) ConnectCustomKeyStore(input *ConnectCustomKeyStoreInput) (*ConnectCustomKeyStoreOutput, error) {
@@ -374,37 +373,37 @@ func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *request.Request,
 
 // CreateAlias API operation for AWS Key Management Service.
 //
-// Creates a friendly name for a customer master key (CMK).
+// Creates a friendly name for a KMS key.
 //
 // Adding, deleting, or updating an alias can allow or deny permission to the
-// CMK. For details, see Using ABAC in AWS KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
-// in the AWS Key Management Service Developer Guide.
+// KMS key. For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
 //
-// You can use an alias to identify a CMK in the AWS KMS console, in the DescribeKey
+// You can use an alias to identify a KMS key in the KMS console, in the DescribeKey
 // operation and in cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations),
-// such as Encrypt and GenerateDataKey. You can also change the CMK that's associated
-// with the alias (UpdateAlias) or delete the alias (DeleteAlias) at any time.
-// These operations don't affect the underlying CMK.
+// such as Encrypt and GenerateDataKey. You can also change the KMS key that's
+// associated with the alias (UpdateAlias) or delete the alias (DeleteAlias)
+// at any time. These operations don't affect the underlying KMS key.
 //
-// You can associate the alias with any customer managed CMK in the same AWS
-// Region. Each alias is associated with only one CMK at a time, but a CMK can
-// have multiple aliases. A valid CMK is required. You can't create an alias
-// without a CMK.
+// You can associate the alias with any customer managed key in the same Amazon
+// Web Services Region. Each alias is associated with only one KMS key at a
+// time, but a KMS key can have multiple aliases. A valid KMS key is required.
+// You can't create an alias without a KMS key.
 //
 // The alias must be unique in the account and Region, but you can have aliases
 // with the same name in different Regions. For detailed information about aliases,
 // see Using aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // This operation does not return a response. To get the alias that you created,
 // use the ListAliases operation.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
 // Cross-account use: No. You cannot perform this operation on an alias in a
-// different AWS account.
+// different Amazon Web Services account.
 //
 // Required permissions
 //
@@ -412,10 +411,10 @@ func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *request.Request,
 //    on the alias (IAM policy).
 //
 //    * kms:CreateAlias (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    on the CMK (key policy).
+//    on the KMS key (key policy).
 //
 // For details, see Controlling access to aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -455,15 +454,15 @@ func (c *KMS) CreateAliasRequest(input *CreateAliasInput) (req *request.Request,
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateAlias
 func (c *KMS) CreateAlias(input *CreateAliasInput) (*CreateAliasOutput, error) {
@@ -532,31 +531,31 @@ func (c *KMS) CreateCustomKeyStoreRequest(input *CreateCustomKeyStoreInput) (req
 // CreateCustomKeyStore API operation for AWS Key Management Service.
 //
 // Creates a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// that is associated with an AWS CloudHSM cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/clusters.html)
+// that is associated with an CloudHSM cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/clusters.html)
 // that you own and manage.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // Before you create the custom key store, you must assemble the required elements,
-// including an AWS CloudHSM cluster that fulfills the requirements for a custom
+// including an CloudHSM cluster that fulfills the requirements for a custom
 // key store. For details about the required elements, see Assemble the Prerequisites
 // (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // When the operation completes successfully, it returns the ID of the new custom
 // key store. Before you can use your new custom key store, you need to use
-// the ConnectCustomKeyStore operation to connect the new key store to its AWS
-// CloudHSM cluster. Even if you are not going to use your custom key store
-// immediately, you might want to connect it to verify that all settings are
-// correct and then disconnect it until you are ready to use it.
+// the ConnectCustomKeyStore operation to connect the new key store to its CloudHSM
+// cluster. Even if you are not going to use your custom key store immediately,
+// you might want to connect it to verify that all settings are correct and
+// then disconnect it until you are ready to use it.
 //
 // For help with failures, see Troubleshooting a Custom Key Store (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:CreateCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy).
@@ -582,10 +581,10 @@ func (c *KMS) CreateCustomKeyStoreRequest(input *CreateCustomKeyStoreInput) (req
 //
 // Returned Error Types:
 //   * CloudHsmClusterInUseException
-//   The request was rejected because the specified AWS CloudHSM cluster is already
+//   The request was rejected because the specified CloudHSM cluster is already
 //   associated with a custom key store or it shares a backup history with a cluster
 //   that is associated with a custom key store. Each custom key store must be
-//   associated with a different AWS CloudHSM cluster.
+//   associated with a different CloudHSM cluster.
 //
 //   Clusters that share a backup history have the same cluster certificate. To
 //   view the cluster certificate of a cluster, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
@@ -597,32 +596,31 @@ func (c *KMS) CreateCustomKeyStoreRequest(input *CreateCustomKeyStoreInput) (req
 //   key store name that is unique in the account.
 //
 //   * CloudHsmClusterNotFoundException
-//   The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
-//   with the specified cluster ID. Retry the request with a different cluster
-//   ID.
+//   The request was rejected because KMS cannot find the CloudHSM cluster with
+//   the specified cluster ID. Retry the request with a different cluster ID.
 //
 //   * InternalException
 //   The request was rejected because an internal exception occurred. The request
 //   can be retried.
 //
 //   * CloudHsmClusterNotActiveException
-//   The request was rejected because the AWS CloudHSM cluster that is associated
+//   The request was rejected because the CloudHSM cluster that is associated
 //   with the custom key store is not active. Initialize and activate the cluster
 //   and try the command again. For detailed instructions, see Getting Started
 //   (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-//   in the AWS CloudHSM User Guide.
+//   in the CloudHSM User Guide.
 //
 //   * IncorrectTrustAnchorException
 //   The request was rejected because the trust anchor certificate in the request
-//   is not the trust anchor certificate for the specified AWS CloudHSM cluster.
+//   is not the trust anchor certificate for the specified CloudHSM cluster.
 //
 //   When you initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
 //   you create the trust anchor certificate and save it in the customerCA.crt
 //   file.
 //
 //   * CloudHsmClusterInvalidConfigurationException
-//   The request was rejected because the associated AWS CloudHSM cluster did
-//   not meet the configuration requirements for a custom key store.
+//   The request was rejected because the associated CloudHSM cluster did not
+//   meet the configuration requirements for a custom key store.
 //
 //      * The cluster must be configured with private subnets in at least two
 //      different Availability Zones in the Region.
@@ -637,20 +635,19 @@ func (c *KMS) CreateCustomKeyStoreRequest(input *CreateCustomKeyStoreInput) (req
 //      operation.
 //
 //      * The cluster must contain at least as many HSMs as the operation requires.
-//      To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//      To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //      operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//      operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//      each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//      the AWS CloudHSM must contain at least one active HSM.
+//      operations, the CloudHSM cluster must have at least two active HSMs, each
+//      in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//      the CloudHSM must contain at least one active HSM.
 //
-//   For information about the requirements for an AWS CloudHSM cluster that is
-//   associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-//   in the AWS Key Management Service Developer Guide. For information about
-//   creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-//   Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-//   in the AWS CloudHSM User Guide. For information about cluster security groups,
+//   For information about the requirements for an CloudHSM cluster that is associated
+//   with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+//   in the Key Management Service Developer Guide. For information about creating
+//   a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+//   in the CloudHSM User Guide. For information about cluster security groups,
 //   see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-//   in the AWS CloudHSM User Guide .
+//   in the CloudHSM User Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateCustomKeyStore
 func (c *KMS) CreateCustomKeyStore(input *CreateCustomKeyStoreInput) (*CreateCustomKeyStoreOutput, error) {
@@ -718,49 +715,44 @@ func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *request.Request,
 
 // CreateGrant API operation for AWS Key Management Service.
 //
-// Adds a grant to a customer master key (CMK).
+// Adds a grant to a KMS key.
 //
-// A grant is a policy instrument that allows AWS principals to use AWS KMS
-// customer master keys (CMKs) in cryptographic operations. It also can allow
-// them to view a CMK (DescribeKey) and create and manage grants. When authorizing
-// access to a CMK, grants are considered along with key policies and IAM policies.
+// A grant is a policy instrument that allows Amazon Web Services principals
+// to use KMS keys in cryptographic operations. It also can allow them to view
+// a KMS key (DescribeKey) and create and manage grants. When authorizing access
+// to a KMS key, grants are considered along with key policies and IAM policies.
 // Grants are often used for temporary permissions because you can create one,
 // use its permissions, and delete it without changing your key policies or
 // IAM policies.
 //
 // For detailed information about grants, including grant terminology, see Using
 // grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
-// in the AWS Key Management Service Developer Guide . For examples of working
-// with grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
 //
 // The CreateGrant operation returns a GrantToken and a GrantId.
 //
 //    * When you create, retire, or revoke a grant, there might be a brief delay,
 //    usually less than five minutes, until the grant is available throughout
-//    AWS KMS. This state is known as eventual consistency. Once the grant has
-//    achieved eventual consistency, the grantee principal can use the permissions
-//    in the grant without identifying the grant. However, to use the permissions
+//    KMS. This state is known as eventual consistency. Once the grant has achieved
+//    eventual consistency, the grantee principal can use the permissions in
+//    the grant without identifying the grant. However, to use the permissions
 //    in the grant immediately, use the GrantToken that CreateGrant returns.
-//    For details, see Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/using-grant-token.html)
-//    in the AWS Key Management Service Developer Guide .
+//    For details, see Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+//    in the Key Management Service Developer Guide .
 //
 //    * The CreateGrant operation also returns a GrantId. You can use the GrantId
 //    and a key identifier to identify the grant in the RetireGrant and RevokeGrant
 //    operations. To find the grant ID, use the ListGrants or ListRetirableGrants
 //    operations.
 //
-// For information about symmetric and asymmetric CMKs, see Using Symmetric
-// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide. For more information about
-// grants, see Grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
-// in the AWS Key Management Service Developer Guide .
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
-//
-// Cross-account use: Yes. To perform this operation on a CMK in a different
-// AWS account, specify the key ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation on a KMS key in a different
+// Amazon Web Services account, specify the key ARN in the value of the KeyId
+// parameter.
 //
 // Required permissions: kms:CreateGrant (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -788,7 +780,7 @@ func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *request.Request,
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -808,15 +800,15 @@ func (c *KMS) CreateGrantRequest(input *CreateGrantInput) (req *request.Request,
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateGrant
 func (c *KMS) CreateGrant(input *CreateGrantInput) (*CreateGrantOutput, error) {
@@ -884,106 +876,111 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 
 // CreateKey API operation for AWS Key Management Service.
 //
-// Creates a unique customer managed customer master key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master-keys)
-// (CMK) in your AWS account and Region.
+// Creates a unique customer managed KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms-keys)
+// in your Amazon Web Services account and Region.
 //
-// You can use the CreateKey operation to create symmetric or asymmetric CMKs.
+// KMS is replacing the term customer master key (CMK) with KMS key and KMS
+// key. The concept has not changed. To prevent breaking changes, KMS is keeping
+// some variations of this term.
 //
-//    * Symmetric CMKs contain a 256-bit symmetric key that never leaves AWS
-//    KMS unencrypted. To use the CMK, you must call AWS KMS. You can use a
-//    symmetric CMK to encrypt and decrypt small amounts of data, but they are
-//    typically used to generate data keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys)
+// You can use the CreateKey operation to create symmetric or asymmetric KMS
+// keys.
+//
+//    * Symmetric KMS keys contain a 256-bit symmetric key that never leaves
+//    KMS unencrypted. To use the KMS key, you must call KMS. You can use a
+//    symmetric KMS key to encrypt and decrypt small amounts of data, but they
+//    are typically used to generate data keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys)
 //    and data keys pairs (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-key-pairs).
 //    For details, see GenerateDataKey and GenerateDataKeyPair.
 //
-//    * Asymmetric CMKs can contain an RSA key pair or an Elliptic Curve (ECC)
-//    key pair. The private key in an asymmetric CMK never leaves AWS KMS unencrypted.
-//    However, you can use the GetPublicKey operation to download the public
-//    key so it can be used outside of AWS KMS. CMKs with RSA key pairs can
-//    be used to encrypt or decrypt data or sign and verify messages (but not
-//    both). CMKs with ECC key pairs can be used only to sign and verify messages.
+//    * Asymmetric KMS keys can contain an RSA key pair or an Elliptic Curve
+//    (ECC) key pair. The private key in an asymmetric KMS key never leaves
+//    KMS unencrypted. However, you can use the GetPublicKey operation to download
+//    the public key so it can be used outside of KMS. KMS keys with RSA key
+//    pairs can be used to encrypt or decrypt data or sign and verify messages
+//    (but not both). KMS keys with ECC key pairs can be used only to sign and
+//    verify messages.
 //
-// For information about symmetric and asymmetric CMKs, see Using Symmetric
-// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// For information about symmetric and asymmetric KMS keys, see Using Symmetric
+// and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
-// To create different types of CMKs, use the following guidance:
+// To create different types of KMS keys, use the following guidance:
 //
-// Asymmetric CMKs
+// Asymmetric KMS keys
 //
-// To create an asymmetric CMK, use the CustomerMasterKeySpec parameter to specify
-// the type of key material in the CMK. Then, use the KeyUsage parameter to
-// determine whether the CMK will be used to encrypt and decrypt or sign and
-// verify. You can't change these properties after the CMK is created.
+// To create an asymmetric KMS key, use the KeySpec parameter to specify the
+// type of key material in the KMS key. Then, use the KeyUsage parameter to
+// determine whether the KMS key will be used to encrypt and decrypt or sign
+// and verify. You can't change these properties after the KMS key is created.
 //
-// Symmetric CMKs
+// Symmetric KMS keys
 //
-// When creating a symmetric CMK, you don't need to specify the CustomerMasterKeySpec
-// or KeyUsage parameters. The default value for CustomerMasterKeySpec, SYMMETRIC_DEFAULT,
+// When creating a symmetric KMS key, you don't need to specify the KeySpec
+// or KeyUsage parameters. The default value for KeySpec, SYMMETRIC_DEFAULT,
 // and the default value for KeyUsage, ENCRYPT_DECRYPT, are the only valid values
-// for symmetric CMKs.
+// for symmetric KMS keys.
 //
 // Multi-Region primary keys
 //
 // Imported key material
 //
-// To create a multi-Region primary key in the local AWS Region, use the MultiRegion
-// parameter with a value of True. To create a multi-Region replica key, that
-// is, a CMK with the same key ID and key material as a primary key, but in
-// a different AWS Region, use the ReplicateKey operation. To change a replica
-// key to a primary key, and its primary key to a replica key, use the UpdatePrimaryRegion
-// operation.
+// To create a multi-Region primary key in the local Amazon Web Services Region,
+// use the MultiRegion parameter with a value of True. To create a multi-Region
+// replica key, that is, a KMS key with the same key ID and key material as
+// a primary key, but in a different Amazon Web Services Region, use the ReplicateKey
+// operation. To change a replica key to a primary key, and its primary key
+// to a replica key, use the UpdatePrimaryRegion operation.
 //
-// This operation supports multi-Region keys, an AWS KMS feature that lets you
-// create multiple interoperable CMKs in different AWS Regions. Because these
-// CMKs have the same key ID, key material, and other metadata, you can use
-// them to encrypt data in one AWS Region and decrypt it in a different AWS
-// Region without making a cross-Region call or exposing the plaintext data.
-// For more information about multi-Region keys, see Using multi-Region keys
-// (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
-// in the AWS Key Management Service Developer Guide.
+// This operation supports multi-Region keys, an KMS feature that lets you create
+// multiple interoperable KMS keys in different Amazon Web Services Regions.
+// Because these KMS keys have the same key ID, key material, and other metadata,
+// you can use them interchangeably to encrypt data in one Amazon Web Services
+// Region and decrypt it in a different Amazon Web Services Region without re-encrypting
+// the data or making a cross-Region call. For more information about multi-Region
+// keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+// in the Key Management Service Developer Guide.
 //
 // You can create symmetric and asymmetric multi-Region keys and multi-Region
 // keys with imported key material. You cannot create multi-Region keys in a
 // custom key store.
 //
-// To import your own key material, begin by creating a symmetric CMK with no
-// key material. To do this, use the Origin parameter of CreateKey with a value
-// of EXTERNAL. Next, use GetParametersForImport operation to get a public key
-// and import token, and use the public key to encrypt your key material. Then,
-// use ImportKeyMaterial with your import token to import the key material.
+// To import your own key material, begin by creating a symmetric KMS key with
+// no key material. To do this, use the Origin parameter of CreateKey with a
+// value of EXTERNAL. Next, use GetParametersForImport operation to get a public
+// key and import token, and use the public key to encrypt your key material.
+// Then, use ImportKeyMaterial with your import token to import the key material.
 // For step-by-step instructions, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-// in the AWS Key Management Service Developer Guide . You cannot import the
-// key material into an asymmetric CMK.
+// in the Key Management Service Developer Guide . You cannot import the key
+// material into an asymmetric KMS key.
 //
 // To create a multi-Region primary key with imported key material, use the
 // Origin parameter of CreateKey with a value of EXTERNAL and the MultiRegion
 // parameter with a value of True. To create replicas of the multi-Region primary
 // key, use the ReplicateKey operation. For more information about multi-Region
 // keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Custom key store
 //
-// To create a symmetric CMK in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+// To create a symmetric KMS key in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
 // use the CustomKeyStoreId parameter to specify the custom key store. You must
-// also use the Origin parameter with a value of AWS_CLOUDHSM. The AWS CloudHSM
+// also use the Origin parameter with a value of AWS_CLOUDHSM. The CloudHSM
 // cluster that is associated with the custom key store must have at least two
-// active HSMs in different Availability Zones in the AWS Region.
+// active HSMs in different Availability Zones in the Amazon Web Services Region.
 //
-// You cannot create an asymmetric CMK or a multi-Region CMK in a custom key
-// store. For information about custom key stores in AWS KMS see Using Custom
-// Key Stores (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// in the AWS Key Management Service Developer Guide .
+// You cannot create an asymmetric KMS key in a custom key store. For information
+// about custom key stores in KMS see Using Custom Key Stores (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
+// in the Key Management Service Developer Guide .
 //
-// Cross-account use: No. You cannot use this operation to create a CMK in a
-// different AWS account.
+// Cross-account use: No. You cannot use this operation to create a KMS key
+// in a different Amazon Web Services account.
 //
 // Required permissions: kms:CreateKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy). To use the Tags parameter, kms:TagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy). For examples and information about related permissions, see
-// Allow a user to create CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-create-key)
-// in the AWS Key Management Service Developer Guide.
+// Allow a user to create KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-create-key)
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -1024,13 +1021,13 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * TagException
 //   The request was rejected because one or more tags are not valid.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * CustomKeyStoreInvalidStateException
@@ -1053,8 +1050,8 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 //      for all other ConnectionState values.
 //
 //   * CloudHsmClusterInvalidConfigurationException
-//   The request was rejected because the associated AWS CloudHSM cluster did
-//   not meet the configuration requirements for a custom key store.
+//   The request was rejected because the associated CloudHSM cluster did not
+//   meet the configuration requirements for a custom key store.
 //
 //      * The cluster must be configured with private subnets in at least two
 //      different Availability Zones in the Region.
@@ -1069,20 +1066,19 @@ func (c *KMS) CreateKeyRequest(input *CreateKeyInput) (req *request.Request, out
 //      operation.
 //
 //      * The cluster must contain at least as many HSMs as the operation requires.
-//      To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//      To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //      operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//      operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//      each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//      the AWS CloudHSM must contain at least one active HSM.
+//      operations, the CloudHSM cluster must have at least two active HSMs, each
+//      in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//      the CloudHSM must contain at least one active HSM.
 //
-//   For information about the requirements for an AWS CloudHSM cluster that is
-//   associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-//   in the AWS Key Management Service Developer Guide. For information about
-//   creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-//   Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-//   in the AWS CloudHSM User Guide. For information about cluster security groups,
+//   For information about the requirements for an CloudHSM cluster that is associated
+//   with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+//   in the Key Management Service Developer Guide. For information about creating
+//   a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+//   in the CloudHSM User Guide. For information about cluster security groups,
 //   see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-//   in the AWS CloudHSM User Guide .
+//   in the CloudHSM User Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/CreateKey
 func (c *KMS) CreateKey(input *CreateKeyInput) (*CreateKeyOutput, error) {
@@ -1150,8 +1146,8 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 
 // Decrypt API operation for AWS Key Management Service.
 //
-// Decrypts ciphertext that was encrypted by a AWS KMS customer master key (CMK)
-// using any of the following operations:
+// Decrypts ciphertext that was encrypted by a KMS key using any of the following
+// operations:
 //
 //    * Encrypt
 //
@@ -1164,46 +1160,52 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //    * GenerateDataKeyPairWithoutPlaintext
 //
 // You can use this operation to decrypt ciphertext that was encrypted under
-// a symmetric or asymmetric CMK. When the CMK is asymmetric, you must specify
-// the CMK and the encryption algorithm that was used to encrypt the ciphertext.
-// For information about symmetric and asymmetric CMKs, see Using Symmetric
-// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// a symmetric or asymmetric KMS key. When the KMS key is asymmetric, you must
+// specify the KMS key and the encryption algorithm that was used to encrypt
+// the ciphertext. For information about symmetric and asymmetric KMS keys,
+// see Using Symmetric and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
 // The Decrypt operation also decrypts ciphertext that was encrypted outside
-// of AWS KMS by the public key in an AWS KMS asymmetric CMK. However, it cannot
-// decrypt ciphertext produced by other libraries, such as the AWS Encryption
-// SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
+// of KMS by the public key in an KMS asymmetric KMS key. However, it cannot
+// decrypt ciphertext produced by other libraries, such as the Amazon Web Services
+// Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
 // or Amazon S3 client-side encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html).
-// These libraries return a ciphertext format that is incompatible with AWS
-// KMS.
+// These libraries return a ciphertext format that is incompatible with KMS.
 //
-// If the ciphertext was encrypted under a symmetric CMK, the KeyId parameter
-// is optional. AWS KMS can get this information from metadata that it adds
-// to the symmetric ciphertext blob. This feature adds durability to your implementation
+// If the ciphertext was encrypted under a symmetric KMS key, the KeyId parameter
+// is optional. KMS can get this information from metadata that it adds to the
+// symmetric ciphertext blob. This feature adds durability to your implementation
 // by ensuring that authorized users can decrypt ciphertext decades after it
-// was encrypted, even if they've lost track of the CMK ID. However, specifying
-// the CMK is always recommended as a best practice. When you use the KeyId
-// parameter to specify a CMK, AWS KMS only uses the CMK you specify. If the
-// ciphertext was encrypted under a different CMK, the Decrypt operation fails.
-// This practice ensures that you use the CMK that you intend.
+// was encrypted, even if they've lost track of the key ID. However, specifying
+// the KMS key is always recommended as a best practice. When you use the KeyId
+// parameter to specify a KMS key, KMS only uses the KMS key you specify. If
+// the ciphertext was encrypted under a different KMS key, the Decrypt operation
+// fails. This practice ensures that you use the KMS key that you intend.
 //
 // Whenever possible, use key policies to give users permission to call the
-// Decrypt operation on a particular CMK, instead of using IAM policies. Otherwise,
-// you might create an IAM user policy that gives the user Decrypt permission
-// on all CMKs. This user could decrypt ciphertext that was encrypted by CMKs
-// in other accounts if the key policy for the cross-account CMK permits it.
-// If you must use an IAM policy for Decrypt permissions, limit the user to
-// particular CMKs or particular trusted accounts. For details, see Best practices
-// for IAM policies (https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policies-best-practices)
-// in the AWS Key Management Service Developer Guide.
+// Decrypt operation on a particular KMS key, instead of using IAM policies.
+// Otherwise, you might create an IAM user policy that gives the user Decrypt
+// permission on all KMS keys. This user could decrypt ciphertext that was encrypted
+// by KMS keys in other accounts if the key policy for the cross-account KMS
+// key permits it. If you must use an IAM policy for Decrypt permissions, limit
+// the user to particular KMS keys or particular trusted accounts. For details,
+// see Best practices for IAM policies (https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policies-best-practices)
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// Applications in Amazon Web Services Nitro Enclaves can call this operation
+// by using the Amazon Web Services Nitro Enclaves Development Kit (https://github.com/aws/aws-nitro-enclaves-sdk-c).
+// For information about the supporting parameters, see How Amazon Web Services
+// Nitro Enclaves use KMS (https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. You can decrypt a ciphertext using a CMK in a different
-// AWS account.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
+//
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:Decrypt (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -1231,7 +1233,7 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidCiphertextException
 //   From the Decrypt or ReEncrypt operation, the request was rejected because
@@ -1239,32 +1241,33 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //   the ciphertext, such as the encryption context, is corrupted, missing, or
 //   otherwise invalid.
 //
-//   From the ImportKeyMaterial operation, the request was rejected because AWS
-//   KMS could not decrypt the encrypted (wrapped) key material.
+//   From the ImportKeyMaterial operation, the request was rejected because KMS
+//   could not decrypt the encrypted (wrapped) key material.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * IncorrectKeyException
-//   The request was rejected because the specified CMK cannot decrypt the data.
-//   The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
-//   must identify the same CMK that was used to encrypt the ciphertext.
+//   The request was rejected because the specified KMS key cannot decrypt the
+//   data. The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+//   must identify the same KMS key that was used to encrypt the ciphertext.
 //
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -1281,9 +1284,9 @@ func (c *KMS) DecryptRequest(input *DecryptInput) (req *request.Request, output 
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Decrypt
 func (c *KMS) Decrypt(input *DecryptInput) (*DecryptOutput, error) {
@@ -1355,20 +1358,20 @@ func (c *KMS) DeleteAliasRequest(input *DeleteAliasInput) (req *request.Request,
 // Deletes the specified alias.
 //
 // Adding, deleting, or updating an alias can allow or deny permission to the
-// CMK. For details, see Using ABAC in AWS KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
-// in the AWS Key Management Service Developer Guide.
+// KMS key. For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
 //
-// Because an alias is not a property of a CMK, you can delete and change the
-// aliases of a CMK without affecting the CMK. Also, aliases do not appear in
-// the response from the DescribeKey operation. To get the aliases of all CMKs,
-// use the ListAliases operation.
+// Because an alias is not a property of a KMS key, you can delete and change
+// the aliases of a KMS key without affecting the KMS key. Also, aliases do
+// not appear in the response from the DescribeKey operation. To get the aliases
+// of all KMS keys, use the ListAliases operation.
 //
-// Each CMK can have multiple aliases. To change the alias of a CMK, use DeleteAlias
-// to delete the current alias and CreateAlias to create a new alias. To associate
-// an existing alias with a different customer master key (CMK), call UpdateAlias.
+// Each KMS key can have multiple aliases. To change the alias of a KMS key,
+// use DeleteAlias to delete the current alias and CreateAlias to create a new
+// alias. To associate an existing alias with a different KMS key, call UpdateAlias.
 //
 // Cross-account use: No. You cannot perform this operation on an alias in a
-// different AWS account.
+// different Amazon Web Services account.
 //
 // Required permissions
 //
@@ -1376,10 +1379,10 @@ func (c *KMS) DeleteAliasRequest(input *DeleteAliasInput) (req *request.Request,
 //    on the alias (IAM policy).
 //
 //    * kms:DeleteAlias (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    on the CMK (key policy).
+//    on the KMS key (key policy).
 //
 // For details, see Controlling access to aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -1413,9 +1416,9 @@ func (c *KMS) DeleteAliasRequest(input *DeleteAliasInput) (req *request.Request,
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/DeleteAlias
 func (c *KMS) DeleteAlias(input *DeleteAliasInput) (*DeleteAliasOutput, error) {
@@ -1485,37 +1488,35 @@ func (c *KMS) DeleteCustomKeyStoreRequest(input *DeleteCustomKeyStoreInput) (req
 // DeleteCustomKeyStore API operation for AWS Key Management Service.
 //
 // Deletes a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
-// This operation does not delete the AWS CloudHSM cluster that is associated
-// with the custom key store, or affect any users or keys in the cluster.
+// This operation does not delete the CloudHSM cluster that is associated with
+// the custom key store, or affect any users or keys in the cluster.
 //
-// The custom key store that you delete cannot contain any AWS KMS customer
-// master keys (CMKs) (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys).
+// The custom key store that you delete cannot contain any KMS KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys).
 // Before deleting the key store, verify that you will never need to use any
-// of the CMKs in the key store for any cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
-// Then, use ScheduleKeyDeletion to delete the AWS KMS customer master keys
-// (CMKs) from the key store. When the scheduled waiting period expires, the
-// ScheduleKeyDeletion operation deletes the CMKs. Then it makes a best effort
-// to delete the key material from the associated cluster. However, you might
-// need to manually delete the orphaned key material (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key)
+// of the KMS keys in the key store for any cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
+// Then, use ScheduleKeyDeletion to delete the KMS keys from the key store.
+// When the scheduled waiting period expires, the ScheduleKeyDeletion operation
+// deletes the KMS keys. Then it makes a best effort to delete the key material
+// from the associated cluster. However, you might need to manually delete the
+// orphaned key material (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key)
 // from the cluster and its backups.
 //
-// After all CMKs are deleted from AWS KMS, use DisconnectCustomKeyStore to
-// disconnect the key store from AWS KMS. Then, you can delete the custom key
-// store.
+// After all KMS keys are deleted from KMS, use DisconnectCustomKeyStore to
+// disconnect the key store from KMS. Then, you can delete the custom key store.
 //
 // Instead of deleting the custom key store, consider using DisconnectCustomKeyStore
-// to disconnect it from AWS KMS. While the key store is disconnected, you cannot
-// create or use the CMKs in the key store. But, you do not need to delete CMKs
-// and you can reconnect a disconnected custom key store at any time.
+// to disconnect it from KMS. While the key store is disconnected, you cannot
+// create or use the KMS keys in the key store. But, you do not need to delete
+// KMS keys and you can reconnect a disconnected custom key store at any time.
 //
 // If the operation succeeds, it returns a JSON object with no properties.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:DeleteCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -1541,10 +1542,10 @@ func (c *KMS) DeleteCustomKeyStoreRequest(input *DeleteCustomKeyStoreInput) (req
 //
 // Returned Error Types:
 //   * CustomKeyStoreHasCMKsException
-//   The request was rejected because the custom key store contains AWS KMS customer
-//   master keys (CMKs). After verifying that you do not need to use the CMKs,
-//   use the ScheduleKeyDeletion operation to delete the CMKs. After they are
-//   deleted, you can delete the custom key store.
+//   The request was rejected because the custom key store contains KMS keys.
+//   After verifying that you do not need to use the KMS keys, use the ScheduleKeyDeletion
+//   operation to delete the KMS keys. After they are deleted, you can delete
+//   the custom key store.
 //
 //   * CustomKeyStoreInvalidStateException
 //   The request was rejected because of the ConnectionState of the custom key
@@ -1566,7 +1567,7 @@ func (c *KMS) DeleteCustomKeyStoreRequest(input *DeleteCustomKeyStoreInput) (req
 //      for all other ConnectionState values.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * InternalException
@@ -1641,22 +1642,23 @@ func (c *KMS) DeleteImportedKeyMaterialRequest(input *DeleteImportedKeyMaterialI
 // DeleteImportedKeyMaterial API operation for AWS Key Management Service.
 //
 // Deletes key material that you previously imported. This operation makes the
-// specified customer master key (CMK) unusable. For more information about
-// importing key material into AWS KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// specified KMS key unusable. For more information about importing key material
+// into KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+// in the Key Management Service Developer Guide.
 //
-// When the specified CMK is in the PendingDeletion state, this operation does
-// not change the CMK's state. Otherwise, it changes the CMK's state to PendingImport.
+// When the specified KMS key is in the PendingDeletion state, this operation
+// does not change the KMS key's state. Otherwise, it changes the KMS key's
+// state to PendingImport.
 //
 // After you delete key material, you can use ImportKeyMaterial to reimport
-// the same key material into the CMK.
+// the same key material into the KMS key.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:DeleteImportedKeyMaterial (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -1699,9 +1701,9 @@ func (c *KMS) DeleteImportedKeyMaterialRequest(input *DeleteImportedKeyMaterialI
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/DeleteImportedKeyMaterial
 func (c *KMS) DeleteImportedKeyMaterial(input *DeleteImportedKeyMaterialInput) (*DeleteImportedKeyMaterialOutput, error) {
@@ -1773,32 +1775,32 @@ func (c *KMS) DescribeCustomKeyStoresRequest(input *DescribeCustomKeyStoresInput
 // in the account and Region.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // By default, this operation returns information about all custom key stores
 // in the account and Region. To get only information about a particular custom
 // key store, use either the CustomKeyStoreName or CustomKeyStoreId parameter
 // (but not both).
 //
-// To determine whether the custom key store is connected to its AWS CloudHSM
-// cluster, use the ConnectionState element in the response. If an attempt to
-// connect the custom key store failed, the ConnectionState value is FAILED
-// and the ConnectionErrorCode element in the response indicates the cause of
-// the failure. For help interpreting the ConnectionErrorCode, see CustomKeyStoresListEntry.
+// To determine whether the custom key store is connected to its CloudHSM cluster,
+// use the ConnectionState element in the response. If an attempt to connect
+// the custom key store failed, the ConnectionState value is FAILED and the
+// ConnectionErrorCode element in the response indicates the cause of the failure.
+// For help interpreting the ConnectionErrorCode, see CustomKeyStoresListEntry.
 //
 // Custom key stores have a DISCONNECTED connection state if the key store has
 // never been connected or you use the DisconnectCustomKeyStore operation to
 // disconnect it. If your custom key store state is CONNECTED but you are having
-// trouble using it, make sure that its associated AWS CloudHSM cluster is active
+// trouble using it, make sure that its associated CloudHSM cluster is active
 // and contains the minimum number of HSMs required for the operation, if any.
 //
 // For help repairing your custom key store, see the Troubleshooting Custom
 // Key Stores (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html)
-// topic in the AWS Key Management Service Developer Guide.
+// topic in the Key Management Service Developer Guide.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:DescribeCustomKeyStores (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -1824,7 +1826,7 @@ func (c *KMS) DescribeCustomKeyStoresRequest(input *DescribeCustomKeyStoresInput
 //
 // Returned Error Types:
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * InvalidMarkerException
@@ -1901,41 +1903,45 @@ func (c *KMS) DescribeKeyRequest(input *DescribeKeyInput) (req *request.Request,
 
 // DescribeKey API operation for AWS Key Management Service.
 //
-// Provides detailed information about a customer master key (CMK). You can
-// run DescribeKey on a customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
-// or an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
+// Provides detailed information about a KMS key. You can run DescribeKey on
+// a customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
+// or an Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
 //
 // This detailed information includes the key ARN, creation date (and deletion
 // date, if applicable), the key state, and the origin and expiration date (if
-// any) of the key material. For CMKs in custom key stores, it includes information
-// about the custom key store, such as the key store ID and the AWS CloudHSM
-// cluster ID. It includes fields, like KeySpec, that help you distinguish symmetric
-// from asymmetric CMKs. It also provides information that is particularly important
-// to asymmetric CMKs, such as the key usage (encryption or signing) and the
-// encryption algorithms or signing algorithms that the CMK supports.
+// any) of the key material. It includes fields, like KeySpec, that help you
+// distinguish symmetric from asymmetric KMS keys. It also provides information
+// that is particularly important to asymmetric keys, such as the key usage
+// (encryption or signing) and the encryption algorithms or signing algorithms
+// that the KMS key supports. For KMS keys in custom key stores, it includes
+// information about the custom key store, such as the key store ID and the
+// CloudHSM cluster ID. For multi-Region keys, it displays the primary key and
+// all related replica keys.
 //
 // DescribeKey does not return the following information:
 //
-//    * Aliases associated with the CMK. To get this information, use ListAliases.
+//    * Aliases associated with the KMS key. To get this information, use ListAliases.
 //
-//    * Whether automatic key rotation is enabled on the CMK. To get this information,
-//    use GetKeyRotationStatus. Also, some key states prevent a CMK from being
-//    automatically rotated. For details, see How Automatic Key Rotation Works
-//    (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-how-it-works)
-//    in AWS Key Management Service Developer Guide.
+//    * Whether automatic key rotation is enabled on the KMS key. To get this
+//    information, use GetKeyRotationStatus. Also, some key states prevent a
+//    KMS key from being automatically rotated. For details, see How Automatic
+//    Key Rotation Works (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-how-it-works)
+//    in Key Management Service Developer Guide.
 //
-//    * Tags on the CMK. To get this information, use ListResourceTags.
+//    * Tags on the KMS key. To get this information, use ListResourceTags.
 //
-//    * Key policies and grants on the CMK. To get this information, use GetKeyPolicy
-//    and ListGrants.
+//    * Key policies and grants on the KMS key. To get this information, use
+//    GetKeyPolicy and ListGrants.
 //
-// If you call the DescribeKey operation on a predefined AWS alias, that is,
-// an AWS alias with no key ID, AWS KMS creates an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys).
-// Then, it associates the alias with the new CMK, and returns the KeyId and
-// Arn of the new CMK in the response.
+// If you call the DescribeKey operation on a predefined Amazon Web Services
+// alias, that is, an Amazon Web Services alias with no key ID, KMS creates
+// an Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
+// Then, it associates the alias with the new KMS key, and returns the KeyId
+// and Arn of the new KMS key in the response.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:DescribeKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2047,19 +2053,19 @@ func (c *KMS) DisableKeyRequest(input *DisableKeyInput) (req *request.Request, o
 
 // DisableKey API operation for AWS Key Management Service.
 //
-// Sets the state of a customer master key (CMK) to disabled. This change temporarily
-// prevents use of the CMK for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
+// Sets the state of a KMS key to disabled. This change temporarily prevents
+// use of the KMS key for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
 //
-// For more information about how key state affects the use of a CMK, see Key
-// state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide .
+// For more information about how key state affects the use of a KMS key, see
+// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide .
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:DisableKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2094,9 +2100,9 @@ func (c *KMS) DisableKeyRequest(input *DisableKeyInput) (req *request.Request, o
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/DisableKey
 func (c *KMS) DisableKey(input *DisableKeyInput) (*DisableKeyOutput, error) {
@@ -2166,21 +2172,21 @@ func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *re
 // DisableKeyRotation API operation for AWS Key Management Service.
 //
 // Disables automatic rotation of the key material (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
-// for the specified symmetric customer master key (CMK).
+// for the specified symmetric KMS key.
 //
-// You cannot enable automatic rotation of asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
-// CMKs with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
-// or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// You cannot enable automatic rotation of asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
+// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 // To enable or disable automatic rotation of a set of related multi-Region
 // keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-replica-key),
 // set the property on the primary key.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:DisableKeyRotation (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2204,7 +2210,7 @@ func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *re
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidArnException
 //   The request was rejected because a specified ARN, or an ARN in a key policy,
@@ -2222,9 +2228,9 @@ func (c *KMS) DisableKeyRotationRequest(input *DisableKeyRotationInput) (req *re
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -2298,14 +2304,14 @@ func (c *KMS) DisconnectCustomKeyStoreRequest(input *DisconnectCustomKeyStoreInp
 // DisconnectCustomKeyStore API operation for AWS Key Management Service.
 //
 // Disconnects the custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// from its associated AWS CloudHSM cluster. While a custom key store is disconnected,
-// you can manage the custom key store and its customer master keys (CMKs),
-// but you cannot create or use CMKs in the custom key store. You can reconnect
-// the custom key store at any time.
+// from its associated CloudHSM cluster. While a custom key store is disconnected,
+// you can manage the custom key store and its KMS keys, but you cannot create
+// or use KMS keys in the custom key store. You can reconnect the custom key
+// store at any time.
 //
-// While a custom key store is disconnected, all attempts to create customer
-// master keys (CMKs) in the custom key store or to use existing CMKs in cryptographic
-// operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
+// While a custom key store is disconnected, all attempts to create KMS keys
+// in the custom key store or to use existing KMS keys in cryptographic operations
+// (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
 // will fail. This action can prevent users from storing and accessing sensitive
 // data.
 //
@@ -2316,11 +2322,11 @@ func (c *KMS) DisconnectCustomKeyStoreRequest(input *DisconnectCustomKeyStoreInp
 // If the operation succeeds, it returns a JSON object with no properties.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:DisconnectCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -2365,7 +2371,7 @@ func (c *KMS) DisconnectCustomKeyStoreRequest(input *DisconnectCustomKeyStoreInp
 //      for all other ConnectionState values.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * InternalException
@@ -2439,15 +2445,15 @@ func (c *KMS) EnableKeyRequest(input *EnableKeyInput) (req *request.Request, out
 
 // EnableKey API operation for AWS Key Management Service.
 //
-// Sets the key state of a customer master key (CMK) to enabled. This allows
-// you to use the CMK for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
+// Sets the key state of a KMS key to enabled. This allows you to use the KMS
+// key for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations).
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:EnableKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2481,15 +2487,15 @@ func (c *KMS) EnableKeyRequest(input *EnableKeyInput) (req *request.Request, out
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/EnableKey
 func (c *KMS) EnableKey(input *EnableKeyInput) (*EnableKeyOutput, error) {
@@ -2559,21 +2565,21 @@ func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *requ
 // EnableKeyRotation API operation for AWS Key Management Service.
 //
 // Enables automatic rotation of the key material (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
-// for the specified symmetric customer master key (CMK).
+// for the specified symmetric KMS key.
 //
-// You cannot enable automatic rotation of asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
-// CMKs with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
-// or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// You cannot enable automatic rotation of asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
+// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 // To enable or disable automatic rotation of a set of related multi-Region
 // keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-replica-key),
 // set the property on the primary key.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:EnableKeyRotation (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2597,7 +2603,7 @@ func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *requ
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidArnException
 //   The request was rejected because a specified ARN, or an ARN in a key policy,
@@ -2615,9 +2621,9 @@ func (c *KMS) EnableKeyRotationRequest(input *EnableKeyRotationInput) (req *requ
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -2689,55 +2695,56 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 
 // Encrypt API operation for AWS Key Management Service.
 //
-// Encrypts plaintext into ciphertext by using a customer master key (CMK).
-// The Encrypt operation has two primary use cases:
+// Encrypts plaintext into ciphertext by using a KMS key. The Encrypt operation
+// has two primary use cases:
 //
 //    * You can encrypt small amounts of arbitrary data, such as a personal
 //    identifier or database password, or other sensitive information.
 //
-//    * You can use the Encrypt operation to move encrypted data from one AWS
-//    Region to another. For example, in Region A, generate a data key and use
-//    the plaintext key to encrypt your data. Then, in Region A, use the Encrypt
-//    operation to encrypt the plaintext data key under a CMK in Region B. Now,
-//    you can move the encrypted data and the encrypted data key to Region B.
-//    When necessary, you can decrypt the encrypted data key and the encrypted
-//    data entirely within in Region B.
+//    * You can use the Encrypt operation to move encrypted data from one Amazon
+//    Web Services Region to another. For example, in Region A, generate a data
+//    key and use the plaintext key to encrypt your data. Then, in Region A,
+//    use the Encrypt operation to encrypt the plaintext data key under a KMS
+//    key in Region B. Now, you can move the encrypted data and the encrypted
+//    data key to Region B. When necessary, you can decrypt the encrypted data
+//    key and the encrypted data entirely within in Region B.
 //
 // You don't need to use the Encrypt operation to encrypt a data key. The GenerateDataKey
 // and GenerateDataKeyPair operations return a plaintext data key and an encrypted
 // copy of that data key.
 //
-// When you encrypt data, you must specify a symmetric or asymmetric CMK to
-// use in the encryption operation. The CMK must have a KeyUsage value of ENCRYPT_DECRYPT.
-// To find the KeyUsage of a CMK, use the DescribeKey operation.
+// When you encrypt data, you must specify a symmetric or asymmetric KMS key
+// to use in the encryption operation. The KMS key must have a KeyUsage value
+// of ENCRYPT_DECRYPT. To find the KeyUsage of a KMS key, use the DescribeKey
+// operation.
 //
-// If you use a symmetric CMK, you can use an encryption context to add additional
-// security to your encryption operation. If you specify an EncryptionContext
+// If you use a symmetric KMS key, you can use an encryption context to add
+// additional security to your encryption operation. If you specify an EncryptionContext
 // when encrypting data, you must specify the same encryption context (a case-sensitive
 // exact match) when decrypting the data. Otherwise, the request to decrypt
 // fails with an InvalidCiphertextException. For more information, see Encryption
 // Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// If you specify an asymmetric CMK, you must also specify the encryption algorithm.
-// The algorithm must be compatible with the CMK type.
+// If you specify an asymmetric KMS key, you must also specify the encryption
+// algorithm. The algorithm must be compatible with the KMS key type.
 //
-// When you use an asymmetric CMK to encrypt or reencrypt data, be sure to record
-// the CMK and encryption algorithm that you choose. You will be required to
-// provide the same CMK and encryption algorithm when you decrypt the data.
-// If the CMK and algorithm do not match the values used to encrypt the data,
-// the decrypt operation fails.
+// When you use an asymmetric KMS key to encrypt or reencrypt data, be sure
+// to record the KMS key and encryption algorithm that you choose. You will
+// be required to provide the same KMS key and encryption algorithm when you
+// decrypt the data. If the KMS key and algorithm do not match the values used
+// to encrypt the data, the decrypt operation fails.
 //
-// You are not required to supply the CMK ID and encryption algorithm when you
-// decrypt with symmetric CMKs because AWS KMS stores this information in the
-// ciphertext blob. AWS KMS cannot store metadata in ciphertext generated with
-// asymmetric keys. The standard format for asymmetric key ciphertext does not
-// include configurable fields.
+// You are not required to supply the key ID and encryption algorithm when you
+// decrypt with symmetric KMS keys because KMS stores this information in the
+// ciphertext blob. KMS cannot store metadata in ciphertext generated with asymmetric
+// keys. The standard format for asymmetric key ciphertext does not include
+// configurable fields.
 //
 // The maximum size of the data that you can encrypt varies with the type of
-// CMK and the encryption algorithm that you choose.
+// KMS key and the encryption algorithm that you choose.
 //
-//    * Symmetric CMKs SYMMETRIC_DEFAULT: 4096 bytes
+//    * Symmetric KMS keys SYMMETRIC_DEFAULT: 4096 bytes
 //
 //    * RSA_2048 RSAES_OAEP_SHA_1: 214 bytes RSAES_OAEP_SHA_256: 190 bytes
 //
@@ -2745,12 +2752,13 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //
 //    * RSA_4096 RSAES_OAEP_SHA_1: 470 bytes RSAES_OAEP_SHA_256: 446 bytes
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:Encrypt (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2776,11 +2784,11 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -2789,17 +2797,18 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -2812,9 +2821,9 @@ func (c *KMS) EncryptRequest(input *EncryptInput) (req *request.Request, output 
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Encrypt
 func (c *KMS) Encrypt(input *EncryptInput) (*EncryptOutput, error) {
@@ -2884,18 +2893,18 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //
 // Generates a unique symmetric data key for client-side encryption. This operation
 // returns a plaintext copy of the data key and a copy that is encrypted under
-// a customer master key (CMK) that you specify. You can use the plaintext key
-// to encrypt your data outside of AWS KMS and store the encrypted data key
-// with the encrypted data.
+// a KMS key that you specify. You can use the plaintext key to encrypt your
+// data outside of KMS and store the encrypted data key with the encrypted data.
 //
 // GenerateDataKey returns a unique data key for each request. The bytes in
-// the plaintext key are not related to the caller or the CMK.
+// the plaintext key are not related to the caller or the KMS key.
 //
-// To generate a data key, specify the symmetric CMK that will be used to encrypt
-// the data key. You cannot use an asymmetric CMK to generate data keys. To
-// get the type of your CMK, use the DescribeKey operation. You must also specify
-// the length of the data key. Use either the KeySpec or NumberOfBytes parameters
-// (but not both). For 128-bit and 256-bit data keys, use the KeySpec parameter.
+// To generate a data key, specify the symmetric KMS key that will be used to
+// encrypt the data key. You cannot use an asymmetric KMS key to generate data
+// keys. To get the type of your KMS key, use the DescribeKey operation. You
+// must also specify the length of the data key. Use either the KeySpec or NumberOfBytes
+// parameters (but not both). For 128-bit and 256-bit data keys, use the KeySpec
+// parameter.
 //
 // To get only an encrypted copy of the data key, use GenerateDataKeyWithoutPlaintext.
 // To generate an asymmetric data key pair, use the GenerateDataKeyPair or GenerateDataKeyPairWithoutPlaintext
@@ -2906,41 +2915,48 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 // the same encryption context (a case-sensitive exact match) when decrypting
 // the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
 // For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// Applications in Amazon Web Services Nitro Enclaves can call this operation
+// by using the Amazon Web Services Nitro Enclaves Development Kit (https://github.com/aws/aws-nitro-enclaves-sdk-c).
+// For information about the supporting parameters, see How Amazon Web Services
+// Nitro Enclaves use KMS (https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html)
+// in the Key Management Service Developer Guide.
+//
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
 // How to use your data key
 //
 // We recommend that you use the following pattern to encrypt data locally in
 // your application. You can write your own code or use a client-side encryption
-// library, such as the AWS Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/),
+// library, such as the Amazon Web Services Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/),
 // the Amazon DynamoDB Encryption Client (https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/),
 // or Amazon S3 client-side encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html)
 // to do these tasks for you.
 //
-// To encrypt data outside of AWS KMS:
+// To encrypt data outside of KMS:
 //
 // Use the GenerateDataKey operation to get a data key.
 //
 // Use the plaintext data key (in the Plaintext field of the response) to encrypt
-// your data outside of AWS KMS. Then erase the plaintext data key from memory.
+// your data outside of KMS. Then erase the plaintext data key from memory.
 //
 // Store the encrypted data key (in the CiphertextBlob field of the response)
 // with the encrypted data.
 //
-// To decrypt data outside of AWS KMS:
+// To decrypt data outside of KMS:
 //
 // Use the Decrypt operation to decrypt the encrypted data key. The operation
 // returns a plaintext copy of the data key.
 //
-// Use the plaintext data key to decrypt data outside of AWS KMS, then erase
-// the plaintext data key from memory.
+// Use the plaintext data key to decrypt data outside of KMS, then erase the
+// plaintext data key from memory.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GenerateDataKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -2970,11 +2986,11 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -2983,17 +2999,18 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -3006,9 +3023,9 @@ func (c *KMS) GenerateDataKeyRequest(input *GenerateDataKeyInput) (req *request.
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKey
 func (c *KMS) GenerateDataKey(input *GenerateDataKeyInput) (*GenerateDataKeyOutput, error) {
@@ -3078,22 +3095,24 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 //
 // Generates a unique asymmetric data key pair. The GenerateDataKeyPair operation
 // returns a plaintext public key, a plaintext private key, and a copy of the
-// private key that is encrypted under the symmetric CMK you specify. You can
-// use the data key pair to perform asymmetric cryptography outside of AWS KMS.
-//
-// GenerateDataKeyPair returns a unique data key pair for each request. The
-// bytes in the keys are not related to the caller or the CMK that is used to
-// encrypt the private key.
+// private key that is encrypted under the symmetric KMS key you specify. You
+// can use the data key pair to perform asymmetric cryptography and implement
+// digital signatures outside of KMS.
 //
 // You can use the public key that GenerateDataKeyPair returns to encrypt data
-// or verify a signature outside of AWS KMS. Then, store the encrypted private
-// key with the data. When you are ready to decrypt data or sign a message,
-// you can use the Decrypt operation to decrypt the encrypted private key.
+// or verify a signature outside of KMS. Then, store the encrypted private key
+// with the data. When you are ready to decrypt data or sign a message, you
+// can use the Decrypt operation to decrypt the encrypted private key.
 //
-// To generate a data key pair, you must specify a symmetric customer master
-// key (CMK) to encrypt the private key in a data key pair. You cannot use an
-// asymmetric CMK or a CMK in a custom key store. To get the type and origin
-// of your CMK, use the DescribeKey operation.
+// To generate a data key pair, you must specify a symmetric KMS key to encrypt
+// the private key in a data key pair. You cannot use an asymmetric KMS key
+// or a KMS key in a custom key store. To get the type and origin of your KMS
+// key, use the DescribeKey operation.
+//
+// Use the KeyPairSpec parameter to choose an RSA or Elliptic Curve (ECC) data
+// key pair. KMS recommends that your use ECC key pairs for signing, and use
+// RSA key pairs for either encryption or signing, but not both. However, KMS
+// cannot enforce any restrictions on the use of data key pairs outside of KMS.
 //
 // If you are using the data key pair to encrypt data, or for any operation
 // where you don't immediately need a private key, consider using the GenerateDataKeyPairWithoutPlaintext
@@ -3103,19 +3122,26 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 // to decrypt the data or sign a message, use the Decrypt operation to decrypt
 // the encrypted private key in the data key pair.
 //
+// GenerateDataKeyPair returns a unique data key pair for each request. The
+// bytes in the keys are not related to the caller or the KMS key that is used
+// to encrypt the private key. The public key is a DER-encoded X.509 SubjectPublicKeyInfo,
+// as specified in RFC 5280 (https://tools.ietf.org/html/rfc5280). The private
+// key is a DER-encoded PKCS8 PrivateKeyInfo, as specified in RFC 5958 (https://tools.ietf.org/html/rfc5958).
+//
 // You can use the optional encryption context to add additional security to
 // the encryption operation. If you specify an EncryptionContext, you must specify
 // the same encryption context (a case-sensitive exact match) when decrypting
 // the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
 // For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GenerateDataKeyPair (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3145,11 +3171,11 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -3158,17 +3184,18 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -3181,9 +3208,9 @@ func (c *KMS) GenerateDataKeyPairRequest(input *GenerateDataKeyPairInput) (req *
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -3257,37 +3284,43 @@ func (c *KMS) GenerateDataKeyPairWithoutPlaintextRequest(input *GenerateDataKeyP
 //
 // Generates a unique asymmetric data key pair. The GenerateDataKeyPairWithoutPlaintext
 // operation returns a plaintext public key and a copy of the private key that
-// is encrypted under the symmetric CMK you specify. Unlike GenerateDataKeyPair,
+// is encrypted under the symmetric KMS key you specify. Unlike GenerateDataKeyPair,
 // this operation does not return a plaintext private key.
 //
-// To generate a data key pair, you must specify a symmetric customer master
-// key (CMK) to encrypt the private key in the data key pair. You cannot use
-// an asymmetric CMK or a CMK in a custom key store. To get the type and origin
-// of your CMK, use the KeySpec field in the DescribeKey response.
-//
 // You can use the public key that GenerateDataKeyPairWithoutPlaintext returns
-// to encrypt data or verify a signature outside of AWS KMS. Then, store the
-// encrypted private key with the data. When you are ready to decrypt data or
-// sign a message, you can use the Decrypt operation to decrypt the encrypted
-// private key.
+// to encrypt data or verify a signature outside of KMS. Then, store the encrypted
+// private key with the data. When you are ready to decrypt data or sign a message,
+// you can use the Decrypt operation to decrypt the encrypted private key.
+//
+// To generate a data key pair, you must specify a symmetric KMS key to encrypt
+// the private key in a data key pair. You cannot use an asymmetric KMS key
+// or a KMS key in a custom key store. To get the type and origin of your KMS
+// key, use the DescribeKey operation.
+//
+// Use the KeyPairSpec parameter to choose an RSA or Elliptic Curve (ECC) data
+// key pair. KMS recommends that your use ECC key pairs for signing, and use
+// RSA key pairs for either encryption or signing, but not both. However, KMS
+// cannot enforce any restrictions on the use of data key pairs outside of KMS.
 //
 // GenerateDataKeyPairWithoutPlaintext returns a unique data key pair for each
-// request. The bytes in the key are not related to the caller or CMK that is
-// used to encrypt the private key.
+// request. The bytes in the key are not related to the caller or KMS key that
+// is used to encrypt the private key. The public key is a DER-encoded X.509
+// SubjectPublicKeyInfo, as specified in RFC 5280 (https://tools.ietf.org/html/rfc5280).
 //
 // You can use the optional encryption context to add additional security to
 // the encryption operation. If you specify an EncryptionContext, you must specify
 // the same encryption context (a case-sensitive exact match) when decrypting
 // the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
 // For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GenerateDataKeyPairWithoutPlaintext (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3317,11 +3350,11 @@ func (c *KMS) GenerateDataKeyPairWithoutPlaintextRequest(input *GenerateDataKeyP
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -3330,17 +3363,18 @@ func (c *KMS) GenerateDataKeyPairWithoutPlaintextRequest(input *GenerateDataKeyP
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -3353,9 +3387,9 @@ func (c *KMS) GenerateDataKeyPairWithoutPlaintextRequest(input *GenerateDataKeyP
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -3428,8 +3462,8 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 // GenerateDataKeyWithoutPlaintext API operation for AWS Key Management Service.
 //
 // Generates a unique symmetric data key. This operation returns a data key
-// that is encrypted under a customer master key (CMK) that you specify. To
-// request an asymmetric data key pair, use the GenerateDataKeyPair or GenerateDataKeyPairWithoutPlaintext
+// that is encrypted under a KMS key that you specify. To request an asymmetric
+// data key pair, use the GenerateDataKeyPair or GenerateDataKeyPairWithoutPlaintext
 // operations.
 //
 // GenerateDataKeyWithoutPlaintext is identical to the GenerateDataKey operation
@@ -3448,13 +3482,12 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 // never sees the plaintext data key.
 //
 // GenerateDataKeyWithoutPlaintext returns a unique data key for each request.
-// The bytes in the keys are not related to the caller or CMK that is used to
-// encrypt the private key.
+// The bytes in the keys are not related to the caller or KMS key that is used
+// to encrypt the private key.
 //
-// To generate a data key, you must specify the symmetric customer master key
-// (CMK) that is used to encrypt the data key. You cannot use an asymmetric
-// CMK to generate a data key. To get the type of your CMK, use the DescribeKey
-// operation.
+// To generate a data key, you must specify the symmetric KMS key that is used
+// to encrypt the data key. You cannot use an asymmetric KMS key to generate
+// a data key. To get the type of your KMS key, use the DescribeKey operation.
 //
 // If the operation succeeds, you will find the encrypted copy of the data key
 // in the CiphertextBlob field.
@@ -3464,14 +3497,15 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 // the same encryption context (a case-sensitive exact match) when decrypting
 // the encrypted data key. Otherwise, the request to decrypt fails with an InvalidCiphertextException.
 // For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GenerateDataKeyWithoutPlaintext (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3501,11 +3535,11 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -3514,17 +3548,18 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -3537,9 +3572,9 @@ func (c *KMS) GenerateDataKeyWithoutPlaintextRequest(input *GenerateDataKeyWitho
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GenerateDataKeyWithoutPlaintext
 func (c *KMS) GenerateDataKeyWithoutPlaintext(input *GenerateDataKeyWithoutPlaintextInput) (*GenerateDataKeyWithoutPlaintextOutput, error) {
@@ -3609,13 +3644,19 @@ func (c *KMS) GenerateRandomRequest(input *GenerateRandomInput) (req *request.Re
 //
 // Returns a random byte string that is cryptographically secure.
 //
-// By default, the random byte string is generated in AWS KMS. To generate the
-// byte string in the AWS CloudHSM cluster that is associated with a custom
-// key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+// By default, the random byte string is generated in KMS. To generate the byte
+// string in the CloudHSM cluster that is associated with a custom key store
+// (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
 // specify the custom key store ID.
 //
-// For more information about entropy and random number generation, see AWS
-// Key Management Service Cryptographic Details (https://docs.aws.amazon.com/kms/latest/cryptographic-details/).
+// Applications in Amazon Web Services Nitro Enclaves can call this operation
+// by using the Amazon Web Services Nitro Enclaves Development Kit (https://github.com/aws/aws-nitro-enclaves-sdk-c).
+// For information about the supporting parameters, see How Amazon Web Services
+// Nitro Enclaves use KMS (https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html)
+// in the Key Management Service Developer Guide.
+//
+// For more information about entropy and random number generation, see Key
+// Management Service Cryptographic Details (https://docs.aws.amazon.com/kms/latest/cryptographic-details/).
 //
 // Required permissions: kms:GenerateRandom (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -3637,7 +3678,7 @@ func (c *KMS) GenerateRandomRequest(input *GenerateRandomInput) (req *request.Re
 //   can be retried.
 //
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * CustomKeyStoreInvalidStateException
@@ -3725,10 +3766,10 @@ func (c *KMS) GetKeyPolicyRequest(input *GetKeyPolicyInput) (req *request.Reques
 
 // GetKeyPolicy API operation for AWS Key Management Service.
 //
-// Gets a key policy attached to the specified customer master key (CMK).
+// Gets a key policy attached to the specified KMS key.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:GetKeyPolicy (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3763,9 +3804,9 @@ func (c *KMS) GetKeyPolicyRequest(input *GetKeyPolicyInput) (req *request.Reques
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetKeyPolicy
 func (c *KMS) GetKeyPolicy(input *GetKeyPolicyInput) (*GetKeyPolicyOutput, error) {
@@ -3835,30 +3876,31 @@ func (c *KMS) GetKeyRotationStatusRequest(input *GetKeyRotationStatusInput) (req
 //
 // Gets a Boolean value that indicates whether automatic rotation of the key
 // material (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html)
-// is enabled for the specified customer master key (CMK).
+// is enabled for the specified KMS key.
 //
-// You cannot enable automatic rotation of asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
-// CMKs with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
-// or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+// You cannot enable automatic rotation of asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
+// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 // To enable or disable automatic rotation of a set of related multi-Region
 // keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-replica-key),
-// set the property on the primary key. The key rotation status for these CMKs
-// is always false.
+// set the property on the primary key. The key rotation status for these KMS
+// keys is always false.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
 //    * Disabled: The key rotation status does not change when you disable a
-//    CMK. However, while the CMK is disabled, AWS KMS does not rotate the backing
-//    key.
+//    KMS key. However, while the KMS key is disabled, KMS does not rotate the
+//    key material.
 //
-//    * Pending deletion: While a CMK is pending deletion, its key rotation
-//    status is false and AWS KMS does not rotate the backing key. If you cancel
+//    * Pending deletion: While a KMS key is pending deletion, its key rotation
+//    status is false and KMS does not rotate the key material. If you cancel
 //    the deletion, the original key rotation status is restored.
 //
-// Cross-account use: Yes. To perform this operation on a CMK in a different
-// AWS account, specify the key ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation on a KMS key in a different
+// Amazon Web Services account, specify the key ARN in the value of the KeyId
+// parameter.
 //
 // Required permissions: kms:GetKeyRotationStatus (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -3897,9 +3939,9 @@ func (c *KMS) GetKeyRotationStatusRequest(input *GetKeyRotationStatusInput) (req
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * UnsupportedOperationException
 //   The request was rejected because a specified parameter is not supported or
@@ -3972,19 +4014,20 @@ func (c *KMS) GetParametersForImportRequest(input *GetParametersForImportInput) 
 // GetParametersForImport API operation for AWS Key Management Service.
 //
 // Returns the items you need to import key material into a symmetric, customer
-// managed customer master key (CMK). For more information about importing key
-// material into AWS KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// managed KMS key. For more information about importing key material into KMS,
+// see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+// in the Key Management Service Developer Guide.
 //
 // This operation returns a public key and an import token. Use the public key
 // to encrypt the symmetric key material. Store the import token to send with
 // a subsequent ImportKeyMaterial request.
 //
-// You must specify the key ID of the symmetric CMK into which you will import
-// key material. This CMK's Origin must be EXTERNAL. You must also specify the
-// wrapping algorithm and type of wrapping key (public key) that you will use
-// to encrypt the key material. You cannot perform this operation on an asymmetric
-// CMK or on any CMK in a different AWS account.
+// You must specify the key ID of the symmetric KMS key into which you will
+// import key material. This KMS key's Origin must be EXTERNAL. You must also
+// specify the wrapping algorithm and type of wrapping key (public key) that
+// you will use to encrypt the key material. You cannot perform this operation
+// on an asymmetric KMS key or on any KMS key in a different Amazon Web Services
+// account.
 //
 // To import key material, you must use the public key and import token from
 // the same response. These items are valid for 24 hours. The expiration date
@@ -3992,12 +4035,12 @@ func (c *KMS) GetParametersForImportRequest(input *GetParametersForImportInput) 
 // expired token in an ImportKeyMaterial request. If your key and token expire,
 // send another GetParametersForImport request.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:GetParametersForImport (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -4040,9 +4083,9 @@ func (c *KMS) GetParametersForImportRequest(input *GetParametersForImportInput) 
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetParametersForImport
 func (c *KMS) GetParametersForImport(input *GetParametersForImportInput) (*GetParametersForImportOutput, error) {
@@ -4110,27 +4153,26 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 
 // GetPublicKey API operation for AWS Key Management Service.
 //
-// Returns the public key of an asymmetric CMK. Unlike the private key of a
-// asymmetric CMK, which never leaves AWS KMS unencrypted, callers with kms:GetPublicKey
-// permission can download the public key of an asymmetric CMK. You can share
-// the public key to allow others to encrypt messages and verify signatures
-// outside of AWS KMS. For information about symmetric and asymmetric CMKs,
-// see Using Symmetric and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// Returns the public key of an asymmetric KMS key. Unlike the private key of
+// a asymmetric KMS key, which never leaves KMS unencrypted, callers with kms:GetPublicKey
+// permission can download the public key of an asymmetric KMS key. You can
+// share the public key to allow others to encrypt messages and verify signatures
+// outside of KMS. For information about symmetric and asymmetric KMS keys,
+// see Using Symmetric and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
 // You do not need to download the public key. Instead, you can use the public
-// key within AWS KMS by calling the Encrypt, ReEncrypt, or Verify operations
-// with the identifier of an asymmetric CMK. When you use the public key within
-// AWS KMS, you benefit from the authentication, authorization, and logging
-// that are part of every AWS KMS operation. You also reduce of risk of encrypting
-// data that cannot be decrypted. These features are not effective outside of
-// AWS KMS. For details, see Special Considerations for Downloading Public Keys
-// (https://docs.aws.amazon.com/kms/latest/developerguide/download-public-key.html#download-public-key-considerations).
+// key within KMS by calling the Encrypt, ReEncrypt, or Verify operations with
+// the identifier of an asymmetric KMS key. When you use the public key within
+// KMS, you benefit from the authentication, authorization, and logging that
+// are part of every KMS operation. You also reduce of risk of encrypting data
+// that cannot be decrypted. These features are not effective outside of KMS.
+// For details, see Special Considerations for Downloading Public Keys (https://docs.aws.amazon.com/kms/latest/developerguide/download-public-key.html#download-public-key-considerations).
 //
-// To help you use the public key safely outside of AWS KMS, GetPublicKey returns
+// To help you use the public key safely outside of KMS, GetPublicKey returns
 // important information about the public key in the response, including:
 //
-//    * CustomerMasterKeySpec (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-CustomerMasterKeySpec):
+//    * KeySpec (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-KeySpec):
 //    The type of key material in the public key, such as RSA_4096 or ECC_NIST_P521.
 //
 //    * KeyUsage (https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-KeyUsage):
@@ -4141,19 +4183,20 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 //    A list of the encryption algorithms or the signing algorithms for the
 //    key.
 //
-// Although AWS KMS cannot enforce these restrictions on external operations,
-// it is crucial that you use this information to prevent the public key from
-// being used improperly. For example, you can prevent a public signing key
-// from being used encrypt data, or prevent a public key from being used with
-// an encryption algorithm that is not supported by AWS KMS. You can also avoid
-// errors, such as using the wrong signing algorithm in a verification operation.
+// Although KMS cannot enforce these restrictions on external operations, it
+// is crucial that you use this information to prevent the public key from being
+// used improperly. For example, you can prevent a public signing key from being
+// used encrypt data, or prevent a public key from being used with an encryption
+// algorithm that is not supported by KMS. You can also avoid errors, such as
+// using the wrong signing algorithm in a verification operation.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:GetPublicKey (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -4173,11 +4216,11 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -4197,17 +4240,18 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InternalException
 //   The request was rejected because an internal exception occurred. The request
@@ -4217,9 +4261,9 @@ func (c *KMS) GetPublicKeyRequest(input *GetPublicKeyInput) (req *request.Reques
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/GetPublicKey
 func (c *KMS) GetPublicKey(input *GetPublicKeyInput) (*GetPublicKeyOutput, error) {
@@ -4288,15 +4332,16 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 
 // ImportKeyMaterial API operation for AWS Key Management Service.
 //
-// Imports key material into an existing symmetric AWS KMS customer master key
-// (CMK) that was created without key material. After you successfully import
-// key material into a CMK, you can reimport the same key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#reimport-key-material)
-// into that CMK, but you cannot import different key material.
+// Imports key material into an existing symmetric KMS KMS key that was created
+// without key material. After you successfully import key material into a KMS
+// key, you can reimport the same key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#reimport-key-material)
+// into that KMS key, but you cannot import different key material.
 //
-// You cannot perform this operation on an asymmetric CMK or on any CMK in a
-// different AWS account. For more information about creating CMKs with no key
-// material and then importing key material, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// You cannot perform this operation on an asymmetric KMS key or on any KMS
+// key in a different Amazon Web Services account. For more information about
+// creating KMS keys with no key material and then importing key material, see
+// Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+// in the Key Management Service Developer Guide.
 //
 // Before using this operation, call GetParametersForImport. Its response includes
 // a public key and an import token. Use the public key to encrypt the key material.
@@ -4304,10 +4349,10 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //
 // When calling this operation, you must specify the following values:
 //
-//    * The key ID or key ARN of a CMK with no key material. Its Origin must
-//    be EXTERNAL. To create a CMK with no key material, call CreateKey and
-//    set the value of its Origin parameter to EXTERNAL. To get the Origin of
-//    a CMK, call DescribeKey.)
+//    * The key ID or key ARN of a KMS key with no key material. Its Origin
+//    must be EXTERNAL. To create a KMS key with no key material, call CreateKey
+//    and set the value of its Origin parameter to EXTERNAL. To get the Origin
+//    of a KMS key, call DescribeKey.)
 //
 //    * The encrypted key material. To get the public key to encrypt the key
 //    material, call GetParametersForImport.
@@ -4316,27 +4361,27 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //    a public key and token from the same GetParametersForImport response.
 //
 //    * Whether the key material expires and if so, when. If you set an expiration
-//    date, AWS KMS deletes the key material from the CMK on the specified date,
-//    and the CMK becomes unusable. To use the CMK again, you must reimport
+//    date, KMS deletes the key material from the KMS key on the specified date,
+//    and the KMS key becomes unusable. To use the KMS key again, you must reimport
 //    the same key material. The only way to change an expiration date is by
 //    reimporting the same key material and specifying a new expiration date.
 //
-// When this operation is successful, the key state of the CMK changes from
-// PendingImport to Enabled, and you can use the CMK.
+// When this operation is successful, the key state of the KMS key changes from
+// PendingImport to Enabled, and you can use the KMS key.
 //
 // If this operation fails, use the exception to help determine the problem.
 // If the error is related to the key material, the import token, or wrapping
 // key, use GetParametersForImport to get a new public key and import token
-// for the CMK and repeat the import procedure. For help, see How To Import
+// for the KMS key and repeat the import procedure. For help, see How To Import
 // Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#importing-keys-overview)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:ImportKeyMaterial (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -4379,9 +4424,9 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * InvalidCiphertextException
 //   From the Decrypt or ReEncrypt operation, the request was rejected because
@@ -4389,13 +4434,13 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //   the ciphertext, such as the encryption context, is corrupted, missing, or
 //   otherwise invalid.
 //
-//   From the ImportKeyMaterial operation, the request was rejected because AWS
-//   KMS could not decrypt the encrypted (wrapped) key material.
+//   From the ImportKeyMaterial operation, the request was rejected because KMS
+//   could not decrypt the encrypted (wrapped) key material.
 //
 //   * IncorrectKeyMaterialException
 //   The request was rejected because the key material in the request is, expired,
 //   invalid, or is not the same key material that was previously imported into
-//   this customer master key (CMK).
+//   this KMS key.
 //
 //   * ExpiredImportTokenException
 //   The request was rejected because the specified import token is expired. Use
@@ -4404,7 +4449,7 @@ func (c *KMS) ImportKeyMaterialRequest(input *ImportKeyMaterialInput) (req *requ
 //
 //   * InvalidImportTokenException
 //   The request was rejected because the provided import token is invalid or
-//   is associated with a different customer master key (CMK).
+//   is associated with a different KMS key.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ImportKeyMaterial
 func (c *KMS) ImportKeyMaterial(input *ImportKeyMaterialInput) (*ImportKeyMaterialOutput, error) {
@@ -4478,30 +4523,33 @@ func (c *KMS) ListAliasesRequest(input *ListAliasesInput) (req *request.Request,
 
 // ListAliases API operation for AWS Key Management Service.
 //
-// Gets a list of aliases in the caller's AWS account and region. For more information
-// about aliases, see CreateAlias.
+// Gets a list of aliases in the caller's Amazon Web Services account and region.
+// For more information about aliases, see CreateAlias.
 //
 // By default, the ListAliases operation returns all aliases in the account
-// and region. To get only the aliases associated with a particular customer
-// master key (CMK), use the KeyId parameter.
+// and region. To get only the aliases associated with a particular KMS key,
+// use the KeyId parameter.
 //
 // The ListAliases response can include aliases that you created and associated
-// with your customer managed CMKs, and aliases that AWS created and associated
-// with AWS managed CMKs in your account. You can recognize AWS aliases because
-// their names have the format aws/<service-name>, such as aws/dynamodb.
+// with your customer managed keys, and aliases that Amazon Web Services created
+// and associated with Amazon Web Services managed keys in your account. You
+// can recognize Amazon Web Services aliases because their names have the format
+// aws/<service-name>, such as aws/dynamodb.
 //
 // The response might also include aliases that have no TargetKeyId field. These
-// are predefined aliases that AWS has created but has not yet associated with
-// a CMK. Aliases that AWS creates in your account, including predefined aliases,
-// do not count against your AWS KMS aliases quota (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#aliases-limit).
+// are predefined aliases that Amazon Web Services has created but has not yet
+// associated with a KMS key. Aliases that Amazon Web Services creates in your
+// account, including predefined aliases, do not count against your KMS aliases
+// quota (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#aliases-limit).
 //
-// Cross-account use: No. ListAliases does not return aliases in other AWS accounts.
+// Cross-account use: No. ListAliases does not return aliases in other Amazon
+// Web Services accounts.
 //
 // Required permissions: kms:ListAliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
 //
 // For details, see Controlling access to aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -4663,19 +4711,25 @@ func (c *KMS) ListGrantsRequest(input *ListGrantsInput) (req *request.Request, o
 
 // ListGrants API operation for AWS Key Management Service.
 //
-// Gets a list of all grants for the specified customer master key (CMK).
+// Gets a list of all grants for the specified KMS key.
 //
-// You must specify the CMK in all requests. You can filter the grant list by
-// grant ID or grantee principal.
+// You must specify the KMS key in all requests. You can filter the grant list
+// by grant ID or grantee principal.
+//
+// For detailed information about grants, including grant terminology, see Using
+// grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
 //
 // The GranteePrincipal field in the ListGrants response usually contains the
 // user or role designated as the grantee principal in the grant. However, when
-// the grantee principal in the grant is an AWS service, the GranteePrincipal
-// field contains the service principal (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services),
+// the grantee principal in the grant is an Amazon Web Services service, the
+// GranteePrincipal field contains the service principal (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services),
 // which might represent several different grantee principals.
 //
-// Cross-account use: Yes. To perform this operation on a CMK in a different
-// AWS account, specify the key ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation on a KMS key in a different
+// Amazon Web Services account, specify the key ARN in the value of the KeyId
+// parameter.
 //
 // Required permissions: kms:ListGrants (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -4725,9 +4779,9 @@ func (c *KMS) ListGrantsRequest(input *ListGrantsInput) (req *request.Request, o
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListGrants
 func (c *KMS) ListGrants(input *ListGrantsInput) (*ListGrantsResponse, error) {
@@ -4853,12 +4907,12 @@ func (c *KMS) ListKeyPoliciesRequest(input *ListKeyPoliciesInput) (req *request.
 
 // ListKeyPolicies API operation for AWS Key Management Service.
 //
-// Gets the names of the key policies that are attached to a customer master
-// key (CMK). This operation is designed to get policy names that you can use
-// in a GetKeyPolicy operation. However, the only valid policy name is default.
+// Gets the names of the key policies that are attached to a KMS key. This operation
+// is designed to get policy names that you can use in a GetKeyPolicy operation.
+// However, the only valid policy name is default.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:ListKeyPolicies (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -4897,9 +4951,9 @@ func (c *KMS) ListKeyPoliciesRequest(input *ListKeyPoliciesInput) (req *request.
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ListKeyPolicies
 func (c *KMS) ListKeyPolicies(input *ListKeyPoliciesInput) (*ListKeyPoliciesOutput, error) {
@@ -5025,11 +5079,11 @@ func (c *KMS) ListKeysRequest(input *ListKeysInput) (req *request.Request, outpu
 
 // ListKeys API operation for AWS Key Management Service.
 //
-// Gets a list of all customer master keys (CMKs) in the caller's AWS account
-// and Region.
+// Gets a list of all KMS keys in the caller's Amazon Web Services account and
+// Region.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:ListKeys (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -5182,15 +5236,15 @@ func (c *KMS) ListResourceTagsRequest(input *ListResourceTagsInput) (req *reques
 
 // ListResourceTags API operation for AWS Key Management Service.
 //
-// Returns all tags on the specified customer master key (CMK).
+// Returns all tags on the specified KMS key.
 //
 // For general information about tags, including the format and syntax, see
-// Tagging AWS resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+// Tagging Amazon Web Services resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
 // in the Amazon Web Services General Reference. For information about using
-// tags in AWS KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+// tags in KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:ListResourceTags (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -5295,24 +5349,28 @@ func (c *KMS) ListRetirableGrantsRequest(input *ListRetirableGrantsInput) (req *
 
 // ListRetirableGrants API operation for AWS Key Management Service.
 //
-// Returns information about all grants in the AWS account and Region that have
-// the specified retiring principal. For more information about grants, see
-// Grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
-// in the AWS Key Management Service Developer Guide .
+// Returns information about all grants in the Amazon Web Services account and
+// Region that have the specified retiring principal.
 //
-// You can specify any principal in your AWS account. The grants that are returned
-// include grants for CMKs in your AWS account and other AWS accounts.
+// You can specify any principal in your Amazon Web Services account. The grants
+// that are returned include grants for KMS keys in your Amazon Web Services
+// account and other Amazon Web Services accounts. You might use this operation
+// to determine which grants you may retire. To retire a grant, use the RetireGrant
+// operation.
 //
-// You might use this operation to determine which grants you may retire. To
-// retire a grant, use the RetireGrant operation.
+// For detailed information about grants, including grant terminology, see Using
+// grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
 //
-// Cross-account use: You must specify a principal in your AWS account. However,
-// this operation can return grants in any AWS account. You do not need kms:ListRetirableGrants
-// permission (or any other additional permission) in any AWS account other
-// than your own.
+// Cross-account use: You must specify a principal in your Amazon Web Services
+// account. However, this operation can return grants in any Amazon Web Services
+// account. You do not need kms:ListRetirableGrants permission (or any other
+// additional permission) in any Amazon Web Services account other than your
+// own.
 //
 // Required permissions: kms:ListRetirableGrants (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-// (IAM policy) in your AWS account.
+// (IAM policy) in your Amazon Web Services account.
 //
 // Related operations:
 //
@@ -5419,17 +5477,18 @@ func (c *KMS) PutKeyPolicyRequest(input *PutKeyPolicyInput) (req *request.Reques
 
 // PutKeyPolicy API operation for AWS Key Management Service.
 //
-// Attaches a key policy to the specified customer master key (CMK).
+// Attaches a key policy to the specified KMS key.
 //
 // For more information about key policies, see Key Policies (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
-// in the AWS Key Management Service Developer Guide. For help writing and formatting
+// in the Key Management Service Developer Guide. For help writing and formatting
 // a JSON policy document, see the IAM JSON Policy Reference (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html)
-// in the IAM User Guide . For examples of adding a key policy in multiple programming
-// languages, see Setting a key policy (https://docs.aws.amazon.com/kms/latest/developerguide/programming-key-policies.html#put-policy)
-// in the AWS Key Management Service Developer Guide.
+// in the Identity and Access Management User Guide . For examples of adding
+// a key policy in multiple programming languages, see Setting a key policy
+// (https://docs.aws.amazon.com/kms/latest/developerguide/programming-key-policies.html#put-policy)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:PutKeyPolicy (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -5471,15 +5530,15 @@ func (c *KMS) PutKeyPolicyRequest(input *PutKeyPolicyInput) (req *request.Reques
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/PutKeyPolicy
 func (c *KMS) PutKeyPolicy(input *PutKeyPolicyInput) (*PutKeyPolicyOutput, error) {
@@ -5547,80 +5606,80 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 
 // ReEncrypt API operation for AWS Key Management Service.
 //
-// Decrypts ciphertext and then reencrypts it entirely within AWS KMS. You can
-// use this operation to change the customer master key (CMK) under which data
-// is encrypted, such as when you manually rotate (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-manually)
-// a CMK or change the CMK that protects a ciphertext. You can also use it to
-// reencrypt ciphertext under the same CMK, such as to change the encryption
-// context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+// Decrypts ciphertext and then reencrypts it entirely within KMS. You can use
+// this operation to change the KMS key under which data is encrypted, such
+// as when you manually rotate (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-manually)
+// a KMS key or change the KMS key that protects a ciphertext. You can also
+// use it to reencrypt ciphertext under the same KMS key, such as to change
+// the encryption context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
 // of a ciphertext.
 //
 // The ReEncrypt operation can decrypt ciphertext that was encrypted by using
-// an AWS KMS CMK in an AWS KMS operation, such as Encrypt or GenerateDataKey.
-// It can also decrypt ciphertext that was encrypted by using the public key
-// of an asymmetric CMK (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks)
-// outside of AWS KMS. However, it cannot decrypt ciphertext produced by other
-// libraries, such as the AWS Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
+// an KMS KMS key in an KMS operation, such as Encrypt or GenerateDataKey. It
+// can also decrypt ciphertext that was encrypted by using the public key of
+// an asymmetric KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks)
+// outside of KMS. However, it cannot decrypt ciphertext produced by other libraries,
+// such as the Amazon Web Services Encryption SDK (https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/)
 // or Amazon S3 client-side encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html).
-// These libraries return a ciphertext format that is incompatible with AWS
-// KMS.
+// These libraries return a ciphertext format that is incompatible with KMS.
 //
 // When you use the ReEncrypt operation, you need to provide information for
 // the decrypt operation and the subsequent encrypt operation.
 //
-//    * If your ciphertext was encrypted under an asymmetric CMK, you must use
-//    the SourceKeyId parameter to identify the CMK that encrypted the ciphertext.
-//    You must also supply the encryption algorithm that was used. This information
-//    is required to decrypt the data.
+//    * If your ciphertext was encrypted under an asymmetric KMS key, you must
+//    use the SourceKeyId parameter to identify the KMS key that encrypted the
+//    ciphertext. You must also supply the encryption algorithm that was used.
+//    This information is required to decrypt the data.
 //
-//    * If your ciphertext was encrypted under a symmetric CMK, the SourceKeyId
-//    parameter is optional. AWS KMS can get this information from metadata
-//    that it adds to the symmetric ciphertext blob. This feature adds durability
+//    * If your ciphertext was encrypted under a symmetric KMS key, the SourceKeyId
+//    parameter is optional. KMS can get this information from metadata that
+//    it adds to the symmetric ciphertext blob. This feature adds durability
 //    to your implementation by ensuring that authorized users can decrypt ciphertext
-//    decades after it was encrypted, even if they've lost track of the CMK
-//    ID. However, specifying the source CMK is always recommended as a best
-//    practice. When you use the SourceKeyId parameter to specify a CMK, AWS
-//    KMS uses only the CMK you specify. If the ciphertext was encrypted under
-//    a different CMK, the ReEncrypt operation fails. This practice ensures
-//    that you use the CMK that you intend.
+//    decades after it was encrypted, even if they've lost track of the key
+//    ID. However, specifying the source KMS key is always recommended as a
+//    best practice. When you use the SourceKeyId parameter to specify a KMS
+//    key, KMS uses only the KMS key you specify. If the ciphertext was encrypted
+//    under a different KMS key, the ReEncrypt operation fails. This practice
+//    ensures that you use the KMS key that you intend.
 //
 //    * To reencrypt the data, you must use the DestinationKeyId parameter specify
-//    the CMK that re-encrypts the data after it is decrypted. You can select
-//    a symmetric or asymmetric CMK. If the destination CMK is an asymmetric
-//    CMK, you must also provide the encryption algorithm. The algorithm that
-//    you choose must be compatible with the CMK. When you use an asymmetric
-//    CMK to encrypt or reencrypt data, be sure to record the CMK and encryption
-//    algorithm that you choose. You will be required to provide the same CMK
-//    and encryption algorithm when you decrypt the data. If the CMK and algorithm
-//    do not match the values used to encrypt the data, the decrypt operation
-//    fails. You are not required to supply the CMK ID and encryption algorithm
-//    when you decrypt with symmetric CMKs because AWS KMS stores this information
-//    in the ciphertext blob. AWS KMS cannot store metadata in ciphertext generated
-//    with asymmetric keys. The standard format for asymmetric key ciphertext
-//    does not include configurable fields.
+//    the KMS key that re-encrypts the data after it is decrypted. You can select
+//    a symmetric or asymmetric KMS key. If the destination KMS key is an asymmetric
+//    KMS key, you must also provide the encryption algorithm. The algorithm
+//    that you choose must be compatible with the KMS key. When you use an asymmetric
+//    KMS key to encrypt or reencrypt data, be sure to record the KMS key and
+//    encryption algorithm that you choose. You will be required to provide
+//    the same KMS key and encryption algorithm when you decrypt the data. If
+//    the KMS key and algorithm do not match the values used to encrypt the
+//    data, the decrypt operation fails. You are not required to supply the
+//    key ID and encryption algorithm when you decrypt with symmetric KMS keys
+//    because KMS stores this information in the ciphertext blob. KMS cannot
+//    store metadata in ciphertext generated with asymmetric keys. The standard
+//    format for asymmetric key ciphertext does not include configurable fields.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. The source CMK and destination CMK can be in different
-// AWS accounts. Either or both CMKs can be in a different account than the
-// caller.
+// Cross-account use: Yes. The source KMS key and destination KMS key can be
+// in different Amazon Web Services accounts. Either or both KMS keys can be
+// in a different account than the caller. To specify a KMS key in a different
+// account, you must use its key ARN or alias ARN.
 //
 // Required permissions:
 //
 //    * kms:ReEncryptFrom (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    permission on the source CMK (key policy)
+//    permission on the source KMS key (key policy)
 //
 //    * kms:ReEncryptTo (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    permission on the destination CMK (key policy)
+//    permission on the destination KMS key (key policy)
 //
-// To permit reencryption from or to a CMK, include the "kms:ReEncrypt*" permission
-// in your key policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html).
+// To permit reencryption from or to a KMS key, include the "kms:ReEncrypt*"
+// permission in your key policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html).
 // This permission is automatically included in the key policy when you use
-// the console to create a CMK. But you must include it manually when you create
-// a CMK programmatically or when you use the PutKeyPolicy operation to set
-// a key policy.
+// the console to create a KMS key. But you must include it manually when you
+// create a KMS key programmatically or when you use the PutKeyPolicy operation
+// to set a key policy.
 //
 // Related operations:
 //
@@ -5645,7 +5704,7 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidCiphertextException
 //   From the Decrypt or ReEncrypt operation, the request was rejected because
@@ -5653,17 +5712,17 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //   the ciphertext, such as the encryption context, is corrupted, missing, or
 //   otherwise invalid.
 //
-//   From the ImportKeyMaterial operation, the request was rejected because AWS
-//   KMS could not decrypt the encrypted (wrapped) key material.
+//   From the ImportKeyMaterial operation, the request was rejected because KMS
+//   could not decrypt the encrypted (wrapped) key material.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * IncorrectKeyException
-//   The request was rejected because the specified CMK cannot decrypt the data.
-//   The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
-//   must identify the same CMK that was used to encrypt the ciphertext.
+//   The request was rejected because the specified KMS key cannot decrypt the
+//   data. The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+//   must identify the same KMS key that was used to encrypt the ciphertext.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -5672,17 +5731,18 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -5695,9 +5755,9 @@ func (c *KMS) ReEncryptRequest(input *ReEncryptInput) (req *request.Request, out
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ReEncrypt
 func (c *KMS) ReEncrypt(input *ReEncryptInput) (*ReEncryptOutput, error) {
@@ -5767,33 +5827,34 @@ func (c *KMS) ReplicateKeyRequest(input *ReplicateKeyInput) (req *request.Reques
 //
 // Replicates a multi-Region key into the specified Region. This operation creates
 // a multi-Region replica key based on a multi-Region primary key in a different
-// Region of the same AWS partition. You can create multiple replicas of a primary
-// key, but each must be in a different Region. To create a multi-Region primary
-// key, use the CreateKey operation.
+// Region of the same Amazon Web Services partition. You can create multiple
+// replicas of a primary key, but each must be in a different Region. To create
+// a multi-Region primary key, use the CreateKey operation.
 //
-// This operation supports multi-Region keys, an AWS KMS feature that lets you
-// create multiple interoperable CMKs in different AWS Regions. Because these
-// CMKs have the same key ID, key material, and other metadata, you can use
-// them to encrypt data in one AWS Region and decrypt it in a different AWS
-// Region without making a cross-Region call or exposing the plaintext data.
-// For more information about multi-Region keys, see Using multi-Region keys
-// (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
-// in the AWS Key Management Service Developer Guide.
+// This operation supports multi-Region keys, an KMS feature that lets you create
+// multiple interoperable KMS keys in different Amazon Web Services Regions.
+// Because these KMS keys have the same key ID, key material, and other metadata,
+// you can use them interchangeably to encrypt data in one Amazon Web Services
+// Region and decrypt it in a different Amazon Web Services Region without re-encrypting
+// the data or making a cross-Region call. For more information about multi-Region
+// keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+// in the Key Management Service Developer Guide.
 //
-// A replica key is a fully-functional CMK that can be used independently of
-// its primary and peer replica keys. A primary key and its replica keys share
-// properties that make them interoperable. They have the same key ID (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-id)
+// A replica key is a fully-functional KMS key that can be used independently
+// of its primary and peer replica keys. A primary key and its replica keys
+// share properties that make them interoperable. They have the same key ID
+// (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-id)
 // and key material. They also have the same key spec (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-spec),
 // key usage (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-usage),
 // key material origin (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-origin),
 // and automatic key rotation status (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html).
-// AWS KMS automatically synchronizes these shared properties among related
-// multi-Region keys. All other properties of a replica key can differ, including
-// its key policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html),
+// KMS automatically synchronizes these shared properties among related multi-Region
+// keys. All other properties of a replica key can differ, including its key
+// policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html),
 // tags (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html),
 // aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html),
 // and key state (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html).
-// AWS KMS pricing and quotas for CMKs apply to each primary key and replica
+// KMS pricing and quotas for KMS keys apply to each primary key and replica
 // key.
 //
 // When this operation completes, the new replica key has a transient key state
@@ -5803,31 +5864,31 @@ func (c *KMS) ReplicateKeyRequest(input *ReplicateKeyInput) (req *request.Reques
 // it in cryptographic operations. If you are creating and using the replica
 // key programmatically, retry on KMSInvalidStateException or call DescribeKey
 // to check its KeyState value before using it. For details about the Creating
-// key state, see Key state: Effect on your CMK (kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// key state, see Key state: Effect on your KMS key (kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// The AWS CloudTrail log of a ReplicateKey operation records a ReplicateKey
-// operation in the primary key's Region and a CreateKey operation in the replica
-// key's Region.
+// The CloudTrail log of a ReplicateKey operation records a ReplicateKey operation
+// in the primary key's Region and a CreateKey operation in the replica key's
+// Region.
 //
 // If you replicate a multi-Region primary key with imported key material, the
 // replica key is created with no key material. You must import the same key
 // material that you imported into the primary key. For details, see Importing
 // key material into multi-Region keys (kms/latest/developerguide/multi-region-keys-import.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // To convert a replica key to a primary key, use the UpdatePrimaryRegion operation.
 //
 // ReplicateKey uses different default values for the KeyPolicy and Tags parameters
-// than those used in the AWS KMS console. For details, see the parameter descriptions.
+// than those used in the KMS console. For details, see the parameter descriptions.
 //
-// Cross-account use: No. You cannot use this operation to create a CMK in a
-// different AWS account.
+// Cross-account use: No. You cannot use this operation to create a replica
+// key in a different Amazon Web Services account.
 //
 // Required permissions:
 //
-//    * kms:ReplicateKey on the primary CMK (in the primary CMK's Region). Include
-//    this permission in the primary CMK's key policy.
+//    * kms:ReplicateKey on the primary key (in the primary key's Region). Include
+//    this permission in the primary key's key policy.
 //
 //    * kms:CreateKey in an IAM policy in the replica Region.
 //
@@ -5853,7 +5914,7 @@ func (c *KMS) ReplicateKeyRequest(input *ReplicateKeyInput) (req *request.Reques
 //   exists.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidArnException
 //   The request was rejected because a specified ARN, or an ARN in a key policy,
@@ -5863,9 +5924,9 @@ func (c *KMS) ReplicateKeyRequest(input *ReplicateKeyInput) (req *request.Reques
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * InternalException
 //   The request was rejected because an internal exception occurred. The request
@@ -5874,7 +5935,7 @@ func (c *KMS) ReplicateKeyRequest(input *ReplicateKeyInput) (req *request.Reques
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * MalformedPolicyDocumentException
 //   The request was rejected because the specified policy is not syntactically
@@ -5960,27 +6021,27 @@ func (c *KMS) RetireGrantRequest(input *RetireGrantInput) (req *request.Request,
 //
 // Deletes a grant. Typically, you retire a grant when you no longer need its
 // permissions. To identify the grant to retire, use a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token),
-// or both the grant ID and a key identifier (key ID or key ARN) of the customer
-// master key (CMK). The CreateGrant operation returns both values.
+// or both the grant ID and a key identifier (key ID or key ARN) of the KMS
+// key. The CreateGrant operation returns both values.
 //
 // This operation can be called by the retiring principal for a grant, by the
 // grantee principal if the grant allows the RetireGrant operation, and by the
-// AWS account (root user) in which the grant is created. It can also be called
-// by principals to whom permission for retiring a grant is delegated. For details,
-// see Retiring and revoking grants (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#grant-delete)
-// in the AWS Key Management Service Developer Guide.
+// Amazon Web Services account (root user) in which the grant is created. It
+// can also be called by principals to whom permission for retiring a grant
+// is delegated. For details, see Retiring and revoking grants (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#grant-delete)
+// in the Key Management Service Developer Guide.
 //
 // For detailed information about grants, including grant terminology, see Using
 // grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
-// in the AWS Key Management Service Developer Guide . For examples of working
-// with grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
 //
-// Cross-account use: Yes. You can retire a grant on a CMK in a different AWS
-// account.
+// Cross-account use: Yes. You can retire a grant on a KMS key in a different
+// Amazon Web Services account.
 //
 // Required permissions::Permission to retire a grant is determined primarily
 // by the grant. For details, see Retiring and revoking grants (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#grant-delete)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -6026,9 +6087,9 @@ func (c *KMS) RetireGrantRequest(input *RetireGrantInput) (req *request.Request,
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/RetireGrant
 func (c *KMS) RetireGrant(input *RetireGrantInput) (*RetireGrantOutput, error) {
@@ -6100,16 +6161,22 @@ func (c *KMS) RevokeGrantRequest(input *RevokeGrantInput) (req *request.Request,
 // Deletes the specified grant. You revoke a grant to terminate the permissions
 // that the grant allows. For more information, see Retiring and revoking grants
 // (https://docs.aws.amazon.com/kms/latest/developerguide/managing-grants.html#grant-delete)
-// in the AWS Key Management Service Developer Guide .
+// in the Key Management Service Developer Guide .
 //
 // When you create, retire, or revoke a grant, there might be a brief delay,
-// usually less than five minutes, until the grant is available throughout AWS
-// KMS. This state is known as eventual consistency. For details, see Eventual
-// consistency (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-eventual-consistency)
-// in the AWS Key Management Service Developer Guide .
+// usually less than five minutes, until the grant is available throughout KMS.
+// This state is known as eventual consistency. For details, see Eventual consistency
+// (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-eventual-consistency)
+// in the Key Management Service Developer Guide .
 //
-// Cross-account use: Yes. To perform this operation on a CMK in a different
-// AWS account, specify the key ARN in the value of the KeyId parameter.
+// For detailed information about grants, including grant terminology, see Using
+// grants (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
+// in the Key Management Service Developer Guide . For examples of working with
+// grants in several programming languages, see Programming grants (https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html).
+//
+// Cross-account use: Yes. To perform this operation on a KMS key in a different
+// Amazon Web Services account, specify the key ARN in the value of the KeyId
+// parameter.
 //
 // Required permissions: kms:RevokeGrant (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy).
@@ -6155,9 +6222,9 @@ func (c *KMS) RevokeGrantRequest(input *RevokeGrantInput) (req *request.Request,
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/RevokeGrant
 func (c *KMS) RevokeGrant(input *RevokeGrantInput) (*RevokeGrantOutput, error) {
@@ -6225,49 +6292,49 @@ func (c *KMS) ScheduleKeyDeletionRequest(input *ScheduleKeyDeletionInput) (req *
 
 // ScheduleKeyDeletion API operation for AWS Key Management Service.
 //
-// Schedules the deletion of a customer master key (CMK). By default, AWS KMS
-// applies a waiting period of 30 days, but you can specify a waiting period
-// of 7-30 days. When this operation is successful, the key state of the CMK
-// changes to PendingDeletion and the key can't be used in any cryptographic
-// operations. It remains in this state for the duration of the waiting period.
-// Before the waiting period ends, you can use CancelKeyDeletion to cancel the
-// deletion of the CMK. After the waiting period ends, AWS KMS deletes the CMK,
-// its key material, and all AWS KMS data associated with it, including all
-// aliases that refer to it.
+// Schedules the deletion of a KMS key. By default, KMS applies a waiting period
+// of 30 days, but you can specify a waiting period of 7-30 days. When this
+// operation is successful, the key state of the KMS key changes to PendingDeletion
+// and the key can't be used in any cryptographic operations. It remains in
+// this state for the duration of the waiting period. Before the waiting period
+// ends, you can use CancelKeyDeletion to cancel the deletion of the KMS key.
+// After the waiting period ends, KMS deletes the KMS key, its key material,
+// and all KMS data associated with it, including all aliases that refer to
+// it.
 //
-// Deleting a CMK is a destructive and potentially dangerous operation. When
-// a CMK is deleted, all data that was encrypted under the CMK is unrecoverable.
-// (The only exception is a multi-Region replica key.) To prevent the use of
-// a CMK without deleting it, use DisableKey.
+// Deleting a KMS key is a destructive and potentially dangerous operation.
+// When a KMS key is deleted, all data that was encrypted under the KMS key
+// is unrecoverable. (The only exception is a multi-Region replica key.) To
+// prevent the use of a KMS key without deleting it, use DisableKey.
 //
-// If you schedule deletion of a CMK from a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
-// when the waiting period expires, ScheduleKeyDeletion deletes the CMK from
-// AWS KMS. Then AWS KMS makes a best effort to delete the key material from
-// the associated AWS CloudHSM cluster. However, you might need to manually
-// delete the orphaned key material (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key)
+// If you schedule deletion of a KMS key from a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+// when the waiting period expires, ScheduleKeyDeletion deletes the KMS key
+// from KMS. Then KMS makes a best effort to delete the key material from the
+// associated CloudHSM cluster. However, you might need to manually delete the
+// orphaned key material (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key)
 // from the cluster and its backups.
 //
 // You can schedule the deletion of a multi-Region primary key and its replica
-// keys at any time. However, AWS KMS will not delete a multi-Region primary
-// key with existing replica keys. If you schedule the deletion of a primary
-// key with replicas, its key state changes to PendingReplicaDeletion and it
-// cannot be replicated or used in cryptographic operations. This status can
-// continue indefinitely. When the last of its replicas keys is deleted (not
-// just scheduled), the key state of the primary key changes to PendingDeletion
-// and its waiting period (PendingWindowInDays) begins. For details, see Deleting
-// multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-delete.html)
-// in the AWS Key Management Service Developer Guide.
+// keys at any time. However, KMS will not delete a multi-Region primary key
+// with existing replica keys. If you schedule the deletion of a primary key
+// with replicas, its key state changes to PendingReplicaDeletion and it cannot
+// be replicated or used in cryptographic operations. This status can continue
+// indefinitely. When the last of its replicas keys is deleted (not just scheduled),
+// the key state of the primary key changes to PendingDeletion and its waiting
+// period (PendingWindowInDays) begins. For details, see Deleting multi-Region
+// keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-delete.html)
+// in the Key Management Service Developer Guide.
 //
-// For more information about scheduling a CMK for deletion, see Deleting Customer
-// Master Keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
-// in the AWS Key Management Service Developer Guide.
+// For more information about scheduling a KMS key for deletion, see Deleting
+// KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html)
+// in the Key Management Service Developer Guide.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:ScheduleKeyDeletion (key policy)
 //
@@ -6305,9 +6372,9 @@ func (c *KMS) ScheduleKeyDeletionRequest(input *ScheduleKeyDeletionInput) (req *
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/ScheduleKeyDeletion
 func (c *KMS) ScheduleKeyDeletion(input *ScheduleKeyDeletionInput) (*ScheduleKeyDeletionOutput, error) {
@@ -6377,23 +6444,24 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //
 // Creates a digital signature (https://en.wikipedia.org/wiki/Digital_signature)
 // for a message or message digest by using the private key in an asymmetric
-// CMK. To verify the signature, use the Verify operation, or use the public
-// key in the same asymmetric CMK outside of AWS KMS. For information about
-// symmetric and asymmetric CMKs, see Using Symmetric and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// KMS key. To verify the signature, use the Verify operation, or use the public
+// key in the same asymmetric KMS key outside of KMS. For information about
+// symmetric and asymmetric KMS keys, see Using Symmetric and Asymmetric KMS
+// keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
 // Digital signatures are generated and verified by using asymmetric key pair,
-// such as an RSA or ECC pair that is represented by an asymmetric customer
-// master key (CMK). The key owner (or an authorized user) uses their private
-// key to sign a message. Anyone with the public key can verify that the message
-// was signed with that particular private key and that the message hasn't changed
-// since it was signed.
+// such as an RSA or ECC pair that is represented by an asymmetric KMS key.
+// The key owner (or an authorized user) uses their private key to sign a message.
+// Anyone with the public key can verify that the message was signed with that
+// particular private key and that the message hasn't changed since it was signed.
 //
 // To use the Sign operation, provide the following information:
 //
-//    * Use the KeyId parameter to identify an asymmetric CMK with a KeyUsage
-//    value of SIGN_VERIFY. To get the KeyUsage value of a CMK, use the DescribeKey
-//    operation. The caller must have kms:Sign permission on the CMK.
+//    * Use the KeyId parameter to identify an asymmetric KMS key with a KeyUsage
+//    value of SIGN_VERIFY. To get the KeyUsage value of a KMS key, use the
+//    DescribeKey operation. The caller must have kms:Sign permission on the
+//    KMS key.
 //
 //    * Use the Message parameter to specify the message or message digest to
 //    sign. You can submit messages of up to 4096 bytes. To sign a larger message,
@@ -6401,21 +6469,22 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //    in the Message parameter. To indicate whether the message is a full message
 //    or a digest, use the MessageType parameter.
 //
-//    * Choose a signing algorithm that is compatible with the CMK.
+//    * Choose a signing algorithm that is compatible with the KMS key.
 //
-// When signing a message, be sure to record the CMK and the signing algorithm.
+// When signing a message, be sure to record the KMS key and the signing algorithm.
 // This information is required to verify the signature.
 //
 // To verify the signature that this operation generates, use the Verify operation.
 // Or use the GetPublicKey operation to download the public key and then use
-// the public key to verify the signature outside of AWS KMS.
+// the public key to verify the signature outside of KMS.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:Sign (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -6435,11 +6504,11 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -6448,17 +6517,18 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -6471,9 +6541,9 @@ func (c *KMS) SignRequest(input *SignInput) (req *request.Request, output *SignO
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Sign
 func (c *KMS) Sign(input *SignInput) (*SignOutput, error) {
@@ -6542,37 +6612,37 @@ func (c *KMS) TagResourceRequest(input *TagResourceInput) (req *request.Request,
 
 // TagResource API operation for AWS Key Management Service.
 //
-// Adds or edits tags on a customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
+// Adds or edits tags on a customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
 //
-// Tagging or untagging a CMK can allow or deny permission to the CMK. For details,
-// see Using ABAC in AWS KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
-// in the AWS Key Management Service Developer Guide.
+// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
 //
 // Each tag consists of a tag key and a tag value, both of which are case-sensitive
 // strings. The tag value can be an empty (null) string. To add a tag, specify
 // a new tag key and a tag value. To edit a tag, specify an existing tag key
 // and a new tag value.
 //
-// You can use this operation to tag a customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk),
-// but you cannot tag an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk),
-// an AWS owned CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk),
+// You can use this operation to tag a customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk),
+// but you cannot tag an Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk),
+// an Amazon Web Services owned key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk),
 // a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#keystore-concept),
 // or an alias (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#alias-concept).
 //
-// You can also add tags to a CMK while creating it (CreateKey) or replicating
+// You can also add tags to a KMS key while creating it (CreateKey) or replicating
 // it (ReplicateKey).
 //
-// For information about using tags in AWS KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+// For information about using tags in KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
 // For general information about tags, including the format and syntax, see
-// Tagging AWS resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+// Tagging Amazon Web Services resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
 // in the Amazon Web Services General Reference.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:TagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -6611,14 +6681,14 @@ func (c *KMS) TagResourceRequest(input *TagResourceInput) (req *request.Request,
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * TagException
 //   The request was rejected because one or more tags are not valid.
@@ -6690,29 +6760,29 @@ func (c *KMS) UntagResourceRequest(input *UntagResourceInput) (req *request.Requ
 
 // UntagResource API operation for AWS Key Management Service.
 //
-// Deletes tags from a customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
-// To delete a tag, specify the tag key and the CMK.
+// Deletes tags from a customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
+// To delete a tag, specify the tag key and the KMS key.
 //
-// Tagging or untagging a CMK can allow or deny permission to the CMK. For details,
-// see Using ABAC in AWS KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
-// in the AWS Key Management Service Developer Guide.
+// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
 //
 // When it succeeds, the UntagResource operation doesn't return any output.
-// Also, if the specified tag key isn't found on the CMK, it doesn't throw an
-// exception or return a response. To confirm that the operation worked, use
-// the ListResourceTags operation.
+// Also, if the specified tag key isn't found on the KMS key, it doesn't throw
+// an exception or return a response. To confirm that the operation worked,
+// use the ListResourceTags operation.
 //
-// For information about using tags in AWS KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+// For information about using tags in KMS, see Tagging keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
 // For general information about tags, including the format and syntax, see
-// Tagging AWS resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+// Tagging Amazon Web Services resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
 // in the Amazon Web Services General Reference.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:UntagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -6751,9 +6821,9 @@ func (c *KMS) UntagResourceRequest(input *UntagResourceInput) (req *request.Requ
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * TagException
 //   The request was rejected because one or more tags are not valid.
@@ -6825,35 +6895,35 @@ func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Request,
 
 // UpdateAlias API operation for AWS Key Management Service.
 //
-// Associates an existing AWS KMS alias with a different customer master key
-// (CMK). Each alias is associated with only one CMK at a time, although a CMK
-// can have multiple aliases. The alias and the CMK must be in the same AWS
+// Associates an existing KMS alias with a different KMS key. Each alias is
+// associated with only one KMS key at a time, although a KMS key can have multiple
+// aliases. The alias and the KMS key must be in the same Amazon Web Services
 // account and Region.
 //
 // Adding, deleting, or updating an alias can allow or deny permission to the
-// CMK. For details, see Using ABAC in AWS KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
-// in the AWS Key Management Service Developer Guide.
+// KMS key. For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+// in the Key Management Service Developer Guide.
 //
-// The current and new CMK must be the same type (both symmetric or both asymmetric),
-// and they must have the same key usage (ENCRYPT_DECRYPT or SIGN_VERIFY). This
-// restriction prevents errors in code that uses aliases. If you must assign
-// an alias to a different type of CMK, use DeleteAlias to delete the old alias
-// and CreateAlias to create a new alias.
+// The current and new KMS key must be the same type (both symmetric or both
+// asymmetric), and they must have the same key usage (ENCRYPT_DECRYPT or SIGN_VERIFY).
+// This restriction prevents errors in code that uses aliases. If you must assign
+// an alias to a different type of KMS key, use DeleteAlias to delete the old
+// alias and CreateAlias to create a new alias.
 //
 // You cannot use UpdateAlias to change an alias name. To change an alias name,
 // use DeleteAlias to delete the old alias and CreateAlias to create a new alias.
 //
-// Because an alias is not a property of a CMK, you can create, update, and
-// delete the aliases of a CMK without affecting the CMK. Also, aliases do not
-// appear in the response from the DescribeKey operation. To get the aliases
-// of all CMKs in the account, use the ListAliases operation.
+// Because an alias is not a property of a KMS key, you can create, update,
+// and delete the aliases of a KMS key without affecting the KMS key. Also,
+// aliases do not appear in the response from the DescribeKey operation. To
+// get the aliases of all KMS keys in the account, use the ListAliases operation.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions
 //
@@ -6861,13 +6931,13 @@ func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Request,
 //    on the alias (IAM policy).
 //
 //    * kms:UpdateAlias (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    on the current CMK (key policy).
+//    on the current KMS key (key policy).
 //
 //    * kms:UpdateAlias (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
-//    on the new CMK (key policy).
+//    on the new KMS key (key policy).
 //
 // For details, see Controlling access to aliases (https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 //
 // Related operations:
 //
@@ -6900,15 +6970,15 @@ func (c *KMS) UpdateAliasRequest(input *UpdateAliasInput) (req *request.Request,
 //   * LimitExceededException
 //   The request was rejected because a quota was exceeded. For more information,
 //   see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-//   in the AWS Key Management Service Developer Guide.
+//   in the Key Management Service Developer Guide.
 //
 //   * InvalidStateException
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdateAlias
 func (c *KMS) UpdateAlias(input *UpdateAliasInput) (*UpdateAliasOutput, error) {
@@ -6992,28 +7062,28 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //    * Use the NewCustomKeyStoreName parameter to change the friendly name
 //    of the custom key store to the value that you specify.
 //
-//    * Use the KeyStorePassword parameter tell AWS KMS the current password
-//    of the kmsuser crypto user (CU) (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
-//    in the associated AWS CloudHSM cluster. You can use this parameter to
-//    fix connection failures (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-password)
-//    that occur when AWS KMS cannot log into the associated cluster because
-//    the kmsuser password has changed. This value does not change the password
-//    in the AWS CloudHSM cluster.
+//    * Use the KeyStorePassword parameter tell KMS the current password of
+//    the kmsuser crypto user (CU) (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
+//    in the associated CloudHSM cluster. You can use this parameter to fix
+//    connection failures (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-password)
+//    that occur when KMS cannot log into the associated cluster because the
+//    kmsuser password has changed. This value does not change the password
+//    in the CloudHSM cluster.
 //
 //    * Use the CloudHsmClusterId parameter to associate the custom key store
-//    with a different, but related, AWS CloudHSM cluster. You can use this
-//    parameter to repair a custom key store if its AWS CloudHSM cluster becomes
-//    corrupted or is deleted, or when you need to create or restore a cluster
-//    from a backup.
+//    with a different, but related, CloudHSM cluster. You can use this parameter
+//    to repair a custom key store if its CloudHSM cluster becomes corrupted
+//    or is deleted, or when you need to create or restore a cluster from a
+//    backup.
 //
 // If the operation succeeds, it returns a JSON object with no properties.
 //
 // This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-// feature in AWS KMS, which combines the convenience and extensive integration
-// of AWS KMS with the isolation and control of a single-tenant key store.
+// feature in KMS, which combines the convenience and extensive integration
+// of KMS with the isolation and control of a single-tenant key store.
 //
 // Cross-account use: No. You cannot perform this operation on a custom key
-// store in a different AWS account.
+// store in a different Amazon Web Services account.
 //
 // Required permissions: kms:UpdateCustomKeyStore (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (IAM policy)
@@ -7039,7 +7109,7 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //
 // Returned Error Types:
 //   * CustomKeyStoreNotFoundException
-//   The request was rejected because AWS KMS cannot find a custom key store with
+//   The request was rejected because KMS cannot find a custom key store with
 //   the specified key store name or ID.
 //
 //   * CustomKeyStoreNameInUseException
@@ -7048,14 +7118,13 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //   key store name that is unique in the account.
 //
 //   * CloudHsmClusterNotFoundException
-//   The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
-//   with the specified cluster ID. Retry the request with a different cluster
-//   ID.
+//   The request was rejected because KMS cannot find the CloudHSM cluster with
+//   the specified cluster ID. Retry the request with a different cluster ID.
 //
 //   * CloudHsmClusterNotRelatedException
-//   The request was rejected because the specified AWS CloudHSM cluster has a
-//   different cluster certificate than the original cluster. You cannot use the
-//   operation to specify an unrelated cluster.
+//   The request was rejected because the specified CloudHSM cluster has a different
+//   cluster certificate than the original cluster. You cannot use the operation
+//   to specify an unrelated cluster.
 //
 //   Specify a cluster that shares a backup history with the original cluster.
 //   This includes clusters that were created from a backup of the current cluster,
@@ -7090,15 +7159,15 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //   can be retried.
 //
 //   * CloudHsmClusterNotActiveException
-//   The request was rejected because the AWS CloudHSM cluster that is associated
+//   The request was rejected because the CloudHSM cluster that is associated
 //   with the custom key store is not active. Initialize and activate the cluster
 //   and try the command again. For detailed instructions, see Getting Started
 //   (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-//   in the AWS CloudHSM User Guide.
+//   in the CloudHSM User Guide.
 //
 //   * CloudHsmClusterInvalidConfigurationException
-//   The request was rejected because the associated AWS CloudHSM cluster did
-//   not meet the configuration requirements for a custom key store.
+//   The request was rejected because the associated CloudHSM cluster did not
+//   meet the configuration requirements for a custom key store.
 //
 //      * The cluster must be configured with private subnets in at least two
 //      different Availability Zones in the Region.
@@ -7113,20 +7182,19 @@ func (c *KMS) UpdateCustomKeyStoreRequest(input *UpdateCustomKeyStoreInput) (req
 //      operation.
 //
 //      * The cluster must contain at least as many HSMs as the operation requires.
-//      To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//      To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //      operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//      operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//      each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//      the AWS CloudHSM must contain at least one active HSM.
+//      operations, the CloudHSM cluster must have at least two active HSMs, each
+//      in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//      the CloudHSM must contain at least one active HSM.
 //
-//   For information about the requirements for an AWS CloudHSM cluster that is
-//   associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-//   in the AWS Key Management Service Developer Guide. For information about
-//   creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-//   Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-//   in the AWS CloudHSM User Guide. For information about cluster security groups,
+//   For information about the requirements for an CloudHSM cluster that is associated
+//   with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+//   in the Key Management Service Developer Guide. For information about creating
+//   a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+//   in the CloudHSM User Guide. For information about cluster security groups,
 //   see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-//   in the AWS CloudHSM User Guide .
+//   in the CloudHSM User Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdateCustomKeyStore
 func (c *KMS) UpdateCustomKeyStore(input *UpdateCustomKeyStoreInput) (*UpdateCustomKeyStoreOutput, error) {
@@ -7195,15 +7263,15 @@ func (c *KMS) UpdateKeyDescriptionRequest(input *UpdateKeyDescriptionInput) (req
 
 // UpdateKeyDescription API operation for AWS Key Management Service.
 //
-// Updates the description of a customer master key (CMK). To see the description
-// of a CMK, use DescribeKey.
+// Updates the description of a KMS key. To see the description of a KMS key,
+// use DescribeKey.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: No. You cannot perform this operation on a CMK in a different
-// AWS account.
+// Cross-account use: No. You cannot perform this operation on a KMS key in
+// a different Amazon Web Services account.
 //
 // Required permissions: kms:UpdateKeyDescription (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -7242,9 +7310,9 @@ func (c *KMS) UpdateKeyDescriptionRequest(input *UpdateKeyDescriptionInput) (req
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/UpdateKeyDescription
 func (c *KMS) UpdateKeyDescription(input *UpdateKeyDescriptionInput) (*UpdateKeyDescriptionOutput, error) {
@@ -7320,16 +7388,17 @@ func (c *KMS) UpdatePrimaryRegionRequest(input *UpdatePrimaryRegionInput) (req *
 // you have a primary key in us-east-1 and a replica key in eu-west-2. If you
 // run UpdatePrimaryRegion with a PrimaryRegion value of eu-west-2, the primary
 // key is now the key in eu-west-2, and the key in us-east-1 becomes a replica
-// key. For details, see
+// key. For details, see Updating the primary Region (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-update)
+// in the Key Management Service Developer Guide.
 //
-// This operation supports multi-Region keys, an AWS KMS feature that lets you
-// create multiple interoperable CMKs in different AWS Regions. Because these
-// CMKs have the same key ID, key material, and other metadata, you can use
-// them to encrypt data in one AWS Region and decrypt it in a different AWS
-// Region without making a cross-Region call or exposing the plaintext data.
-// For more information about multi-Region keys, see Using multi-Region keys
-// (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
-// in the AWS Key Management Service Developer Guide.
+// This operation supports multi-Region keys, an KMS feature that lets you create
+// multiple interoperable KMS keys in different Amazon Web Services Regions.
+// Because these KMS keys have the same key ID, key material, and other metadata,
+// you can use them interchangeably to encrypt data in one Amazon Web Services
+// Region and decrypt it in a different Amazon Web Services Region without re-encrypting
+// the data or making a cross-Region call. For more information about multi-Region
+// keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+// in the Key Management Service Developer Guide.
 //
 // The primary key of a multi-Region key is the source for properties that are
 // always shared by primary and replica keys, including the key material, key
@@ -7340,13 +7409,13 @@ func (c *KMS) UpdatePrimaryRegionRequest(input *UpdatePrimaryRegionInput) (req *
 // and automatic key rotation (https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html).
 // It's the only key that can be replicated. You cannot delete the primary key
 // (https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html)
-// until all replicas are deleted.
+// until all replica keys are deleted.
 //
 // The key ID and primary Region that you specify uniquely identify the replica
 // key that will become the primary key. The primary Region must already have
-// a replica key. This operation does not create a CMK in the specified Region.
-// To find the replica keys, use the DescribeKey operation on the primary key
-// or any replica key. To create a replica key, use the ReplicateKey operation.
+// a replica key. This operation does not create a KMS key in the specified
+// Region. To find the replica keys, use the DescribeKey operation on the primary
+// key or any replica key. To create a replica key, use the ReplicateKey operation.
 //
 // You can run this operation while using the affected multi-Region keys in
 // cryptographic operations. This operation should not delay, interrupt, or
@@ -7360,21 +7429,22 @@ func (c *KMS) UpdatePrimaryRegionRequest(input *UpdatePrimaryRegionInput) (req *
 // state is Updating, you can use the keys in cryptographic operations, but
 // you cannot replicate the new primary key or perform certain management operations,
 // such as enabling or disabling these keys. For details about the Updating
-// key state, see Key state: Effect on your CMK (kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// key state, see Key state: Effect on your KMS key (kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
 // This operation does not return any output. To verify that primary key is
 // changed, use the DescribeKey operation.
 //
-// Cross-account use: No. You cannot use this operation in a different AWS account.
+// Cross-account use: No. You cannot use this operation in a different Amazon
+// Web Services account.
 //
 // Required permissions:
 //
-//    * kms:UpdatePrimaryRegion on the current primary CMK (in the primary CMK's
-//    Region). Include this permission primary CMK's key policy.
+//    * kms:UpdatePrimaryRegion on the current primary key (in the primary key's
+//    Region). Include this permission primary key's key policy.
 //
-//    * kms:UpdatePrimaryRegion on the current replica CMK (in the replica CMK's
-//    Region). Include this permission in the replica CMK's key policy.
+//    * kms:UpdatePrimaryRegion on the current replica key (in the replica key's
+//    Region). Include this permission in the replica key's key policy.
 //
 // Related operations
 //
@@ -7391,7 +7461,7 @@ func (c *KMS) UpdatePrimaryRegionRequest(input *UpdatePrimaryRegionInput) (req *
 //
 // Returned Error Types:
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * InvalidArnException
 //   The request was rejected because a specified ARN, or an ARN in a key policy,
@@ -7401,9 +7471,9 @@ func (c *KMS) UpdatePrimaryRegionRequest(input *UpdatePrimaryRegionInput) (req *
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * InternalException
 //   The request was rejected because an internal exception occurred. The request
@@ -7486,36 +7556,37 @@ func (c *KMS) VerifyRequest(input *VerifyInput) (req *request.Request, output *V
 // Verifies a digital signature that was generated by the Sign operation.
 //
 // Verification confirms that an authorized user signed the message with the
-// specified CMK and signing algorithm, and the message hasn't changed since
+// specified KMS key and signing algorithm, and the message hasn't changed since
 // it was signed. If the signature is verified, the value of the SignatureValid
 // field in the response is True. If the signature verification fails, the Verify
 // operation fails with an KMSInvalidSignatureException exception.
 //
 // A digital signature is generated by using the private key in an asymmetric
-// CMK. The signature is verified by using the public key in the same asymmetric
-// CMK. For information about symmetric and asymmetric CMKs, see Using Symmetric
-// and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-// in the AWS Key Management Service Developer Guide.
+// KMS key. The signature is verified by using the public key in the same asymmetric
+// KMS key. For information about symmetric and asymmetric KMS keys, see Using
+// Symmetric and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+// in the Key Management Service Developer Guide.
 //
 // To verify a digital signature, you can use the Verify operation. Specify
-// the same asymmetric CMK, message, and signing algorithm that were used to
-// produce the signature.
+// the same asymmetric KMS key, message, and signing algorithm that were used
+// to produce the signature.
 //
 // You can also verify the digital signature by using the public key of the
-// CMK outside of AWS KMS. Use the GetPublicKey operation to download the public
-// key in the asymmetric CMK and then use the public key to verify the signature
-// outside of AWS KMS. The advantage of using the Verify operation is that it
-// is performed within AWS KMS. As a result, it's easy to call, the operation
-// is performed within the FIPS boundary, it is logged in AWS CloudTrail, and
-// you can use key policy and IAM policy to determine who is authorized to use
-// the CMK to verify signatures.
+// KMS key outside of KMS. Use the GetPublicKey operation to download the public
+// key in the asymmetric KMS key and then use the public key to verify the signature
+// outside of KMS. The advantage of using the Verify operation is that it is
+// performed within KMS. As a result, it's easy to call, the operation is performed
+// within the FIPS boundary, it is logged in CloudTrail, and you can use key
+// policy and IAM policy to determine who is authorized to use the KMS key to
+// verify signatures.
 //
-// The CMK that you use for this operation must be in a compatible key state.
-// For details, see Key state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide.
+// The KMS key that you use for this operation must be in a compatible key state.
+// For details, see Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide.
 //
-// Cross-account use: Yes. To perform this operation with a CMK in a different
-// AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.
+// Cross-account use: Yes. To perform this operation with a KMS key in a different
+// Amazon Web Services account, specify the key ARN or alias ARN in the value
+// of the KeyId parameter.
 //
 // Required permissions: kms:Verify (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 // (key policy)
@@ -7535,11 +7606,11 @@ func (c *KMS) VerifyRequest(input *VerifyInput) (req *request.Request, output *V
 //   be found.
 //
 //   * DisabledException
-//   The request was rejected because the specified CMK is not enabled.
+//   The request was rejected because the specified KMS key is not enabled.
 //
 //   * KeyUnavailableException
-//   The request was rejected because the specified CMK was not available. You
-//   can retry the request.
+//   The request was rejected because the specified KMS key was not available.
+//   You can retry the request.
 //
 //   * DependencyTimeoutException
 //   The system timed out while trying to fulfill the request. The request can
@@ -7548,17 +7619,18 @@ func (c *KMS) VerifyRequest(input *VerifyInput) (req *request.Request, output *V
 //   * InvalidKeyUsageException
 //   The request was rejected for one of the following reasons:
 //
-//      * The KeyUsage value of the CMK is incompatible with the API operation.
+//      * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //      * The encryption algorithm or signing algorithm specified for the operation
-//      is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//      is incompatible with the type of key material in the KMS key (KeySpec).
 //
 //   For encrypting, decrypting, re-encrypting, and generating data keys, the
 //   KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-//   must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+//   must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+//   operation.
 //
-//   To find the encryption or signing algorithms supported for a particular CMK,
-//   use the DescribeKey operation.
+//   To find the encryption or signing algorithms supported for a particular KMS
+//   key, use the DescribeKey operation.
 //
 //   * InvalidGrantTokenException
 //   The request was rejected because the specified grant token is not valid.
@@ -7571,14 +7643,14 @@ func (c *KMS) VerifyRequest(input *VerifyInput) (req *request.Request, output *V
 //   The request was rejected because the state of the specified resource is not
 //   valid for this request.
 //
-//   For more information about how key state affects the use of a CMK, see How
-//   Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-//   in the AWS Key Management Service Developer Guide .
+//   For more information about how key state affects the use of a KMS key, see
+//   Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+//   in the Key Management Service Developer Guide .
 //
 //   * KMSInvalidSignatureException
 //   The request was rejected because the signature verification failed. Signature
 //   verification fails when it cannot confirm that signature was produced by
-//   signing the specified message with the specified CMK and signing algorithm.
+//   signing the specified message with the specified KMS key and signing algorithm.
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/kms-2014-11-01/Verify
 func (c *KMS) Verify(input *VerifyInput) (*VerifyOutput, error) {
@@ -7616,11 +7688,12 @@ type AliasListEntry struct {
 	// Region. Formatted as Unix time.
 	CreationDate *time.Time `type:"timestamp"`
 
-	// Date and time that the alias was most recently associated with a CMK in the
-	// account and Region. Formatted as Unix time.
+	// Date and time that the alias was most recently associated with a KMS key
+	// in the account and Region. Formatted as Unix time.
 	LastUpdatedDate *time.Time `type:"timestamp"`
 
-	// String that contains the key identifier of the CMK associated with the alias.
+	// String that contains the key identifier of the KMS key associated with the
+	// alias.
 	TargetKeyId *string `min:"1" type:"string"`
 }
 
@@ -7724,9 +7797,9 @@ func (s *AlreadyExistsException) RequestID() string {
 type CancelKeyDeletionInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the customer master key (CMK) whose deletion is being canceled.
+	// Identifies the KMS key whose deletion is being canceled.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -7734,7 +7807,7 @@ type CancelKeyDeletionInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -7776,7 +7849,7 @@ type CancelKeyDeletionOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK whose deletion is canceled.
+	// of the KMS key whose deletion is canceled.
 	KeyId *string `min:"1" type:"string"`
 }
 
@@ -7796,10 +7869,10 @@ func (s *CancelKeyDeletionOutput) SetKeyId(v string) *CancelKeyDeletionOutput {
 	return s
 }
 
-// The request was rejected because the specified AWS CloudHSM cluster is already
+// The request was rejected because the specified CloudHSM cluster is already
 // associated with a custom key store or it shares a backup history with a cluster
 // that is associated with a custom key store. Each custom key store must be
-// associated with a different AWS CloudHSM cluster.
+// associated with a different CloudHSM cluster.
 //
 // Clusters that share a backup history have the same cluster certificate. To
 // view the cluster certificate of a cluster, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
@@ -7859,8 +7932,8 @@ func (s *CloudHsmClusterInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because the associated AWS CloudHSM cluster did
-// not meet the configuration requirements for a custom key store.
+// The request was rejected because the associated CloudHSM cluster did not
+// meet the configuration requirements for a custom key store.
 //
 //    * The cluster must be configured with private subnets in at least two
 //    different Availability Zones in the Region.
@@ -7875,20 +7948,19 @@ func (s *CloudHsmClusterInUseException) RequestID() string {
 //    operation.
 //
 //    * The cluster must contain at least as many HSMs as the operation requires.
-//    To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+//    To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 //    operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-//    operations, the AWS CloudHSM cluster must have at least two active HSMs,
-//    each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-//    the AWS CloudHSM must contain at least one active HSM.
+//    operations, the CloudHSM cluster must have at least two active HSMs, each
+//    in a different Availability Zone. For the ConnectCustomKeyStore operation,
+//    the CloudHSM must contain at least one active HSM.
 //
-// For information about the requirements for an AWS CloudHSM cluster that is
-// associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-// in the AWS Key Management Service Developer Guide. For information about
-// creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-// Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-// in the AWS CloudHSM User Guide. For information about cluster security groups,
+// For information about the requirements for an CloudHSM cluster that is associated
+// with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+// in the Key Management Service Developer Guide. For information about creating
+// a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+// in the CloudHSM User Guide. For information about cluster security groups,
 // see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-// in the AWS CloudHSM User Guide .
+// in the CloudHSM User Guide .
 type CloudHsmClusterInvalidConfigurationException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -7944,11 +8016,11 @@ func (s *CloudHsmClusterInvalidConfigurationException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because the AWS CloudHSM cluster that is associated
+// The request was rejected because the CloudHSM cluster that is associated
 // with the custom key store is not active. Initialize and activate the cluster
 // and try the command again. For detailed instructions, see Getting Started
 // (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-// in the AWS CloudHSM User Guide.
+// in the CloudHSM User Guide.
 type CloudHsmClusterNotActiveException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -8004,9 +8076,8 @@ func (s *CloudHsmClusterNotActiveException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
-// with the specified cluster ID. Retry the request with a different cluster
-// ID.
+// The request was rejected because KMS cannot find the CloudHSM cluster with
+// the specified cluster ID. Retry the request with a different cluster ID.
 type CloudHsmClusterNotFoundException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -8062,9 +8133,9 @@ func (s *CloudHsmClusterNotFoundException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because the specified AWS CloudHSM cluster has a
-// different cluster certificate than the original cluster. You cannot use the
-// operation to specify an unrelated cluster.
+// The request was rejected because the specified CloudHSM cluster has a different
+// cluster certificate than the original cluster. You cannot use the operation
+// to specify an unrelated cluster.
 //
 // Specify a cluster that shares a backup history with the original cluster.
 // This includes clusters that were created from a backup of the current cluster,
@@ -8194,21 +8265,21 @@ type CreateAliasInput struct {
 	// The AliasName value must be string of 1-256 characters. It can contain only
 	// alphanumeric characters, forward slashes (/), underscores (_), and dashes
 	// (-). The alias name cannot begin with alias/aws/. The alias/aws/ prefix is
-	// reserved for AWS managed CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
+	// reserved for Amazon Web Services managed keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
 	//
 	// AliasName is a required field
 	AliasName *string `min:"1" type:"string" required:"true"`
 
-	// Associates the alias with the specified customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
-	// The CMK must be in the same AWS Region.
+	// Associates the alias with the specified customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
+	// The KMS key must be in the same Amazon Web Services Region.
 	//
-	// A valid CMK ID is required. If you supply a null or empty string value, this
+	// A valid key ID is required. If you supply a null or empty string value, this
 	// operation returns an error.
 	//
 	// For help finding the key ID and ARN, see Finding the Key ID and ARN (https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide .
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -8216,7 +8287,7 @@ type CreateAliasInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// TargetKeyId is a required field
 	TargetKeyId *string `min:"1" type:"string" required:"true"`
@@ -8283,28 +8354,28 @@ func (s CreateAliasOutput) GoString() string {
 type CreateCustomKeyStoreInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the AWS CloudHSM cluster for the custom key store. Enter the cluster
-	// ID of any active AWS CloudHSM cluster that is not already associated with
-	// a custom key store. To find the cluster ID, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
+	// Identifies the CloudHSM cluster for the custom key store. Enter the cluster
+	// ID of any active CloudHSM cluster that is not already associated with a custom
+	// key store. To find the cluster ID, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
 	// operation.
 	//
 	// CloudHsmClusterId is a required field
 	CloudHsmClusterId *string `min:"19" type:"string" required:"true"`
 
 	// Specifies a friendly name for the custom key store. The name must be unique
-	// in your AWS account.
+	// in your Amazon Web Services account.
 	//
 	// CustomKeyStoreName is a required field
 	CustomKeyStoreName *string `min:"1" type:"string" required:"true"`
 
 	// Enter the password of the kmsuser crypto user (CU) account (https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser)
-	// in the specified AWS CloudHSM cluster. AWS KMS logs into the cluster as this
-	// user to manage key material on your behalf.
+	// in the specified CloudHSM cluster. KMS logs into the cluster as this user
+	// to manage key material on your behalf.
 	//
 	// The password must be a string of 7 to 32 characters. Its value is case sensitive.
 	//
-	// This parameter tells AWS KMS the kmsuser account password; it does not change
-	// the password in the AWS CloudHSM cluster.
+	// This parameter tells KMS the kmsuser account password; it does not change
+	// the password in the CloudHSM cluster.
 	//
 	// KeyStorePassword is a required field
 	KeyStorePassword *string `min:"7" type:"string" required:"true" sensitive:"true"`
@@ -8413,51 +8484,52 @@ type CreateGrantInput struct {
 
 	// Specifies a grant constraint.
 	//
-	// AWS KMS supports the EncryptionContextEquals and EncryptionContextSubset
-	// grant constraints. Each constraint value can include up to 8 encryption context
+	// KMS supports the EncryptionContextEquals and EncryptionContextSubset grant
+	// constraints. Each constraint value can include up to 8 encryption context
 	// pairs. The encryption context value in each constraint cannot exceed 384
 	// characters.
 	//
-	// These grant constraints allow a cryptographic operation (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// only when the encryption context in the request matches (EncryptionContextEquals)
-	// or includes (EncryptionContextSubset) the encryption context specified in
-	// this structure. For more information about encryption context, see Encryption
-	// Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide . For information about
-	// grant constraints, see Using grant constraints (https://docs.aws.amazon.com/kms/latest/developerguide/create-grant-overview.html#grant-constraints)
-	// in the AWS Key Management Service Developer Guide.
+	// These grant constraints allow the permissions in the grant only when the
+	// encryption context in the request matches (EncryptionContextEquals) or includes
+	// (EncryptionContextSubset) the encryption context specified in this structure.
+	// For information about grant constraints, see Using grant constraints (https://docs.aws.amazon.com/kms/latest/developerguide/create-grant-overview.html#grant-constraints)
+	// in the Key Management Service Developer Guide. For more information about
+	// encryption context, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
+	// in the Key Management Service Developer Guide .
 	//
 	// The encryption context grant constraints are supported only on operations
 	// that include an encryption context. You cannot use an encryption context
-	// grant constraint for cryptographic operations with asymmetric CMKs or for
-	// management operations, such as DescribeKey or RetireGrant.
+	// grant constraint for cryptographic operations with asymmetric KMS keys or
+	// for management operations, such as DescribeKey or RetireGrant.
 	Constraints *GrantConstraints `type:"structure"`
 
 	// A list of grant tokens.
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
 	// The identity that gets the permissions specified in the grant.
 	//
 	// To specify the principal, use the Amazon Resource Name (ARN) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// of an AWS principal. Valid AWS principals include AWS accounts (root), IAM
-	// users, IAM roles, federated users, and assumed role users. For examples of
-	// the ARN syntax to use for specifying a principal, see AWS Identity and Access
-	// Management (IAM) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
-	// in the Example ARNs section of the AWS General Reference.
+	// of an Amazon Web Services principal. Valid Amazon Web Services principals
+	// include Amazon Web Services accounts (root), IAM users, IAM roles, federated
+	// users, and assumed role users. For examples of the ARN syntax to use for
+	// specifying a principal, see Amazon Web Services Identity and Access Management
+	// (IAM) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
+	// in the Example ARNs section of the Amazon Web Services General Reference.
 	//
 	// GranteePrincipal is a required field
 	GranteePrincipal *string `min:"1" type:"string" required:"true"`
 
-	// Identifies the customer master key (CMK) for the grant. The grant gives principals
-	// permission to use this CMK.
+	// Identifies the KMS key for the grant. The grant gives principals permission
+	// to use this KMS key.
 	//
-	// Specify the key ID or key ARN of the CMK. To specify a CMK in a different
-	// AWS account, you must use the key ARN.
+	// Specify the key ID or key ARN of the KMS key. To specify a KMS key in a different
+	// Amazon Web Services account, you must use the key ARN.
 	//
 	// For example:
 	//
@@ -8465,7 +8537,7 @@ type CreateGrantInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -8486,25 +8558,31 @@ type CreateGrantInput struct {
 
 	// A list of operations that the grant permits.
 	//
-	// The operation must be supported on the CMK. For example, you cannot create
-	// a grant for a symmetric CMK that allows the Sign operation, or a grant for
-	// an asymmetric CMK that allows the GenerateDataKey operation. If you try,
-	// AWS KMS returns a ValidationError exception. For details, see Grant operations
+	// The operation must be supported on the KMS key. For example, you cannot create
+	// a grant for a symmetric KMS key that allows the Sign operation, or a grant
+	// for an asymmetric KMS key that allows the GenerateDataKey operation. If you
+	// try, KMS returns a ValidationError exception. For details, see Grant operations
 	// (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-grant-operations)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	//
 	// Operations is a required field
 	Operations []*string `type:"list" required:"true"`
 
-	// The principal that is given permission to retire the grant by using RetireGrant
-	// operation.
+	// The principal that has permission to use the RetireGrant operation to retire
+	// the grant.
 	//
 	// To specify the principal, use the Amazon Resource Name (ARN) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// of an AWS principal. Valid AWS principals include AWS accounts (root), IAM
-	// users, federated users, and assumed role users. For examples of the ARN syntax
-	// to use for specifying a principal, see AWS Identity and Access Management
-	// (IAM) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
-	// in the Example ARNs section of the AWS General Reference.
+	// of an Amazon Web Services principal. Valid Amazon Web Services principals
+	// include Amazon Web Services accounts (root), IAM users, federated users,
+	// and assumed role users. For examples of the ARN syntax to use for specifying
+	// a principal, see Amazon Web Services Identity and Access Management (IAM)
+	// (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
+	// in the Example ARNs section of the Amazon Web Services General Reference.
+	//
+	// The grant determines the retiring principal. Other principals might have
+	// permission to retire the grant or revoke the grant. For details, see RevokeGrant
+	// and Retiring and revoking grants (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#grant-delete)
+	// in the Key Management Service Developer Guide.
 	RetiringPrincipal *string `min:"1" type:"string"`
 }
 
@@ -8603,8 +8681,9 @@ type CreateGrantOutput struct {
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantToken *string `min:"1" type:"string"`
 }
 
@@ -8635,61 +8714,79 @@ type CreateKeyInput struct {
 
 	// A flag to indicate whether to bypass the key policy lockout safety check.
 	//
-	// Setting this value to true increases the risk that the CMK becomes unmanageable.
+	// Setting this value to true increases the risk that the KMS key becomes unmanageable.
 	// Do not set this value to true indiscriminately.
 	//
 	// For more information, refer to the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	// section in the AWS Key Management Service Developer Guide .
+	// section in the Key Management Service Developer Guide .
 	//
 	// Use this parameter only when you include a policy in the request and you
 	// intend to prevent the principal that is making the request from making a
-	// subsequent PutKeyPolicy request on the CMK.
+	// subsequent PutKeyPolicy request on the KMS key.
 	//
 	// The default value is false.
 	BypassPolicyLockoutSafetyCheck *bool `type:"boolean"`
 
-	// Creates the CMK in the specified custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-	// and the key material in its associated AWS CloudHSM cluster. To create a
-	// CMK in a custom key store, you must also specify the Origin parameter with
-	// a value of AWS_CLOUDHSM. The AWS CloudHSM cluster that is associated with
-	// the custom key store must have at least two active HSMs, each in a different
+	// Creates the KMS key in the specified custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
+	// and the key material in its associated CloudHSM cluster. To create a KMS
+	// key in a custom key store, you must also specify the Origin parameter with
+	// a value of AWS_CLOUDHSM. The CloudHSM cluster that is associated with the
+	// custom key store must have at least two active HSMs, each in a different
 	// Availability Zone in the Region.
 	//
-	// This parameter is valid only for symmetric CMKs and regional CMKs. You cannot
-	// create an asymmetric CMK or a multi-Region CMK in a custom key store.
+	// This parameter is valid only for symmetric KMS keys and regional KMS keys.
+	// You cannot create an asymmetric KMS key or a multi-Region key in a custom
+	// key store.
 	//
 	// To find the ID of a custom key store, use the DescribeCustomKeyStores operation.
 	//
-	// The response includes the custom key store ID and the ID of the AWS CloudHSM
+	// The response includes the custom key store ID and the ID of the CloudHSM
 	// cluster.
 	//
 	// This operation is part of the Custom Key Store feature (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-	// feature in AWS KMS, which combines the convenience and extensive integration
-	// of AWS KMS with the isolation and control of a single-tenant key store.
+	// feature in KMS, which combines the convenience and extensive integration
+	// of KMS with the isolation and control of a single-tenant key store.
 	CustomKeyStoreId *string `min:"1" type:"string"`
 
-	// Specifies the type of CMK to create. The default value, SYMMETRIC_DEFAULT,
-	// creates a CMK with a 256-bit symmetric key for encryption and decryption.
-	// For help choosing a key spec for your CMK, see How to Choose Your CMK Configuration
-	// (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html)
-	// in the AWS Key Management Service Developer Guide.
+	// Instead, use the KeySpec parameter.
 	//
-	// The CustomerMasterKeySpec determines whether the CMK contains a symmetric
-	// key or an asymmetric key pair. It also determines the encryption algorithms
-	// or signing algorithms that the CMK supports. You can't change the CustomerMasterKeySpec
-	// after the CMK is created. To further restrict the algorithms that can be
-	// used with the CMK, use a condition key in its key policy or IAM policy. For
+	// The KeySpec and CustomerMasterKeySpec parameters work the same way. Only
+	// the names differ. We recommend that you use KeySpec parameter in your code.
+	// However, to avoid breaking changes, KMS will support both parameters.
+	//
+	// Deprecated: This parameter has been deprecated. Instead, use the KeySpec parameter.
+	CustomerMasterKeySpec *string `deprecated:"true" type:"string" enum:"CustomerMasterKeySpec"`
+
+	// A description of the KMS key.
+	//
+	// Use a description that helps you decide whether the KMS key is appropriate
+	// for a task. The default value is an empty string (no description).
+	//
+	// To set or change the description after the key is created, use UpdateKeyDescription.
+	Description *string `type:"string"`
+
+	// Specifies the type of KMS key to create. The default value, SYMMETRIC_DEFAULT,
+	// creates a KMS key with a 256-bit symmetric key for encryption and decryption.
+	// For help choosing a key spec for your KMS key, see How to Choose Your KMS
+	// key Configuration (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html)
+	// in the Key Management Service Developer Guide .
+	//
+	// The KeySpec determines whether the KMS key contains a symmetric key or an
+	// asymmetric key pair. It also determines the encryption algorithms or signing
+	// algorithms that the KMS key supports. You can't change the KeySpec after
+	// the KMS key is created. To further restrict the algorithms that can be used
+	// with the KMS key, use a condition key in its key policy or IAM policy. For
 	// more information, see kms:EncryptionAlgorithm (https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-encryption-algorithm)
 	// or kms:Signing Algorithm (https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-signing-algorithm)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide .
 	//
-	// AWS services that are integrated with AWS KMS (http://aws.amazon.com/kms/features/#AWS_Service_Integration)
-	// use symmetric CMKs to protect your data. These services do not support asymmetric
-	// CMKs. For help determining whether a CMK is symmetric or asymmetric, see
-	// Identifying Symmetric and Asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/find-symm-asymm.html)
-	// in the AWS Key Management Service Developer Guide.
+	// Amazon Web Services services that are integrated with KMS (http://aws.amazon.com/kms/features/#AWS_Service_Integration)
+	// use symmetric KMS keys to protect your data. These services do not support
+	// asymmetric KMS keys. For help determining whether a KMS key is symmetric
+	// or asymmetric, see Identifying Symmetric and Asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/find-symm-asymm.html)
+	// in the Key Management Service Developer Guide.
 	//
-	// AWS KMS supports the following key specs for CMKs:
+	// KMS supports the following key specs for KMS keys:
 	//
 	//    * Symmetric key (default) SYMMETRIC_DEFAULT (AES-256-GCM)
 	//
@@ -8700,118 +8797,115 @@ type CreateKeyInput struct {
 	//
 	//    * Other asymmetric elliptic curve key pairs ECC_SECG_P256K1 (secp256k1),
 	//    commonly used for cryptocurrencies.
-	CustomerMasterKeySpec *string `type:"string" enum:"CustomerMasterKeySpec"`
-
-	// A description of the CMK.
-	//
-	// Use a description that helps you decide whether the CMK is appropriate for
-	// a task. The default value is an empty string (no description).
-	Description *string `type:"string"`
+	KeySpec *string `type:"string" enum:"KeySpec"`
 
 	// Determines the cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// for which you can use the CMK. The default value is ENCRYPT_DECRYPT. This
-	// parameter is required only for asymmetric CMKs. You can't change the KeyUsage
-	// value after the CMK is created.
+	// for which you can use the KMS key. The default value is ENCRYPT_DECRYPT.
+	// This parameter is required only for asymmetric KMS keys. You can't change
+	// the KeyUsage value after the KMS key is created.
 	//
 	// Select only one valid value.
 	//
-	//    * For symmetric CMKs, omit the parameter or specify ENCRYPT_DECRYPT.
+	//    * For symmetric KMS keys, omit the parameter or specify ENCRYPT_DECRYPT.
 	//
-	//    * For asymmetric CMKs with RSA key material, specify ENCRYPT_DECRYPT or
-	//    SIGN_VERIFY.
+	//    * For asymmetric KMS keys with RSA key material, specify ENCRYPT_DECRYPT
+	//    or SIGN_VERIFY.
 	//
-	//    * For asymmetric CMKs with ECC key material, specify SIGN_VERIFY.
+	//    * For asymmetric KMS keys with ECC key material, specify SIGN_VERIFY.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
 
-	// Creates a multi-Region primary key that you can replicate into other AWS
-	// Regions. You cannot change this value after you create the CMK.
+	// Creates a multi-Region primary key that you can replicate into other Amazon
+	// Web Services Regions. You cannot change this value after you create the KMS
+	// key.
 	//
-	// For a multi-Region key, set this parameter to True. For a single-Region CMK,
-	// omit this parameter or set it to False. The default value is False.
+	// For a multi-Region key, set this parameter to True. For a single-Region KMS
+	// key, omit this parameter or set it to False. The default value is False.
 	//
-	// This operation supports multi-Region keys, an AWS KMS feature that lets you
-	// create multiple interoperable CMKs in different AWS Regions. Because these
-	// CMKs have the same key ID, key material, and other metadata, you can use
-	// them to encrypt data in one AWS Region and decrypt it in a different AWS
-	// Region without making a cross-Region call or exposing the plaintext data.
-	// For more information about multi-Region keys, see Using multi-Region keys
-	// (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
-	// in the AWS Key Management Service Developer Guide.
+	// This operation supports multi-Region keys, an KMS feature that lets you create
+	// multiple interoperable KMS keys in different Amazon Web Services Regions.
+	// Because these KMS keys have the same key ID, key material, and other metadata,
+	// you can use them interchangeably to encrypt data in one Amazon Web Services
+	// Region and decrypt it in a different Amazon Web Services Region without re-encrypting
+	// the data or making a cross-Region call. For more information about multi-Region
+	// keys, see Using multi-Region keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
+	// in the Key Management Service Developer Guide.
 	//
 	// This value creates a primary key, not a replica. To create a replica key,
 	// use the ReplicateKey operation.
 	//
-	// You can create a symmetric or asymmetric multi-Region CMK, and you can create
-	// a multi-Region CMK with imported key material. However, you cannot create
-	// a multi-Region CMK in a custom key store.
+	// You can create a symmetric or asymmetric multi-Region key, and you can create
+	// a multi-Region key with imported key material. However, you cannot create
+	// a multi-Region key in a custom key store.
 	MultiRegion *bool `type:"boolean"`
 
-	// The source of the key material for the CMK. You cannot change the origin
-	// after you create the CMK. The default is AWS_KMS, which means that AWS KMS
+	// The source of the key material for the KMS key. You cannot change the origin
+	// after you create the KMS key. The default is AWS_KMS, which means that KMS
 	// creates the key material.
 	//
-	// To create a CMK with no key material (for imported key material), set the
-	// value to EXTERNAL. For more information about importing key material into
-	// AWS KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-	// in the AWS Key Management Service Developer Guide. This value is valid only
-	// for symmetric CMKs.
+	// To create a KMS key with no key material (for imported key material), set
+	// the value to EXTERNAL. For more information about importing key material
+	// into KMS, see Importing Key Material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+	// in the Key Management Service Developer Guide. This value is valid only for
+	// symmetric KMS keys.
 	//
-	// To create a CMK in an AWS KMS custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-	// and create its key material in the associated AWS CloudHSM cluster, set this
+	// To create a KMS key in an KMS custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
+	// and create its key material in the associated CloudHSM cluster, set this
 	// value to AWS_CLOUDHSM. You must also use the CustomKeyStoreId parameter to
-	// identify the custom key store. This value is valid only for symmetric CMKs.
+	// identify the custom key store. This value is valid only for symmetric KMS
+	// keys.
 	Origin *string `type:"string" enum:"OriginType"`
 
-	// The key policy to attach to the CMK.
+	// The key policy to attach to the KMS key.
 	//
 	// If you provide a key policy, it must meet the following criteria:
 	//
 	//    * If you don't set BypassPolicyLockoutSafetyCheck to true, the key policy
 	//    must allow the principal that is making the CreateKey request to make
-	//    a subsequent PutKeyPolicy request on the CMK. This reduces the risk that
-	//    the CMK becomes unmanageable. For more information, refer to the scenario
-	//    in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	//    section of the AWS Key Management Service Developer Guide .
+	//    a subsequent PutKeyPolicy request on the KMS key. This reduces the risk
+	//    that the KMS key becomes unmanageable. For more information, refer to
+	//    the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	//    section of the Key Management Service Developer Guide .
 	//
 	//    * Each statement in the key policy must contain one or more principals.
-	//    The principals in the key policy must exist and be visible to AWS KMS.
-	//    When you create a new AWS principal (for example, an IAM user or role),
-	//    you might need to enforce a delay before including the new principal in
-	//    a key policy because the new principal might not be immediately visible
-	//    to AWS KMS. For more information, see Changes that I make are not always
-	//    immediately visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
-	//    in the AWS Identity and Access Management User Guide.
+	//    The principals in the key policy must exist and be visible to KMS. When
+	//    you create a new Amazon Web Services principal (for example, an IAM user
+	//    or role), you might need to enforce a delay before including the new principal
+	//    in a key policy because the new principal might not be immediately visible
+	//    to KMS. For more information, see Changes that I make are not always immediately
+	//    visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    in the Amazon Web Services Identity and Access Management User Guide.
 	//
-	// If you do not provide a key policy, AWS KMS attaches a default key policy
-	// to the CMK. For more information, see Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default)
-	// in the AWS Key Management Service Developer Guide.
+	// If you do not provide a key policy, KMS attaches a default key policy to
+	// the KMS key. For more information, see Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default)
+	// in the Key Management Service Developer Guide.
 	//
 	// The key policy size quota is 32 kilobytes (32768 bytes).
 	//
 	// For help writing and formatting a JSON policy document, see the IAM JSON
 	// Policy Reference (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html)
-	// in the IAM User Guide .
+	// in the Identity and Access Management User Guide .
 	Policy *string `min:"1" type:"string"`
 
-	// Assigns one or more tags to the CMK. Use this parameter to tag the CMK when
-	// it is created. To tag an existing CMK, use the TagResource operation.
+	// Assigns one or more tags to the KMS key. Use this parameter to tag the KMS
+	// key when it is created. To tag an existing KMS key, use the TagResource operation.
 	//
-	// Tagging or untagging a CMK can allow or deny permission to the CMK. For details,
-	// see Using ABAC in AWS KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
-	// in the AWS Key Management Service Developer Guide.
+	// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+	// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+	// in the Key Management Service Developer Guide.
 	//
 	// To use this parameter, you must have kms:TagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 	// permission in an IAM policy.
 	//
 	// Each tag consists of a tag key and a tag value. Both the tag key and the
 	// tag value are required, but the tag value can be an empty (null) string.
-	// You cannot have more than one tag on a CMK with the same tag key. If you
-	// specify an existing tag key with a different tag value, AWS KMS replaces
+	// You cannot have more than one tag on a KMS key with the same tag key. If
+	// you specify an existing tag key with a different tag value, KMS replaces
 	// the current tag value with the specified one.
 	//
-	// When you assign tags to an AWS resource, AWS generates a cost allocation
-	// report with usage and costs aggregated by tags. Tags can also be used to
-	// control access to a CMK. For details, see Tagging Keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+	// When you add tags to an Amazon Web Services resource, Amazon Web Services
+	// generates a cost allocation report with usage and costs aggregated by tags.
+	// Tags can also be used to control access to a KMS key. For details, see Tagging
+	// Keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
 	Tags []*Tag `type:"list"`
 }
 
@@ -8875,6 +8969,12 @@ func (s *CreateKeyInput) SetDescription(v string) *CreateKeyInput {
 	return s
 }
 
+// SetKeySpec sets the KeySpec field's value.
+func (s *CreateKeyInput) SetKeySpec(v string) *CreateKeyInput {
+	s.KeySpec = &v
+	return s
+}
+
 // SetKeyUsage sets the KeyUsage field's value.
 func (s *CreateKeyInput) SetKeyUsage(v string) *CreateKeyInput {
 	s.KeyUsage = &v
@@ -8908,7 +9008,7 @@ func (s *CreateKeyInput) SetTags(v []*Tag) *CreateKeyInput {
 type CreateKeyOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Metadata associated with the CMK.
+	// Metadata associated with the KMS key.
 	KeyMetadata *KeyMetadata `type:"structure"`
 }
 
@@ -8928,10 +9028,10 @@ func (s *CreateKeyOutput) SetKeyMetadata(v *KeyMetadata) *CreateKeyOutput {
 	return s
 }
 
-// The request was rejected because the custom key store contains AWS KMS customer
-// master keys (CMKs). After verifying that you do not need to use the CMKs,
-// use the ScheduleKeyDeletion operation to delete the CMKs. After they are
-// deleted, you can delete the custom key store.
+// The request was rejected because the custom key store contains KMS keys.
+// After verifying that you do not need to use the KMS keys, use the ScheduleKeyDeletion
+// operation to delete the KMS keys. After they are deleted, you can delete
+// the custom key store.
 type CustomKeyStoreHasCMKsException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -9117,7 +9217,7 @@ func (s *CustomKeyStoreNameInUseException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// The request was rejected because AWS KMS cannot find a custom key store with
+// The request was rejected because KMS cannot find a custom key store with
 // the specified key store name or ID.
 type CustomKeyStoreNotFoundException struct {
 	_            struct{}                  `type:"structure"`
@@ -9179,84 +9279,83 @@ func (s *CustomKeyStoreNotFoundException) RequestID() string {
 type CustomKeyStoresListEntry struct {
 	_ struct{} `type:"structure"`
 
-	// A unique identifier for the AWS CloudHSM cluster that is associated with
-	// the custom key store.
+	// A unique identifier for the CloudHSM cluster that is associated with the
+	// custom key store.
 	CloudHsmClusterId *string `min:"19" type:"string"`
 
 	// Describes the connection error. This field appears in the response only when
 	// the ConnectionState is FAILED. For help resolving these errors, see How to
 	// Fix a Connection Failure (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed)
-	// in AWS Key Management Service Developer Guide.
+	// in Key Management Service Developer Guide.
 	//
 	// Valid values are:
 	//
-	//    * CLUSTER_NOT_FOUND - AWS KMS cannot find the AWS CloudHSM cluster with
-	//    the specified cluster ID.
+	//    * CLUSTER_NOT_FOUND - KMS cannot find the CloudHSM cluster with the specified
+	//    cluster ID.
 	//
-	//    * INSUFFICIENT_CLOUDHSM_HSMS - The associated AWS CloudHSM cluster does
-	//    not contain any active HSMs. To connect a custom key store to its AWS
-	//    CloudHSM cluster, the cluster must contain at least one active HSM.
+	//    * INSUFFICIENT_CLOUDHSM_HSMS - The associated CloudHSM cluster does not
+	//    contain any active HSMs. To connect a custom key store to its CloudHSM
+	//    cluster, the cluster must contain at least one active HSM.
 	//
-	//    * INTERNAL_ERROR - AWS KMS could not complete the request due to an internal
+	//    * INTERNAL_ERROR - KMS could not complete the request due to an internal
 	//    error. Retry the request. For ConnectCustomKeyStore requests, disconnect
 	//    the custom key store before trying to connect again.
 	//
-	//    * INVALID_CREDENTIALS - AWS KMS does not have the correct password for
-	//    the kmsuser crypto user in the AWS CloudHSM cluster. Before you can connect
-	//    your custom key store to its AWS CloudHSM cluster, you must change the
-	//    kmsuser account password and update the key store password value for the
-	//    custom key store.
+	//    * INVALID_CREDENTIALS - KMS does not have the correct password for the
+	//    kmsuser crypto user in the CloudHSM cluster. Before you can connect your
+	//    custom key store to its CloudHSM cluster, you must change the kmsuser
+	//    account password and update the key store password value for the custom
+	//    key store.
 	//
-	//    * NETWORK_ERRORS - Network errors are preventing AWS KMS from connecting
-	//    to the custom key store.
+	//    * NETWORK_ERRORS - Network errors are preventing KMS from connecting to
+	//    the custom key store.
 	//
-	//    * SUBNET_NOT_FOUND - A subnet in the AWS CloudHSM cluster configuration
-	//    was deleted. If AWS KMS cannot find all of the subnets in the cluster
-	//    configuration, attempts to connect the custom key store to the AWS CloudHSM
-	//    cluster fail. To fix this error, create a cluster from a recent backup
-	//    and associate it with your custom key store. (This process creates a new
-	//    cluster configuration with a VPC and private subnets.) For details, see
-	//    How to Fix a Connection Failure (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed)
-	//    in the AWS Key Management Service Developer Guide.
+	//    * SUBNET_NOT_FOUND - A subnet in the CloudHSM cluster configuration was
+	//    deleted. If KMS cannot find all of the subnets in the cluster configuration,
+	//    attempts to connect the custom key store to the CloudHSM cluster fail.
+	//    To fix this error, create a cluster from a recent backup and associate
+	//    it with your custom key store. (This process creates a new cluster configuration
+	//    with a VPC and private subnets.) For details, see How to Fix a Connection
+	//    Failure (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed)
+	//    in the Key Management Service Developer Guide.
 	//
 	//    * USER_LOCKED_OUT - The kmsuser CU account is locked out of the associated
-	//    AWS CloudHSM cluster due to too many failed password attempts. Before
-	//    you can connect your custom key store to its AWS CloudHSM cluster, you
-	//    must change the kmsuser account password and update the key store password
-	//    value for the custom key store.
+	//    CloudHSM cluster due to too many failed password attempts. Before you
+	//    can connect your custom key store to its CloudHSM cluster, you must change
+	//    the kmsuser account password and update the key store password value for
+	//    the custom key store.
 	//
 	//    * USER_LOGGED_IN - The kmsuser CU account is logged into the the associated
-	//    AWS CloudHSM cluster. This prevents AWS KMS from rotating the kmsuser
-	//    account password and logging into the cluster. Before you can connect
-	//    your custom key store to its AWS CloudHSM cluster, you must log the kmsuser
-	//    CU out of the cluster. If you changed the kmsuser password to log into
-	//    the cluster, you must also and update the key store password value for
-	//    the custom key store. For help, see How to Log Out and Reconnect (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#login-kmsuser-2)
-	//    in the AWS Key Management Service Developer Guide.
+	//    CloudHSM cluster. This prevents KMS from rotating the kmsuser account
+	//    password and logging into the cluster. Before you can connect your custom
+	//    key store to its CloudHSM cluster, you must log the kmsuser CU out of
+	//    the cluster. If you changed the kmsuser password to log into the cluster,
+	//    you must also and update the key store password value for the custom key
+	//    store. For help, see How to Log Out and Reconnect (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#login-kmsuser-2)
+	//    in the Key Management Service Developer Guide.
 	//
-	//    * USER_NOT_FOUND - AWS KMS cannot find a kmsuser CU account in the associated
-	//    AWS CloudHSM cluster. Before you can connect your custom key store to
-	//    its AWS CloudHSM cluster, you must create a kmsuser CU account in the
-	//    cluster, and then update the key store password value for the custom key
-	//    store.
+	//    * USER_NOT_FOUND - KMS cannot find a kmsuser CU account in the associated
+	//    CloudHSM cluster. Before you can connect your custom key store to its
+	//    CloudHSM cluster, you must create a kmsuser CU account in the cluster,
+	//    and then update the key store password value for the custom key store.
 	ConnectionErrorCode *string `type:"string" enum:"ConnectionErrorCodeType"`
 
-	// Indicates whether the custom key store is connected to its AWS CloudHSM cluster.
+	// Indicates whether the custom key store is connected to its CloudHSM cluster.
 	//
-	// You can create and use CMKs in your custom key stores only when its connection
+	// You can create and use KMS keys in your custom key stores only when its connection
 	// state is CONNECTED.
 	//
 	// The value is DISCONNECTED if the key store has never been connected or you
 	// use the DisconnectCustomKeyStore operation to disconnect it. If the value
 	// is CONNECTED but you are having trouble using the custom key store, make
-	// sure that its associated AWS CloudHSM cluster is active and contains at least
+	// sure that its associated CloudHSM cluster is active and contains at least
 	// one active HSM.
 	//
 	// A value of FAILED indicates that an attempt to connect was unsuccessful.
 	// The ConnectionErrorCode field in the response indicates the cause of the
 	// failure. For help resolving a connection failure, see Troubleshooting a Custom
 	// Key Store (https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	ConnectionState *string `type:"string" enum:"ConnectionStateType"`
 
 	// The date and time when the custom key store was created.
@@ -9268,8 +9367,8 @@ type CustomKeyStoresListEntry struct {
 	// The user-specified friendly name for the custom key store.
 	CustomKeyStoreName *string `min:"1" type:"string"`
 
-	// The trust anchor certificate of the associated AWS CloudHSM cluster. When
-	// you initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
+	// The trust anchor certificate of the associated CloudHSM cluster. When you
+	// initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
 	// you create this certificate and save it in the customerCA.crt file.
 	TrustAnchorCertificate *string `min:"1" type:"string"`
 }
@@ -9341,47 +9440,47 @@ type DecryptInput struct {
 	// a different algorithm, the Decrypt operation fails.
 	//
 	// This parameter is required only when the ciphertext was encrypted under an
-	// asymmetric CMK. The default value, SYMMETRIC_DEFAULT, represents the only
-	// supported algorithm that is valid for symmetric CMKs.
+	// asymmetric KMS key. The default value, SYMMETRIC_DEFAULT, represents the
+	// only supported algorithm that is valid for symmetric KMS keys.
 	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// Specifies the encryption context to use when decrypting the data. An encryption
 	// context is valid only for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// with a symmetric CMK. The standard asymmetric encryption algorithms that
-	// AWS KMS uses do not support an encryption context.
+	// with a symmetric KMS key. The standard asymmetric encryption algorithms that
+	// KMS uses do not support an encryption context.
 	//
 	// An encryption context is a collection of non-secret key-value pairs that
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
 	// Use a grant token when your permission to call this operation comes from
-	// a newly created grant that has not yet achieved eventual consistency. Use
-	// a grant token when your permission to call this operation comes from a new
-	// grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// a new grant that has not yet achieved eventual consistency. For more information,
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Specifies the customer master key (CMK) that AWS KMS uses to decrypt the
-	// ciphertext. Enter a key ID of the CMK that was used to encrypt the ciphertext.
+	// Specifies the KMS key that KMS uses to decrypt the ciphertext. Enter a key
+	// ID of the KMS key that was used to encrypt the ciphertext.
 	//
 	// This parameter is required only when the ciphertext was encrypted under an
-	// asymmetric CMK. If you used a symmetric CMK, AWS KMS can get the CMK from
-	// metadata that it adds to the symmetric ciphertext blob. However, it is always
-	// recommended as a best practice. This practice ensures that you use the CMK
-	// that you intend.
+	// asymmetric KMS key. If you used a symmetric KMS key, KMS can get the KMS
+	// key from metadata that it adds to the symmetric ciphertext blob. However,
+	// it is always recommended as a best practice. This practice ensures that you
+	// use the KMS key that you intend.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -9393,8 +9492,8 @@ type DecryptInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	KeyId *string `min:"1" type:"string"`
 }
 
@@ -9464,11 +9563,11 @@ type DecryptOutput struct {
 	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that was used to decrypt the ciphertext.
+	// of the KMS key that was used to decrypt the ciphertext.
 	KeyId *string `min:"1" type:"string"`
 
-	// Decrypted plaintext data. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// Decrypted plaintext data. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" sensitive:"true"`
@@ -9617,10 +9716,10 @@ func (s DeleteCustomKeyStoreOutput) GoString() string {
 type DeleteImportedKeyMaterialInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the CMK from which you are deleting imported key material. The
-	// Origin of the CMK must be EXTERNAL.
+	// Identifies the KMS key from which you are deleting imported key material.
+	// The Origin of the KMS key must be EXTERNAL.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -9628,7 +9727,7 @@ type DeleteImportedKeyMaterialInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -9759,7 +9858,7 @@ type DescribeCustomKeyStoresInput struct {
 	CustomKeyStoreName *string `min:"1" type:"string"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	Limit *int64 `min:"1" type:"integer"`
 
@@ -9877,19 +9976,22 @@ type DescribeKeyInput struct {
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Describes the specified customer master key (CMK).
+	// Describes the specified KMS key.
 	//
-	// If you specify a predefined AWS alias (an AWS alias with no key ID), KMS
-	// associates the alias with an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys)
+	// If you specify a predefined Amazon Web Services alias (an Amazon Web Services
+	// alias with no key ID), KMS associates the alias with an Amazon Web Services
+	// managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html##aws-managed-cmk)
 	// and returns its KeyId and Arn in the response.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -9901,8 +10003,8 @@ type DescribeKeyInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -9972,9 +10074,9 @@ func (s *DescribeKeyOutput) SetKeyMetadata(v *KeyMetadata) *DescribeKeyOutput {
 type DisableKeyInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the customer master key (CMK) to disable.
+	// Identifies the KMS key to disable.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -9982,7 +10084,7 @@ type DisableKeyInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10037,12 +10139,12 @@ func (s DisableKeyOutput) GoString() string {
 type DisableKeyRotationInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies a symmetric customer master key (CMK). You cannot enable or disable
-	// automatic rotation of asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html#asymmetric-cmks),
-	// CMKs with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
-	// or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+	// Identifies a symmetric KMS key. You cannot enable or disable automatic rotation
+	// of asymmetric KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html#asymmetric-cmks),
+	// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+	// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -10050,7 +10152,7 @@ type DisableKeyRotationInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10102,7 +10204,7 @@ func (s DisableKeyRotationOutput) GoString() string {
 	return s.String()
 }
 
-// The request was rejected because the specified CMK is not enabled.
+// The request was rejected because the specified KMS key is not enabled.
 type DisabledException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -10217,9 +10319,9 @@ func (s DisconnectCustomKeyStoreOutput) GoString() string {
 type EnableKeyInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the customer master key (CMK) to enable.
+	// Identifies the KMS key to enable.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -10227,7 +10329,7 @@ type EnableKeyInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10282,15 +10384,15 @@ func (s EnableKeyOutput) GoString() string {
 type EnableKeyRotationInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies a symmetric customer master key (CMK). You cannot enable automatic
-	// rotation of asymmetric CMKs (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
-	// CMKs with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
-	// or CMKs in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+	// Identifies a symmetric KMS key. You cannot enable automatic rotation of asymmetric
+	// KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks),
+	// KMS keys with imported key material (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html),
+	// or KMS keys in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 	// To enable or disable automatic rotation of a set of related multi-Region
 	// keys (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-replica-key),
 	// set the property on the primary key.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -10298,7 +10400,7 @@ type EnableKeyRotationInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10353,42 +10455,44 @@ func (s EnableKeyRotationOutput) GoString() string {
 type EncryptInput struct {
 	_ struct{} `type:"structure"`
 
-	// Specifies the encryption algorithm that AWS KMS will use to encrypt the plaintext
-	// message. The algorithm must be compatible with the CMK that you specify.
+	// Specifies the encryption algorithm that KMS will use to encrypt the plaintext
+	// message. The algorithm must be compatible with the KMS key that you specify.
 	//
-	// This parameter is required only for asymmetric CMKs. The default value, SYMMETRIC_DEFAULT,
-	// is the algorithm used for symmetric CMKs. If you are using an asymmetric
-	// CMK, we recommend RSAES_OAEP_SHA_256.
+	// This parameter is required only for asymmetric KMS keys. The default value,
+	// SYMMETRIC_DEFAULT, is the algorithm used for symmetric KMS keys. If you are
+	// using an asymmetric KMS key, we recommend RSAES_OAEP_SHA_256.
 	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// Specifies the encryption context that will be used to encrypt the data. An
 	// encryption context is valid only for cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// with a symmetric CMK. The standard asymmetric encryption algorithms that
-	// AWS KMS uses do not support an encryption context.
+	// with a symmetric KMS key. The standard asymmetric encryption algorithms that
+	// KMS uses do not support an encryption context.
 	//
 	// An encryption context is a collection of non-secret key-value pairs that
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Identifies the customer master key (CMK) to use in the encryption operation.
+	// Identifies the KMS key to use in the encryption operation.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -10400,8 +10504,8 @@ type EncryptInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10479,8 +10583,8 @@ func (s *EncryptInput) SetPlaintext(v []byte) *EncryptInput {
 type EncryptOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The encrypted plaintext. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The encrypted plaintext. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
@@ -10489,7 +10593,7 @@ type EncryptOutput struct {
 	EncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that was used to encrypt the plaintext.
+	// of the KMS key that was used to encrypt the plaintext.
 	KeyId *string `min:"1" type:"string"`
 }
 
@@ -10589,25 +10693,27 @@ type GenerateDataKeyInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Identifies the symmetric CMK that encrypts the data key.
+	// Identifies the symmetric KMS key that encrypts the data key.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -10619,8 +10725,8 @@ type GenerateDataKeyInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -10703,20 +10809,20 @@ func (s *GenerateDataKeyInput) SetNumberOfBytes(v int64) *GenerateDataKeyInput {
 type GenerateDataKeyOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The encrypted copy of the data key. When you use the HTTP API or the AWS
-	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The encrypted copy of the data key. When you use the HTTP API or the Amazon
+	// Web Services CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that encrypted the data key.
+	// of the KMS key that encrypted the data key.
 	KeyId *string `min:"1" type:"string"`
 
-	// The plaintext data key. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded. Use this data key
-	// to encrypt your data outside of KMS. Then, remove it from memory as soon
-	// as possible.
+	// The plaintext data key. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded. Use
+	// this data key to encrypt your data outside of KMS. Then, remove it from memory
+	// as soon as possible.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" sensitive:"true"`
@@ -10760,27 +10866,30 @@ type GenerateDataKeyPairInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Specifies the symmetric CMK that encrypts the private key in the data key
-	// pair. You cannot specify an asymmetric CMK or a CMK in a custom key store.
-	// To get the type and origin of your CMK, use the DescribeKey operation.
+	// Specifies the symmetric KMS key that encrypts the private key in the data
+	// key pair. You cannot specify an asymmetric KMS key or a KMS key in a custom
+	// key store. To get the type and origin of your KMS key, use the DescribeKey
+	// operation.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -10792,18 +10901,18 @@ type GenerateDataKeyPairInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Determines the type of data key pair that is generated.
 	//
-	// The AWS KMS rule that restricts the use of asymmetric RSA CMKs to encrypt
+	// The KMS rule that restricts the use of asymmetric RSA KMS keys to encrypt
 	// and decrypt or to sign and verify (but not both), and the rule that permits
-	// you to use ECC CMKs only to sign and verify, are not effective outside of
-	// AWS KMS.
+	// you to use ECC KMS keys only to sign and verify, are not effective on data
+	// key pairs, which are used outside of KMS.
 	//
 	// KeyPairSpec is a required field
 	KeyPairSpec *string `type:"string" required:"true" enum:"DataKeyPairSpec"`
@@ -10866,20 +10975,20 @@ type GenerateDataKeyPairOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that encrypted the private key.
+	// of the KMS key that encrypted the private key.
 	KeyId *string `min:"1" type:"string"`
 
 	// The type of data key pair that was generated.
 	KeyPairSpec *string `type:"string" enum:"DataKeyPairSpec"`
 
-	// The encrypted copy of the private key. When you use the HTTP API or the AWS
-	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The encrypted copy of the private key. When you use the HTTP API or the Amazon
+	// Web Services CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// PrivateKeyCiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	PrivateKeyCiphertextBlob []byte `min:"1" type:"blob"`
 
-	// The plaintext copy of the private key. When you use the HTTP API or the AWS
-	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The plaintext copy of the private key. When you use the HTTP API or the Amazon
+	// Web Services CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// PrivateKeyPlaintext is automatically base64 encoded/decoded by the SDK.
 	PrivateKeyPlaintext []byte `min:"1" type:"blob" sensitive:"true"`
@@ -10940,28 +11049,30 @@ type GenerateDataKeyPairWithoutPlaintextInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Specifies the CMK that encrypts the private key in the data key pair. You
-	// must specify a symmetric CMK. You cannot use an asymmetric CMK or a CMK in
-	// a custom key store. To get the type and origin of your CMK, use the DescribeKey
-	// operation.
+	// Specifies the KMS key that encrypts the private key in the data key pair.
+	// You must specify a symmetric KMS key. You cannot use an asymmetric KMS key
+	// or a KMS key in a custom key store. To get the type and origin of your KMS
+	// key, use the DescribeKey operation.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -10973,18 +11084,18 @@ type GenerateDataKeyPairWithoutPlaintextInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Determines the type of data key pair that is generated.
 	//
-	// The AWS KMS rule that restricts the use of asymmetric RSA CMKs to encrypt
+	// The KMS rule that restricts the use of asymmetric RSA KMS keys to encrypt
 	// and decrypt or to sign and verify (but not both), and the rule that permits
-	// you to use ECC CMKs only to sign and verify, are not effective outside of
-	// AWS KMS.
+	// you to use ECC KMS keys only to sign and verify, are not effective on data
+	// key pairs, which are used outside of KMS.
 	//
 	// KeyPairSpec is a required field
 	KeyPairSpec *string `type:"string" required:"true" enum:"DataKeyPairSpec"`
@@ -11047,14 +11158,14 @@ type GenerateDataKeyPairWithoutPlaintextOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that encrypted the private key.
+	// of the KMS key that encrypted the private key.
 	KeyId *string `min:"1" type:"string"`
 
 	// The type of data key pair that was generated.
 	KeyPairSpec *string `type:"string" enum:"DataKeyPairSpec"`
 
-	// The encrypted copy of the private key. When you use the HTTP API or the AWS
-	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The encrypted copy of the private key. When you use the HTTP API or the Amazon
+	// Web Services CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// PrivateKeyCiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	PrivateKeyCiphertextBlob []byte `min:"1" type:"blob"`
@@ -11109,26 +11220,27 @@ type GenerateDataKeyWithoutPlaintextInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	EncryptionContext map[string]*string `type:"map"`
 
 	// A list of grant tokens.
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// The identifier of the symmetric customer master key (CMK) that encrypts the
-	// data key.
+	// The identifier of the symmetric KMS key that encrypts the data key.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -11140,8 +11252,8 @@ type GenerateDataKeyWithoutPlaintextInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -11219,14 +11331,14 @@ func (s *GenerateDataKeyWithoutPlaintextInput) SetNumberOfBytes(v int64) *Genera
 type GenerateDataKeyWithoutPlaintextOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The encrypted data key. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The encrypted data key. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that encrypted the data key.
+	// of the KMS key that encrypted the data key.
 	KeyId *string `min:"1" type:"string"`
 }
 
@@ -11255,7 +11367,7 @@ func (s *GenerateDataKeyWithoutPlaintextOutput) SetKeyId(v string) *GenerateData
 type GenerateRandomInput struct {
 	_ struct{} `type:"structure"`
 
-	// Generates the random byte string in the AWS CloudHSM cluster that is associated
+	// Generates the random byte string in the CloudHSM cluster that is associated
 	// with the specified custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
 	// To find the ID of a custom key store, use the DescribeCustomKeyStores operation.
 	CustomKeyStoreId *string `min:"1" type:"string"`
@@ -11305,8 +11417,8 @@ func (s *GenerateRandomInput) SetNumberOfBytes(v int64) *GenerateRandomInput {
 type GenerateRandomOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The random byte string. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The random byte string. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// Plaintext is automatically base64 encoded/decoded by the SDK.
 	Plaintext []byte `min:"1" type:"blob" sensitive:"true"`
@@ -11331,9 +11443,9 @@ func (s *GenerateRandomOutput) SetPlaintext(v []byte) *GenerateRandomOutput {
 type GetKeyPolicyInput struct {
 	_ struct{} `type:"structure"`
 
-	// Gets the key policy for the specified customer master key (CMK).
+	// Gets the key policy for the specified KMS key.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -11341,7 +11453,7 @@ type GetKeyPolicyInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -11423,10 +11535,10 @@ func (s *GetKeyPolicyOutput) SetPolicy(v string) *GetKeyPolicyOutput {
 type GetKeyRotationStatusInput struct {
 	_ struct{} `type:"structure"`
 
-	// Gets the rotation status for the specified customer master key (CMK).
+	// Gets the rotation status for the specified KMS key.
 	//
-	// Specify the key ID or key ARN of the CMK. To specify a CMK in a different
-	// AWS account, you must use the key ARN.
+	// Specify the key ID or key ARN of the KMS key. To specify a KMS key in a different
+	// Amazon Web Services account, you must use the key ARN.
 	//
 	// For example:
 	//
@@ -11434,7 +11546,7 @@ type GetKeyRotationStatusInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -11498,10 +11610,10 @@ func (s *GetKeyRotationStatusOutput) SetKeyRotationEnabled(v bool) *GetKeyRotati
 type GetParametersForImportInput struct {
 	_ struct{} `type:"structure"`
 
-	// The identifier of the symmetric CMK into which you will import key material.
-	// The Origin of the CMK must be EXTERNAL.
+	// The identifier of the symmetric KMS key into which you will import key material.
+	// The Origin of the KMS key must be EXTERNAL.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -11509,7 +11621,7 @@ type GetParametersForImportInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -11517,7 +11629,7 @@ type GetParametersForImportInput struct {
 	// The algorithm you will use to encrypt the key material before importing it
 	// with ImportKeyMaterial. For more information, see Encrypt the Key Material
 	// (https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-encrypt-key-material.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	//
 	// WrappingAlgorithm is a required field
 	WrappingAlgorithm *string `type:"string" required:"true" enum:"AlgorithmSpec"`
@@ -11588,8 +11700,8 @@ type GetParametersForImportOutput struct {
 	ImportToken []byte `min:"1" type:"blob"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK to use in a subsequent ImportKeyMaterial request. This is the
-	// same CMK specified in the GetParametersForImport request.
+	// of the KMS key to use in a subsequent ImportKeyMaterial request. This is
+	// the same KMS key specified in the GetParametersForImport request.
 	KeyId *string `min:"1" type:"string"`
 
 	// The time at which the import token and public key are no longer valid. After
@@ -11645,15 +11757,17 @@ type GetPublicKeyInput struct {
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Identifies the asymmetric CMK that includes the public key.
+	// Identifies the asymmetric KMS key that includes the public key.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -11665,8 +11779,8 @@ type GetPublicKeyInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -11713,41 +11827,49 @@ func (s *GetPublicKeyInput) SetKeyId(v string) *GetPublicKeyInput {
 type GetPublicKeyOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The type of the of the public key that was downloaded.
-	CustomerMasterKeySpec *string `type:"string" enum:"CustomerMasterKeySpec"`
-
-	// The encryption algorithms that AWS KMS supports for this key.
+	// Instead, use the KeySpec field in the GetPublicKey response.
 	//
-	// This information is critical. If a public key encrypts data outside of AWS
-	// KMS by using an unsupported encryption algorithm, the ciphertext cannot be
-	// decrypted.
+	// The KeySpec and CustomerMasterKeySpec fields have the same value. We recommend
+	// that you use the KeySpec field in your code. However, to avoid breaking changes,
+	// KMS will support both fields.
+	//
+	// Deprecated: This field has been deprecated. Instead, use the KeySpec field.
+	CustomerMasterKeySpec *string `deprecated:"true" type:"string" enum:"CustomerMasterKeySpec"`
+
+	// The encryption algorithms that KMS supports for this key.
+	//
+	// This information is critical. If a public key encrypts data outside of KMS
+	// by using an unsupported encryption algorithm, the ciphertext cannot be decrypted.
 	//
 	// This field appears in the response only when the KeyUsage of the public key
 	// is ENCRYPT_DECRYPT.
 	EncryptionAlgorithms []*string `type:"list"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the asymmetric CMK from which the public key was downloaded.
+	// of the asymmetric KMS key from which the public key was downloaded.
 	KeyId *string `min:"1" type:"string"`
+
+	// The type of the of the public key that was downloaded.
+	KeySpec *string `type:"string" enum:"KeySpec"`
 
 	// The permitted use of the public key. Valid values are ENCRYPT_DECRYPT or
 	// SIGN_VERIFY.
 	//
 	// This information is critical. If a public key with SIGN_VERIFY key usage
-	// encrypts data outside of AWS KMS, the ciphertext cannot be decrypted.
+	// encrypts data outside of KMS, the ciphertext cannot be decrypted.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
 
 	// The exported public key.
 	//
 	// The value is a DER-encoded X.509 public key, also known as SubjectPublicKeyInfo
 	// (SPKI), as defined in RFC 5280 (https://tools.ietf.org/html/rfc5280). When
-	// you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise,
-	// it is not Base64-encoded.
+	// you use the HTTP API or the Amazon Web Services CLI, the value is Base64-encoded.
+	// Otherwise, it is not Base64-encoded.
 	//
 	// PublicKey is automatically base64 encoded/decoded by the SDK.
 	PublicKey []byte `min:"1" type:"blob"`
 
-	// The signing algorithms that AWS KMS supports for this key.
+	// The signing algorithms that KMS supports for this key.
 	//
 	// This field appears in the response only when the KeyUsage of the public key
 	// is SIGN_VERIFY.
@@ -11782,6 +11904,12 @@ func (s *GetPublicKeyOutput) SetKeyId(v string) *GetPublicKeyOutput {
 	return s
 }
 
+// SetKeySpec sets the KeySpec field's value.
+func (s *GetPublicKeyOutput) SetKeySpec(v string) *GetPublicKeyOutput {
+	s.KeySpec = &v
+	return s
+}
+
 // SetKeyUsage sets the KeyUsage field's value.
 func (s *GetPublicKeyOutput) SetKeyUsage(v string) *GetPublicKeyOutput {
 	s.KeyUsage = &v
@@ -11804,11 +11932,11 @@ func (s *GetPublicKeyOutput) SetSigningAlgorithms(v []*string) *GetPublicKeyOutp
 // in the grant only when the operation request includes the specified encryption
 // context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context).
 //
-// AWS KMS applies the grant constraints only to cryptographic operations that
-// support an encryption context, that is, all cryptographic operations with
-// a symmetric CMK (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#symmetric-cmks).
+// KMS applies the grant constraints only to cryptographic operations that support
+// an encryption context, that is, all cryptographic operations with a symmetric
+// KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#symmetric-cmks).
 // Grant constraints are not applied to operations that do not support an encryption
-// context, such as cryptographic operations with asymmetric CMKs and management
+// context, such as cryptographic operations with asymmetric KMS keys and management
 // operations, such as DescribeKey or RetireGrant.
 //
 // In a cryptographic operation, the encryption context in the decryption operation
@@ -11822,7 +11950,7 @@ func (s *GetPublicKeyOutput) SetSigningAlgorithms(v []*string) *GetPublicKeyOutp
 // only by case. To require a fully case-sensitive encryption context, use the
 // kms:EncryptionContext: and kms:EncryptionContextKeys conditions in an IAM
 // or key policy. For details, see kms:EncryptionContext: (https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-encryption-context)
-// in the AWS Key Management Service Developer Guide .
+// in the Key Management Service Developer Guide .
 type GrantConstraints struct {
 	_ struct{} `type:"structure"`
 
@@ -11880,16 +12008,15 @@ type GrantListEntry struct {
 	//
 	// The GranteePrincipal field in the ListGrants response usually contains the
 	// user or role designated as the grantee principal in the grant. However, when
-	// the grantee principal in the grant is an AWS service, the GranteePrincipal
-	// field contains the service principal (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services),
+	// the grantee principal in the grant is an Amazon Web Services service, the
+	// GranteePrincipal field contains the service principal (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services),
 	// which might represent several different grantee principals.
 	GranteePrincipal *string `min:"1" type:"string"`
 
-	// The AWS account under which the grant was issued.
+	// The Amazon Web Services account under which the grant was issued.
 	IssuingAccount *string `min:"1" type:"string"`
 
-	// The unique identifier for the customer master key (CMK) to which the grant
-	// applies.
+	// The unique identifier for the KMS key to which the grant applies.
 	KeyId *string `min:"1" type:"string"`
 
 	// The friendly name that identifies the grant. If a name was provided in the
@@ -11994,11 +12121,11 @@ type ImportKeyMaterialInput struct {
 	// ImportToken is a required field
 	ImportToken []byte `min:"1" type:"blob" required:"true"`
 
-	// The identifier of the symmetric CMK that receives the imported key material.
-	// The CMK's Origin must be EXTERNAL. This must be the same CMK specified in
-	// the KeyID parameter of the corresponding GetParametersForImport request.
+	// The identifier of the symmetric KMS key that receives the imported key material.
+	// The KMS key's Origin must be EXTERNAL. This must be the same KMS key specified
+	// in the KeyID parameter of the corresponding GetParametersForImport request.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -12006,13 +12133,13 @@ type ImportKeyMaterialInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// The time at which the imported key material expires. When the key material
-	// expires, AWS KMS deletes the key material and the CMK becomes unusable. You
+	// expires, KMS deletes the key material and the KMS key becomes unusable. You
 	// must omit this parameter when the ExpirationModel parameter is set to KEY_MATERIAL_DOES_NOT_EXPIRE.
 	// Otherwise it is required.
 	ValidTo *time.Time `type:"timestamp"`
@@ -12100,9 +12227,9 @@ func (s ImportKeyMaterialOutput) GoString() string {
 	return s.String()
 }
 
-// The request was rejected because the specified CMK cannot decrypt the data.
-// The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
-// must identify the same CMK that was used to encrypt the ciphertext.
+// The request was rejected because the specified KMS key cannot decrypt the
+// data. The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+// must identify the same KMS key that was used to encrypt the ciphertext.
 type IncorrectKeyException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12160,7 +12287,7 @@ func (s *IncorrectKeyException) RequestID() string {
 
 // The request was rejected because the key material in the request is, expired,
 // invalid, or is not the same key material that was previously imported into
-// this customer master key (CMK).
+// this KMS key.
 type IncorrectKeyMaterialException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12217,7 +12344,7 @@ func (s *IncorrectKeyMaterialException) RequestID() string {
 }
 
 // The request was rejected because the trust anchor certificate in the request
-// is not the trust anchor certificate for the specified AWS CloudHSM cluster.
+// is not the trust anchor certificate for the specified CloudHSM cluster.
 //
 // When you initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
 // you create the trust anchor certificate and save it in the customerCA.crt
@@ -12452,8 +12579,8 @@ func (s *InvalidArnException) RequestID() string {
 // the ciphertext, such as the encryption context, is corrupted, missing, or
 // otherwise invalid.
 //
-// From the ImportKeyMaterial operation, the request was rejected because AWS
-// KMS could not decrypt the encrypted (wrapped) key material.
+// From the ImportKeyMaterial operation, the request was rejected because KMS
+// could not decrypt the encrypted (wrapped) key material.
 type InvalidCiphertextException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12622,7 +12749,7 @@ func (s *InvalidGrantTokenException) RequestID() string {
 }
 
 // The request was rejected because the provided import token is invalid or
-// is associated with a different customer master key (CMK).
+// is associated with a different KMS key.
 type InvalidImportTokenException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12680,17 +12807,18 @@ func (s *InvalidImportTokenException) RequestID() string {
 
 // The request was rejected for one of the following reasons:
 //
-//    * The KeyUsage value of the CMK is incompatible with the API operation.
+//    * The KeyUsage value of the KMS key is incompatible with the API operation.
 //
 //    * The encryption algorithm or signing algorithm specified for the operation
-//    is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+//    is incompatible with the type of key material in the KMS key (KeySpec).
 //
 // For encrypting, decrypting, re-encrypting, and generating data keys, the
 // KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-// must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+// must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+// operation.
 //
-// To find the encryption or signing algorithms supported for a particular CMK,
-// use the DescribeKey operation.
+// To find the encryption or signing algorithms supported for a particular KMS
+// key, use the DescribeKey operation.
 type InvalidKeyUsageException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12806,9 +12934,9 @@ func (s *InvalidMarkerException) RequestID() string {
 // The request was rejected because the state of the specified resource is not
 // valid for this request.
 //
-// For more information about how key state affects the use of a CMK, see How
-// Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-// in the AWS Key Management Service Developer Guide .
+// For more information about how key state affects the use of a KMS key, see
+// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+// in the Key Management Service Developer Guide .
 type InvalidStateException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12866,7 +12994,7 @@ func (s *InvalidStateException) RequestID() string {
 
 // The request was rejected because the signature verification failed. Signature
 // verification fails when it cannot confirm that signature was produced by
-// signing the specified message with the specified CMK and signing algorithm.
+// signing the specified message with the specified KMS key and signing algorithm.
 type KMSInvalidSignatureException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -12955,125 +13083,134 @@ func (s *KeyListEntry) SetKeyId(v string) *KeyListEntry {
 	return s
 }
 
-// Contains metadata about a customer master key (CMK).
+// Contains metadata about a KMS key.
 //
 // This data type is used as a response element for the CreateKey and DescribeKey
 // operations.
 type KeyMetadata struct {
 	_ struct{} `type:"structure"`
 
-	// The twelve-digit account ID of the AWS account that owns the CMK.
+	// The twelve-digit account ID of the Amazon Web Services account that owns
+	// the KMS key.
 	AWSAccountId *string `type:"string"`
 
-	// The Amazon Resource Name (ARN) of the CMK. For examples, see AWS Key Management
-	// Service (AWS KMS) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms)
-	// in the Example ARNs section of the AWS General Reference.
+	// The Amazon Resource Name (ARN) of the KMS key. For examples, see Key Management
+	// Service (KMS) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-kms)
+	// in the Example ARNs section of the Amazon Web Services General Reference.
 	Arn *string `min:"20" type:"string"`
 
-	// The cluster ID of the AWS CloudHSM cluster that contains the key material
-	// for the CMK. When you create a CMK in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
-	// AWS KMS creates the key material for the CMK in the associated AWS CloudHSM
-	// cluster. This value is present only when the CMK is created in a custom key
-	// store.
+	// The cluster ID of the CloudHSM cluster that contains the key material for
+	// the KMS key. When you create a KMS key in a custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+	// KMS creates the key material for the KMS key in the associated CloudHSM cluster.
+	// This value is present only when the KMS key is created in a custom key store.
 	CloudHsmClusterId *string `min:"19" type:"string"`
 
-	// The date and time when the CMK was created.
+	// The date and time when the KMS key was created.
 	CreationDate *time.Time `type:"timestamp"`
 
 	// A unique identifier for the custom key store (https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-	// that contains the CMK. This value is present only when the CMK is created
-	// in a custom key store.
+	// that contains the KMS key. This value is present only when the KMS key is
+	// created in a custom key store.
 	CustomKeyStoreId *string `min:"1" type:"string"`
 
-	// Describes the type of key material in the CMK.
-	CustomerMasterKeySpec *string `type:"string" enum:"CustomerMasterKeySpec"`
+	// Instead, use the KeySpec field.
+	//
+	// The KeySpec and CustomerMasterKeySpec fields have the same value. We recommend
+	// that you use the KeySpec field in your code. However, to avoid breaking changes,
+	// KMS will support both fields.
+	//
+	// Deprecated: This field has been deprecated. Instead, use the KeySpec field.
+	CustomerMasterKeySpec *string `deprecated:"true" type:"string" enum:"CustomerMasterKeySpec"`
 
-	// The date and time after which AWS KMS deletes this CMK. This value is present
-	// only when the CMK is scheduled for deletion, that is, when its KeyState is
-	// PendingDeletion.
+	// The date and time after which KMS deletes this KMS key. This value is present
+	// only when the KMS key is scheduled for deletion, that is, when its KeyState
+	// is PendingDeletion.
 	//
 	// When the primary key in a multi-Region key is scheduled for deletion but
 	// still has replica keys, its key state is PendingReplicaDeletion and the length
 	// of its waiting period is displayed in the PendingDeletionWindowInDays field.
 	DeletionDate *time.Time `type:"timestamp"`
 
-	// The description of the CMK.
+	// The description of the KMS key.
 	Description *string `type:"string"`
 
-	// Specifies whether the CMK is enabled. When KeyState is Enabled this value
+	// Specifies whether the KMS key is enabled. When KeyState is Enabled this value
 	// is true, otherwise it is false.
 	Enabled *bool `type:"boolean"`
 
-	// The encryption algorithms that the CMK supports. You cannot use the CMK with
-	// other encryption algorithms within AWS KMS.
+	// The encryption algorithms that the KMS key supports. You cannot use the KMS
+	// key with other encryption algorithms within KMS.
 	//
-	// This value is present only when the KeyUsage of the CMK is ENCRYPT_DECRYPT.
+	// This value is present only when the KeyUsage of the KMS key is ENCRYPT_DECRYPT.
 	EncryptionAlgorithms []*string `type:"list"`
 
-	// Specifies whether the CMK's key material expires. This value is present only
-	// when Origin is EXTERNAL, otherwise this value is omitted.
+	// Specifies whether the KMS key's key material expires. This value is present
+	// only when Origin is EXTERNAL, otherwise this value is omitted.
 	ExpirationModel *string `type:"string" enum:"ExpirationModelType"`
 
-	// The globally unique identifier for the CMK.
+	// The globally unique identifier for the KMS key.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// The manager of the CMK. CMKs in your AWS account are either customer managed
-	// or AWS managed. For more information about the difference, see Customer Master
-	// Keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys)
-	// in the AWS Key Management Service Developer Guide.
+	// The manager of the KMS key. KMS keys in your Amazon Web Services account
+	// are either customer managed or Amazon Web Services managed. For more information
+	// about the difference, see KMS keys (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys)
+	// in the Key Management Service Developer Guide.
 	KeyManager *string `type:"string" enum:"KeyManagerType"`
 
-	// The current status of the CMK.
+	// Describes the type of key material in the KMS key.
+	KeySpec *string `type:"string" enum:"KeySpec"`
+
+	// The current status of the KMS key.
 	//
-	// For more information about how key state affects the use of a CMK, see Key
-	// state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-	// in the AWS Key Management Service Developer Guide.
+	// For more information about how key state affects the use of a KMS key, see
+	// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+	// in the Key Management Service Developer Guide.
 	KeyState *string `type:"string" enum:"KeyState"`
 
 	// The cryptographic operations (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations)
-	// for which you can use the CMK.
+	// for which you can use the KMS key.
 	KeyUsage *string `type:"string" enum:"KeyUsageType"`
 
-	// Indicates whether the CMK is a multi-Region (True) or regional (False) key.
-	// This value is True for multi-Region primary and replica CMKs and False for
-	// regional CMKs.
+	// Indicates whether the KMS key is a multi-Region (True) or regional (False)
+	// key. This value is True for multi-Region primary and replica keys and False
+	// for regional KMS keys.
 	//
 	// For more information about multi-Region keys, see Using multi-Region keys
 	// (https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	MultiRegion *bool `type:"boolean"`
 
-	// Lists the primary and replica CMKs in same multi-Region CMK. This field is
+	// Lists the primary and replica keys in same multi-Region key. This field is
 	// present only when the value of the MultiRegion field is True.
 	//
-	// For more information about any listed CMK, use the DescribeKey operation.
+	// For more information about any listed KMS key, use the DescribeKey operation.
 	//
-	//    * MultiRegionKeyType indicates whether the CMK is a PRIMARY or REPLICA
+	//    * MultiRegionKeyType indicates whether the KMS key is a PRIMARY or REPLICA
 	//    key.
 	//
 	//    * PrimaryKey displays the key ARN and Region of the primary key. This
-	//    field displays the current CMK if it is the primary key.
+	//    field displays the current KMS key if it is the primary key.
 	//
 	//    * ReplicaKeys displays the key ARNs and Regions of all replica keys. This
-	//    field includes the current CMK if it is a replica key.
+	//    field includes the current KMS key if it is a replica key.
 	MultiRegionConfiguration *MultiRegionConfiguration `type:"structure"`
 
-	// The source of the CMK's key material. When this value is AWS_KMS, AWS KMS
-	// created the key material. When this value is EXTERNAL, the key material was
-	// imported from your existing key management infrastructure or the CMK lacks
-	// key material. When this value is AWS_CLOUDHSM, the key material was created
-	// in the AWS CloudHSM cluster associated with a custom key store.
+	// The source of the key material for the KMS key. When this value is AWS_KMS,
+	// KMS created the key material. When this value is EXTERNAL, the key material
+	// was imported or the KMS key doesn't have any key material. When this value
+	// is AWS_CLOUDHSM, the key material was created in the CloudHSM cluster associated
+	// with a custom key store.
 	Origin *string `type:"string" enum:"OriginType"`
 
 	// The waiting period before the primary key in a multi-Region key is deleted.
 	// This waiting period begins when the last of its replica keys is deleted.
-	// This value is present only when the KeyState of the CMK is PendingReplicaDeletion.
-	// That indicates that the CMK is the primary key in a multi-Region key, it
-	// is scheduled for deletion, and it still has existing replica keys.
+	// This value is present only when the KeyState of the KMS key is PendingReplicaDeletion.
+	// That indicates that the KMS key is the primary key in a multi-Region key,
+	// it is scheduled for deletion, and it still has existing replica keys.
 	//
-	// When a regional CMK or a replica key in a multi-Region key is scheduled for
+	// When a single-Region KMS key or a multi-Region replica key is scheduled for
 	// deletion, its deletion date is displayed in the DeletionDate field. However,
 	// when the primary key in a multi-Region key is scheduled for deletion, its
 	// waiting period doesn't begin until all of its replica keys are deleted. This
@@ -13082,15 +13219,15 @@ type KeyMetadata struct {
 	// to PendingDeletion and the deletion date appears in the DeletionDate field.
 	PendingDeletionWindowInDays *int64 `min:"1" type:"integer"`
 
-	// The signing algorithms that the CMK supports. You cannot use the CMK with
-	// other signing algorithms within AWS KMS.
+	// The signing algorithms that the KMS key supports. You cannot use the KMS
+	// key with other signing algorithms within KMS.
 	//
-	// This field appears only when the KeyUsage of the CMK is SIGN_VERIFY.
+	// This field appears only when the KeyUsage of the KMS key is SIGN_VERIFY.
 	SigningAlgorithms []*string `type:"list"`
 
 	// The time at which the imported key material expires. When the key material
-	// expires, AWS KMS deletes the key material and the CMK becomes unusable. This
-	// value is present only for CMKs whose Origin is EXTERNAL and whose ExpirationModel
+	// expires, KMS deletes the key material and the KMS key becomes unusable. This
+	// value is present only for KMS keys whose Origin is EXTERNAL and whose ExpirationModel
 	// is KEY_MATERIAL_EXPIRES, otherwise this value is omitted.
 	ValidTo *time.Time `type:"timestamp"`
 }
@@ -13183,6 +13320,12 @@ func (s *KeyMetadata) SetKeyManager(v string) *KeyMetadata {
 	return s
 }
 
+// SetKeySpec sets the KeySpec field's value.
+func (s *KeyMetadata) SetKeySpec(v string) *KeyMetadata {
+	s.KeySpec = &v
+	return s
+}
+
 // SetKeyState sets the KeyState field's value.
 func (s *KeyMetadata) SetKeyState(v string) *KeyMetadata {
 	s.KeyState = &v
@@ -13231,8 +13374,8 @@ func (s *KeyMetadata) SetValidTo(v time.Time) *KeyMetadata {
 	return s
 }
 
-// The request was rejected because the specified CMK was not available. You
-// can retry the request.
+// The request was rejected because the specified KMS key was not available.
+// You can retry the request.
 type KeyUnavailableException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -13290,7 +13433,7 @@ func (s *KeyUnavailableException) RequestID() string {
 
 // The request was rejected because a quota was exceeded. For more information,
 // see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-// in the AWS Key Management Service Developer Guide.
+// in the Key Management Service Developer Guide.
 type LimitExceededException struct {
 	_            struct{}                  `type:"structure"`
 	RespMetadata protocol.ResponseMetadata `json:"-" xml:"-"`
@@ -13349,13 +13492,13 @@ func (s *LimitExceededException) RequestID() string {
 type ListAliasesInput struct {
 	_ struct{} `type:"structure"`
 
-	// Lists only aliases that are associated with the specified CMK. Enter a CMK
-	// in your AWS account.
+	// Lists only aliases that are associated with the specified KMS key. Enter
+	// a KMS key in your Amazon Web Services account.
 	//
 	// This parameter is optional. If you omit it, ListAliases returns all aliases
 	// in the account and Region.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -13363,11 +13506,11 @@ type ListAliasesInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	KeyId *string `min:"1" type:"string"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -13483,11 +13626,10 @@ type ListGrantsInput struct {
 	// for the grant.
 	GranteePrincipal *string `min:"1" type:"string"`
 
-	// Returns only grants for the specified customer master key (CMK). This parameter
-	// is required.
+	// Returns only grants for the specified KMS key. This parameter is required.
 	//
-	// Specify the key ID or key ARN of the CMK. To specify a CMK in a different
-	// AWS account, you must use the key ARN.
+	// Specify the key ID or key ARN of the KMS key. To specify a KMS key in a different
+	// Amazon Web Services account, you must use the key ARN.
 	//
 	// For example:
 	//
@@ -13495,13 +13637,13 @@ type ListGrantsInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -13630,9 +13772,9 @@ func (s *ListGrantsResponse) SetTruncated(v bool) *ListGrantsResponse {
 type ListKeyPoliciesInput struct {
 	_ struct{} `type:"structure"`
 
-	// Gets the names of key policies for the specified customer master key (CMK).
+	// Gets the names of key policies for the specified KMS key.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -13640,13 +13782,13 @@ type ListKeyPoliciesInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -13760,7 +13902,7 @@ type ListKeysInput struct {
 	_ struct{} `type:"structure"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -13814,7 +13956,7 @@ func (s *ListKeysInput) SetMarker(v string) *ListKeysInput {
 type ListKeysOutput struct {
 	_ struct{} `type:"structure"`
 
-	// A list of customer master keys (CMKs).
+	// A list of KMS keys.
 	Keys []*KeyListEntry `type:"list"`
 
 	// When Truncated is true, this element is present and contains the value to
@@ -13859,9 +14001,9 @@ func (s *ListKeysOutput) SetTruncated(v bool) *ListKeysOutput {
 type ListResourceTagsInput struct {
 	_ struct{} `type:"structure"`
 
-	// Gets tags on the specified customer master key (CMK).
+	// Gets tags on the specified KMS key.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -13869,13 +14011,13 @@ type ListResourceTagsInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -13952,9 +14094,9 @@ type ListResourceTagsOutput struct {
 
 	// A list of tags. Each tag consists of a tag key and a tag value.
 	//
-	// Tagging or untagging a CMK can allow or deny permission to the CMK. For details,
-	// see Using ABAC in AWS KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
-	// in the AWS Key Management Service Developer Guide.
+	// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+	// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+	// in the Key Management Service Developer Guide.
 	Tags []*Tag `type:"list"`
 
 	// A flag that indicates whether there are more items in the list. When this
@@ -13996,7 +14138,7 @@ type ListRetirableGrantsInput struct {
 	_ struct{} `type:"structure"`
 
 	// Use this parameter to specify the maximum number of items to return. When
-	// this value is present, AWS KMS does not return more than the specified number
+	// this value is present, KMS does not return more than the specified number
 	// of items, but it might return fewer.
 	//
 	// This value is optional. If you include a value, it must be between 1 and
@@ -14009,13 +14151,13 @@ type ListRetirableGrantsInput struct {
 	Marker *string `min:"1" type:"string"`
 
 	// The retiring principal for which to list grants. Enter a principal in your
-	// AWS account.
+	// Amazon Web Services account.
 	//
 	// To specify the retiring principal, use the Amazon Resource Name (ARN) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-	// of an AWS principal. Valid AWS principals include AWS accounts (root), IAM
-	// users, federated users, and assumed role users. For examples of the ARN syntax
-	// for specifying a principal, see AWS Identity and Access Management (IAM)
-	// (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
+	// of an Amazon Web Services principal. Valid Amazon Web Services principals
+	// include Amazon Web Services accounts (root), IAM users, federated users,
+	// and assumed role users. For examples of the ARN syntax for specifying a principal,
+	// see Amazon Web Services Identity and Access Management (IAM) (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
 	// in the Example ARNs section of the Amazon Web Services General Reference.
 	//
 	// RetiringPrincipal is a required field
@@ -14129,22 +14271,22 @@ func (s *MalformedPolicyDocumentException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
-// Describes the configuration of this multi-Region CMK. This field appears
-// only when the CMK is a primary or replica of a multi-Region CMK.
+// Describes the configuration of this multi-Region key. This field appears
+// only when the KMS key is a primary or replica of a multi-Region key.
 //
-// For more information about any listed CMK, use the DescribeKey operation.
+// For more information about any listed KMS key, use the DescribeKey operation.
 type MultiRegionConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	// Indicates whether the CMK is a PRIMARY or REPLICA key.
+	// Indicates whether the KMS key is a PRIMARY or REPLICA key.
 	MultiRegionKeyType *string `type:"string" enum:"MultiRegionKeyType"`
 
 	// Displays the key ARN and Region of the primary key. This field includes the
-	// current CMK if it is the primary key.
+	// current KMS key if it is the primary key.
 	PrimaryKey *MultiRegionKey `type:"structure"`
 
 	// displays the key ARNs and Regions of all replica keys. This field includes
-	// the current CMK if it is a replica key.
+	// the current KMS key if it is a replica key.
 	ReplicaKeys []*MultiRegionKey `type:"list"`
 }
 
@@ -14183,7 +14325,8 @@ type MultiRegionKey struct {
 	// Displays the key ARN of a primary or replica key of a multi-Region key.
 	Arn *string `min:"20" type:"string"`
 
-	// Displays the AWS Region of a primary or replica key in a multi-Region key.
+	// Displays the Amazon Web Services Region of a primary or replica key in a
+	// multi-Region key.
 	Region *string `min:"1" type:"string"`
 }
 
@@ -14271,21 +14414,22 @@ type PutKeyPolicyInput struct {
 
 	// A flag to indicate whether to bypass the key policy lockout safety check.
 	//
-	// Setting this value to true increases the risk that the CMK becomes unmanageable.
+	// Setting this value to true increases the risk that the KMS key becomes unmanageable.
 	// Do not set this value to true indiscriminately.
 	//
 	// For more information, refer to the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	// section in the AWS Key Management Service Developer Guide.
+	// section in the Key Management Service Developer Guide.
 	//
 	// Use this parameter only when you intend to prevent the principal that is
-	// making the request from making a subsequent PutKeyPolicy request on the CMK.
+	// making the request from making a subsequent PutKeyPolicy request on the KMS
+	// key.
 	//
 	// The default value is false.
 	BypassPolicyLockoutSafetyCheck *bool `type:"boolean"`
 
-	// Sets the key policy on the specified customer master key (CMK).
+	// Sets the key policy on the specified KMS key.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -14293,34 +14437,34 @@ type PutKeyPolicyInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// The key policy to attach to the CMK.
+	// The key policy to attach to the KMS key.
 	//
 	// The key policy must meet the following criteria:
 	//
 	//    * If you don't set BypassPolicyLockoutSafetyCheck to true, the key policy
 	//    must allow the principal that is making the PutKeyPolicy request to make
-	//    a subsequent PutKeyPolicy request on the CMK. This reduces the risk that
-	//    the CMK becomes unmanageable. For more information, refer to the scenario
-	//    in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	//    section of the AWS Key Management Service Developer Guide.
+	//    a subsequent PutKeyPolicy request on the KMS key. This reduces the risk
+	//    that the KMS key becomes unmanageable. For more information, refer to
+	//    the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
+	//    section of the Key Management Service Developer Guide.
 	//
 	//    * Each statement in the key policy must contain one or more principals.
-	//    The principals in the key policy must exist and be visible to AWS KMS.
-	//    When you create a new AWS principal (for example, an IAM user or role),
-	//    you might need to enforce a delay before including the new principal in
-	//    a key policy because the new principal might not be immediately visible
-	//    to AWS KMS. For more information, see Changes that I make are not always
-	//    immediately visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
-	//    in the AWS Identity and Access Management User Guide.
+	//    The principals in the key policy must exist and be visible to KMS. When
+	//    you create a new Amazon Web Services principal (for example, an IAM user
+	//    or role), you might need to enforce a delay before including the new principal
+	//    in a key policy because the new principal might not be immediately visible
+	//    to KMS. For more information, see Changes that I make are not always immediately
+	//    visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    in the Amazon Web Services Identity and Access Management User Guide.
 	//
 	// The key policy cannot exceed 32 kilobytes (32768 bytes). For more information,
 	// see Resource Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/resource-limits.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	//
 	// Policy is a required field
 	Policy *string `min:"1" type:"string" required:"true"`
@@ -14417,37 +14561,38 @@ type ReEncryptInput struct {
 	// CiphertextBlob is a required field
 	CiphertextBlob []byte `min:"1" type:"blob" required:"true"`
 
-	// Specifies the encryption algorithm that AWS KMS will use to reecrypt the
-	// data after it has decrypted it. The default value, SYMMETRIC_DEFAULT, represents
-	// the encryption algorithm used for symmetric CMKs.
+	// Specifies the encryption algorithm that KMS will use to reecrypt the data
+	// after it has decrypted it. The default value, SYMMETRIC_DEFAULT, represents
+	// the encryption algorithm used for symmetric KMS keys.
 	//
-	// This parameter is required only when the destination CMK is an asymmetric
-	// CMK.
+	// This parameter is required only when the destination KMS key is an asymmetric
+	// KMS key.
 	DestinationEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// Specifies that encryption context to use when the reencrypting the data.
 	//
-	// A destination encryption context is valid only when the destination CMK is
-	// a symmetric CMK. The standard ciphertext format for asymmetric CMKs does
-	// not include fields for metadata.
+	// A destination encryption context is valid only when the destination KMS key
+	// is a symmetric KMS key. The standard ciphertext format for asymmetric KMS
+	// keys does not include fields for metadata.
 	//
 	// An encryption context is a collection of non-secret key-value pairs that
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	DestinationEncryptionContext map[string]*string `type:"map"`
 
-	// A unique identifier for the CMK that is used to reencrypt the data. Specify
-	// a symmetric or asymmetric CMK with a KeyUsage value of ENCRYPT_DECRYPT. To
-	// find the KeyUsage value of a CMK, use the DescribeKey operation.
+	// A unique identifier for the KMS key that is used to reencrypt the data. Specify
+	// a symmetric or asymmetric KMS key with a KeyUsage value of ENCRYPT_DECRYPT.
+	// To find the KeyUsage value of a KMS key, use the DescribeKey operation.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -14459,8 +14604,8 @@ type ReEncryptInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// DestinationKeyId is a required field
 	DestinationKeyId *string `min:"1" type:"string" required:"true"`
@@ -14469,19 +14614,20 @@ type ReEncryptInput struct {
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Specifies the encryption algorithm that AWS KMS will use to decrypt the ciphertext
+	// Specifies the encryption algorithm that KMS will use to decrypt the ciphertext
 	// before it is reencrypted. The default value, SYMMETRIC_DEFAULT, represents
-	// the algorithm used for symmetric CMKs.
+	// the algorithm used for symmetric KMS keys.
 	//
 	// Specify the same algorithm that was used to encrypt the ciphertext. If you
 	// specify a different algorithm, the decrypt attempt fails.
 	//
 	// This parameter is required only when the ciphertext was encrypted under an
-	// asymmetric CMK.
+	// asymmetric KMS key.
 	SourceEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// Specifies the encryption context to use to decrypt the ciphertext. Enter
@@ -14491,25 +14637,26 @@ type ReEncryptInput struct {
 	// represents additional authenticated data. When you use an encryption context
 	// to encrypt data, you must specify the same (an exact case-sensitive match)
 	// encryption context to decrypt the data. An encryption context is optional
-	// when encrypting with a symmetric CMK, but it is highly recommended.
+	// when encrypting with a symmetric KMS key, but it is highly recommended.
 	//
 	// For more information, see Encryption Context (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	SourceEncryptionContext map[string]*string `type:"map"`
 
-	// Specifies the customer master key (CMK) that AWS KMS will use to decrypt
-	// the ciphertext before it is re-encrypted. Enter a key ID of the CMK that
-	// was used to encrypt the ciphertext.
+	// Specifies the KMS key that KMS will use to decrypt the ciphertext before
+	// it is re-encrypted. Enter a key ID of the KMS key that was used to encrypt
+	// the ciphertext.
 	//
 	// This parameter is required only when the ciphertext was encrypted under an
-	// asymmetric CMK. If you used a symmetric CMK, AWS KMS can get the CMK from
-	// metadata that it adds to the symmetric ciphertext blob. However, it is always
-	// recommended as a best practice. This practice ensures that you use the CMK
-	// that you intend.
+	// asymmetric KMS key. If you used a symmetric KMS key, KMS can get the KMS
+	// key from metadata that it adds to the symmetric ciphertext blob. However,
+	// it is always recommended as a best practice. This practice ensures that you
+	// use the KMS key that you intend.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -14521,8 +14668,8 @@ type ReEncryptInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	SourceKeyId *string `min:"1" type:"string"`
 }
 
@@ -14612,8 +14759,8 @@ func (s *ReEncryptInput) SetSourceKeyId(v string) *ReEncryptInput {
 type ReEncryptOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The reencrypted data. When you use the HTTP API or the AWS CLI, the value
-	// is Base64-encoded. Otherwise, it is not Base64-encoded.
+	// The reencrypted data. When you use the HTTP API or the Amazon Web Services
+	// CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.
 	//
 	// CiphertextBlob is automatically base64 encoded/decoded by the SDK.
 	CiphertextBlob []byte `min:"1" type:"blob"`
@@ -14622,14 +14769,14 @@ type ReEncryptOutput struct {
 	DestinationEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK that was used to reencrypt the data.
+	// of the KMS key that was used to reencrypt the data.
 	KeyId *string `min:"1" type:"string"`
 
 	// The encryption algorithm that was used to decrypt the ciphertext before it
 	// was reencrypted.
 	SourceEncryptionAlgorithm *string `type:"string" enum:"EncryptionAlgorithmSpec"`
 
-	// Unique identifier of the CMK used to originally encrypt the data.
+	// Unique identifier of the KMS key used to originally encrypt the data.
 	SourceKeyId *string `min:"1" type:"string"`
 }
 
@@ -14678,29 +14825,28 @@ type ReplicateKeyInput struct {
 
 	// A flag to indicate whether to bypass the key policy lockout safety check.
 	//
-	// Setting this value to true increases the risk that the CMK becomes unmanageable.
+	// Setting this value to true increases the risk that the KMS key becomes unmanageable.
 	// Do not set this value to true indiscriminately.
 	//
 	// For more information, refer to the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	// section in the AWS Key Management Service Developer Guide.
+	// section in the Key Management Service Developer Guide.
 	//
 	// Use this parameter only when you intend to prevent the principal that is
-	// making the request from making a subsequent PutKeyPolicy request on the CMK.
+	// making the request from making a subsequent PutKeyPolicy request on the KMS
+	// key.
 	//
 	// The default value is false.
 	BypassPolicyLockoutSafetyCheck *bool `type:"boolean"`
 
-	// A description of the CMK. Use a description that helps you decide whether
-	// the CMK is appropriate for a task. The default value is an empty string (no
-	// description).
+	// A description of the KMS key. The default value is an empty string (no description).
 	//
 	// The description is not a shared property of multi-Region keys. You can specify
 	// the same description or a different description for each key in a set of
-	// related multi-Region keys. AWS KMS does not synchronize this property.
+	// related multi-Region keys. KMS does not synchronize this property.
 	Description *string `type:"string"`
 
 	// Identifies the multi-Region primary key that is being replicated. To determine
-	// whether a CMK is a multi-Region primary key, use the DescribeKey operation
+	// whether a KMS key is a multi-Region primary key, use the DescribeKey operation
 	// to check the value of the MultiRegionKeyType property.
 	//
 	// Specify the key ID or key ARN of a multi-Region primary key.
@@ -14711,52 +14857,54 @@ type ReplicateKeyInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// The key policy to attach to the CMK. This parameter is optional. If you do
-	// not provide a key policy, AWS KMS attaches the default key policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default)
-	// to the CMK.
+	// The key policy to attach to the KMS key. This parameter is optional. If you
+	// do not provide a key policy, KMS attaches the default key policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default)
+	// to the KMS key.
 	//
 	// The key policy is not a shared property of multi-Region keys. You can specify
 	// the same key policy or a different key policy for each key in a set of related
-	// multi-Region keys. AWS KMS does not synchronize this property.
+	// multi-Region keys. KMS does not synchronize this property.
 	//
 	// If you provide a key policy, it must meet the following criteria:
 	//
 	//    * If you don't set BypassPolicyLockoutSafetyCheck to true, the key policy
-	//    must give the caller kms:PutKeyPolicy permission on the replica CMK. This
-	//    reduces the risk that the CMK becomes unmanageable. For more information,
+	//    must give the caller kms:PutKeyPolicy permission on the replica key. This
+	//    reduces the risk that the KMS key becomes unmanageable. For more information,
 	//    refer to the scenario in the Default Key Policy (https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam)
-	//    section of the AWS Key Management Service Developer Guide .
+	//    section of the Key Management Service Developer Guide .
 	//
 	//    * Each statement in the key policy must contain one or more principals.
-	//    The principals in the key policy must exist and be visible to AWS KMS.
-	//    When you create a new AWS principal (for example, an IAM user or role),
-	//    you might need to enforce a delay before including the new principal in
-	//    a key policy because the new principal might not be immediately visible
-	//    to AWS KMS. For more information, see Changes that I make are not always
-	//    immediately visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
-	//    in the AWS Identity and Access Management User Guide.
+	//    The principals in the key policy must exist and be visible to KMS. When
+	//    you create a new Amazon Web Services principal (for example, an IAM user
+	//    or role), you might need to enforce a delay before including the new principal
+	//    in a key policy because the new principal might not be immediately visible
+	//    to KMS. For more information, see Changes that I make are not always immediately
+	//    visible (https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency)
+	//    in the Identity and Access Management User Guide .
 	//
 	//    * The key policy size quota is 32 kilobytes (32768 bytes).
 	Policy *string `min:"1" type:"string"`
 
-	// The Region ID of the AWS Region for this replica key.
+	// The Region ID of the Amazon Web Services Region for this replica key.
 	//
-	// Enter the Region ID, such as us-east-1 or ap-southeast-2. For a list of AWS
-	// Regions in which AWS KMS is supported, see AWS KMS service endpoints (https://docs.aws.amazon.com/general/latest/gr/kms.html#kms_region)
-	// in the Amazon Web Services General Reference.
+	// Enter the Region ID, such as us-east-1 or ap-southeast-2. For a list of Amazon
+	// Web Services Regions in which KMS is supported, see KMS service endpoints
+	// (https://docs.aws.amazon.com/general/latest/gr/kms.html#kms_region) in the
+	// Amazon Web Services General Reference.
 	//
-	// The replica must be in a different AWS Region than its primary key and other
-	// replicas of that primary key, but in the same AWS partition. AWS KMS must
-	// be available in the replica Region. If the Region is not enabled by default,
-	// the AWS account must be enabled in the Region.
+	// The replica must be in a different Amazon Web Services Region than its primary
+	// key and other replicas of that primary key, but in the same Amazon Web Services
+	// partition. KMS must be available in the replica Region. If the Region is
+	// not enabled by default, the Amazon Web Services account must be enabled in
+	// the Region.
 	//
-	// For information about AWS partitions, see Amazon Resource Names (ARNs) in
-	// the Amazon Web Services General Reference. (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
+	// For information about Amazon Web Services partitions, see Amazon Resource
+	// Names (ARNs) in the Amazon Web Services General Reference. (https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// For information about enabling and disabling Regions, see Enabling a Region
 	// (https://docs.aws.amazon.com/general/latest/gr/rande-manage.html#rande-manage-enable)
 	// and Disabling a Region (https://docs.aws.amazon.com/general/latest/gr/rande-manage.html#rande-manage-disable)
@@ -14766,28 +14914,30 @@ type ReplicateKeyInput struct {
 	ReplicaRegion *string `min:"1" type:"string" required:"true"`
 
 	// Assigns one or more tags to the replica key. Use this parameter to tag the
-	// CMK when it is created. To tag an existing CMK, use the TagResource operation.
+	// KMS key when it is created. To tag an existing KMS key, use the TagResource
+	// operation.
 	//
-	// Tagging or untagging a CMK can allow or deny permission to the CMK. For details,
-	// see Using ABAC in AWS KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
-	// in the AWS Key Management Service Developer Guide.
+	// Tagging or untagging a KMS key can allow or deny permission to the KMS key.
+	// For details, see Using ABAC in KMS (https://docs.aws.amazon.com/kms/latest/developerguide/abac.html)
+	// in the Key Management Service Developer Guide.
 	//
 	// To use this parameter, you must have kms:TagResource (https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html)
 	// permission in an IAM policy.
 	//
 	// Tags are not a shared property of multi-Region keys. You can specify the
 	// same tags or different tags for each key in a set of related multi-Region
-	// keys. AWS KMS does not synchronize this property.
+	// keys. KMS does not synchronize this property.
 	//
 	// Each tag consists of a tag key and a tag value. Both the tag key and the
 	// tag value are required, but the tag value can be an empty (null) string.
-	// You cannot have more than one tag on a CMK with the same tag key. If you
-	// specify an existing tag key with a different tag value, AWS KMS replaces
+	// You cannot have more than one tag on a KMS key with the same tag key. If
+	// you specify an existing tag key with a different tag value, KMS replaces
 	// the current tag value with the specified one.
 	//
-	// When you assign tags to an AWS resource, AWS generates a cost allocation
-	// report with usage and costs aggregated by tags. Tags can also be used to
-	// control access to a CMK. For details, see Tagging Keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
+	// When you add tags to an Amazon Web Services resource, Amazon Web Services
+	// generates a cost allocation report with usage and costs aggregated by tags.
+	// Tags can also be used to control access to a KMS key. For details, see Tagging
+	// Keys (https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html).
 	Tags []*Tag `type:"list"`
 }
 
@@ -14875,11 +15025,11 @@ func (s *ReplicateKeyInput) SetTags(v []*Tag) *ReplicateKeyInput {
 type ReplicateKeyOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Displays details about the new replica CMK, including its Amazon Resource
+	// Displays details about the new replica key, including its Amazon Resource
 	// Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
 	// and key state (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html).
-	// It also includes the ARN and AWS Region of its primary key and other replica
-	// keys.
+	// It also includes the ARN and Amazon Web Services Region of its primary key
+	// and other replica keys.
 	ReplicaKeyMetadata *KeyMetadata `type:"structure"`
 
 	// The key policy of the new replica key. The value is a key policy document
@@ -14934,11 +15084,11 @@ type RetireGrantInput struct {
 	// Only the CreateGrant operation returns a grant token. For details, see Grant
 	// token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
 	// and Eventual consistency (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#terms-eventual-consistency)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	GrantToken *string `min:"1" type:"string"`
 
-	// The key ARN CMK associated with the grant. To find the key ARN, use the ListKeys
-	// operation.
+	// The key ARN KMS key associated with the grant. To find the key ARN, use the
+	// ListKeys operation.
 	//
 	// For example: arn:aws:kms:us-east-2:444455556666:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	KeyId *string `min:"1" type:"string"`
@@ -15014,11 +15164,11 @@ type RevokeGrantInput struct {
 	// GrantId is a required field
 	GrantId *string `min:"1" type:"string" required:"true"`
 
-	// A unique identifier for the customer master key (CMK) associated with the
-	// grant. To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// A unique identifier for the KMS key associated with the grant. To get the
+	// key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
-	// Specify the key ID or key ARN of the CMK. To specify a CMK in a different
-	// AWS account, you must use the key ARN.
+	// Specify the key ID or key ARN of the KMS key. To specify a KMS key in a different
+	// Amazon Web Services account, you must use the key ARN.
 	//
 	// For example:
 	//
@@ -15026,7 +15176,7 @@ type RevokeGrantInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -15093,9 +15243,9 @@ func (s RevokeGrantOutput) GoString() string {
 type ScheduleKeyDeletionInput struct {
 	_ struct{} `type:"structure"`
 
-	// The unique identifier of the customer master key (CMK) to delete.
+	// The unique identifier of the KMS key to delete.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -15103,15 +15253,15 @@ type ScheduleKeyDeletionInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
 	// The waiting period, specified in number of days. After the waiting period
-	// ends, AWS KMS deletes the customer master key (CMK).
+	// ends, KMS deletes the KMS key.
 	//
-	// If the CMK is a multi-Region primary key with replicas, the waiting period
+	// If the KMS key is a multi-Region primary key with replicas, the waiting period
 	// begins when the last of its replica keys is deleted. Otherwise, the waiting
 	// period begins immediately.
 	//
@@ -15164,27 +15314,27 @@ func (s *ScheduleKeyDeletionInput) SetPendingWindowInDays(v int64) *ScheduleKeyD
 type ScheduleKeyDeletionOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The date and time after which AWS KMS deletes the customer master key (CMK).
+	// The date and time after which KMS deletes the KMS key.
 	//
-	// If the CMK is a multi-Region primary key with replica keys, this field does
-	// not appear. The deletion date for the primary key isn't known until its last
-	// replica key is deleted.
+	// If the KMS key is a multi-Region primary key with replica keys, this field
+	// does not appear. The deletion date for the primary key isn't known until
+	// its last replica key is deleted.
 	DeletionDate *time.Time `type:"timestamp"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the CMK whose deletion is scheduled.
+	// of the KMS key whose deletion is scheduled.
 	KeyId *string `min:"1" type:"string"`
 
-	// The current status of the CMK.
+	// The current status of the KMS key.
 	//
-	// For more information about how key state affects the use of a CMK, see Key
-	// state: Effect on your CMK (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-	// in the AWS Key Management Service Developer Guide.
+	// For more information about how key state affects the use of a KMS key, see
+	// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+	// in the Key Management Service Developer Guide.
 	KeyState *string `type:"string" enum:"KeyState"`
 
-	// The waiting period before the CMK is deleted.
+	// The waiting period before the KMS key is deleted.
 	//
-	// If the CMK is a multi-Region primary key with replicas, the waiting period
+	// If the KMS key is a multi-Region primary key with replicas, the waiting period
 	// begins when the last of its replica keys is deleted. Otherwise, the waiting
 	// period begins immediately.
 	PendingWindowInDays *int64 `min:"1" type:"integer"`
@@ -15231,17 +15381,19 @@ type SignInput struct {
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Identifies an asymmetric CMK. AWS KMS uses the private key in the asymmetric
-	// CMK to sign the message. The KeyUsage type of the CMK must be SIGN_VERIFY.
-	// To find the KeyUsage of a CMK, use the DescribeKey operation.
+	// Identifies an asymmetric KMS key. KMS uses the private key in the asymmetric
+	// KMS key to sign the message. The KeyUsage type of the KMS key must be SIGN_VERIFY.
+	// To find the KeyUsage of a KMS key, use the DescribeKey operation.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -15253,8 +15405,8 @@ type SignInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -15262,23 +15414,23 @@ type SignInput struct {
 	// Specifies the message or message digest to sign. Messages can be 0-4096 bytes.
 	// To sign a larger message, provide the message digest.
 	//
-	// If you provide a message, AWS KMS generates a hash digest of the message
-	// and then signs it.
+	// If you provide a message, KMS generates a hash digest of the message and
+	// then signs it.
 	//
 	// Message is automatically base64 encoded/decoded by the SDK.
 	//
 	// Message is a required field
 	Message []byte `min:"1" type:"blob" required:"true" sensitive:"true"`
 
-	// Tells AWS KMS whether the value of the Message parameter is a message or
-	// message digest. The default value, RAW, indicates a message. To indicate
-	// a message digest, enter DIGEST.
+	// Tells KMS whether the value of the Message parameter is a message or message
+	// digest. The default value, RAW, indicates a message. To indicate a message
+	// digest, enter DIGEST.
 	MessageType *string `type:"string" enum:"MessageType"`
 
 	// Specifies the signing algorithm to use when signing the message.
 	//
 	// Choose an algorithm that is compatible with the type and size of the specified
-	// asymmetric CMK.
+	// asymmetric KMS key.
 	//
 	// SigningAlgorithm is a required field
 	SigningAlgorithm *string `type:"string" required:"true" enum:"SigningAlgorithmSpec"`
@@ -15353,7 +15505,7 @@ type SignOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the asymmetric CMK that was used to sign the message.
+	// of the asymmetric KMS key that was used to sign the message.
 	KeyId *string `min:"1" type:"string"`
 
 	// The cryptographic signature that was generated for the message.
@@ -15367,8 +15519,8 @@ type SignOutput struct {
 	//    This is the most commonly used signature format and is appropriate for
 	//    most uses.
 	//
-	// When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise,
-	// it is not Base64-encoded.
+	// When you use the HTTP API or the Amazon Web Services CLI, the value is Base64-encoded.
+	// Otherwise, it is not Base64-encoded.
 	//
 	// Signature is automatically base64 encoded/decoded by the SDK.
 	Signature []byte `min:"1" type:"blob"`
@@ -15410,7 +15562,7 @@ func (s *SignOutput) SetSigningAlgorithm(v string) *SignOutput {
 //
 // For information about the rules that apply to tag keys and tag values, see
 // User-Defined Tag Restrictions (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html)
-// in the AWS Billing and Cost Management User Guide.
+// in the Amazon Web Services Billing and Cost Management User Guide.
 type Tag struct {
 	_ struct{} `type:"structure"`
 
@@ -15525,9 +15677,9 @@ func (s *TagException) RequestID() string {
 type TagResourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies a customer managed CMK in the account and Region.
+	// Identifies a customer managed key in the account and Region.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -15535,7 +15687,7 @@ type TagResourceInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -15545,8 +15697,8 @@ type TagResourceInput struct {
 	// Each tag consists of a tag key and a tag value. The tag value can be an empty
 	// (null) string.
 	//
-	// You cannot have more than one tag on a CMK with the same tag key. If you
-	// specify an existing tag key with a different tag value, AWS KMS replaces
+	// You cannot have more than one tag on a KMS key with the same tag key. If
+	// you specify an existing tag key with a different tag value, KMS replaces
 	// the current tag value with the specified one.
 	//
 	// Tags is a required field
@@ -15678,9 +15830,9 @@ func (s *UnsupportedOperationException) RequestID() string {
 type UntagResourceInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the CMK from which you are removing tags.
+	// Identifies the KMS key from which you are removing tags.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -15688,7 +15840,7 @@ type UntagResourceInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -15757,22 +15909,23 @@ func (s UntagResourceOutput) GoString() string {
 type UpdateAliasInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the alias that is changing its CMK. This value must begin with
-	// alias/ followed by the alias name, such as alias/ExampleAlias. You cannot
+	// Identifies the alias that is changing its KMS key. This value must begin
+	// with alias/ followed by the alias name, such as alias/ExampleAlias. You cannot
 	// use UpdateAlias to change the alias name.
 	//
 	// AliasName is a required field
 	AliasName *string `min:"1" type:"string" required:"true"`
 
-	// Identifies the customer managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
+	// Identifies the customer managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk)
 	// to associate with the alias. You don't have permission to associate an alias
-	// with an AWS managed CMK (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
+	// with an Amazon Web Services managed key (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk).
 	//
-	// The CMK must be in the same AWS account and Region as the alias. Also, the
-	// new target CMK must be the same type as the current target CMK (both symmetric
-	// or both asymmetric) and they must have the same key usage.
+	// The KMS key must be in the same Amazon Web Services account and Region as
+	// the alias. Also, the new target KMS key must be the same type as the current
+	// target KMS key (both symmetric or both asymmetric) and they must have the
+	// same key usage.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -15780,9 +15933,9 @@ type UpdateAliasInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
-	// To verify that the alias is mapped to the correct CMK, use ListAliases.
+	// To verify that the alias is mapped to the correct KMS key, use ListAliases.
 	//
 	// TargetKeyId is a required field
 	TargetKeyId *string `min:"1" type:"string" required:"true"`
@@ -15849,7 +16002,7 @@ func (s UpdateAliasOutput) GoString() string {
 type UpdateCustomKeyStoreInput struct {
 	_ struct{} `type:"structure"`
 
-	// Associates the custom key store with a related AWS CloudHSM cluster.
+	// Associates the custom key store with a related CloudHSM cluster.
 	//
 	// Enter the cluster ID of the cluster that you used to create the custom key
 	// store or a cluster that shares a backup history and has the same cluster
@@ -15868,16 +16021,16 @@ type UpdateCustomKeyStoreInput struct {
 	// CustomKeyStoreId is a required field
 	CustomKeyStoreId *string `min:"1" type:"string" required:"true"`
 
-	// Enter the current password of the kmsuser crypto user (CU) in the AWS CloudHSM
+	// Enter the current password of the kmsuser crypto user (CU) in the CloudHSM
 	// cluster that is associated with the custom key store.
 	//
-	// This parameter tells AWS KMS the current password of the kmsuser crypto user
-	// (CU). It does not set or change the password of any users in the AWS CloudHSM
+	// This parameter tells KMS the current password of the kmsuser crypto user
+	// (CU). It does not set or change the password of any users in the CloudHSM
 	// cluster.
 	KeyStorePassword *string `min:"7" type:"string" sensitive:"true"`
 
 	// Changes the friendly name of the custom key store to the value that you specify.
-	// The custom key store name must be unique in the AWS account.
+	// The custom key store name must be unique in the Amazon Web Services account.
 	NewCustomKeyStoreName *string `min:"1" type:"string"`
 }
 
@@ -15957,14 +16110,14 @@ func (s UpdateCustomKeyStoreOutput) GoString() string {
 type UpdateKeyDescriptionInput struct {
 	_ struct{} `type:"structure"`
 
-	// New description for the CMK.
+	// New description for the KMS key.
 	//
 	// Description is a required field
 	Description *string `type:"string" required:"true"`
 
-	// Updates the description of the specified customer master key (CMK).
+	// Updates the description of the specified KMS key.
 	//
-	// Specify the key ID or key ARN of the CMK.
+	// Specify the key ID or key ARN of the KMS key.
 	//
 	// For example:
 	//
@@ -15972,7 +16125,7 @@ type UpdateKeyDescriptionInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -16036,8 +16189,8 @@ func (s UpdateKeyDescriptionOutput) GoString() string {
 type UpdatePrimaryRegionInput struct {
 	_ struct{} `type:"structure"`
 
-	// Identifies the current primary key. When the operation completes, this CMK
-	// will be a replica key.
+	// Identifies the current primary key. When the operation completes, this KMS
+	// key will be a replica key.
 	//
 	// Specify the key ID or key ARN of a multi-Region primary key.
 	//
@@ -16047,13 +16200,14 @@ type UpdatePrimaryRegionInput struct {
 	//
 	//    * Key ARN: arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
 
-	// The AWS Region of the new primary key. Enter the Region ID, such as us-east-1
-	// or ap-southeast-2. There must be an existing replica key in this Region.
+	// The Amazon Web Services Region of the new primary key. Enter the Region ID,
+	// such as us-east-1 or ap-southeast-2. There must be an existing replica key
+	// in this Region.
 	//
 	// When the operation completes, the multi-Region key in this Region will be
 	// the primary key.
@@ -16127,17 +16281,19 @@ type VerifyInput struct {
 	//
 	// Use a grant token when your permission to call this operation comes from
 	// a new grant that has not yet achieved eventual consistency. For more information,
-	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#grant_token)
-	// in the AWS Key Management Service Developer Guide.
+	// see Grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token)
+	// and Using a grant token (https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token)
+	// in the Key Management Service Developer Guide.
 	GrantTokens []*string `type:"list"`
 
-	// Identifies the asymmetric CMK that will be used to verify the signature.
-	// This must be the same CMK that was used to generate the signature. If you
-	// specify a different CMK, the signature verification fails.
+	// Identifies the asymmetric KMS key that will be used to verify the signature.
+	// This must be the same KMS key that was used to generate the signature. If
+	// you specify a different KMS key, the signature verification fails.
 	//
-	// To specify a CMK, use its key ID, key ARN, alias name, or alias ARN. When
-	// using an alias name, prefix it with "alias/". To specify a CMK in a different
-	// AWS account, you must use the key ARN or alias ARN.
+	// To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN.
+	// When using an alias name, prefix it with "alias/". To specify a KMS key in
+	// a different Amazon Web Services account, you must use the key ARN or alias
+	// ARN.
 	//
 	// For example:
 	//
@@ -16149,8 +16305,8 @@ type VerifyInput struct {
 	//
 	//    * Alias ARN: arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias
 	//
-	// To get the key ID and key ARN for a CMK, use ListKeys or DescribeKey. To
-	// get the alias name and alias ARN, use ListAliases.
+	// To get the key ID and key ARN for a KMS key, use ListKeys or DescribeKey.
+	// To get the alias name and alias ARN, use ListAliases.
 	//
 	// KeyId is a required field
 	KeyId *string `min:"1" type:"string" required:"true"`
@@ -16168,9 +16324,9 @@ type VerifyInput struct {
 	// Message is a required field
 	Message []byte `min:"1" type:"blob" required:"true" sensitive:"true"`
 
-	// Tells AWS KMS whether the value of the Message parameter is a message or
-	// message digest. The default value, RAW, indicates a message. To indicate
-	// a message digest, enter DIGEST.
+	// Tells KMS whether the value of the Message parameter is a message or message
+	// digest. The default value, RAW, indicates a message. To indicate a message
+	// digest, enter DIGEST.
 	//
 	// Use the DIGEST value only when the value of the Message parameter is a message
 	// digest. If you use the DIGEST value with a raw message, the security of the
@@ -16272,7 +16428,7 @@ type VerifyOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
-	// of the asymmetric CMK that was used to verify the signature.
+	// of the asymmetric KMS key that was used to verify the signature.
 	KeyId *string `min:"1" type:"string"`
 
 	// A Boolean value that indicates whether the signature was verified. A value
@@ -16610,6 +16766,46 @@ func KeyManagerType_Values() []string {
 	return []string{
 		KeyManagerTypeAws,
 		KeyManagerTypeCustomer,
+	}
+}
+
+const (
+	// KeySpecRsa2048 is a KeySpec enum value
+	KeySpecRsa2048 = "RSA_2048"
+
+	// KeySpecRsa3072 is a KeySpec enum value
+	KeySpecRsa3072 = "RSA_3072"
+
+	// KeySpecRsa4096 is a KeySpec enum value
+	KeySpecRsa4096 = "RSA_4096"
+
+	// KeySpecEccNistP256 is a KeySpec enum value
+	KeySpecEccNistP256 = "ECC_NIST_P256"
+
+	// KeySpecEccNistP384 is a KeySpec enum value
+	KeySpecEccNistP384 = "ECC_NIST_P384"
+
+	// KeySpecEccNistP521 is a KeySpec enum value
+	KeySpecEccNistP521 = "ECC_NIST_P521"
+
+	// KeySpecEccSecgP256k1 is a KeySpec enum value
+	KeySpecEccSecgP256k1 = "ECC_SECG_P256K1"
+
+	// KeySpecSymmetricDefault is a KeySpec enum value
+	KeySpecSymmetricDefault = "SYMMETRIC_DEFAULT"
+)
+
+// KeySpec_Values returns all elements of the KeySpec enum
+func KeySpec_Values() []string {
+	return []string{
+		KeySpecRsa2048,
+		KeySpecRsa3072,
+		KeySpecRsa4096,
+		KeySpecEccNistP256,
+		KeySpecEccNistP384,
+		KeySpecEccNistP521,
+		KeySpecEccSecgP256k1,
+		KeySpecSymmetricDefault,
 	}
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/kms/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kms/doc.go
@@ -3,21 +3,26 @@
 // Package kms provides the client and types for making API
 // requests to AWS Key Management Service.
 //
-// AWS Key Management Service (AWS KMS) is an encryption and key management
-// web service. This guide describes the AWS KMS operations that you can call
-// programmatically. For general information about AWS KMS, see the AWS Key
-// Management Service Developer Guide (https://docs.aws.amazon.com/kms/latest/developerguide/).
+// Key Management Service (KMS) is an encryption and key management web service.
+// This guide describes the KMS operations that you can call programmatically.
+// For general information about KMS, see the Key Management Service Developer
+// Guide (https://docs.aws.amazon.com/kms/latest/developerguide/).
 //
-// AWS provides SDKs that consist of libraries and sample code for various programming
-// languages and platforms (Java, Ruby, .Net, macOS, Android, etc.). The SDKs
-// provide a convenient way to create programmatic access to AWS KMS and other
-// AWS services. For example, the SDKs take care of tasks such as signing requests
-// (see below), managing errors, and retrying requests automatically. For more
-// information about the AWS SDKs, including how to download and install them,
-// see Tools for Amazon Web Services (http://aws.amazon.com/tools/).
+// KMS is replacing the term customer master key (CMK) with KMS key and KMS
+// key. The concept has not changed. To prevent breaking changes, KMS is keeping
+// some variations of this term.
 //
-// We recommend that you use the AWS SDKs to make programmatic API calls to
-// AWS KMS.
+// Amazon Web Services provides SDKs that consist of libraries and sample code
+// for various programming languages and platforms (Java, Ruby, .Net, macOS,
+// Android, etc.). The SDKs provide a convenient way to create programmatic
+// access to KMS and other Amazon Web Services services. For example, the SDKs
+// take care of tasks such as signing requests (see below), managing errors,
+// and retrying requests automatically. For more information about the Amazon
+// Web Services SDKs, including how to download and install them, see Tools
+// for Amazon Web Services (http://aws.amazon.com/tools/).
+//
+// We recommend that you use the Amazon Web Services SDKs to make programmatic
+// API calls to KMS.
 //
 // Clients must support TLS (Transport Layer Security) 1.0. We recommend TLS
 // 1.2. Clients must also support cipher suites with Perfect Forward Secrecy
@@ -28,30 +33,31 @@
 // Signing Requests
 //
 // Requests must be signed by using an access key ID and a secret access key.
-// We strongly recommend that you do not use your AWS account (root) access
-// key ID and secret key for everyday work with AWS KMS. Instead, use the access
-// key ID and secret access key for an IAM user. You can also use the AWS Security
-// Token Service to generate temporary security credentials that you can use
-// to sign requests.
+// We strongly recommend that you do not use your Amazon Web Services account
+// (root) access key ID and secret key for everyday work with KMS. Instead,
+// use the access key ID and secret access key for an IAM user. You can also
+// use the Amazon Web Services Security Token Service to generate temporary
+// security credentials that you can use to sign requests.
 //
-// All AWS KMS operations require Signature Version 4 (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+// All KMS operations require Signature Version 4 (https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
 //
 // Logging API Requests
 //
-// AWS KMS supports AWS CloudTrail, a service that logs AWS API calls and related
-// events for your AWS account and delivers them to an Amazon S3 bucket that
-// you specify. By using the information collected by CloudTrail, you can determine
-// what requests were made to AWS KMS, who made the request, when it was made,
-// and so on. To learn more about CloudTrail, including how to turn it on and
-// find your log files, see the AWS CloudTrail User Guide (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/).
+// KMS supports CloudTrail, a service that logs Amazon Web Services API calls
+// and related events for your Amazon Web Services account and delivers them
+// to an Amazon S3 bucket that you specify. By using the information collected
+// by CloudTrail, you can determine what requests were made to KMS, who made
+// the request, when it was made, and so on. To learn more about CloudTrail,
+// including how to turn it on and find your log files, see the CloudTrail User
+// Guide (https://docs.aws.amazon.com/awscloudtrail/latest/userguide/).
 //
 // Additional Resources
 //
 // For more information about credentials and request signing, see the following:
 //
-//    * AWS Security Credentials (https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html)
+//    * Amazon Web Services Security Credentials (https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html)
 //    - This topic provides general information about the types of credentials
-//    used for accessing AWS.
+//    used to access Amazon Web Services.
 //
 //    * Temporary Security Credentials (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html)
 //    - This section of the IAM User Guide describes how to create and use temporary

--- a/vendor/github.com/aws/aws-sdk-go/service/kms/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kms/errors.go
@@ -18,10 +18,10 @@ const (
 	// ErrCodeCloudHsmClusterInUseException for service response error code
 	// "CloudHsmClusterInUseException".
 	//
-	// The request was rejected because the specified AWS CloudHSM cluster is already
+	// The request was rejected because the specified CloudHSM cluster is already
 	// associated with a custom key store or it shares a backup history with a cluster
 	// that is associated with a custom key store. Each custom key store must be
-	// associated with a different AWS CloudHSM cluster.
+	// associated with a different CloudHSM cluster.
 	//
 	// Clusters that share a backup history have the same cluster certificate. To
 	// view the cluster certificate of a cluster, use the DescribeClusters (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html)
@@ -31,8 +31,8 @@ const (
 	// ErrCodeCloudHsmClusterInvalidConfigurationException for service response error code
 	// "CloudHsmClusterInvalidConfigurationException".
 	//
-	// The request was rejected because the associated AWS CloudHSM cluster did
-	// not meet the configuration requirements for a custom key store.
+	// The request was rejected because the associated CloudHSM cluster did not
+	// meet the configuration requirements for a custom key store.
 	//
 	//    * The cluster must be configured with private subnets in at least two
 	//    different Availability Zones in the Region.
@@ -47,46 +47,44 @@ const (
 	//    operation.
 	//
 	//    * The cluster must contain at least as many HSMs as the operation requires.
-	//    To add HSMs, use the AWS CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
+	//    To add HSMs, use the CloudHSM CreateHsm (https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html)
 	//    operation. For the CreateCustomKeyStore, UpdateCustomKeyStore, and CreateKey
-	//    operations, the AWS CloudHSM cluster must have at least two active HSMs,
-	//    each in a different Availability Zone. For the ConnectCustomKeyStore operation,
-	//    the AWS CloudHSM must contain at least one active HSM.
+	//    operations, the CloudHSM cluster must have at least two active HSMs, each
+	//    in a different Availability Zone. For the ConnectCustomKeyStore operation,
+	//    the CloudHSM must contain at least one active HSM.
 	//
-	// For information about the requirements for an AWS CloudHSM cluster that is
-	// associated with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
-	// in the AWS Key Management Service Developer Guide. For information about
-	// creating a private subnet for an AWS CloudHSM cluster, see Create a Private
-	// Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
-	// in the AWS CloudHSM User Guide. For information about cluster security groups,
+	// For information about the requirements for an CloudHSM cluster that is associated
+	// with a custom key store, see Assemble the Prerequisites (https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore)
+	// in the Key Management Service Developer Guide. For information about creating
+	// a private subnet for an CloudHSM cluster, see Create a Private Subnet (https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html)
+	// in the CloudHSM User Guide. For information about cluster security groups,
 	// see Configure a Default Security Group (https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html)
-	// in the AWS CloudHSM User Guide .
+	// in the CloudHSM User Guide .
 	ErrCodeCloudHsmClusterInvalidConfigurationException = "CloudHsmClusterInvalidConfigurationException"
 
 	// ErrCodeCloudHsmClusterNotActiveException for service response error code
 	// "CloudHsmClusterNotActiveException".
 	//
-	// The request was rejected because the AWS CloudHSM cluster that is associated
+	// The request was rejected because the CloudHSM cluster that is associated
 	// with the custom key store is not active. Initialize and activate the cluster
 	// and try the command again. For detailed instructions, see Getting Started
 	// (https://docs.aws.amazon.com/cloudhsm/latest/userguide/getting-started.html)
-	// in the AWS CloudHSM User Guide.
+	// in the CloudHSM User Guide.
 	ErrCodeCloudHsmClusterNotActiveException = "CloudHsmClusterNotActiveException"
 
 	// ErrCodeCloudHsmClusterNotFoundException for service response error code
 	// "CloudHsmClusterNotFoundException".
 	//
-	// The request was rejected because AWS KMS cannot find the AWS CloudHSM cluster
-	// with the specified cluster ID. Retry the request with a different cluster
-	// ID.
+	// The request was rejected because KMS cannot find the CloudHSM cluster with
+	// the specified cluster ID. Retry the request with a different cluster ID.
 	ErrCodeCloudHsmClusterNotFoundException = "CloudHsmClusterNotFoundException"
 
 	// ErrCodeCloudHsmClusterNotRelatedException for service response error code
 	// "CloudHsmClusterNotRelatedException".
 	//
-	// The request was rejected because the specified AWS CloudHSM cluster has a
-	// different cluster certificate than the original cluster. You cannot use the
-	// operation to specify an unrelated cluster.
+	// The request was rejected because the specified CloudHSM cluster has a different
+	// cluster certificate than the original cluster. You cannot use the operation
+	// to specify an unrelated cluster.
 	//
 	// Specify a cluster that shares a backup history with the original cluster.
 	// This includes clusters that were created from a backup of the current cluster,
@@ -101,10 +99,10 @@ const (
 	// ErrCodeCustomKeyStoreHasCMKsException for service response error code
 	// "CustomKeyStoreHasCMKsException".
 	//
-	// The request was rejected because the custom key store contains AWS KMS customer
-	// master keys (CMKs). After verifying that you do not need to use the CMKs,
-	// use the ScheduleKeyDeletion operation to delete the CMKs. After they are
-	// deleted, you can delete the custom key store.
+	// The request was rejected because the custom key store contains KMS keys.
+	// After verifying that you do not need to use the KMS keys, use the ScheduleKeyDeletion
+	// operation to delete the KMS keys. After they are deleted, you can delete
+	// the custom key store.
 	ErrCodeCustomKeyStoreHasCMKsException = "CustomKeyStoreHasCMKsException"
 
 	// ErrCodeCustomKeyStoreInvalidStateException for service response error code
@@ -140,7 +138,7 @@ const (
 	// ErrCodeCustomKeyStoreNotFoundException for service response error code
 	// "CustomKeyStoreNotFoundException".
 	//
-	// The request was rejected because AWS KMS cannot find a custom key store with
+	// The request was rejected because KMS cannot find a custom key store with
 	// the specified key store name or ID.
 	ErrCodeCustomKeyStoreNotFoundException = "CustomKeyStoreNotFoundException"
 
@@ -154,7 +152,7 @@ const (
 	// ErrCodeDisabledException for service response error code
 	// "DisabledException".
 	//
-	// The request was rejected because the specified CMK is not enabled.
+	// The request was rejected because the specified KMS key is not enabled.
 	ErrCodeDisabledException = "DisabledException"
 
 	// ErrCodeExpiredImportTokenException for service response error code
@@ -168,9 +166,9 @@ const (
 	// ErrCodeIncorrectKeyException for service response error code
 	// "IncorrectKeyException".
 	//
-	// The request was rejected because the specified CMK cannot decrypt the data.
-	// The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
-	// must identify the same CMK that was used to encrypt the ciphertext.
+	// The request was rejected because the specified KMS key cannot decrypt the
+	// data. The KeyId in a Decrypt request and the SourceKeyId in a ReEncrypt request
+	// must identify the same KMS key that was used to encrypt the ciphertext.
 	ErrCodeIncorrectKeyException = "IncorrectKeyException"
 
 	// ErrCodeIncorrectKeyMaterialException for service response error code
@@ -178,14 +176,14 @@ const (
 	//
 	// The request was rejected because the key material in the request is, expired,
 	// invalid, or is not the same key material that was previously imported into
-	// this customer master key (CMK).
+	// this KMS key.
 	ErrCodeIncorrectKeyMaterialException = "IncorrectKeyMaterialException"
 
 	// ErrCodeIncorrectTrustAnchorException for service response error code
 	// "IncorrectTrustAnchorException".
 	//
 	// The request was rejected because the trust anchor certificate in the request
-	// is not the trust anchor certificate for the specified AWS CloudHSM cluster.
+	// is not the trust anchor certificate for the specified CloudHSM cluster.
 	//
 	// When you initialize the cluster (https://docs.aws.amazon.com/cloudhsm/latest/userguide/initialize-cluster.html#sign-csr),
 	// you create the trust anchor certificate and save it in the customerCA.crt
@@ -220,8 +218,8 @@ const (
 	// the ciphertext, such as the encryption context, is corrupted, missing, or
 	// otherwise invalid.
 	//
-	// From the ImportKeyMaterial operation, the request was rejected because AWS
-	// KMS could not decrypt the encrypted (wrapped) key material.
+	// From the ImportKeyMaterial operation, the request was rejected because KMS
+	// could not decrypt the encrypted (wrapped) key material.
 	ErrCodeInvalidCiphertextException = "InvalidCiphertextException"
 
 	// ErrCodeInvalidGrantIdException for service response error code
@@ -240,7 +238,7 @@ const (
 	// "InvalidImportTokenException".
 	//
 	// The request was rejected because the provided import token is invalid or
-	// is associated with a different customer master key (CMK).
+	// is associated with a different KMS key.
 	ErrCodeInvalidImportTokenException = "InvalidImportTokenException"
 
 	// ErrCodeInvalidKeyUsageException for service response error code
@@ -248,17 +246,18 @@ const (
 	//
 	// The request was rejected for one of the following reasons:
 	//
-	//    * The KeyUsage value of the CMK is incompatible with the API operation.
+	//    * The KeyUsage value of the KMS key is incompatible with the API operation.
 	//
 	//    * The encryption algorithm or signing algorithm specified for the operation
-	//    is incompatible with the type of key material in the CMK (CustomerMasterKeySpec).
+	//    is incompatible with the type of key material in the KMS key (KeySpec).
 	//
 	// For encrypting, decrypting, re-encrypting, and generating data keys, the
 	// KeyUsage must be ENCRYPT_DECRYPT. For signing and verifying, the KeyUsage
-	// must be SIGN_VERIFY. To find the KeyUsage of a CMK, use the DescribeKey operation.
+	// must be SIGN_VERIFY. To find the KeyUsage of a KMS key, use the DescribeKey
+	// operation.
 	//
-	// To find the encryption or signing algorithms supported for a particular CMK,
-	// use the DescribeKey operation.
+	// To find the encryption or signing algorithms supported for a particular KMS
+	// key, use the DescribeKey operation.
 	ErrCodeInvalidKeyUsageException = "InvalidKeyUsageException"
 
 	// ErrCodeInvalidMarkerException for service response error code
@@ -274,9 +273,9 @@ const (
 	// The request was rejected because the state of the specified resource is not
 	// valid for this request.
 	//
-	// For more information about how key state affects the use of a CMK, see How
-	// Key State Affects Use of a Customer Master Key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
-	// in the AWS Key Management Service Developer Guide .
+	// For more information about how key state affects the use of a KMS key, see
+	// Key state: Effect on your KMS key (https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html)
+	// in the Key Management Service Developer Guide .
 	ErrCodeInvalidStateException = "KMSInvalidStateException"
 
 	// ErrCodeKMSInvalidSignatureException for service response error code
@@ -284,14 +283,14 @@ const (
 	//
 	// The request was rejected because the signature verification failed. Signature
 	// verification fails when it cannot confirm that signature was produced by
-	// signing the specified message with the specified CMK and signing algorithm.
+	// signing the specified message with the specified KMS key and signing algorithm.
 	ErrCodeKMSInvalidSignatureException = "KMSInvalidSignatureException"
 
 	// ErrCodeKeyUnavailableException for service response error code
 	// "KeyUnavailableException".
 	//
-	// The request was rejected because the specified CMK was not available. You
-	// can retry the request.
+	// The request was rejected because the specified KMS key was not available.
+	// You can retry the request.
 	ErrCodeKeyUnavailableException = "KeyUnavailableException"
 
 	// ErrCodeLimitExceededException for service response error code
@@ -299,7 +298,7 @@ const (
 	//
 	// The request was rejected because a quota was exceeded. For more information,
 	// see Quotas (https://docs.aws.amazon.com/kms/latest/developerguide/limits.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Key Management Service Developer Guide.
 	ErrCodeLimitExceededException = "LimitExceededException"
 
 	// ErrCodeMalformedPolicyDocumentException for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
@@ -161,10 +161,11 @@ func (c *Route53) AssociateVPCWithHostedZoneRequest(input *AssociateVPCWithHoste
 // To perform the association, the VPC and the private hosted zone must already
 // exist. You can't convert a public hosted zone into a private hosted zone.
 //
-// If you want to associate a VPC that was created by using one account with
-// a private hosted zone that was created by using a different account, the
-// account that created the private hosted zone must first submit a CreateVPCAssociationAuthorization
-// request. Then the account that created the VPC must submit an AssociateVPCWithHostedZone
+// If you want to associate a VPC that was created by using one Amazon Web Services
+// account with a private hosted zone that was created by using a different
+// account, the Amazon Web Services account that created the private hosted
+// zone must first submit a CreateVPCAssociationAuthorization request. Then
+// the account that created the VPC must submit an AssociateVPCWithHostedZone
 // request.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -626,8 +627,8 @@ func (c *Route53) CreateHealthCheckRequest(input *CreateHealthCheckInput) (req *
 //   To request a higher limit, create a case (http://aws.amazon.com/route53-request)
 //   with the Amazon Web Services Support Center.
 //
-//   You have reached the maximum number of active health checks for an account.
-//   To request a higher limit, create a case (http://aws.amazon.com/route53-request)
+//   You have reached the maximum number of active health checks for an Amazon
+//   Web Services account. To request a higher limit, create a case (http://aws.amazon.com/route53-request)
 //   with the Amazon Web Services Support Center.
 //
 //   * ErrCodeHealthCheckAlreadyExists "HealthCheckAlreadyExists"
@@ -1030,8 +1031,8 @@ func (c *Route53) CreateQueryLoggingConfigRequest(input *CreateQueryLoggingConfi
 //
 //    * You must create the log group in the us-east-1 region.
 //
-//    * You must use the same account to create the log group and the hosted
-//    zone that you want to configure query logging for.
+//    * You must use the same Amazon Web Services account to create the log
+//    group and the hosted zone that you want to configure query logging for.
 //
 //    * When you create log groups for query logging, we recommend that you
 //    use a consistent prefix, for example: /aws/route53/hosted zone name In
@@ -1217,7 +1218,8 @@ func (c *Route53) CreateReusableDelegationSetRequest(input *CreateReusableDelega
 // CreateReusableDelegationSet API operation for Amazon Route 53.
 //
 // Creates a delegation set (a group of four name servers) that can be reused
-// by multiple hosted zones that were created by the same account.
+// by multiple hosted zones that were created by the same Amazon Web Services
+// account.
 //
 // You can also create a reusable delegation set that uses the four name servers
 // that are associated with an existing hosted zone. Specify the hosted zone
@@ -1685,12 +1687,12 @@ func (c *Route53) CreateVPCAssociationAuthorizationRequest(input *CreateVPCAssoc
 
 // CreateVPCAssociationAuthorization API operation for Amazon Route 53.
 //
-// Authorizes the account that created a specified VPC to submit an AssociateVPCWithHostedZone
-// request to associate the VPC with a specified hosted zone that was created
-// by a different account. To submit a CreateVPCAssociationAuthorization request,
-// you must use the account that created the hosted zone. After you authorize
-// the association, use the account that created the VPC to submit an AssociateVPCWithHostedZone
-// request.
+// Authorizes the Amazon Web Services account that created a specified VPC to
+// submit an AssociateVPCWithHostedZone request to associate the VPC with a
+// specified hosted zone that was created by a different account. To submit
+// a CreateVPCAssociationAuthorization request, you must use the account that
+// created the hosted zone. After you authorize the association, use the account
+// that created the VPC to submit an AssociateVPCWithHostedZone request.
 //
 // If you want to associate multiple VPCs that you created by using one account
 // with a hosted zone that you created by using a different account, you must
@@ -2039,7 +2041,7 @@ func (c *Route53) DeleteHostedZoneRequest(input *DeleteHostedZoneInput) (req *re
 //    zone.
 //
 //    * Use the ListHostedZones action to get a list of the hosted zones associated
-//    with the current account.
+//    with the current Amazon Web Services account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2626,9 +2628,9 @@ func (c *Route53) DeleteVPCAssociationAuthorizationRequest(input *DeleteVPCAssoc
 // account. You must use the account that created the hosted zone to submit
 // a DeleteVPCAssociationAuthorization request.
 //
-// Sending this request only prevents the account that created the VPC from
-// associating the VPC with the Amazon Route 53 hosted zone in the future. If
-// the VPC is already associated with the hosted zone, DeleteVPCAssociationAuthorization
+// Sending this request only prevents the Amazon Web Services account that created
+// the VPC from associating the VPC with the Amazon Route 53 hosted zone in
+// the future. If the VPC is already associated with the hosted zone, DeleteVPCAssociationAuthorization
 // won't disassociate the VPC from the hosted zone. If you want to delete an
 // existing association, use DisassociateVPCFromHostedZone.
 //
@@ -3055,8 +3057,8 @@ func (c *Route53) GetAccountLimitRequest(input *GetAccountLimitInput) (req *requ
 // case (https://console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase&limitType=service-code-route53).
 //
 // You can also view account limits in Amazon Web Services Trusted Advisor.
-// Sign in to the Management Console and open the Trusted Advisor console at
-// https://console.aws.amazon.com/trustedadvisor/ (https://console.aws.amazon.com/trustedadvisor).
+// Sign in to the Amazon Web Services Management Console and open the Trusted
+// Advisor console at https://console.aws.amazon.com/trustedadvisor/ (https://console.aws.amazon.com/trustedadvisor).
 // Then choose Service limits in the navigation pane.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3583,7 +3585,7 @@ func (c *Route53) GetHealthCheckCountRequest(input *GetHealthCheckCountInput) (r
 // GetHealthCheckCount API operation for Amazon Route 53.
 //
 // Retrieves the number of health checks that are associated with the current
-// account.
+// Amazon Web Services account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3909,7 +3911,7 @@ func (c *Route53) GetHostedZoneCountRequest(input *GetHostedZoneCountInput) (req
 // GetHostedZoneCount API operation for Amazon Route 53.
 //
 // Retrieves the number of hosted zones that are associated with the current
-// account.
+// Amazon Web Services account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4511,7 +4513,7 @@ func (c *Route53) GetTrafficPolicyInstanceCountRequest(input *GetTrafficPolicyIn
 // GetTrafficPolicyInstanceCount API operation for Amazon Route 53.
 //
 // Gets the number of traffic policy instances that are associated with the
-// current account.
+// current Amazon Web Services account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4682,7 +4684,7 @@ func (c *Route53) ListHealthChecksRequest(input *ListHealthChecksInput) (req *re
 // ListHealthChecks API operation for Amazon Route 53.
 //
 // Retrieve a list of the health checks that are associated with the current
-// account.
+// Amazon Web Services account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4824,8 +4826,8 @@ func (c *Route53) ListHostedZonesRequest(input *ListHostedZonesInput) (req *requ
 // ListHostedZones API operation for Amazon Route 53.
 //
 // Retrieves a list of the public and private hosted zones that are associated
-// with the current account. The response includes a HostedZones child element
-// for each hosted zone.
+// with the current Amazon Web Services account. The response includes a HostedZones
+// child element for each hosted zone.
 //
 // Amazon Route 53 returns a maximum of 100 items in each response. If you have
 // a lot of hosted zones, you can use the maxitems parameter to list them in
@@ -4968,7 +4970,7 @@ func (c *Route53) ListHostedZonesByNameRequest(input *ListHostedZonesByNameInput
 //
 // Retrieves a list of your hosted zones in lexicographic order. The response
 // includes a HostedZones child element for each hosted zone created by the
-// current account.
+// current Amazon Web Services account.
 //
 // ListHostedZonesByName sorts hosted zones by name with the labels reversed.
 // For example:
@@ -5004,16 +5006,17 @@ func (c *Route53) ListHostedZonesByNameRequest(input *ListHostedZonesByNameInput
 //    the current response.
 //
 //    * If the value of IsTruncated in the response is true, there are more
-//    hosted zones associated with the current account. If IsTruncated is false,
-//    this response includes the last hosted zone that is associated with the
-//    current account. The NextDNSName element and NextHostedZoneId elements
-//    are omitted from the response.
+//    hosted zones associated with the current Amazon Web Services account.
+//    If IsTruncated is false, this response includes the last hosted zone that
+//    is associated with the current account. The NextDNSName element and NextHostedZoneId
+//    elements are omitted from the response.
 //
 //    * The NextDNSName and NextHostedZoneId elements in the response contain
 //    the domain name and the hosted zone ID of the next hosted zone that is
-//    associated with the current account. If you want to list more hosted zones,
-//    make another call to ListHostedZonesByName, and specify the value of NextDNSName
-//    and NextHostedZoneId in the dnsname and hostedzoneid parameters, respectively.
+//    associated with the current Amazon Web Services account. If you want to
+//    list more hosted zones, make another call to ListHostedZonesByName, and
+//    specify the value of NextDNSName and NextHostedZoneId in the dnsname and
+//    hostedzoneid parameters, respectively.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5096,13 +5099,14 @@ func (c *Route53) ListHostedZonesByVPCRequest(input *ListHostedZonesByVPCInput) 
 // ListHostedZonesByVPC API operation for Amazon Route 53.
 //
 // Lists all the private hosted zones that a specified VPC is associated with,
-// regardless of which account or Amazon Web Services service owns the hosted
-// zones. The HostedZoneOwner structure in the response contains one of the
-// following values:
+// regardless of which Amazon Web Services account or Amazon Web Services service
+// owns the hosted zones. The HostedZoneOwner structure in the response contains
+// one of the following values:
 //
 //    * An OwningAccount element, which contains the account number of either
-//    the current account or another account. Some services, such as Cloud Map,
-//    create hosted zones using the current account.
+//    the current Amazon Web Services account or another Amazon Web Services
+//    account. Some services, such as Cloud Map, create hosted zones using the
+//    current account.
 //
 //    * An OwningService element, which identifies the Amazon Web Services service
 //    that created and owns the hosted zone. For example, if a hosted zone was
@@ -5197,8 +5201,8 @@ func (c *Route53) ListQueryLoggingConfigsRequest(input *ListQueryLoggingConfigsI
 // ListQueryLoggingConfigs API operation for Amazon Route 53.
 //
 // Lists the configurations for DNS query logging that are associated with the
-// current account or the configuration that is associated with a specified
-// hosted zone.
+// current Amazon Web Services account or the configuration that is associated
+// with a specified hosted zone.
 //
 // For more information about DNS query logs, see CreateQueryLoggingConfig (https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateQueryLoggingConfig.html).
 // Additional information, including the format of DNS query logs, appears in
@@ -5546,7 +5550,7 @@ func (c *Route53) ListReusableDelegationSetsRequest(input *ListReusableDelegatio
 // ListReusableDelegationSets API operation for Amazon Route 53.
 //
 // Retrieves a list of the reusable delegation sets that are associated with
-// the current account.
+// the current Amazon Web Services account.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -5824,8 +5828,8 @@ func (c *Route53) ListTrafficPoliciesRequest(input *ListTrafficPoliciesInput) (r
 // ListTrafficPolicies API operation for Amazon Route 53.
 //
 // Gets information about the latest version for every traffic policy that is
-// associated with the current account. Policies are listed in the order that
-// they were created in.
+// associated with the current Amazon Web Services account. Policies are listed
+// in the order that they were created in.
 //
 // For information about how of deleting a traffic policy affects the response
 // from ListTrafficPolicies, see DeleteTrafficPolicy (https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteTrafficPolicy.html).
@@ -5908,7 +5912,7 @@ func (c *Route53) ListTrafficPolicyInstancesRequest(input *ListTrafficPolicyInst
 // ListTrafficPolicyInstances API operation for Amazon Route 53.
 //
 // Gets information about the traffic policy instances that you created by using
-// the current account.
+// the current Amazon Web Services account.
 //
 // After you submit an UpdateTrafficPolicyInstance request, there's a brief
 // delay while Amazon Route 53 creates the resource record sets that are specified
@@ -7073,8 +7077,9 @@ type AliasTarget struct {
 	// the CNAME attribute for the environment. You can use the following methods
 	// to get the value of the CNAME attribute:
 	//
-	//    * Management Console: For information about how to get the value by using
-	//    the console, see Using Custom Domains with Elastic Beanstalk (https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html)
+	//    * Amazon Web Services Management Console: For information about how to
+	//    get the value by using the console, see Using Custom Domains with Elastic
+	//    Beanstalk (https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html)
 	//    in the Elastic Beanstalk Developer Guide.
 	//
 	//    * Elastic Beanstalk API: Use the DescribeEnvironments action to get the
@@ -7089,13 +7094,14 @@ type AliasTarget struct {
 	// ELB load balancer
 	//
 	// Specify the DNS name that is associated with the load balancer. Get the DNS
-	// name by using the Management Console, the ELB API, or the CLI.
+	// name by using the Amazon Web Services Management Console, the ELB API, or
+	// the CLI.
 	//
-	//    * Management Console: Go to the EC2 page, choose Load Balancers in the
-	//    navigation pane, choose the load balancer, choose the Description tab,
-	//    and get the value of the DNS name field. If you're routing traffic to
-	//    a Classic Load Balancer, get the value that begins with dualstack. If
-	//    you're routing traffic to another type of load balancer, get the value
+	//    * Amazon Web Services Management Console: Go to the EC2 page, choose Load
+	//    Balancers in the navigation pane, choose the load balancer, choose the
+	//    Description tab, and get the value of the DNS name field. If you're routing
+	//    traffic to a Classic Load Balancer, get the value that begins with dualstack.
+	//    If you're routing traffic to another type of load balancer, get the value
 	//    that applies to the record type, A or AAAA.
 	//
 	//    * Elastic Load Balancing API: Use DescribeLoadBalancers to get the value
@@ -7257,9 +7263,9 @@ type AliasTarget struct {
 	//    that there are separate columns for Application and Classic Load Balancers
 	//    and for Network Load Balancers.
 	//
-	//    * Management Console: Go to the Amazon EC2 page, choose Load Balancers
-	//    in the navigation pane, select the load balancer, and get the value of
-	//    the Hosted zone field on the Description tab.
+	//    * Amazon Web Services Management Console: Go to the Amazon EC2 page, choose
+	//    Load Balancers in the navigation pane, select the load balancer, and get
+	//    the value of the Hosted zone field on the Description tab.
 	//
 	//    * Elastic Load Balancing API: Use DescribeLoadBalancers to get the applicable
 	//    value. For more information, see the applicable guide: Classic Load Balancers:
@@ -9746,21 +9752,22 @@ func (s DeleteTrafficPolicyOutput) GoString() string {
 }
 
 // A complex type that contains information about the request to remove authorization
-// to associate a VPC that was created by one account with a hosted zone that
-// was created with a different account.
+// to associate a VPC that was created by one Amazon Web Services account with
+// a hosted zone that was created with a different Amazon Web Services account.
 type DeleteVPCAssociationAuthorizationInput struct {
 	_ struct{} `locationName:"DeleteVPCAssociationAuthorizationRequest" type:"structure" xmlURI:"https://route53.amazonaws.com/doc/2013-04-01/"`
 
-	// When removing authorization to associate a VPC that was created by one account
-	// with a hosted zone that was created with a different account, the ID of the
-	// hosted zone.
+	// When removing authorization to associate a VPC that was created by one Amazon
+	// Web Services account with a hosted zone that was created with a different
+	// Amazon Web Services account, the ID of the hosted zone.
 	//
 	// HostedZoneId is a required field
 	HostedZoneId *string `location:"uri" locationName:"Id" type:"string" required:"true"`
 
-	// When removing authorization to associate a VPC that was created by one account
-	// with a hosted zone that was created with a different account, a complex type
-	// that includes the ID and region of the VPC.
+	// When removing authorization to associate a VPC that was created by one Amazon
+	// Web Services account with a hosted zone that was created with a different
+	// Amazon Web Services account, a complex type that includes the ID and region
+	// of the VPC.
 	//
 	// VPC is a required field
 	VPC *VPC `type:"structure" required:"true"`
@@ -10670,7 +10677,7 @@ func (s *GetGeoLocationOutput) SetGeoLocationDetails(v *GeoLocationDetails) *Get
 }
 
 // A request for the number of health checks that are associated with the current
-// account.
+// Amazon Web Services account.
 type GetHealthCheckCountInput struct {
 	_ struct{} `locationName:"GetHealthCheckCountRequest" type:"structure"`
 }
@@ -10689,7 +10696,8 @@ func (s GetHealthCheckCountInput) GoString() string {
 type GetHealthCheckCountOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The number of health checks associated with the current account.
+	// The number of health checks associated with the current Amazon Web Services
+	// account.
 	//
 	// HealthCheckCount is a required field
 	HealthCheckCount *int64 `type:"long" required:"true"`
@@ -10837,7 +10845,7 @@ type GetHealthCheckOutput struct {
 	_ struct{} `type:"structure"`
 
 	// A complex type that contains information about one health check that is associated
-	// with the current account.
+	// with the current Amazon Web Services account.
 	//
 	// HealthCheck is a required field
 	HealthCheck *HealthCheck `type:"structure" required:"true"`
@@ -10935,7 +10943,7 @@ func (s *GetHealthCheckStatusOutput) SetHealthCheckObservations(v []*HealthCheck
 }
 
 // A request to retrieve a count of all the hosted zones that are associated
-// with the current account.
+// with the current Amazon Web Services account.
 type GetHostedZoneCountInput struct {
 	_ struct{} `locationName:"GetHostedZoneCountRequest" type:"structure"`
 }
@@ -10955,7 +10963,7 @@ type GetHostedZoneCountOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The total number of public and private hosted zones that are associated with
-	// the current account.
+	// the current Amazon Web Services account.
 	//
 	// HostedZoneCount is a required field
 	HostedZoneCount *int64 `type:"long" required:"true"`
@@ -11476,7 +11484,7 @@ func (s *GetTrafficPolicyInput) SetVersion(v int64) *GetTrafficPolicyInput {
 }
 
 // Request to get the number of traffic policy instances that are associated
-// with the current account.
+// with the current Amazon Web Services account.
 type GetTrafficPolicyInstanceCountInput struct {
 	_ struct{} `locationName:"GetTrafficPolicyInstanceCountRequest" type:"structure"`
 }
@@ -11497,7 +11505,7 @@ type GetTrafficPolicyInstanceCountOutput struct {
 	_ struct{} `type:"structure"`
 
 	// The number of traffic policy instances that are associated with the current
-	// account.
+	// Amazon Web Services account.
 	//
 	// TrafficPolicyInstanceCount is a required field
 	TrafficPolicyInstanceCount *int64 `type:"integer" required:"true"`
@@ -11795,7 +11803,7 @@ type HealthCheckConfig struct {
 	// If you don't specify a value for FullyQualifiedDomainName, Route 53 substitutes
 	// the value of IPAddress in the Host header in each of the preceding cases.
 	//
-	// If you don't specify a value for IPAddress :
+	// If you don't specify a value for IPAddress:
 	//
 	// Route 53 sends a DNS request to the domain that you specify for FullyQualifiedDomainName
 	// at the interval that you specify for RequestInterval. Using an IPv4 address
@@ -11941,8 +11949,11 @@ type HealthCheckConfig struct {
 	// parameters, for example, /welcome.html?language=jp&login=y.
 	ResourcePath *string `type:"string"`
 
-	// The Amazon Resource Name (ARN) for Route53 Application Recovery Controller
+	// The Amazon Resource Name (ARN) for the Route 53 Application Recovery Controller
 	// routing control.
+	//
+	// For more information about Route 53 Application Recovery Controller, see
+	// Route 53 Application Recovery Controller Developer Guide. (https://docs.aws.amazon.com/r53recovery/latest/dg/what-is-route-53-recovery.html).
 	RoutingControlArn *string `min:"1" type:"string"`
 
 	// If the value of Type is HTTP_STR_MATCH or HTTPS_STR_MATCH, the string that
@@ -12372,11 +12383,11 @@ func (s *HostedZoneLimit) SetValue(v int64) *HostedZoneLimit {
 type HostedZoneOwner struct {
 	_ struct{} `type:"structure"`
 
-	// If the hosted zone was created by an account, or was created by an Amazon
-	// Web Services service that creates hosted zones using the current account,
-	// OwningAccount contains the account ID of that account. For example, when
-	// you use Cloud Map to create a hosted zone, Cloud Map creates the hosted zone
-	// using the current account.
+	// If the hosted zone was created by an Amazon Web Services account, or was
+	// created by an Amazon Web Services service that creates hosted zones using
+	// the current account, OwningAccount contains the account ID of that account.
+	// For example, when you use Cloud Map to create a hosted zone, Cloud Map creates
+	// the hosted zone using the current Amazon Web Services account.
 	OwningAccount *string `type:"string"`
 
 	// If an Amazon Web Services service uses its own account to create a hosted
@@ -12429,7 +12440,8 @@ type HostedZoneSummary struct {
 	Name *string `type:"string" required:"true"`
 
 	// The owner of a private hosted zone that the specified VPC is associated with.
-	// The owner can be either an account or an Amazon Web Services service.
+	// The owner can be either an Amazon Web Services account or an Amazon Web Services
+	// service.
 	//
 	// Owner is a required field
 	Owner *HostedZoneOwner `type:"structure" required:"true"`
@@ -12922,7 +12934,7 @@ func (s *ListGeoLocationsOutput) SetNextSubdivisionCode(v string) *ListGeoLocati
 }
 
 // A request to retrieve a list of the health checks that are associated with
-// the current account.
+// the current Amazon Web Services account.
 type ListHealthChecksInput struct {
 	_ struct{} `locationName:"ListHealthChecksRequest" type:"structure"`
 
@@ -12971,7 +12983,7 @@ type ListHealthChecksOutput struct {
 	_ struct{} `type:"structure"`
 
 	// A complex type that contains one HealthCheck element for each health check
-	// that is associated with the current account.
+	// that is associated with the current Amazon Web Services account.
 	//
 	// HealthChecks is a required field
 	HealthChecks []*HealthCheck `locationNameList:"HealthCheck" type:"list" required:"true"`
@@ -13043,17 +13055,17 @@ func (s *ListHealthChecksOutput) SetNextMarker(v string) *ListHealthChecksOutput
 }
 
 // Retrieves a list of the public and private hosted zones that are associated
-// with the current account in ASCII order by domain name.
+// with the current Amazon Web Services account in ASCII order by domain name.
 type ListHostedZonesByNameInput struct {
 	_ struct{} `locationName:"ListHostedZonesByNameRequest" type:"structure"`
 
 	// (Optional) For your first request to ListHostedZonesByName, include the dnsname
 	// parameter only if you want to specify the name of the first hosted zone in
 	// the response. If you don't include the dnsname parameter, Amazon Route 53
-	// returns all of the hosted zones that were created by the current account,
-	// in ASCII order. For subsequent requests, include both dnsname and hostedzoneid
-	// parameters. For dnsname, specify the value of NextDNSName from the previous
-	// response.
+	// returns all of the hosted zones that were created by the current Amazon Web
+	// Services account, in ASCII order. For subsequent requests, include both dnsname
+	// and hostedzoneid parameters. For dnsname, specify the value of NextDNSName
+	// from the previous response.
 	DNSName *string `location:"querystring" locationName:"dnsname" type:"string"`
 
 	// (Optional) For your first request to ListHostedZonesByName, do not include
@@ -13205,7 +13217,7 @@ func (s *ListHostedZonesByNameOutput) SetNextHostedZoneId(v string) *ListHostedZ
 }
 
 // Lists all the private hosted zones that a specified VPC is associated with,
-// regardless of which account created the hosted zones.
+// regardless of which Amazon Web Services account created the hosted zones.
 type ListHostedZonesByVPCInput struct {
 	_ struct{} `locationName:"ListHostedZonesByVPCRequest" type:"structure"`
 
@@ -13343,7 +13355,7 @@ func (s *ListHostedZonesByVPCOutput) SetNextToken(v string) *ListHostedZonesByVP
 }
 
 // A request to retrieve a list of the public and private hosted zones that
-// are associated with the current account.
+// are associated with the current Amazon Web Services account.
 type ListHostedZonesInput struct {
 	_ struct{} `locationName:"ListHostedZonesRequest" type:"structure"`
 
@@ -13483,20 +13495,22 @@ type ListQueryLoggingConfigsInput struct {
 	// with a hosted zone, specify the ID in HostedZoneId.
 	//
 	// If you don't specify a hosted zone ID, ListQueryLoggingConfigs returns all
-	// of the configurations that are associated with the current account.
+	// of the configurations that are associated with the current Amazon Web Services
+	// account.
 	HostedZoneId *string `location:"querystring" locationName:"hostedzoneid" type:"string"`
 
 	// (Optional) The maximum number of query logging configurations that you want
 	// Amazon Route 53 to return in response to the current request. If the current
-	// account has more than MaxResults configurations, use the value of NextToken
-	// (https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListQueryLoggingConfigs.html#API_ListQueryLoggingConfigs_RequestSyntax)
+	// Amazon Web Services account has more than MaxResults configurations, use
+	// the value of NextToken (https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListQueryLoggingConfigs.html#API_ListQueryLoggingConfigs_RequestSyntax)
 	// in the response to get the next page of results.
 	//
 	// If you don't specify a value for MaxResults, Route 53 returns up to 100 configurations.
 	MaxResults *string `location:"querystring" locationName:"maxresults" type:"string"`
 
-	// (Optional) If the current account has more than MaxResults query logging
-	// configurations, use NextToken to get the second and subsequent pages of results.
+	// (Optional) If the current Amazon Web Services account has more than MaxResults
+	// query logging configurations, use NextToken to get the second and subsequent
+	// pages of results.
 	//
 	// For the first ListQueryLoggingConfigs request, omit this value.
 	//
@@ -13537,8 +13551,8 @@ type ListQueryLoggingConfigsOutput struct {
 	_ struct{} `type:"structure"`
 
 	// If a response includes the last of the query logging configurations that
-	// are associated with the current account, NextToken doesn't appear in the
-	// response.
+	// are associated with the current Amazon Web Services account, NextToken doesn't
+	// appear in the response.
 	//
 	// If a response doesn't include the last of the configurations, you can get
 	// more configurations by submitting another ListQueryLoggingConfigs (https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListQueryLoggingConfigs.html)
@@ -13548,7 +13562,7 @@ type ListQueryLoggingConfigsOutput struct {
 
 	// An array that contains one QueryLoggingConfig (https://docs.aws.amazon.com/Route53/latest/APIReference/API_QueryLoggingConfig.html)
 	// element for each configuration for DNS query logging that is associated with
-	// the current account.
+	// the current Amazon Web Services account.
 	//
 	// QueryLoggingConfigs is a required field
 	QueryLoggingConfigs []*QueryLoggingConfig `locationNameList:"QueryLoggingConfig" type:"list" required:"true"`
@@ -13783,7 +13797,7 @@ func (s *ListResourceRecordSetsOutput) SetResourceRecordSets(v []*ResourceRecord
 }
 
 // A request to get a list of the reusable delegation sets that are associated
-// with the current account.
+// with the current Amazon Web Services account.
 type ListReusableDelegationSetsInput struct {
 	_ struct{} `locationName:"ListReusableDelegationSetsRequest" type:"structure"`
 
@@ -13828,12 +13842,12 @@ func (s *ListReusableDelegationSetsInput) SetMaxItems(v string) *ListReusableDel
 }
 
 // A complex type that contains information about the reusable delegation sets
-// that are associated with the current account.
+// that are associated with the current Amazon Web Services account.
 type ListReusableDelegationSetsOutput struct {
 	_ struct{} `type:"structure"`
 
 	// A complex type that contains one DelegationSet element for each reusable
-	// delegation set that was created by the current account.
+	// delegation set that was created by the current Amazon Web Services account.
 	//
 	// DelegationSets is a required field
 	DelegationSets []*DelegationSet `locationNameList:"DelegationSet" type:"list" required:"true"`
@@ -14086,7 +14100,8 @@ func (s *ListTagsForResourcesOutput) SetResourceTagSets(v []*ResourceTagSet) *Li
 }
 
 // A complex type that contains the information about the request to list the
-// traffic policies that are associated with the current account.
+// traffic policies that are associated with the current Amazon Web Services
+// account.
 type ListTrafficPoliciesInput struct {
 	_ struct{} `locationName:"ListTrafficPoliciesRequest" type:"structure"`
 
@@ -14168,7 +14183,7 @@ type ListTrafficPoliciesOutput struct {
 	TrafficPolicyIdMarker *string `min:"1" type:"string" required:"true"`
 
 	// A list that contains one TrafficPolicySummary element for each traffic policy
-	// that was created by the current account.
+	// that was created by the current Amazon Web Services account.
 	//
 	// TrafficPolicySummaries is a required field
 	TrafficPolicySummaries []*TrafficPolicySummary `locationNameList:"TrafficPolicySummary" type:"list" required:"true"`
@@ -14590,7 +14605,7 @@ func (s *ListTrafficPolicyInstancesByPolicyOutput) SetTrafficPolicyInstances(v [
 }
 
 // A request to get information about the traffic policy instances that you
-// created by using the current account.
+// created by using the current Amazon Web Services account.
 type ListTrafficPolicyInstancesInput struct {
 	_ struct{} `locationName:"ListTrafficPolicyInstancesRequest" type:"structure"`
 
@@ -16286,7 +16301,7 @@ func (s *TrafficPolicyInstance) SetTrafficPolicyVersion(v int64) *TrafficPolicyI
 }
 
 // A complex type that contains information about the latest version of one
-// traffic policy that is associated with the current account.
+// traffic policy that is associated with the current Amazon Web Services account.
 type TrafficPolicySummary struct {
 	_ struct{} `type:"structure"`
 
@@ -16306,7 +16321,8 @@ type TrafficPolicySummary struct {
 	// Name is a required field
 	Name *string `type:"string" required:"true"`
 
-	// The number of traffic policies that are associated with the current account.
+	// The number of traffic policies that are associated with the current Amazon
+	// Web Services account.
 	//
 	// TrafficPolicyCount is a required field
 	TrafficPolicyCount *int64 `min:"1" type:"integer" required:"true"`

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/errors.go
@@ -403,8 +403,8 @@ const (
 	// To request a higher limit, create a case (http://aws.amazon.com/route53-request)
 	// with the Amazon Web Services Support Center.
 	//
-	// You have reached the maximum number of active health checks for an account.
-	// To request a higher limit, create a case (http://aws.amazon.com/route53-request)
+	// You have reached the maximum number of active health checks for an Amazon
+	// Web Services account. To request a higher limit, create a case (http://aws.amazon.com/route53-request)
 	// with the Amazon Web Services Support Center.
 	ErrCodeTooManyHealthChecks = "TooManyHealthChecks"
 

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -396,11 +396,11 @@ func (c *S3) CopyObjectRequest(input *CopyObjectInput) (req *request.Request, ou
 //
 // When you perform a CopyObject operation, you can optionally use the appropriate
 // encryption-related headers to encrypt the object using server-side encryption
-// with AWS managed encryption keys (SSE-S3 or SSE-KMS) or a customer-provided
-// encryption key. With server-side encryption, Amazon S3 encrypts your data
-// as it writes it to disks in its data centers and decrypts the data when you
-// access it. For more information about server-side encryption, see Using Server-Side
-// Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html).
+// with Amazon Web Services managed encryption keys (SSE-S3 or SSE-KMS) or a
+// customer-provided encryption key. With server-side encryption, Amazon S3
+// encrypts your data as it writes it to disks in its data centers and decrypts
+// the data when you access it. For more information about server-side encryption,
+// see Using Server-Side Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html).
 //
 // If a target object uses SSE-KMS, you can enable an S3 Bucket Key for the
 // object. For more information, see Amazon S3 Bucket Keys (https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html)
@@ -411,9 +411,9 @@ func (c *S3) CopyObjectRequest(input *CopyObjectInput) (req *request.Request, ou
 // When copying an object, you can optionally use headers to grant ACL-based
 // permissions. By default, all objects are private. Only the owner has full
 // access control. When adding a new object, you can grant permissions to individual
-// AWS accounts or to predefined groups defined by Amazon S3. These permissions
-// are then added to the ACL on the object. For more information, see Access
-// Control List (ACL) Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)
+// Amazon Web Services accounts or to predefined groups defined by Amazon S3.
+// These permissions are then added to the ACL on the object. For more information,
+// see Access Control List (ACL) Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)
 // and Managing ACLs Using the REST API (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html).
 //
 // Storage Class Options
@@ -529,9 +529,9 @@ func (c *S3) CreateBucketRequest(input *CreateBucketInput) (req *request.Request
 // CreateBucket API operation for Amazon Simple Storage Service.
 //
 // Creates a new S3 bucket. To create a bucket, you must register with Amazon
-// S3 and have a valid AWS Access Key ID to authenticate requests. Anonymous
-// requests are never allowed to create buckets. By creating the bucket, you
-// become the bucket owner.
+// S3 and have a valid Amazon Web Services Access Key ID to authenticate requests.
+// Anonymous requests are never allowed to create buckets. By creating the bucket,
+// you become the bucket owner.
 //
 // Not every string is an acceptable bucket name. For information about bucket
 // naming restrictions, see Bucket naming rules (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
@@ -571,21 +571,33 @@ func (c *S3) CreateBucketRequest(input *CreateBucketInput) (req *request.Request
 //    (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html). You
 //    specify each grantee as a type=value pair, where the type is one of the
 //    following: id – if the value specified is the canonical user ID of an
-//    AWS account uri – if you are granting permissions to a predefined group
-//    emailAddress – if the value specified is the email address of an AWS
-//    account Using email addresses to specify a grantee is only supported in
-//    the following AWS Regions: US East (N. Virginia) US West (N. California)
-//    US West (Oregon) Asia Pacific (Singapore) Asia Pacific (Sydney) Asia Pacific
-//    (Tokyo) Europe (Ireland) South America (São Paulo) For a list of all
-//    the Amazon S3 supported Regions and endpoints, see Regions and Endpoints
-//    (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) in
-//    the AWS General Reference. For example, the following x-amz-grant-read
-//    header grants the AWS accounts identified by account IDs permissions to
-//    read object data and its metadata: x-amz-grant-read: id="11112222333",
-//    id="444455556666"
+//    Amazon Web Services account uri – if you are granting permissions to
+//    a predefined group emailAddress – if the value specified is the email
+//    address of an Amazon Web Services account Using email addresses to specify
+//    a grantee is only supported in the following Amazon Web Services Regions:
+//    US East (N. Virginia) US West (N. California) US West (Oregon) Asia Pacific
+//    (Singapore) Asia Pacific (Sydney) Asia Pacific (Tokyo) Europe (Ireland)
+//    South America (São Paulo) For a list of all the Amazon S3 supported Regions
+//    and endpoints, see Regions and Endpoints (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+//    in the Amazon Web Services General Reference. For example, the following
+//    x-amz-grant-read header grants the Amazon Web Services accounts identified
+//    by account IDs permissions to read object data and its metadata: x-amz-grant-read:
+//    id="11112222333", id="444455556666"
 //
 // You can use either a canned ACL or specify access permissions explicitly.
 // You cannot do both.
+//
+// Permissions
+//
+// If your CreateBucket request specifies ACL permissions and the ACL is public-read,
+// public-read-write, authenticated-read, or if you specify access permissions
+// explicitly through any other ACL, both s3:CreateBucket and s3:PutBucketAcl
+// permissions are needed. If the ACL the CreateBucket request is private, only
+// s3:CreateBucket permission is needed.
+//
+// If ObjectLockEnabledForBucket is set to true in your CreateBucket request,
+// s3:PutBucketObjectLockConfiguration and s3:PutBucketVersioning permissions
+// are required.
 //
 // The following operations are related to CreateBucket:
 //
@@ -607,10 +619,10 @@ func (c *S3) CreateBucketRequest(input *CreateBucketInput) (req *request.Request
 //
 //   * ErrCodeBucketAlreadyOwnedByYou "BucketAlreadyOwnedByYou"
 //   The bucket you tried to create already exists, and you own it. Amazon S3
-//   returns this error in all AWS Regions except in the North Virginia Region.
-//   For legacy compatibility, if you re-create an existing bucket that you already
-//   own in the North Virginia Region, Amazon S3 returns 200 OK and resets the
-//   bucket access control lists (ACLs).
+//   returns this error in all Amazon Web Services Regions except in the North
+//   Virginia Region. For legacy compatibility, if you re-create an existing bucket
+//   that you already own in the North Virginia Region, Amazon S3 returns 200
+//   OK and resets the bucket access control lists (ACLs).
 //
 // See also, https://docs.aws.amazon.com/goto/WebAPI/s3-2006-03-01/CreateBucket
 func (c *S3) CreateBucket(input *CreateBucketInput) (*CreateBucketOutput, error) {
@@ -702,8 +714,8 @@ func (c *S3) CreateMultipartUploadRequest(input *CreateMultipartUploadInput) (re
 // You initiate a multipart upload, send one or more requests to upload parts,
 // and then complete the multipart upload process. You sign each request individually.
 // There is nothing special about signing multipart upload requests. For more
-// information about signing, see Authenticating Requests (AWS Signature Version
-// 4) (https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html).
+// information about signing, see Authenticating Requests (Amazon Web Services
+// Signature Version 4) (https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html).
 //
 // After you initiate a multipart upload and upload one or more parts, to stop
 // being charged for storing the uploaded parts, you must either complete or
@@ -714,25 +726,27 @@ func (c *S3) CreateMultipartUploadRequest(input *CreateMultipartUploadInput) (re
 // You can optionally request server-side encryption. For server-side encryption,
 // Amazon S3 encrypts your data as it writes it to disks in its data centers
 // and decrypts it when you access it. You can provide your own encryption key,
-// or use AWS Key Management Service (AWS KMS) customer master keys (CMKs) or
-// Amazon S3-managed encryption keys. If you choose to provide your own encryption
-// key, the request headers you provide in UploadPart (https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)
+// or use Amazon Web Services Key Management Service (Amazon Web Services KMS)
+// customer master keys (CMKs) or Amazon S3-managed encryption keys. If you
+// choose to provide your own encryption key, the request headers you provide
+// in UploadPart (https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)
 // and UploadPartCopy (https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html)
 // requests must match the headers you used in the request to initiate the upload
 // by using CreateMultipartUpload.
 //
-// To perform a multipart upload with encryption using an AWS KMS CMK, the requester
-// must have permission to the kms:Decrypt and kms:GenerateDataKey* actions
-// on the key. These permissions are required because Amazon S3 must decrypt
-// and read data from the encrypted file parts before it completes the multipart
-// upload. For more information, see Multipart upload API and permissions (https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#mpuAndPermissions)
+// To perform a multipart upload with encryption using an Amazon Web Services
+// KMS CMK, the requester must have permission to the kms:Decrypt and kms:GenerateDataKey*
+// actions on the key. These permissions are required because Amazon S3 must
+// decrypt and read data from the encrypted file parts before it completes the
+// multipart upload. For more information, see Multipart upload API and permissions
+// (https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#mpuAndPermissions)
 // in the Amazon S3 User Guide.
 //
-// If your AWS Identity and Access Management (IAM) user or role is in the same
-// AWS account as the AWS KMS CMK, then you must have these permissions on the
-// key policy. If your IAM user or role belongs to a different account than
-// the key, then you must have the permissions on both the key policy and your
-// IAM user or role.
+// If your Identity and Access Management (IAM) user or role is in the same
+// Amazon Web Services account as the Amazon Web Services KMS CMK, then you
+// must have these permissions on the key policy. If your IAM user or role belongs
+// to a different account than the key, then you must have the permissions on
+// both the key policy and your IAM user or role.
 //
 // For more information, see Protecting Data Using Server-Side Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html).
 //
@@ -759,35 +773,39 @@ func (c *S3) CreateMultipartUploadRequest(input *CreateMultipartUploadInput) (re
 // encryption. Server-side encryption is for data encryption at rest. Amazon
 // S3 encrypts your data as it writes it to disks in its data centers and decrypts
 // it when you access it. The option you use depends on whether you want to
-// use AWS managed encryption keys or provide your own encryption key.
+// use Amazon Web Services managed encryption keys or provide your own encryption
+// key.
 //
 //    * Use encryption keys managed by Amazon S3 or customer master keys (CMKs)
-//    stored in AWS Key Management Service (AWS KMS) – If you want AWS to
-//    manage the keys used to encrypt data, specify the following headers in
-//    the request. x-amz-server-side-encryption x-amz-server-side-encryption-aws-kms-key-id
-//    x-amz-server-side-encryption-context If you specify x-amz-server-side-encryption:aws:kms,
-//    but don't provide x-amz-server-side-encryption-aws-kms-key-id, Amazon
-//    S3 uses the AWS managed CMK in AWS KMS to protect the data. All GET and
-//    PUT requests for an object protected by AWS KMS fail if you don't make
-//    them with SSL or by using SigV4. For more information about server-side
-//    encryption with CMKs stored in AWS KMS (SSE-KMS), see Protecting Data
-//    Using Server-Side Encryption with CMKs stored in AWS KMS (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+//    stored in Amazon Web Services Key Management Service (Amazon Web Services
+//    KMS) – If you want Amazon Web Services to manage the keys used to encrypt
+//    data, specify the following headers in the request. x-amz-server-side-encryption
+//    x-amz-server-side-encryption-aws-kms-key-id x-amz-server-side-encryption-context
+//    If you specify x-amz-server-side-encryption:aws:kms, but don't provide
+//    x-amz-server-side-encryption-aws-kms-key-id, Amazon S3 uses the Amazon
+//    Web Services managed CMK in Amazon Web Services KMS to protect the data.
+//    All GET and PUT requests for an object protected by Amazon Web Services
+//    KMS fail if you don't make them with SSL or by using SigV4. For more information
+//    about server-side encryption with CMKs stored in Amazon Web Services KMS
+//    (SSE-KMS), see Protecting Data Using Server-Side Encryption with CMKs
+//    stored in Amazon Web Services KMS (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 //
 //    * Use customer-provided encryption keys – If you want to manage your
 //    own encryption keys, provide all the following headers in the request.
 //    x-amz-server-side-encryption-customer-algorithm x-amz-server-side-encryption-customer-key
 //    x-amz-server-side-encryption-customer-key-MD5 For more information about
-//    server-side encryption with CMKs stored in AWS KMS (SSE-KMS), see Protecting
-//    Data Using Server-Side Encryption with CMKs stored in AWS KMS (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+//    server-side encryption with CMKs stored in Amazon Web Services KMS (SSE-KMS),
+//    see Protecting Data Using Server-Side Encryption with CMKs stored in Amazon
+//    Web Services KMS (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 //
 // Access-Control-List (ACL)-Specific Request Headers
 //
 // You also can use the following access control–related headers with this
 // operation. By default, all objects are private. Only the owner has full access
 // control. When adding a new object, you can grant permissions to individual
-// AWS accounts or to predefined groups defined by Amazon S3. These permissions
-// are then added to the access control list (ACL) on the object. For more information,
-// see Using ACLs (https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
+// Amazon Web Services accounts or to predefined groups defined by Amazon S3.
+// These permissions are then added to the access control list (ACL) on the
+// object. For more information, see Using ACLs (https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
 // With this operation, you can grant access permissions using one of the following
 // two methods:
 //
@@ -796,26 +814,27 @@ func (c *S3) CreateMultipartUploadRequest(input *CreateMultipartUploadInput) (re
 //    and permissions. For more information, see Canned ACL (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 //
 //    * Specify access permissions explicitly — To explicitly grant access
-//    permissions to specific AWS accounts or groups, use the following headers.
-//    Each header maps to specific permissions that Amazon S3 supports in an
-//    ACL. For more information, see Access Control List (ACL) Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+//    permissions to specific Amazon Web Services accounts or groups, use the
+//    following headers. Each header maps to specific permissions that Amazon
+//    S3 supports in an ACL. For more information, see Access Control List (ACL)
+//    Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 //    In the header, you specify a list of grantees who get the specific permission.
 //    To grant permissions explicitly, use: x-amz-grant-read x-amz-grant-write
 //    x-amz-grant-read-acp x-amz-grant-write-acp x-amz-grant-full-control You
 //    specify each grantee as a type=value pair, where the type is one of the
 //    following: id – if the value specified is the canonical user ID of an
-//    AWS account uri – if you are granting permissions to a predefined group
-//    emailAddress – if the value specified is the email address of an AWS
-//    account Using email addresses to specify a grantee is only supported in
-//    the following AWS Regions: US East (N. Virginia) US West (N. California)
-//    US West (Oregon) Asia Pacific (Singapore) Asia Pacific (Sydney) Asia Pacific
-//    (Tokyo) Europe (Ireland) South America (São Paulo) For a list of all
-//    the Amazon S3 supported Regions and endpoints, see Regions and Endpoints
-//    (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) in
-//    the AWS General Reference. For example, the following x-amz-grant-read
-//    header grants the AWS accounts identified by account IDs permissions to
-//    read object data and its metadata: x-amz-grant-read: id="11112222333",
-//    id="444455556666"
+//    Amazon Web Services account uri – if you are granting permissions to
+//    a predefined group emailAddress – if the value specified is the email
+//    address of an Amazon Web Services account Using email addresses to specify
+//    a grantee is only supported in the following Amazon Web Services Regions:
+//    US East (N. Virginia) US West (N. California) US West (Oregon) Asia Pacific
+//    (Singapore) Asia Pacific (Sydney) Asia Pacific (Tokyo) Europe (Ireland)
+//    South America (São Paulo) For a list of all the Amazon S3 supported Regions
+//    and endpoints, see Regions and Endpoints (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+//    in the Amazon Web Services General Reference. For example, the following
+//    x-amz-grant-read header grants the Amazon Web Services accounts identified
+//    by account IDs permissions to read object data and its metadata: x-amz-grant-read:
+//    id="11112222333", id="444455556666"
 //
 // The following operations are related to CreateMultipartUpload:
 //
@@ -1728,18 +1747,18 @@ func (c *S3) DeleteBucketPolicyRequest(input *DeleteBucketPolicyInput) (req *req
 //
 // This implementation of the DELETE action uses the policy subresource to delete
 // the policy of a specified bucket. If you are using an identity other than
-// the root user of the AWS account that owns the bucket, the calling identity
-// must have the DeleteBucketPolicy permissions on the specified bucket and
-// belong to the bucket owner's account to use this operation.
+// the root user of the Amazon Web Services account that owns the bucket, the
+// calling identity must have the DeleteBucketPolicy permissions on the specified
+// bucket and belong to the bucket owner's account to use this operation.
 //
 // If you don't have DeleteBucketPolicy permissions, Amazon S3 returns a 403
 // Access Denied error. If you have the correct permissions, but you're not
 // using an identity that belongs to the bucket owner's account, Amazon S3 returns
 // a 405 Method Not Allowed error.
 //
-// As a security precaution, the root user of the AWS account that owns a bucket
-// can always use this operation, even if the policy explicitly denies the root
-// user the ability to perform this action.
+// As a security precaution, the root user of the Amazon Web Services account
+// that owns a bucket can always use this operation, even if the policy explicitly
+// denies the root user the ability to perform this action.
 //
 // For more information about bucket policies, see Using Bucket Policies and
 // UserPolicies (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html).
@@ -3356,6 +3375,9 @@ func (c *S3) GetBucketLocationRequest(input *GetBucketLocationInput) (req *reque
 //
 // To use this implementation of the operation, you must be the bucket owner.
 //
+// To use this API against an access point, provide the alias of the access
+// point in place of the bucket name.
+//
 // The following operations are related to GetBucketLocation:
 //
 //    * GetObject (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html)
@@ -3868,18 +3890,18 @@ func (c *S3) GetBucketPolicyRequest(input *GetBucketPolicyInput) (req *request.R
 // GetBucketPolicy API operation for Amazon Simple Storage Service.
 //
 // Returns the policy of a specified bucket. If you are using an identity other
-// than the root user of the AWS account that owns the bucket, the calling identity
-// must have the GetBucketPolicy permissions on the specified bucket and belong
-// to the bucket owner's account in order to use this operation.
+// than the root user of the Amazon Web Services account that owns the bucket,
+// the calling identity must have the GetBucketPolicy permissions on the specified
+// bucket and belong to the bucket owner's account in order to use this operation.
 //
 // If you don't have GetBucketPolicy permissions, Amazon S3 returns a 403 Access
 // Denied error. If you have the correct permissions, but you're not using an
 // identity that belongs to the bucket owner's account, Amazon S3 returns a
 // 405 Method Not Allowed error.
 //
-// As a security precaution, the root user of the AWS account that owns a bucket
-// can always use this operation, even if the policy explicitly denies the root
-// user the ability to perform this action.
+// As a security precaution, the root user of the Amazon Web Services account
+// that owns a bucket can always use this operation, even if the policy explicitly
+// denies the root user the ability to perform this action.
 //
 // For more information about bucket policies, see Using Bucket Policies and
 // User Policies (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html).
@@ -4525,9 +4547,9 @@ func (c *S3) GetObjectRequest(input *GetObjectInput) (req *request.Request, outp
 //
 // Encryption request headers, like x-amz-server-side-encryption, should not
 // be sent for GET requests if your object uses server-side encryption with
-// CMKs stored in AWS KMS (SSE-KMS) or server-side encryption with Amazon S3–managed
-// encryption keys (SSE-S3). If your object does use these types of keys, you’ll
-// get an HTTP 400 BadRequest error.
+// CMKs stored in Amazon Web Services KMS (SSE-KMS) or server-side encryption
+// with Amazon S3–managed encryption keys (SSE-S3). If your object does use
+// these types of keys, you’ll get an HTTP 400 BadRequest error.
 //
 // If you encrypt an object by using server-side encryption with customer-provided
 // encryption keys (SSE-C) when you store the object in Amazon S3, then when
@@ -4542,16 +4564,15 @@ func (c *S3) GetObjectRequest(input *GetObjectInput) (req *request.Request, outp
 // For more information about SSE-C, see Server-Side Encryption (Using Customer-Provided
 // Encryption Keys) (https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html).
 //
-// Assuming you have permission to read object tags (permission for the s3:GetObjectVersionTagging
-// action), the response also returns the x-amz-tagging-count header that provides
-// the count of number of tags associated with the object. You can use GetObjectTagging
-// (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html)
+// Assuming you have the relevant permission to read object tags, the response
+// also returns the x-amz-tagging-count header that provides the count of number
+// of tags associated with the object. You can use GetObjectTagging (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html)
 // to retrieve the tag set associated with an object.
 //
 // Permissions
 //
-// You need the s3:GetObject permission for this operation. For more information,
-// see Specifying Permissions in a Policy (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html).
+// You need the relevant read object (or version) permission for this operation.
+// For more information, see Specifying Permissions in a Policy (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html).
 // If the object you request does not exist, the error Amazon S3 returns depends
 // on whether you also have the s3:ListBucket permission.
 //
@@ -4566,9 +4587,12 @@ func (c *S3) GetObjectRequest(input *GetObjectInput) (req *request.Request, outp
 // By default, the GET action returns the current version of an object. To return
 // a different version, use the versionId subresource.
 //
-// If the current version of the object is a delete marker, Amazon S3 behaves
-// as if the object was deleted and includes x-amz-delete-marker: true in the
-// response.
+//    * You need the s3:GetObjectVersion permission to access a specific version
+//    of an object.
+//
+//    * If the current version of the object is a delete marker, Amazon S3 behaves
+//    as if the object was deleted and includes x-amz-delete-marker: true in
+//    the response.
 //
 // For more information about versioning, see PutBucketVersioning (https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html).
 //
@@ -5322,6 +5346,13 @@ func (c *S3) HeadBucketRequest(input *HeadBucketInput) (req *request.Request, ou
 // Related to Bucket Subresource Operations (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources)
 // and Managing Access Permissions to Your Amazon S3 Resources (https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html).
 //
+// To use this API against an access point, you must provide the alias of the
+// access point in place of the bucket name or specify the access point ARN.
+// When using the access point ARN, you must direct requests to the access point
+// hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
+// When using the Amazon Web Services SDKs, you provide the ARN in place of
+// the bucket name. For more information see, Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html).
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -5424,9 +5455,9 @@ func (c *S3) HeadObjectRequest(input *HeadObjectInput) (req *request.Request, ou
 //
 //    * Encryption request headers, like x-amz-server-side-encryption, should
 //    not be sent for GET requests if your object uses server-side encryption
-//    with CMKs stored in AWS KMS (SSE-KMS) or server-side encryption with Amazon
-//    S3–managed encryption keys (SSE-S3). If your object does use these types
-//    of keys, you’ll get an HTTP 400 BadRequest error.
+//    with CMKs stored in Amazon Web Services KMS (SSE-KMS) or server-side encryption
+//    with Amazon S3–managed encryption keys (SSE-S3). If your object does
+//    use these types of keys, you’ll get an HTTP 400 BadRequest error.
 //
 //    * The last modified property in this case is the creation date of the
 //    object.
@@ -5450,8 +5481,8 @@ func (c *S3) HeadObjectRequest(input *HeadObjectInput) (req *request.Request, ou
 //
 // Permissions
 //
-// You need the s3:GetObject permission for this operation. For more information,
-// see Specifying Permissions in a Policy (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html).
+// You need the relevant read object (or version) permission for this operation.
+// For more information, see Specifying Permissions in a Policy (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html).
 // If the object you request does not exist, the error Amazon S3 returns depends
 // on whether you also have the s3:ListBucket permission.
 //
@@ -6507,11 +6538,11 @@ func (c *S3) ListObjectsV2Request(input *ListObjectsV2Input) (req *request.Reque
 //
 // To use this operation, you must have READ access to the bucket.
 //
-// To use this action in an AWS Identity and Access Management (IAM) policy,
-// you must have permissions to perform the s3:ListBucket action. The bucket
-// owner has this permission by default and can grant this permission to others.
-// For more information about permissions, see Permissions Related to Bucket
-// Subresource Operations (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources)
+// To use this action in an Identity and Access Management (IAM) policy, you
+// must have permissions to perform the s3:ListBucket action. The bucket owner
+// has this permission by default and can grant this permission to others. For
+// more information about permissions, see Permissions Related to Bucket Subresource
+// Operations (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources)
 // and Managing Access Permissions to Your Amazon S3 Resources (https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html).
 //
 // This section describes the latest revision of this action. We recommend that
@@ -6962,27 +6993,28 @@ func (c *S3) PutBucketAclRequest(input *PutBucketAclInput) (req *request.Request
 //
 //    * Specify access permissions explicitly with the x-amz-grant-read, x-amz-grant-read-acp,
 //    x-amz-grant-write-acp, and x-amz-grant-full-control headers. When using
-//    these headers, you specify explicit access permissions and grantees (AWS
-//    accounts or Amazon S3 groups) who will receive the permission. If you
-//    use these ACL-specific headers, you cannot use the x-amz-acl header to
-//    set a canned ACL. These parameters map to the set of permissions that
+//    these headers, you specify explicit access permissions and grantees (Amazon
+//    Web Services accounts or Amazon S3 groups) who will receive the permission.
+//    If you use these ACL-specific headers, you cannot use the x-amz-acl header
+//    to set a canned ACL. These parameters map to the set of permissions that
 //    Amazon S3 supports in an ACL. For more information, see Access Control
 //    List (ACL) Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 //    You specify each grantee as a type=value pair, where the type is one of
 //    the following: id – if the value specified is the canonical user ID
-//    of an AWS account uri – if you are granting permissions to a predefined
-//    group emailAddress – if the value specified is the email address of
-//    an AWS account Using email addresses to specify a grantee is only supported
-//    in the following AWS Regions: US East (N. Virginia) US West (N. California)
-//    US West (Oregon) Asia Pacific (Singapore) Asia Pacific (Sydney) Asia Pacific
-//    (Tokyo) Europe (Ireland) South America (São Paulo) For a list of all
-//    the Amazon S3 supported Regions and endpoints, see Regions and Endpoints
-//    (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) in
-//    the AWS General Reference. For example, the following x-amz-grant-write
-//    header grants create, overwrite, and delete objects permission to LogDelivery
-//    group predefined by Amazon S3 and two AWS accounts identified by their
-//    email addresses. x-amz-grant-write: uri="http://acs.amazonaws.com/groups/s3/LogDelivery",
-//    id="111122223333", id="555566667777"
+//    of an Amazon Web Services account uri – if you are granting permissions
+//    to a predefined group emailAddress – if the value specified is the email
+//    address of an Amazon Web Services account Using email addresses to specify
+//    a grantee is only supported in the following Amazon Web Services Regions:
+//    US East (N. Virginia) US West (N. California) US West (Oregon) Asia Pacific
+//    (Singapore) Asia Pacific (Sydney) Asia Pacific (Tokyo) Europe (Ireland)
+//    South America (São Paulo) For a list of all the Amazon S3 supported Regions
+//    and endpoints, see Regions and Endpoints (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+//    in the Amazon Web Services General Reference. For example, the following
+//    x-amz-grant-write header grants create, overwrite, and delete objects
+//    permission to LogDelivery group predefined by Amazon S3 and two Amazon
+//    Web Services accounts identified by their email addresses. x-amz-grant-write:
+//    uri="http://acs.amazonaws.com/groups/s3/LogDelivery", id="111122223333",
+//    id="555566667777"
 //
 // You can use either a canned ACL or specify access permissions explicitly.
 // You cannot do both.
@@ -7003,12 +7035,12 @@ func (c *S3) PutBucketAclRequest(input *PutBucketAclInput) (req *request.Request
 //    xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee>
 //    The grantee is resolved to the CanonicalUser and, in a response to a GET
 //    Object acl request, appears as the CanonicalUser. Using email addresses
-//    to specify a grantee is only supported in the following AWS Regions: US
-//    East (N. Virginia) US West (N. California) US West (Oregon) Asia Pacific
-//    (Singapore) Asia Pacific (Sydney) Asia Pacific (Tokyo) Europe (Ireland)
-//    South America (São Paulo) For a list of all the Amazon S3 supported Regions
-//    and endpoints, see Regions and Endpoints (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-//    in the AWS General Reference.
+//    to specify a grantee is only supported in the following Amazon Web Services
+//    Regions: US East (N. Virginia) US West (N. California) US West (Oregon)
+//    Asia Pacific (Singapore) Asia Pacific (Sydney) Asia Pacific (Tokyo) Europe
+//    (Ireland) South America (São Paulo) For a list of all the Amazon S3 supported
+//    Regions and endpoints, see Regions and Endpoints (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+//    in the Amazon Web Services General Reference.
 //
 // Related Resources
 //
@@ -7339,16 +7371,16 @@ func (c *S3) PutBucketEncryptionRequest(input *PutBucketEncryptionInput) (req *r
 // and Amazon S3 Bucket Key for an existing bucket.
 //
 // Default encryption for a bucket can use server-side encryption with Amazon
-// S3-managed keys (SSE-S3) or AWS KMS customer master keys (SSE-KMS). If you
-// specify default encryption using SSE-KMS, you can also configure Amazon S3
-// Bucket Key. For information about default encryption, see Amazon S3 default
-// bucket encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html)
+// S3-managed keys (SSE-S3) or Amazon Web Services KMS customer master keys
+// (SSE-KMS). If you specify default encryption using SSE-KMS, you can also
+// configure Amazon S3 Bucket Key. For information about default encryption,
+// see Amazon S3 default bucket encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html)
 // in the Amazon S3 User Guide. For more information about S3 Bucket Keys, see
 // Amazon S3 Bucket Keys (https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html)
 // in the Amazon S3 User Guide.
 //
-// This action requires AWS Signature Version 4. For more information, see Authenticating
-// Requests (AWS Signature Version 4) (https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html).
+// This action requires Amazon Web Services Signature Version 4. For more information,
+// see Authenticating Requests (Amazon Web Services Signature Version 4) (https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html).
 //
 // To use this operation, you must have permissions to perform the s3:PutEncryptionConfiguration
 // action. The bucket owner has this permission by default. The bucket owner
@@ -7561,7 +7593,7 @@ func (c *S3) PutBucketInventoryConfigurationRequest(input *PutBucketInventoryCon
 // a daily or weekly basis, and the results are published to a flat file. The
 // bucket that is inventoried is called the source bucket, and the bucket where
 // the inventory flat file is stored is called the destination bucket. The destination
-// bucket must be in the same AWS Region as the source bucket.
+// bucket must be in the same Amazon Web Services Region as the source bucket.
 //
 // When you configure an inventory for a source bucket, you specify the destination
 // bucket where you want the inventory to be stored, and whether to generate
@@ -7696,10 +7728,10 @@ func (c *S3) PutBucketLifecycleRequest(input *PutBucketLifecycleInput) (req *req
 //
 // By default, all Amazon S3 resources, including buckets, objects, and related
 // subresources (for example, lifecycle configuration and website configuration)
-// are private. Only the resource owner, the AWS account that created the resource,
-// can access it. The resource owner can optionally grant access permissions
-// to others by writing an access policy. For this operation, users must get
-// the s3:PutLifecycleConfiguration permission.
+// are private. Only the resource owner, the Amazon Web Services account that
+// created the resource, can access it. The resource owner can optionally grant
+// access permissions to others by writing an access policy. For this operation,
+// users must get the s3:PutLifecycleConfiguration permission.
 //
 // You can also explicitly deny permissions. Explicit denial also supersedes
 // any other permissions. If you want to prevent users or accounts from removing
@@ -7728,10 +7760,10 @@ func (c *S3) PutBucketLifecycleRequest(input *PutBucketLifecycleInput) (req *req
 //    * RestoreObject (https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html)
 //
 //    * By default, a resource owner—in this case, a bucket owner, which is
-//    the AWS account that created the bucket—can perform any of the operations.
-//    A resource owner can also grant others permission to perform the operation.
-//    For more information, see the following topics in the Amazon S3 User Guide:
-//    Specifying Permissions in a Policy (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html)
+//    the Amazon Web Services account that created the bucket—can perform
+//    any of the operations. A resource owner can also grant others permission
+//    to perform the operation. For more information, see the following topics
+//    in the Amazon S3 User Guide: Specifying Permissions in a Policy (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html)
 //    Managing Access Permissions to your Amazon S3 Resources (https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html)
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -7852,10 +7884,10 @@ func (c *S3) PutBucketLifecycleConfigurationRequest(input *PutBucketLifecycleCon
 //
 // By default, all Amazon S3 resources are private, including buckets, objects,
 // and related subresources (for example, lifecycle configuration and website
-// configuration). Only the resource owner (that is, the AWS account that created
-// it) can access the resource. The resource owner can optionally grant access
-// permissions to others by writing an access policy. For this operation, a
-// user must get the s3:PutLifecycleConfiguration permission.
+// configuration). Only the resource owner (that is, the Amazon Web Services
+// account that created it) can access the resource. The resource owner can
+// optionally grant access permissions to others by writing an access policy.
+// For this operation, a user must get the s3:PutLifecycleConfiguration permission.
 //
 // You can also explicitly deny permissions. Explicit deny also supersedes any
 // other permissions. If you want to block users or accounts from removing or
@@ -7958,8 +7990,8 @@ func (c *S3) PutBucketLoggingRequest(input *PutBucketLoggingInput) (req *request
 //
 // Set the logging parameters for a bucket and to specify permissions for who
 // can view and modify the logging parameters. All logs are saved to buckets
-// in the same AWS Region as the source bucket. To set the logging status of
-// a bucket, you must be the bucket owner.
+// in the same Amazon Web Services Region as the source bucket. To set the logging
+// status of a bucket, you must be the bucket owner.
 //
 // The bucket owner is automatically granted FULL_CONTROL to all logs. You use
 // the Grantee request element to grant access to other people. The Permissions
@@ -8289,7 +8321,7 @@ func (c *S3) PutBucketNotificationConfigurationRequest(input *PutBucketNotificat
 // After Amazon S3 receives this request, it first verifies that any Amazon
 // Simple Notification Service (Amazon SNS) or Amazon Simple Queue Service (Amazon
 // SQS) destination exists, and that the bucket owner has permission to publish
-// to it by sending a test notification. In the case of AWS Lambda destinations,
+// to it by sending a test notification. In the case of Lambda destinations,
 // Amazon S3 verifies that the Lambda function permissions grant Amazon S3 permission
 // to invoke the function from the Amazon S3 bucket. For more information, see
 // Configuring Notifications for Amazon S3 Events (https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html).
@@ -8487,21 +8519,21 @@ func (c *S3) PutBucketPolicyRequest(input *PutBucketPolicyInput) (req *request.R
 // PutBucketPolicy API operation for Amazon Simple Storage Service.
 //
 // Applies an Amazon S3 bucket policy to an Amazon S3 bucket. If you are using
-// an identity other than the root user of the AWS account that owns the bucket,
-// the calling identity must have the PutBucketPolicy permissions on the specified
-// bucket and belong to the bucket owner's account in order to use this operation.
+// an identity other than the root user of the Amazon Web Services account that
+// owns the bucket, the calling identity must have the PutBucketPolicy permissions
+// on the specified bucket and belong to the bucket owner's account in order
+// to use this operation.
 //
 // If you don't have PutBucketPolicy permissions, Amazon S3 returns a 403 Access
 // Denied error. If you have the correct permissions, but you're not using an
 // identity that belongs to the bucket owner's account, Amazon S3 returns a
 // 405 Method Not Allowed error.
 //
-// As a security precaution, the root user of the AWS account that owns a bucket
-// can always use this operation, even if the policy explicitly denies the root
-// user the ability to perform this action.
+// As a security precaution, the root user of the Amazon Web Services account
+// that owns a bucket can always use this operation, even if the policy explicitly
+// denies the root user the ability to perform this action.
 //
-// For more information about bucket policies, see Using Bucket Policies and
-// User Policies (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html).
+// For more information, see Bucket policy examples (https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html).
 //
 // The following operations are related to PutBucketPolicy:
 //
@@ -8590,10 +8622,6 @@ func (c *S3) PutBucketReplicationRequest(input *PutBucketReplicationInput) (req 
 // information, see Replication (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html)
 // in the Amazon S3 User Guide.
 //
-// To perform this operation, the user or role performing the action must have
-// the iam:PassRole (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
-// permission.
-//
 // Specify the replication configuration in the request body. In the replication
 // configuration, you provide the name of the destination bucket or buckets
 // where you want Amazon S3 to replicate objects, the IAM role that Amazon S3
@@ -8617,23 +8645,32 @@ func (c *S3) PutBucketReplicationRequest(input *PutBucketReplicationInput) (req 
 // For information about enabling versioning on a bucket, see Using Versioning
 // (https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html).
 //
-// By default, a resource owner, in this case the AWS account that created the
-// bucket, can perform this operation. The resource owner can also grant others
-// permissions to perform the operation. For more information about permissions,
-// see Specifying Permissions in a Policy (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html)
-// and Managing Access Permissions to Your Amazon S3 Resources (https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html).
-//
 // Handling Replication of Encrypted Objects
 //
 // By default, Amazon S3 doesn't replicate objects that are stored at rest using
-// server-side encryption with CMKs stored in AWS KMS. To replicate AWS KMS-encrypted
-// objects, add the following: SourceSelectionCriteria, SseKmsEncryptedObjects,
-// Status, EncryptionConfiguration, and ReplicaKmsKeyID. For information about
-// replication configuration, see Replicating Objects Created with SSE Using
-// CMKs stored in AWS KMS (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-config-for-kms-objects.html).
+// server-side encryption with CMKs stored in Amazon Web Services KMS. To replicate
+// Amazon Web Services KMS-encrypted objects, add the following: SourceSelectionCriteria,
+// SseKmsEncryptedObjects, Status, EncryptionConfiguration, and ReplicaKmsKeyID.
+// For information about replication configuration, see Replicating Objects
+// Created with SSE Using CMKs stored in Amazon Web Services KMS (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-config-for-kms-objects.html).
 //
 // For information on PutBucketReplication errors, see List of replication-related
 // error codes (https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ReplicationErrorCodeList)
+//
+// Permissions
+//
+// To create a PutBucketReplication request, you must have s3:PutReplicationConfiguration
+// permissions for the bucket.
+//
+// By default, a resource owner, in this case the Amazon Web Services account
+// that created the bucket, can perform this operation. The resource owner can
+// also grant others permissions to perform the operation. For more information
+// about permissions, see Specifying Permissions in a Policy (https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html)
+// and Managing Access Permissions to Your Amazon S3 Resources (https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html).
+//
+// To perform this operation, the user or role performing the action must have
+// the iam:PassRole (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html)
+// permission.
 //
 // The following operations are related to PutBucketReplication:
 //
@@ -8809,13 +8846,14 @@ func (c *S3) PutBucketTaggingRequest(input *PutBucketTaggingInput) (req *request
 //
 // Sets the tags for a bucket.
 //
-// Use tags to organize your AWS bill to reflect your own cost structure. To
-// do this, sign up to get your AWS account bill with tag key values included.
-// Then, to see the cost of combined resources, organize your billing information
-// according to resources with the same tag key values. For example, you can
-// tag several resources with a specific application name, and then organize
-// your billing information to see the total cost of that application across
-// several services. For more information, see Cost Allocation and Tagging (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html)
+// Use tags to organize your Amazon Web Services bill to reflect your own cost
+// structure. To do this, sign up to get your Amazon Web Services account bill
+// with tag key values included. Then, to see the cost of combined resources,
+// organize your billing information according to resources with the same tag
+// key values. For example, you can tag several resources with a specific application
+// name, and then organize your billing information to see the total cost of
+// that application across several services. For more information, see Cost
+// Allocation and Tagging (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html)
 // and Using Cost Allocation in Amazon S3 Bucket Tags (https://docs.aws.amazon.com/AmazonS3/latest/dev/CostAllocTagging.html).
 //
 // When this operation sets the tags for a bucket, it will overwrite any current
@@ -8834,7 +8872,7 @@ func (c *S3) PutBucketTaggingRequest(input *PutBucketTaggingInput) (req *request
 //    valid tag. This error can occur if the tag did not pass input validation.
 //    For information about tag restrictions, see User-Defined Tag Restrictions
 //    (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html)
-//    and AWS-Generated Cost Allocation Tag Restrictions (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/aws-tag-restrictions.html).
+//    and Amazon Web Services-Generated Cost Allocation Tag Restrictions (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/aws-tag-restrictions.html).
 //
 //    * Error code: MalformedXMLError Description: The XML provided does not
 //    match the schema.
@@ -9197,31 +9235,40 @@ func (c *S3) PutObjectRequest(input *PutObjectInput) (req *request.Request, outp
 // you can calculate the MD5 while putting an object to Amazon S3 and compare
 // the returned ETag to the calculated MD5 value.
 //
-// The Content-MD5 header is required for any request to upload an object with
-// a retention period configured using Amazon S3 Object Lock. For more information
-// about Amazon S3 Object Lock, see Amazon S3 Object Lock Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)
-// in the Amazon S3 User Guide.
+//    * To successfully complete the PutObject request, you must have the s3:PutObject
+//    in your IAM permissions.
+//
+//    * To successfully change the objects acl of your PutObject request, you
+//    must have the s3:PutObjectAcl in your IAM permissions.
+//
+//    * The Content-MD5 header is required for any request to upload an object
+//    with a retention period configured using Amazon S3 Object Lock. For more
+//    information about Amazon S3 Object Lock, see Amazon S3 Object Lock Overview
+//    (https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html)
+//    in the Amazon S3 User Guide.
 //
 // Server-side Encryption
 //
 // You can optionally request server-side encryption. With server-side encryption,
 // Amazon S3 encrypts your data as it writes it to disks in its data centers
 // and decrypts the data when you access it. You have the option to provide
-// your own encryption key or use AWS managed encryption keys (SSE-S3 or SSE-KMS).
-// For more information, see Using Server-Side Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html).
+// your own encryption key or use Amazon Web Services managed encryption keys
+// (SSE-S3 or SSE-KMS). For more information, see Using Server-Side Encryption
+// (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html).
 //
-// If you request server-side encryption using AWS Key Management Service (SSE-KMS),
-// you can enable an S3 Bucket Key at the object-level. For more information,
-// see Amazon S3 Bucket Keys (https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html)
+// If you request server-side encryption using Amazon Web Services Key Management
+// Service (SSE-KMS), you can enable an S3 Bucket Key at the object-level. For
+// more information, see Amazon S3 Bucket Keys (https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html)
 // in the Amazon S3 User Guide.
 //
 // Access Control List (ACL)-Specific Request Headers
 //
 // You can use headers to grant ACL- based permissions. By default, all objects
 // are private. Only the owner has full access control. When adding a new object,
-// you can grant permissions to individual AWS accounts or to predefined groups
-// defined by Amazon S3. These permissions are then added to the ACL on the
-// object. For more information, see Access Control List (ACL) Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)
+// you can grant permissions to individual Amazon Web Services accounts or to
+// predefined groups defined by Amazon S3. These permissions are then added
+// to the ACL on the object. For more information, see Access Control List (ACL)
+// Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html)
 // and Managing ACLs Using the REST API (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html).
 //
 // Storage Class Options
@@ -9356,26 +9403,26 @@ func (c *S3) PutObjectAclRequest(input *PutObjectAclInput) (req *request.Request
 //
 //    * Specify access permissions explicitly with the x-amz-grant-read, x-amz-grant-read-acp,
 //    x-amz-grant-write-acp, and x-amz-grant-full-control headers. When using
-//    these headers, you specify explicit access permissions and grantees (AWS
-//    accounts or Amazon S3 groups) who will receive the permission. If you
-//    use these ACL-specific headers, you cannot use x-amz-acl header to set
-//    a canned ACL. These parameters map to the set of permissions that Amazon
-//    S3 supports in an ACL. For more information, see Access Control List (ACL)
-//    Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+//    these headers, you specify explicit access permissions and grantees (Amazon
+//    Web Services accounts or Amazon S3 groups) who will receive the permission.
+//    If you use these ACL-specific headers, you cannot use x-amz-acl header
+//    to set a canned ACL. These parameters map to the set of permissions that
+//    Amazon S3 supports in an ACL. For more information, see Access Control
+//    List (ACL) Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 //    You specify each grantee as a type=value pair, where the type is one of
 //    the following: id – if the value specified is the canonical user ID
-//    of an AWS account uri – if you are granting permissions to a predefined
-//    group emailAddress – if the value specified is the email address of
-//    an AWS account Using email addresses to specify a grantee is only supported
-//    in the following AWS Regions: US East (N. Virginia) US West (N. California)
-//    US West (Oregon) Asia Pacific (Singapore) Asia Pacific (Sydney) Asia Pacific
-//    (Tokyo) Europe (Ireland) South America (São Paulo) For a list of all
-//    the Amazon S3 supported Regions and endpoints, see Regions and Endpoints
-//    (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) in
-//    the AWS General Reference. For example, the following x-amz-grant-read
-//    header grants list objects permission to the two AWS accounts identified
-//    by their email addresses. x-amz-grant-read: emailAddress="xyz@amazon.com",
-//    emailAddress="abc@amazon.com"
+//    of an Amazon Web Services account uri – if you are granting permissions
+//    to a predefined group emailAddress – if the value specified is the email
+//    address of an Amazon Web Services account Using email addresses to specify
+//    a grantee is only supported in the following Amazon Web Services Regions:
+//    US East (N. Virginia) US West (N. California) US West (Oregon) Asia Pacific
+//    (Singapore) Asia Pacific (Sydney) Asia Pacific (Tokyo) Europe (Ireland)
+//    South America (São Paulo) For a list of all the Amazon S3 supported Regions
+//    and endpoints, see Regions and Endpoints (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+//    in the Amazon Web Services General Reference. For example, the following
+//    x-amz-grant-read header grants list objects permission to the two Amazon
+//    Web Services accounts identified by their email addresses. x-amz-grant-read:
+//    emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com"
 //
 // You can use either a canned ACL or specify access permissions explicitly.
 // You cannot do both.
@@ -9396,12 +9443,12 @@ func (c *S3) PutObjectAclRequest(input *PutObjectAclInput) (req *request.Request
 //    xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee>
 //    The grantee is resolved to the CanonicalUser and, in a response to a GET
 //    Object acl request, appears as the CanonicalUser. Using email addresses
-//    to specify a grantee is only supported in the following AWS Regions: US
-//    East (N. Virginia) US West (N. California) US West (Oregon) Asia Pacific
-//    (Singapore) Asia Pacific (Sydney) Asia Pacific (Tokyo) Europe (Ireland)
-//    South America (São Paulo) For a list of all the Amazon S3 supported Regions
-//    and endpoints, see Regions and Endpoints (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-//    in the AWS General Reference.
+//    to specify a grantee is only supported in the following Amazon Web Services
+//    Regions: US East (N. Virginia) US West (N. California) US West (Oregon)
+//    Asia Pacific (Singapore) Asia Pacific (Sydney) Asia Pacific (Tokyo) Europe
+//    (Ireland) South America (São Paulo) For a list of all the Amazon S3 supported
+//    Regions and endpoints, see Regions and Endpoints (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+//    in the Amazon Web Services General Reference.
 //
 // Versioning
 //
@@ -9588,7 +9635,7 @@ func (c *S3) PutObjectLockConfigurationRequest(input *PutObjectLockConfiguration
 //    select one. You cannot specify Days and Years at the same time.
 //
 //    * You can only enable Object Lock for new buckets. If you want to turn
-//    on Object Lock for an existing bucket, contact AWS Support.
+//    on Object Lock for an existing bucket, contact Amazon Web Services Support.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -9668,8 +9715,17 @@ func (c *S3) PutObjectRetentionRequest(input *PutObjectRetentionInput) (req *req
 //
 // Places an Object Retention configuration on an object. For more information,
 // see Locking Objects (https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html).
+// Users or accounts require the s3:PutObjectRetention permission in order to
+// place an Object Retention configuration on objects. Bypassing a Governance
+// Retention configuration requires the s3:BypassGovernanceRetention permission.
 //
 // This action is not supported by Amazon S3 on Outposts.
+//
+// Permissions
+//
+// When the Object Lock retention mode is set to compliance, you need s3:PutObjectRetention
+// and s3:BypassGovernanceRetention permissions. For other requests to PutObjectRetention,
+// only s3:PutObjectRetention permissions are required.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -9992,12 +10048,12 @@ func (c *S3) RestoreObjectRequest(input *RestoreObjectInput) (req *request.Reque
 // When making a select request, do the following:
 //
 //    * Define an output location for the select query's output. This must be
-//    an Amazon S3 bucket in the same AWS Region as the bucket that contains
-//    the archive object that is being queried. The AWS account that initiates
-//    the job must have permissions to write to the S3 bucket. You can specify
-//    the storage class and encryption for the output objects stored in the
-//    bucket. For more information about output, see Querying Archived Objects
-//    (https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html)
+//    an Amazon S3 bucket in the same Amazon Web Services Region as the bucket
+//    that contains the archive object that is being queried. The Amazon Web
+//    Services account that initiates the job must have permissions to write
+//    to the S3 bucket. You can specify the storage class and encryption for
+//    the output objects stored in the bucket. For more information about output,
+//    see Querying Archived Objects (https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html)
 //    in the Amazon S3 User Guide. For more information about the S3 structure
 //    in the request body, see the following: PutObject (https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html)
 //    Managing Access with ACLs (https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html)
@@ -10284,10 +10340,10 @@ func (c *S3) SelectObjectContentRequest(input *SelectObjectContentInput) (req *r
 //    Encryption Keys) (https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html)
 //    in the Amazon S3 User Guide. For objects that are encrypted with Amazon
 //    S3 managed encryption keys (SSE-S3) and customer master keys (CMKs) stored
-//    in AWS Key Management Service (SSE-KMS), server-side encryption is handled
-//    transparently, so you don't need to specify anything. For more information
-//    about server-side encryption, including SSE-S3 and SSE-KMS, see Protecting
-//    Data Using Server-Side Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)
+//    in Amazon Web Services Key Management Service (SSE-KMS), server-side encryption
+//    is handled transparently, so you don't need to specify anything. For more
+//    information about server-side encryption, including SSE-S3 and SSE-KMS,
+//    see Protecting Data Using Server-Side Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html)
 //    in the Amazon S3 User Guide.
 //
 // Working with the Response Body
@@ -10295,7 +10351,7 @@ func (c *S3) SelectObjectContentRequest(input *SelectObjectContentInput) (req *r
 // Given the response size is unknown, Amazon S3 Select streams the response
 // as a series of messages and includes a Transfer-Encoding header with chunked
 // as its value in the response. For more information, see Appendix: SelectObjectContent
-// Response (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html) .
+// Response (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html).
 //
 // GetObject Support
 //
@@ -10590,10 +10646,10 @@ func (c *S3) UploadPartRequest(input *UploadPartInput) (req *request.Request, ou
 // data against the provided MD5 value. If they do not match, Amazon S3 returns
 // an error.
 //
-// If the upload request is signed with Signature Version 4, then AWS S3 uses
-// the x-amz-content-sha256 header as a checksum instead of Content-MD5. For
-// more information see Authenticating Requests: Using the Authorization Header
-// (AWS Signature Version 4) (https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html).
+// If the upload request is signed with Signature Version 4, then Amazon Web
+// Services S3 uses the x-amz-content-sha256 header as a checksum instead of
+// Content-MD5. For more information see Authenticating Requests: Using the
+// Authorization Header (Amazon Web Services Signature Version 4) (https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html).
 //
 // Note: After you initiate multipart upload and upload one or more parts, you
 // must either complete or abort multipart upload in order to stop getting charged
@@ -10612,10 +10668,10 @@ func (c *S3) UploadPartRequest(input *UploadPartInput) (req *request.Request, ou
 // You can optionally request server-side encryption where Amazon S3 encrypts
 // your data as it writes it to disks in its data centers and decrypts it for
 // you when you access it. You have the option of providing your own encryption
-// key, or you can use the AWS managed encryption keys. If you choose to provide
-// your own encryption key, the request headers you provide in the request must
-// match the headers you used in the request to initiate the upload by using
-// CreateMultipartUpload (https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html).
+// key, or you can use the Amazon Web Services managed encryption keys. If you
+// choose to provide your own encryption key, the request headers you provide
+// in the request must match the headers you used in the request to initiate
+// the upload by using CreateMultipartUpload (https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html).
 // For more information, go to Using Server-Side Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html)
 // in the Amazon S3 User Guide.
 //
@@ -10902,16 +10958,21 @@ func (c *S3) WriteGetObjectResponseRequest(input *WriteGetObjectResponseInput) (
 // This operation supports metadata that can be returned by GetObject (https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html),
 // in addition to RequestRoute, RequestToken, StatusCode, ErrorCode, and ErrorMessage.
 // The GetObject response metadata is supported so that the WriteGetObjectResponse
-// caller, typically an AWS Lambda function, can provide the same metadata when
+// caller, typically an Lambda function, can provide the same metadata when
 // it internally invokes GetObject. When WriteGetObjectResponse is called by
 // a customer-owned Lambda function, the metadata returned to the end user GetObject
 // call might differ from what Amazon S3 would normally return.
 //
-// AWS provides some prebuilt Lambda functions that you can use with S3 Object
-// Lambda to detect and redact personally identifiable information (PII) and
-// decompress S3 objects. These Lambda functions are available in the AWS Serverless
-// Application Repository, and can be selected through the AWS Management Console
-// when you create your Object Lambda Access Point.
+// You can include any number of metadata headers. When including a metadata
+// header, it should be prefaced with x-amz-meta. For example, x-amz-meta-my-custom-header:
+// MyCustomValue. The primary use case for this is to forward GetObject metadata.
+//
+// Amazon Web Services provides some prebuilt Lambda functions that you can
+// use with S3 Object Lambda to detect and redact personally identifiable information
+// (PII) and decompress S3 objects. These Lambda functions are available in
+// the Amazon Web Services Serverless Application Repository, and can be selected
+// through the Amazon Web Services Management Console when you create your Object
+// Lambda Access Point.
 //
 // Example 1: PII Access Control - This Lambda function uses Amazon Comprehend,
 // a natural language processing (NLP) service using machine learning to find
@@ -10929,8 +10990,8 @@ func (c *S3) WriteGetObjectResponseRequest(input *WriteGetObjectResponseInput) (
 // is equipped to decompress objects stored in S3 in one of six compressed file
 // formats including bzip2, gzip, snappy, zlib, zstandard and ZIP.
 //
-// For information on how to view and use these functions, see Using AWS built
-// Lambda functions (https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-examples.html)
+// For information on how to view and use these functions, see Using Amazon
+// Web Services built Lambda functions (https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-examples.html)
 // in the Amazon S3 User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -10997,17 +11058,17 @@ type AbortMultipartUploadInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -11603,7 +11664,8 @@ func (s *AnalyticsS3BucketDestination) SetPrefix(v string) *AnalyticsS3BucketDes
 }
 
 // In terms of implementation, a Bucket is a resource. An Amazon S3 bucket name
-// is globally unique, and the namespace is shared by all AWS accounts.
+// is globally unique, and the namespace is shared by all Amazon Web Services
+// accounts.
 type Bucket struct {
 	_ struct{} `type:"structure"`
 
@@ -12053,7 +12115,7 @@ func (s *CSVOutput) SetRecordDelimiter(v string) *CSVOutput {
 	return s
 }
 
-// Container for specifying the AWS Lambda notification configuration.
+// Container for specifying the Lambda notification configuration.
 type CloudFunctionConfiguration struct {
 	_ struct{} `type:"structure"`
 
@@ -12149,6 +12211,21 @@ type CompleteMultipartUploadInput struct {
 	_ struct{} `locationName:"CompleteMultipartUploadRequest" type:"structure" payload:"MultipartUpload"`
 
 	// Name of the bucket to which the multipart upload was initiated.
+	//
+	// When using this action with an access point, you must direct requests to
+	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// in the Amazon S3 User Guide.
+	//
+	// When using this action with Amazon S3 on Outposts, you must direct requests
+	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
+	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
@@ -12287,26 +12364,27 @@ func (s CompleteMultipartUploadInput) updateArnableField(v string) (interface{},
 type CompleteMultipartUploadOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the bucket that contains the newly created object.
+	// The name of the bucket that contains the newly created object. Does not return
+	// the access point ARN or access point alias if used.
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	Bucket *string `type:"string"`
 
 	// Indicates whether the multipart upload uses an S3 Bucket Key for server-side
-	// encryption with AWS KMS (SSE-KMS).
+	// encryption with Amazon Web Services KMS (SSE-KMS).
 	BucketKeyEnabled *bool `location:"header" locationName:"x-amz-server-side-encryption-bucket-key-enabled" type:"boolean"`
 
 	// Entity tag that identifies the newly created object's data. Objects with
@@ -12331,15 +12409,15 @@ type CompleteMultipartUploadOutput struct {
 	// request.
 	RequestCharged *string `location:"header" locationName:"x-amz-request-charged" type:"string" enum:"RequestCharged"`
 
-	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
-	// object.
+	// If present, specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetric customer managed customer master key
+	// (CMK) that was used for the object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// If you specified server-side encryption either with an Amazon S3-managed
-	// encryption key or an AWS KMS customer master key (CMK) in your initiate multipart
-	// upload request, the response includes this header. It confirms the encryption
-	// algorithm that Amazon S3 used to encrypt the object.
+	// encryption key or an Amazon Web Services KMS customer master key (CMK) in
+	// your initiate multipart upload request, the response includes this header.
+	// It confirms the encryption algorithm that Amazon S3 used to encrypt the object.
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string" enum:"ServerSideEncryption"`
 
 	// Version ID of the newly created object, in case the bucket has versioning
@@ -12577,17 +12655,17 @@ type CopyObjectInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -12637,8 +12715,9 @@ type CopyObjectInput struct {
 	//    the URL encoding of arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf.
 	//    The value must be URL encoded. Amazon S3 supports copy operations using
 	//    access points only when the source and destination buckets are in the
-	//    same AWS Region. Alternatively, for objects accessed through Amazon S3
-	//    on Outposts, specify the ARN of the object as accessed in the format arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key>.
+	//    same Amazon Web Services Region. Alternatively, for objects accessed through
+	//    Amazon S3 on Outposts, specify the ARN of the object as accessed in the
+	//    format arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key>.
 	//    For example, to copy the object reports/january.pdf through outpost my-outpost
 	//    owned by account 123456789012 in Region us-west-2, use the URL encoding
 	//    of arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf.
@@ -12756,16 +12835,17 @@ type CopyObjectInput struct {
 	// encryption key was transmitted without error.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// Specifies the AWS KMS Encryption Context to use for object encryption. The
-	// value of this header is a base64-encoded UTF-8 string holding JSON with the
-	// encryption context key-value pairs.
+	// Specifies the Amazon Web Services KMS Encryption Context to use for object
+	// encryption. The value of this header is a base64-encoded UTF-8 string holding
+	// JSON with the encryption context key-value pairs.
 	SSEKMSEncryptionContext *string `location:"header" locationName:"x-amz-server-side-encryption-context" type:"string" sensitive:"true"`
 
-	// Specifies the AWS KMS key ID to use for object encryption. All GET and PUT
-	// requests for an object protected by AWS KMS will fail if not made via SSL
-	// or using SigV4. For information about configuring using any of the officially
-	// supported AWS SDKs and AWS CLI, see Specifying the Signature Version in Request
-	// Authentication (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version)
+	// Specifies the Amazon Web Services KMS key ID to use for object encryption.
+	// All GET and PUT requests for an object protected by Amazon Web Services KMS
+	// will fail if not made via SSL or using SigV4. For information about configuring
+	// using any of the officially supported Amazon Web Services SDKs and Amazon
+	// Web Services CLI, see Specifying the Signature Version in Request Authentication
+	// (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version)
 	// in the Amazon S3 User Guide.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
@@ -13123,7 +13203,7 @@ type CopyObjectOutput struct {
 	_ struct{} `type:"structure" payload:"CopyObjectResult"`
 
 	// Indicates whether the copied object uses an S3 Bucket Key for server-side
-	// encryption with AWS KMS (SSE-KMS).
+	// encryption with Amazon Web Services KMS (SSE-KMS).
 	BucketKeyEnabled *bool `location:"header" locationName:"x-amz-server-side-encryption-bucket-key-enabled" type:"boolean"`
 
 	// Container for all response elements.
@@ -13149,14 +13229,14 @@ type CopyObjectOutput struct {
 	// verification of the customer-provided encryption key.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// If present, specifies the AWS KMS Encryption Context to use for object encryption.
-	// The value of this header is a base64-encoded UTF-8 string holding JSON with
-	// the encryption context key-value pairs.
+	// If present, specifies the Amazon Web Services KMS Encryption Context to use
+	// for object encryption. The value of this header is a base64-encoded UTF-8
+	// string holding JSON with the encryption context key-value pairs.
 	SSEKMSEncryptionContext *string `location:"header" locationName:"x-amz-server-side-encryption-context" type:"string" sensitive:"true"`
 
-	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
-	// object.
+	// If present, specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetric customer managed customer master key
+	// (CMK) that was used for the object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// The server-side encryption algorithm used when storing this object in Amazon
@@ -13248,8 +13328,7 @@ type CopyObjectResult struct {
 	_ struct{} `type:"structure"`
 
 	// Returns the ETag of the new object. The ETag reflects only changes to the
-	// contents of an object, not its metadata. The source and destination ETag
-	// is identical for a successfully copied non-multipart object.
+	// contents of an object, not its metadata.
 	ETag *string `type:"string"`
 
 	// Creation date of the object.
@@ -13497,17 +13576,17 @@ type CreateMultipartUploadInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -13607,16 +13686,17 @@ type CreateMultipartUploadInput struct {
 	// encryption key was transmitted without error.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// Specifies the AWS KMS Encryption Context to use for object encryption. The
-	// value of this header is a base64-encoded UTF-8 string holding JSON with the
-	// encryption context key-value pairs.
+	// Specifies the Amazon Web Services KMS Encryption Context to use for object
+	// encryption. The value of this header is a base64-encoded UTF-8 string holding
+	// JSON with the encryption context key-value pairs.
 	SSEKMSEncryptionContext *string `location:"header" locationName:"x-amz-server-side-encryption-context" type:"string" sensitive:"true"`
 
-	// Specifies the ID of the symmetric customer managed AWS KMS CMK to use for
-	// object encryption. All GET and PUT requests for an object protected by AWS
-	// KMS will fail if not made via SSL or using SigV4. For information about configuring
-	// using any of the officially supported AWS SDKs and AWS CLI, see Specifying
-	// the Signature Version in Request Authentication (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version)
+	// Specifies the ID of the symmetric customer managed Amazon Web Services KMS
+	// CMK to use for object encryption. All GET and PUT requests for an object
+	// protected by Amazon Web Services KMS will fail if not made via SSL or using
+	// SigV4. For information about configuring using any of the officially supported
+	// Amazon Web Services SDKs and Amazon Web Services CLI, see Specifying the
+	// Signature Version in Request Authentication (https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version)
 	// in the Amazon S3 User Guide.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
@@ -13907,26 +13987,27 @@ type CreateMultipartUploadOutput struct {
 	// incomplete multipart uploads.
 	AbortRuleId *string `location:"header" locationName:"x-amz-abort-rule-id" type:"string"`
 
-	// The name of the bucket to which the multipart upload was initiated.
+	// The name of the bucket to which the multipart upload was initiated. Does
+	// not return the access point ARN or access point alias if used.
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	Bucket *string `locationName:"Bucket" type:"string"`
 
 	// Indicates whether the multipart upload uses an S3 Bucket Key for server-side
-	// encryption with AWS KMS (SSE-KMS).
+	// encryption with Amazon Web Services KMS (SSE-KMS).
 	BucketKeyEnabled *bool `location:"header" locationName:"x-amz-server-side-encryption-bucket-key-enabled" type:"boolean"`
 
 	// Object key for which the multipart upload was initiated.
@@ -13946,14 +14027,14 @@ type CreateMultipartUploadOutput struct {
 	// verification of the customer-provided encryption key.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// If present, specifies the AWS KMS Encryption Context to use for object encryption.
-	// The value of this header is a base64-encoded UTF-8 string holding JSON with
-	// the encryption context key-value pairs.
+	// If present, specifies the Amazon Web Services KMS Encryption Context to use
+	// for object encryption. The value of this header is a base64-encoded UTF-8
+	// string holding JSON with the encryption context key-value pairs.
 	SSEKMSEncryptionContext *string `location:"header" locationName:"x-amz-server-side-encryption-context" type:"string" sensitive:"true"`
 
-	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
-	// object.
+	// If present, specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetric customer managed customer master key
+	// (CMK) that was used for the object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// The server-side encryption algorithm used when storing this object in Amazon
@@ -15616,24 +15697,25 @@ type DeleteObjectInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// Indicates whether S3 Object Lock should bypass Governance-mode restrictions
-	// to process this operation.
+	// to process this operation. To use this header, you must have the s3:PutBucketPublicAccessBlock
+	// permission.
 	BypassGovernanceRetention *bool `location:"header" locationName:"x-amz-bypass-governance-retention" type:"boolean"`
 
 	// The account ID of the expected bucket owner. If the bucket is owned by a
@@ -15822,17 +15904,17 @@ type DeleteObjectTaggingInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -15973,25 +16055,25 @@ type DeleteObjectsInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
 	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
 
 	// Specifies whether you want to delete this object even if it has a Governance-type
-	// Object Lock in place. You must have sufficient permissions to perform this
-	// operation.
+	// Object Lock in place. To use this header, you must have the s3:PutBucketPublicAccessBlock
+	// permission.
 	BypassGovernanceRetention *bool `location:"header" locationName:"x-amz-bypass-governance-retention" type:"boolean"`
 
 	// Container for the request.
@@ -16328,16 +16410,17 @@ type Destination struct {
 
 	// Specify this only in a cross-account scenario (where source and destination
 	// bucket owners are not the same), and you want to change replica ownership
-	// to the AWS account that owns the destination bucket. If this is not specified
-	// in the replication configuration, the replicas are owned by same AWS account
-	// that owns the source object.
+	// to the Amazon Web Services account that owns the destination bucket. If this
+	// is not specified in the replication configuration, the replicas are owned
+	// by same Amazon Web Services account that owns the source object.
 	AccessControlTranslation *AccessControlTranslation `type:"structure"`
 
 	// Destination bucket owner account ID. In a cross-account scenario, if you
-	// direct Amazon S3 to change replica ownership to the AWS account that owns
-	// the destination bucket by specifying the AccessControlTranslation property,
-	// this is the account ID of the destination bucket owner. For more information,
-	// see Replication Additional Configuration: Changing the Replica Owner (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-change-owner.html)
+	// direct Amazon S3 to change replica ownership to the Amazon Web Services account
+	// that owns the destination bucket by specifying the AccessControlTranslation
+	// property, this is the account ID of the destination bucket owner. For more
+	// information, see Replication Additional Configuration: Changing the Replica
+	// Owner (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-change-owner.html)
 	// in the Amazon S3 User Guide.
 	Account *string `type:"string"`
 
@@ -16472,10 +16555,10 @@ type Encryption struct {
 	KMSContext *string `type:"string"`
 
 	// If the encryption type is aws:kms, this optional value specifies the ID of
-	// the symmetric customer managed AWS KMS CMK to use for encryption of job results.
-	// Amazon S3 only supports symmetric CMKs. For more information, see Using symmetric
-	// and asymmetric keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-	// in the AWS Key Management Service Developer Guide.
+	// the symmetric customer managed Amazon Web Services KMS CMK to use for encryption
+	// of job results. Amazon S3 only supports symmetric CMKs. For more information,
+	// see Using symmetric and asymmetric keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+	// in the Amazon Web Services Key Management Service Developer Guide.
 	KMSKeyId *string `type:"string" sensitive:"true"`
 }
 
@@ -16525,12 +16608,12 @@ func (s *Encryption) SetKMSKeyId(v string) *Encryption {
 type EncryptionConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	// Specifies the ID (Key ARN or Alias ARN) of the customer managed AWS KMS key
-	// stored in AWS Key Management Service (KMS) for the destination bucket. Amazon
-	// S3 uses this key to encrypt replica objects. Amazon S3 only supports symmetric,
-	// customer managed KMS keys. For more information, see Using symmetric and
-	// asymmetric keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-	// in the AWS Key Management Service Developer Guide.
+	// Specifies the ID (Key ARN or Alias ARN) of the customer managed Amazon Web
+	// Services KMS key stored in Amazon Web Services Key Management Service (KMS)
+	// for the destination bucket. Amazon S3 uses this key to encrypt replica objects.
+	// Amazon S3 only supports symmetric, customer managed KMS keys. For more information,
+	// see Using symmetric and asymmetric keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+	// in the Amazon Web Services Key Management Service Developer Guide.
 	ReplicaKmsKeyID *string `type:"string"`
 }
 
@@ -16599,14 +16682,14 @@ type Error struct {
 	//    * Code: AccessDenied Description: Access Denied HTTP Status Code: 403
 	//    Forbidden SOAP Fault Code Prefix: Client
 	//
-	//    * Code: AccountProblem Description: There is a problem with your AWS account
-	//    that prevents the action from completing successfully. Contact AWS Support
-	//    for further assistance. HTTP Status Code: 403 Forbidden SOAP Fault Code
-	//    Prefix: Client
+	//    * Code: AccountProblem Description: There is a problem with your Amazon
+	//    Web Services account that prevents the action from completing successfully.
+	//    Contact Amazon Web Services Support for further assistance. HTTP Status
+	//    Code: 403 Forbidden SOAP Fault Code Prefix: Client
 	//
 	//    * Code: AllAccessDisabled Description: All access to this Amazon S3 resource
-	//    has been disabled. Contact AWS Support for further assistance. HTTP Status
-	//    Code: 403 Forbidden SOAP Fault Code Prefix: Client
+	//    has been disabled. Contact Amazon Web Services Support for further assistance.
+	//    HTTP Status Code: 403 Forbidden SOAP Fault Code Prefix: Client
 	//
 	//    * Code: AmbiguousGrantByEmailAddress Description: The email address you
 	//    provided is associated with more than one account. HTTP Status Code: 400
@@ -16626,8 +16709,8 @@ type Error struct {
 	//    SOAP Fault Code Prefix: Client
 	//
 	//    * Code: BucketAlreadyOwnedByYou Description: The bucket you tried to create
-	//    already exists, and you own it. Amazon S3 returns this error in all AWS
-	//    Regions except in the North Virginia Region. For legacy compatibility,
+	//    already exists, and you own it. Amazon S3 returns this error in all Amazon
+	//    Web Services Regions except in the North Virginia Region. For legacy compatibility,
 	//    if you re-create an existing bucket that you already own in the North
 	//    Virginia Region, Amazon S3 returns 200 OK and resets the bucket access
 	//    control lists (ACLs). Code: 409 Conflict (in all Regions except the North
@@ -16676,9 +16759,9 @@ type Error struct {
 	//    try again. HTTP Status Code: 500 Internal Server Error SOAP Fault Code
 	//    Prefix: Server
 	//
-	//    * Code: InvalidAccessKeyId Description: The AWS access key ID you provided
-	//    does not exist in our records. HTTP Status Code: 403 Forbidden SOAP Fault
-	//    Code Prefix: Client
+	//    * Code: InvalidAccessKeyId Description: The Amazon Web Services access
+	//    key ID you provided does not exist in our records. HTTP Status Code: 403
+	//    Forbidden SOAP Fault Code Prefix: Client
 	//
 	//    * Code: InvalidAddressingHeader Description: You must specify the Anonymous
 	//    role. HTTP Status Code: N/A SOAP Fault Code Prefix: Client
@@ -16719,8 +16802,8 @@ type Error struct {
 	//    Code: 400 Bad Request SOAP Fault Code Prefix: Client
 	//
 	//    * Code: InvalidPayer Description: All access to this object has been disabled.
-	//    Please contact AWS Support for further assistance. HTTP Status Code: 403
-	//    Forbidden SOAP Fault Code Prefix: Client
+	//    Please contact Amazon Web Services Support for further assistance. HTTP
+	//    Status Code: 403 Forbidden SOAP Fault Code Prefix: Client
 	//
 	//    * Code: InvalidPolicyDocument Description: The content of the form does
 	//    not meet the conditions specified in the policy document. HTTP Status
@@ -16756,12 +16839,12 @@ type Error struct {
 	//    on this bucket. HTTP Status Code: 400 Bad Request Code: N/A
 	//
 	//    * Code: InvalidRequest Description: Amazon S3 Transfer Acceleration is
-	//    not supported on this bucket. Contact AWS Support for more information.
-	//    HTTP Status Code: 400 Bad Request Code: N/A
+	//    not supported on this bucket. Contact Amazon Web Services Support for
+	//    more information. HTTP Status Code: 400 Bad Request Code: N/A
 	//
 	//    * Code: InvalidRequest Description: Amazon S3 Transfer Acceleration cannot
-	//    be enabled on this bucket. Contact AWS Support for more information. HTTP
-	//    Status Code: 400 Bad Request Code: N/A
+	//    be enabled on this bucket. Contact Amazon Web Services Support for more
+	//    information. HTTP Status Code: 400 Bad Request Code: N/A
 	//
 	//    * Code: InvalidSecurity Description: The provided security credentials
 	//    are not valid. HTTP Status Code: 403 Forbidden SOAP Fault Code Prefix:
@@ -16869,8 +16952,8 @@ type Error struct {
 	//
 	//    * Code: NotSignedUp Description: Your account is not signed up for the
 	//    Amazon S3 service. You must sign up before you can use Amazon S3. You
-	//    can sign up at the following URL: https://aws.amazon.com/s3 HTTP Status
-	//    Code: 403 Forbidden SOAP Fault Code Prefix: Client
+	//    can sign up at the following URL: Amazon S3 (http://aws.amazon.com/s3)
+	//    HTTP Status Code: 403 Forbidden SOAP Fault Code Prefix: Client
 	//
 	//    * Code: OperationAborted Description: A conflicting conditional action
 	//    is currently in progress against this resource. Try again. HTTP Status
@@ -16908,8 +16991,8 @@ type Error struct {
 	//    Fault Code Prefix: Client
 	//
 	//    * Code: SignatureDoesNotMatch Description: The request signature we calculated
-	//    does not match the signature you provided. Check your AWS secret access
-	//    key and signing method. For more information, see REST Authentication
+	//    does not match the signature you provided. Check your Amazon Web Services
+	//    secret access key and signing method. For more information, see REST Authentication
 	//    (https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html)
 	//    and SOAP Authentication (https://docs.aws.amazon.com/AmazonS3/latest/dev/SOAPAuthentication.html)
 	//    for details. HTTP Status Code: 403 Forbidden SOAP Fault Code Prefix: Client
@@ -19493,9 +19576,9 @@ type GetObjectAclInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -19667,17 +19750,17 @@ type GetObjectInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -19967,9 +20050,9 @@ type GetObjectLegalHoldInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -20122,9 +20205,9 @@ type GetObjectLockConfigurationInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -20241,7 +20324,7 @@ type GetObjectOutput struct {
 	Body io.ReadCloser `type:"blob"`
 
 	// Indicates whether the object uses an S3 Bucket Key for server-side encryption
-	// with AWS KMS (SSE-KMS).
+	// with Amazon Web Services KMS (SSE-KMS).
 	BucketKeyEnabled *bool `location:"header" locationName:"x-amz-server-side-encryption-bucket-key-enabled" type:"boolean"`
 
 	// Specifies caching behavior along the request/reply chain.
@@ -20335,9 +20418,9 @@ type GetObjectOutput struct {
 	// verification of the customer-provided encryption key.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
-	// object.
+	// If present, specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetric customer managed customer master key
+	// (CMK) that was used for the object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// The server-side encryption algorithm used when storing this object in Amazon
@@ -20570,9 +20653,9 @@ type GetObjectRetentionInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -20725,17 +20808,17 @@ type GetObjectTaggingInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -21250,7 +21333,7 @@ type Grantee struct {
 	// Email address of the grantee.
 	//
 	// Using email addresses to specify a grantee is only supported in the following
-	// AWS Regions:
+	// Amazon Web Services Regions:
 	//
 	//    * US East (N. Virginia)
 	//
@@ -21270,7 +21353,7 @@ type Grantee struct {
 	//
 	// For a list of all the Amazon S3 supported Regions and endpoints, see Regions
 	// and Endpoints (https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-	// in the AWS General Reference.
+	// in the Amazon Web Services General Reference.
 	EmailAddress *string `type:"string"`
 
 	// The canonical user ID of the grantee.
@@ -21345,17 +21428,17 @@ type HeadBucketInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -21460,17 +21543,17 @@ type HeadObjectInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -21709,7 +21792,7 @@ type HeadObjectOutput struct {
 	ArchiveStatus *string `location:"header" locationName:"x-amz-archive-status" type:"string" enum:"ArchiveStatus"`
 
 	// Indicates whether the object uses an S3 Bucket Key for server-side encryption
-	// with AWS KMS (SSE-KMS).
+	// with Amazon Web Services KMS (SSE-KMS).
 	BucketKeyEnabled *bool `location:"header" locationName:"x-amz-server-side-encryption-bucket-key-enabled" type:"boolean"`
 
 	// Specifies caching behavior along the request/reply chain.
@@ -21849,15 +21932,16 @@ type HeadObjectOutput struct {
 	// verification of the customer-provided encryption key.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
-	// object.
+	// If present, specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetric customer managed customer master key
+	// (CMK) that was used for the object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
-	// If the object is stored using server-side encryption either with an AWS KMS
-	// customer master key (CMK) or an Amazon S3-managed encryption key, the response
-	// includes this header with the value of the server-side encryption algorithm
-	// used when storing this object in Amazon S3 (for example, AES256, aws:kms).
+	// If the object is stored using server-side encryption either with an Amazon
+	// Web Services KMS customer master key (CMK) or an Amazon S3-managed encryption
+	// key, the response includes this header with the value of the server-side
+	// encryption algorithm used when storing this object in Amazon S3 (for example,
+	// AES256, aws:kms).
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string" enum:"ServerSideEncryption"`
 
 	// Provides storage class information of the object. Amazon S3 returns this
@@ -22119,8 +22203,8 @@ type Initiator struct {
 	// Name of the Principal.
 	DisplayName *string `type:"string"`
 
-	// If the principal is an AWS account, it provides the Canonical User ID. If
-	// the principal is an IAM User, it provides a user ARN value.
+	// If the principal is an Amazon Web Services account, it provides the Canonical
+	// User ID. If the principal is an IAM User, it provides a user ARN value.
 	ID *string `type:"string"`
 }
 
@@ -22901,12 +22985,12 @@ func (s *KeyFilter) SetFilterRules(v []*FilterRule) *KeyFilter {
 	return s
 }
 
-// A container for specifying the configuration for AWS Lambda notifications.
+// A container for specifying the configuration for Lambda notifications.
 type LambdaFunctionConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	// The Amazon S3 bucket event for which to invoke the AWS Lambda function. For
-	// more information, see Supported Event Types (https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+	// The Amazon S3 bucket event for which to invoke the Lambda function. For more
+	// information, see Supported Event Types (https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Events is a required field
@@ -22921,8 +23005,8 @@ type LambdaFunctionConfiguration struct {
 	// If you don't provide one, Amazon S3 will assign an ID.
 	Id *string `type:"string"`
 
-	// The Amazon Resource Name (ARN) of the AWS Lambda function that Amazon S3
-	// invokes when the specified event type occurs.
+	// The Amazon Resource Name (ARN) of the Lambda function that Amazon S3 invokes
+	// when the specified event type occurs.
 	//
 	// LambdaFunctionArn is a required field
 	LambdaFunctionArn *string `locationName:"CloudFunction" type:"string" required:"true"`
@@ -23990,17 +24074,17 @@ type ListMultipartUploadsInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -24170,7 +24254,8 @@ func (s ListMultipartUploadsInput) updateArnableField(v string) (interface{}, er
 type ListMultipartUploadsOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the bucket to which the multipart upload was initiated.
+	// The name of the bucket to which the multipart upload was initiated. Does
+	// not return the access point ARN or access point alias if used.
 	Bucket *string `type:"string"`
 
 	// If you specify a delimiter in the request, then the result returns each distinct
@@ -24630,17 +24715,17 @@ type ListObjectsInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -24662,7 +24747,8 @@ type ListObjectsInput struct {
 	// error.
 	ExpectedBucketOwner *string `location:"header" locationName:"x-amz-expected-bucket-owner" type:"string"`
 
-	// Specifies the key to start with when listing objects in a bucket.
+	// Marker is where you want Amazon S3 to start listing from. Amazon S3 starts
+	// listing after this specified key. Marker can be any key in the bucket.
 	Marker *string `location:"querystring" locationName:"marker" type:"string"`
 
 	// Sets the maximum number of keys returned in the response. By default the
@@ -24924,17 +25010,17 @@ type ListObjectsV2Input struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -25160,17 +25246,17 @@ type ListObjectsV2Output struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	Name *string `type:"string"`
 
@@ -25276,17 +25362,17 @@ type ListPartsInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -25452,13 +25538,14 @@ type ListPartsOutput struct {
 	// incomplete multipart uploads.
 	AbortRuleId *string `location:"header" locationName:"x-amz-abort-rule-id" type:"string"`
 
-	// The name of the bucket to which the multipart upload was initiated.
+	// The name of the bucket to which the multipart upload was initiated. Does
+	// not return the access point ARN or access point alias if used.
 	Bucket *string `type:"string"`
 
 	// Container element that identifies who initiated the multipart upload. If
-	// the initiator is an AWS account, this element provides the same information
-	// as the Owner element. If the initiator is an IAM User, this element provides
-	// the user ARN and display name.
+	// the initiator is an Amazon Web Services account, this element provides the
+	// same information as the Owner element. If the initiator is an IAM User, this
+	// element provides the user ARN and display name.
 	Initiator *Initiator `type:"structure"`
 
 	// Indicates whether the returned list of parts is truncated. A true value indicates
@@ -26228,8 +26315,8 @@ func (s *NoncurrentVersionTransition) SetStorageClass(v string) *NoncurrentVersi
 type NotificationConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	// Describes the AWS Lambda functions to invoke and the events for which to
-	// invoke them.
+	// Describes the Lambda functions to invoke and the events for which to invoke
+	// them.
 	LambdaFunctionConfigurations []*LambdaFunctionConfiguration `locationName:"CloudFunctionConfiguration" type:"list" flattened:"true"`
 
 	// The Amazon Simple Queue Service queues to publish messages to and the events
@@ -26312,7 +26399,7 @@ func (s *NotificationConfiguration) SetTopicConfigurations(v []*TopicConfigurati
 type NotificationConfigurationDeprecated struct {
 	_ struct{} `type:"structure"`
 
-	// Container for specifying the AWS Lambda notification configuration.
+	// Container for specifying the Lambda notification configuration.
 	CloudFunctionConfiguration *CloudFunctionConfiguration `type:"structure"`
 
 	// This data type is deprecated. This data type specifies the configuration
@@ -26390,12 +26477,14 @@ type Object struct {
 	// was created and how it is encrypted as described below:
 	//
 	//    * Objects created by the PUT Object, POST Object, or Copy operation, or
-	//    through the AWS Management Console, and are encrypted by SSE-S3 or plaintext,
-	//    have ETags that are an MD5 digest of their object data.
+	//    through the Amazon Web Services Management Console, and are encrypted
+	//    by SSE-S3 or plaintext, have ETags that are an MD5 digest of their object
+	//    data.
 	//
 	//    * Objects created by the PUT Object, POST Object, or Copy operation, or
-	//    through the AWS Management Console, and are encrypted by SSE-C or SSE-KMS,
-	//    have ETags that are not an MD5 digest of their object data.
+	//    through the Amazon Web Services Management Console, and are encrypted
+	//    by SSE-C or SSE-KMS, have ETags that are not an MD5 digest of their object
+	//    data.
 	//
 	//    * If an object is created by either the Multipart Upload or Part Copy
 	//    operation, the ETag is not an MD5 digest, regardless of the method of
@@ -27155,8 +27244,8 @@ type PublicAccessBlockConfiguration struct {
 
 	// Specifies whether Amazon S3 should restrict public bucket policies for this
 	// bucket. Setting this element to TRUE restricts access to this bucket to only
-	// AWS service principals and authorized users within this account if the bucket
-	// has a public policy.
+	// Amazon Web Service principals and authorized users within this account if
+	// the bucket has a public policy.
 	//
 	// Enabling this setting doesn't affect previously stored bucket policies, except
 	// that public and cross-account access within any public bucket policy, including
@@ -27743,9 +27832,9 @@ type PutBucketEncryptionInput struct {
 	_ struct{} `locationName:"PutBucketEncryptionRequest" type:"structure" payload:"ServerSideEncryptionConfiguration"`
 
 	// Specifies default encryption for a bucket using server-side encryption with
-	// Amazon S3-managed keys (SSE-S3) or customer master keys stored in AWS KMS
-	// (SSE-KMS). For information about the Amazon S3 default encryption feature,
-	// see Amazon S3 Default Bucket Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html)
+	// Amazon S3-managed keys (SSE-S3) or customer master keys stored in Amazon
+	// Web Services KMS (SSE-KMS). For information about the Amazon S3 default encryption
+	// feature, see Amazon S3 Default Bucket Encryption (https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -29699,9 +29788,9 @@ type PutObjectAclInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -29743,17 +29832,17 @@ type PutObjectAclInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Key is a required field
@@ -29953,17 +30042,17 @@ type PutObjectInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -30084,19 +30173,19 @@ type PutObjectInput struct {
 	// encryption key was transmitted without error.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// Specifies the AWS KMS Encryption Context to use for object encryption. The
-	// value of this header is a base64-encoded UTF-8 string holding JSON with the
-	// encryption context key-value pairs.
+	// Specifies the Amazon Web Services KMS Encryption Context to use for object
+	// encryption. The value of this header is a base64-encoded UTF-8 string holding
+	// JSON with the encryption context key-value pairs.
 	SSEKMSEncryptionContext *string `location:"header" locationName:"x-amz-server-side-encryption-context" type:"string" sensitive:"true"`
 
 	// If x-amz-server-side-encryption is present and has the value of aws:kms,
-	// this header specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetrical customer managed customer master key (CMK) that was used for
-	// the object. If you specify x-amz-server-side-encryption:aws:kms, but do not
-	// providex-amz-server-side-encryption-aws-kms-key-id, Amazon S3 uses the AWS
-	// managed CMK in AWS to protect the data. If the KMS key does not exist in
-	// the same account issuing the command, you must use the full ARN and not just
-	// the ID.
+	// this header specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetrical customer managed customer master key
+	// (CMK) that was used for the object. If you specify x-amz-server-side-encryption:aws:kms,
+	// but do not providex-amz-server-side-encryption-aws-kms-key-id, Amazon S3
+	// uses the Amazon Web Services managed CMK in Amazon Web Services to protect
+	// the data. If the KMS key does not exist in the same account issuing the command,
+	// you must use the full ARN and not just the ID.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// The server-side encryption algorithm used when storing this object in Amazon
@@ -30409,9 +30498,9 @@ type PutObjectLegalHoldInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -30713,7 +30802,7 @@ type PutObjectOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Indicates whether the uploaded object uses an S3 Bucket Key for server-side
-	// encryption with AWS KMS (SSE-KMS).
+	// encryption with Amazon Web Services KMS (SSE-KMS).
 	BucketKeyEnabled *bool `location:"header" locationName:"x-amz-server-side-encryption-bucket-key-enabled" type:"boolean"`
 
 	// Entity tag for the uploaded object.
@@ -30740,21 +30829,21 @@ type PutObjectOutput struct {
 	// verification of the customer-provided encryption key.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// If present, specifies the AWS KMS Encryption Context to use for object encryption.
-	// The value of this header is a base64-encoded UTF-8 string holding JSON with
-	// the encryption context key-value pairs.
+	// If present, specifies the Amazon Web Services KMS Encryption Context to use
+	// for object encryption. The value of this header is a base64-encoded UTF-8
+	// string holding JSON with the encryption context key-value pairs.
 	SSEKMSEncryptionContext *string `location:"header" locationName:"x-amz-server-side-encryption-context" type:"string" sensitive:"true"`
 
 	// If x-amz-server-side-encryption is present and has the value of aws:kms,
-	// this header specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
-	// object.
+	// this header specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetric customer managed customer master key
+	// (CMK) that was used for the object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
-	// If you specified server-side encryption either with an AWS KMS customer master
-	// key (CMK) or Amazon S3-managed encryption key in your PUT request, the response
-	// includes this header. It confirms the encryption algorithm that Amazon S3
-	// used to encrypt the object.
+	// If you specified server-side encryption either with an Amazon Web Services
+	// KMS customer master key (CMK) or Amazon S3-managed encryption key in your
+	// PUT request, the response includes this header. It confirms the encryption
+	// algorithm that Amazon S3 used to encrypt the object.
 	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string" enum:"ServerSideEncryption"`
 
 	// Version of the object.
@@ -30839,9 +30928,9 @@ type PutObjectRetentionInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -31015,17 +31104,17 @@ type PutObjectTaggingInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -31672,8 +31761,8 @@ func (s *ReplicaModifications) SetStatus(v string) *ReplicaModifications {
 type ReplicationConfiguration struct {
 	_ struct{} `type:"structure"`
 
-	// The Amazon Resource Name (ARN) of the AWS Identity and Access Management
-	// (IAM) role that Amazon S3 assumes when replicating objects. For more information,
+	// The Amazon Resource Name (ARN) of the Identity and Access Management (IAM)
+	// role that Amazon S3 assumes when replicating objects. For more information,
 	// see How to Set Up Replication (https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-how-setup.html)
 	// in the Amazon S3 User Guide.
 	//
@@ -31797,7 +31886,8 @@ type ReplicationRule struct {
 	// objects that you want to replicate. You can choose to enable or disable the
 	// replication of these objects. Currently, Amazon S3 supports only the filter
 	// that you can specify for objects created with server-side encryption using
-	// a customer master key (CMK) stored in AWS Key Management Service (SSE-KMS).
+	// a customer master key (CMK) stored in Amazon Web Services Key Management
+	// Service (SSE-KMS).
 	SourceSelectionCriteria *SourceSelectionCriteria `type:"structure"`
 
 	// Specifies whether the rule is enabled.
@@ -32112,7 +32202,7 @@ type ReplicationTimeValue struct {
 
 	// Contains an integer specifying time in minutes.
 	//
-	// Valid values: 15 minutes.
+	// Valid value: 15
 	Minutes *int64 `type:"integer"`
 }
 
@@ -32203,17 +32293,17 @@ type RestoreObjectInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -32685,8 +32775,9 @@ func (s *Rule) SetTransition(v *Transition) *Rule {
 type SSEKMS struct {
 	_ struct{} `locationName:"SSE-KMS" type:"structure"`
 
-	// Specifies the ID of the AWS Key Management Service (AWS KMS) symmetric customer
-	// managed customer master key (CMK) to use for encrypting inventory reports.
+	// Specifies the ID of the Amazon Web Services Key Management Service (Amazon
+	// Web Services KMS) symmetric customer managed customer master key (CMK) to
+	// use for encrypting inventory reports.
 	//
 	// KeyId is a required field
 	KeyId *string `type:"string" required:"true" sensitive:"true"`
@@ -33301,9 +33392,9 @@ func (s *SelectParameters) SetOutputSerialization(v *OutputSerialization) *Selec
 type ServerSideEncryptionByDefault struct {
 	_ struct{} `type:"structure"`
 
-	// AWS Key Management Service (KMS) customer AWS KMS key ID to use for the default
-	// encryption. This parameter is allowed if and only if SSEAlgorithm is set
-	// to aws:kms.
+	// Amazon Web Services Key Management Service (KMS) customer Amazon Web Services
+	// KMS key ID to use for the default encryption. This parameter is allowed if
+	// and only if SSEAlgorithm is set to aws:kms.
 	//
 	// You can specify the key ID or the Amazon Resource Name (ARN) of the KMS key.
 	// However, if you are using encryption with cross-account operations, you must
@@ -33318,7 +33409,7 @@ type ServerSideEncryptionByDefault struct {
 	//
 	// Amazon S3 only supports symmetric KMS keys and not asymmetric KMS keys. For
 	// more information, see Using symmetric and asymmetric keys (https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-	// in the AWS Key Management Service Developer Guide.
+	// in the Amazon Web Services Key Management Service Developer Guide.
 	KMSMasterKeyID *string `type:"string" sensitive:"true"`
 
 	// Server-side encryption algorithm to use for the default encryption.
@@ -33472,7 +33563,8 @@ func (s *ServerSideEncryptionRule) SetBucketKeyEnabled(v bool) *ServerSideEncryp
 // objects that you want to replicate. You can choose to enable or disable the
 // replication of these objects. Currently, Amazon S3 supports only the filter
 // that you can specify for objects created with server-side encryption using
-// a customer master key (CMK) stored in AWS Key Management Service (SSE-KMS).
+// a customer master key (CMK) stored in Amazon Web Services Key Management
+// Service (SSE-KMS).
 type SourceSelectionCriteria struct {
 	_ struct{} `type:"structure"`
 
@@ -33488,8 +33580,8 @@ type SourceSelectionCriteria struct {
 	ReplicaModifications *ReplicaModifications `type:"structure"`
 
 	// A container for filter information for the selection of Amazon S3 objects
-	// encrypted with AWS KMS. If you include SourceSelectionCriteria in the replication
-	// configuration, this element is required.
+	// encrypted with Amazon Web Services KMS. If you include SourceSelectionCriteria
+	// in the replication configuration, this element is required.
 	SseKmsEncryptedObjects *SseKmsEncryptedObjects `type:"structure"`
 }
 
@@ -33536,12 +33628,13 @@ func (s *SourceSelectionCriteria) SetSseKmsEncryptedObjects(v *SseKmsEncryptedOb
 }
 
 // A container for filter information for the selection of S3 objects encrypted
-// with AWS KMS.
+// with Amazon Web Services KMS.
 type SseKmsEncryptedObjects struct {
 	_ struct{} `type:"structure"`
 
 	// Specifies whether Amazon S3 replicates objects created with server-side encryption
-	// using an AWS KMS key stored in AWS Key Management Service.
+	// using an Amazon Web Services KMS key stored in Amazon Web Services Key Management
+	// Service.
 	//
 	// Status is a required field
 	Status *string `type:"string" required:"true" enum:"SseKmsEncryptedObjectsStatus"`
@@ -34178,17 +34271,17 @@ type UploadPartCopyInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -34211,8 +34304,9 @@ type UploadPartCopyInput struct {
 	//    the URL encoding of arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf.
 	//    The value must be URL encoded. Amazon S3 supports copy operations using
 	//    access points only when the source and destination buckets are in the
-	//    same AWS Region. Alternatively, for objects accessed through Amazon S3
-	//    on Outposts, specify the ARN of the object as accessed in the format arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key>.
+	//    same Amazon Web Services Region. Alternatively, for objects accessed through
+	//    Amazon S3 on Outposts, specify the ARN of the object as accessed in the
+	//    format arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key>.
 	//    For example, to copy the object reports/january.pdf through outpost my-outpost
 	//    owned by account 123456789012 in Region us-west-2, use the URL encoding
 	//    of arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf.
@@ -34518,7 +34612,7 @@ type UploadPartCopyOutput struct {
 	_ struct{} `type:"structure" payload:"CopyPartResult"`
 
 	// Indicates whether the multipart upload uses an S3 Bucket Key for server-side
-	// encryption with AWS KMS (SSE-KMS).
+	// encryption with Amazon Web Services KMS (SSE-KMS).
 	BucketKeyEnabled *bool `location:"header" locationName:"x-amz-server-side-encryption-bucket-key-enabled" type:"boolean"`
 
 	// Container for all response elements.
@@ -34542,9 +34636,9 @@ type UploadPartCopyOutput struct {
 	// verification of the customer-provided encryption key.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for the
-	// object.
+	// If present, specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetric customer managed customer master key
+	// (CMK) that was used for the object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// The server-side encryption algorithm used when storing this object in Amazon
@@ -34620,17 +34714,17 @@ type UploadPartInput struct {
 	//
 	// When using this action with an access point, you must direct requests to
 	// the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com.
-	// When using this action with an access point through the AWS SDKs, you provide
-	// the access point ARN in place of the bucket name. For more information about
-	// access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
+	// When using this action with an access point through the Amazon Web Services
+	// SDKs, you provide the access point ARN in place of the bucket name. For more
+	// information about access point ARNs, see Using access points (https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html)
 	// in the Amazon S3 User Guide.
 	//
 	// When using this action with Amazon S3 on Outposts, you must direct requests
 	// to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form
 	// AccessPointName-AccountId.outpostID.s3-outposts.Region.amazonaws.com. When
-	// using this action using S3 on Outposts through the AWS SDKs, you provide
-	// the Outposts bucket ARN in place of the bucket name. For more information
-	// about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
+	// using this action using S3 on Outposts through the Amazon Web Services SDKs,
+	// you provide the Outposts bucket ARN in place of the bucket name. For more
+	// information about S3 on Outposts ARNs, see Using S3 on Outposts (https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html)
 	// in the Amazon S3 User Guide.
 	//
 	// Bucket is a required field
@@ -34846,7 +34940,7 @@ type UploadPartOutput struct {
 	_ struct{} `type:"structure"`
 
 	// Indicates whether the multipart upload uses an S3 Bucket Key for server-side
-	// encryption with AWS KMS (SSE-KMS).
+	// encryption with Amazon Web Services KMS (SSE-KMS).
 	BucketKeyEnabled *bool `location:"header" locationName:"x-amz-server-side-encryption-bucket-key-enabled" type:"boolean"`
 
 	// Entity tag for the uploaded object.
@@ -34866,8 +34960,9 @@ type UploadPartOutput struct {
 	// verification of the customer-provided encryption key.
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) was used for the object.
+	// If present, specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetric customer managed customer master key
+	// (CMK) was used for the object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// The server-side encryption algorithm used when storing this object in Amazon
@@ -35067,7 +35162,7 @@ type WriteGetObjectResponseInput struct {
 	Body io.ReadSeeker `type:"blob"`
 
 	// Indicates whether the object stored in Amazon S3 uses an S3 bucket key for
-	// server-side encryption with AWS KMS (SSE-KMS).
+	// server-side encryption with Amazon Web Services KMS (SSE-KMS).
 	BucketKeyEnabled *bool `location:"header" locationName:"x-amz-fwd-header-x-amz-server-side-encryption-bucket-key-enabled" type:"boolean"`
 
 	// Specifies caching behavior along the request/reply chain.
@@ -35180,9 +35275,9 @@ type WriteGetObjectResponseInput struct {
 	// server-side encryption with customer-provided encryption keys (SSE-C) (https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).
 	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-fwd-header-x-amz-server-side-encryption-customer-key-MD5" type:"string"`
 
-	// If present, specifies the ID of the AWS Key Management Service (AWS KMS)
-	// symmetric customer managed customer master key (CMK) that was used for stored
-	// in Amazon S3 object.
+	// If present, specifies the ID of the Amazon Web Services Key Management Service
+	// (Amazon Web Services KMS) symmetric customer managed customer master key
+	// (CMK) that was used for stored in Amazon S3 object.
 	SSEKMSKeyId *string `location:"header" locationName:"x-amz-fwd-header-x-amz-server-side-encryption-aws-kms-key-id" type:"string" sensitive:"true"`
 
 	// The server-side encryption algorithm used when storing requested object in

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/customizations.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/customizations.go
@@ -40,7 +40,7 @@ func defaultInitRequestFn(r *request.Request) {
 		// Auto-populate LocationConstraint with current region
 		r.Handlers.Validate.PushFront(populateLocationConstraint)
 	case opCopyObject, opUploadPartCopy, opCompleteMultipartUpload:
-		r.Handlers.Unmarshal.PushFront(copyMultipartStatusOKUnmarhsalError)
+		r.Handlers.Unmarshal.PushFront(copyMultipartStatusOKUnmarshalError)
 		r.Handlers.Unmarshal.PushBackNamed(s3err.RequestFailureWrapperHandler())
 	case opPutObject, opUploadPart:
 		r.Handlers.Build.PushBack(computeBodyHashes)

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/errors.go
@@ -15,10 +15,10 @@ const (
 	// "BucketAlreadyOwnedByYou".
 	//
 	// The bucket you tried to create already exists, and you own it. Amazon S3
-	// returns this error in all AWS Regions except in the North Virginia Region.
-	// For legacy compatibility, if you re-create an existing bucket that you already
-	// own in the North Virginia Region, Amazon S3 returns 200 OK and resets the
-	// bucket access control lists (ACLs).
+	// returns this error in all Amazon Web Services Regions except in the North
+	// Virginia Region. For legacy compatibility, if you re-create an existing bucket
+	// that you already own in the North Virginia Region, Amazon S3 returns 200
+	// OK and resets the bucket access control lists (ACLs).
 	ErrCodeBucketAlreadyOwnedByYou = "BucketAlreadyOwnedByYou"
 
 	// ErrCodeInvalidObjectState for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/platform_handlers.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/platform_handlers.go
@@ -1,3 +1,4 @@
+//go:build !go1.6
 // +build !go1.6
 
 package s3

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/platform_handlers_go1.6.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/platform_handlers_go1.6.go
@@ -1,3 +1,4 @@
+//go:build go1.6
 // +build go1.6
 
 package s3

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/statusok_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/statusok_error.go
@@ -11,16 +11,21 @@ import (
 	"github.com/aws/aws-sdk-go/internal/sdkio"
 )
 
-func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
+func copyMultipartStatusOKUnmarshalError(r *request.Request) {
 	b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	r.HTTPResponse.Body.Close()
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New(request.ErrCodeSerialization, "unable to read response body", err),
 			r.HTTPResponse.StatusCode,
 			r.RequestID,
 		)
+		// Note, some middleware later in the stack like restxml.Unmarshal expect a valid, non-closed Body
+		// even in case of an error, so we replace it with an empty Reader.
+		r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(nil))
 		return
 	}
+
 	body := bytes.NewReader(b)
 	r.HTTPResponse.Body = ioutil.NopCloser(body)
 	defer body.Seek(0, sdkio.SeekStart)

--- a/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
@@ -2615,25 +2615,42 @@ type CreateQueueInput struct {
 	//    which a ReceiveMessage action waits for a message to arrive. Valid values:
 	//    An integer from 0 to 20 (seconds). Default: 0.
 	//
-	//    * RedrivePolicy – The string that includes the parameters for the dead-letter
-	//    queue functionality of the source queue as a JSON object. For more information
-	//    about the redrive policy and dead-letter queues, see Using Amazon SQS
-	//    Dead-Letter Queues (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
-	//    in the Amazon SQS Developer Guide. deadLetterTargetArn – The Amazon
-	//    Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves
-	//    messages after the value of maxReceiveCount is exceeded. maxReceiveCount
-	//    – The number of times a message is delivered to the source queue before
-	//    being moved to the dead-letter queue. When the ReceiveCount for a message
-	//    exceeds the maxReceiveCount for a queue, Amazon SQS moves the message
-	//    to the dead-letter-queue. The dead-letter queue of a FIFO queue must also
-	//    be a FIFO queue. Similarly, the dead-letter queue of a standard queue
-	//    must also be a standard queue.
-	//
 	//    * VisibilityTimeout – The visibility timeout for the queue, in seconds.
 	//    Valid values: An integer from 0 to 43,200 (12 hours). Default: 30. For
 	//    more information about the visibility timeout, see Visibility Timeout
 	//    (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
 	//    in the Amazon SQS Developer Guide.
+	//
+	// The following attributes apply only to dead-letter queues: (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+	//
+	//    * RedrivePolicy – The string that includes the parameters for the dead-letter
+	//    queue functionality of the source queue as a JSON object. The parameters
+	//    are as follows: deadLetterTargetArn – The Amazon Resource Name (ARN)
+	//    of the dead-letter queue to which Amazon SQS moves messages after the
+	//    value of maxReceiveCount is exceeded. maxReceiveCount – The number of
+	//    times a message is delivered to the source queue before being moved to
+	//    the dead-letter queue. When the ReceiveCount for a message exceeds the
+	//    maxReceiveCount for a queue, Amazon SQS moves the message to the dead-letter-queue.
+	//
+	//    * RedriveAllowPolicy – The string that includes the parameters for the
+	//    permissions for the dead-letter queue redrive permission and which source
+	//    queues can specify dead-letter queues as a JSON object. The parameters
+	//    are as follows: redrivePermission – The permission type that defines
+	//    which source queues can specify the current queue as the dead-letter queue.
+	//    Valid values are: allowAll – (Default) Any source queues in this Amazon
+	//    Web Services account in the same Region can specify this queue as the
+	//    dead-letter queue. denyAll – No source queues can specify this queue
+	//    as the dead-letter queue. byQueue – Only queues specified by the sourceQueueArns
+	//    parameter can specify this queue as the dead-letter queue. sourceQueueArns
+	//    – The Amazon Resource Names (ARN)s of the source queues that can specify
+	//    this queue as the dead-letter queue and redrive messages. You can specify
+	//    this parameter only when the redrivePermission parameter is set to byQueue.
+	//    You can specify up to 10 source queue ARNs. To allow more than 10 source
+	//    queues to specify dead-letter queues, set the redrivePermission parameter
+	//    to allowAll.
+	//
+	// The dead-letter queue of a FIFO queue must also be a FIFO queue. Similarly,
+	// the dead-letter queue of a standard queue must also be a standard queue.
 	//
 	// The following attributes apply only to server-side-encryption (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html):
 	//
@@ -3180,22 +3197,41 @@ type GetQueueAttributesInput struct {
 	//    * ReceiveMessageWaitTimeSeconds – Returns the length of time, in seconds,
 	//    for which the ReceiveMessage action waits for a message to arrive.
 	//
-	//    * RedrivePolicy – The string that includes the parameters for the dead-letter
-	//    queue functionality of the source queue as a JSON object. For more information
-	//    about the redrive policy and dead-letter queues, see Using Amazon SQS
-	//    Dead-Letter Queues (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
-	//    in the Amazon SQS Developer Guide. deadLetterTargetArn – The Amazon
-	//    Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves
-	//    messages after the value of maxReceiveCount is exceeded. maxReceiveCount
-	//    – The number of times a message is delivered to the source queue before
-	//    being moved to the dead-letter queue. When the ReceiveCount for a message
-	//    exceeds the maxReceiveCount for a queue, Amazon SQS moves the message
-	//    to the dead-letter-queue.
-	//
 	//    * VisibilityTimeout – Returns the visibility timeout for the queue.
 	//    For more information about the visibility timeout, see Visibility Timeout
 	//    (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
 	//    in the Amazon SQS Developer Guide.
+	//
+	// The following attributes apply only to dead-letter queues: (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+	//
+	//    * RedrivePolicy – The string that includes the parameters for the dead-letter
+	//    queue functionality of the source queue as a JSON object. The parameters
+	//    are as follows: deadLetterTargetArn – The Amazon Resource Name (ARN)
+	//    of the dead-letter queue to which Amazon SQS moves messages after the
+	//    value of maxReceiveCount is exceeded. maxReceiveCount – The number of
+	//    times a message is delivered to the source queue before being moved to
+	//    the dead-letter queue. When the ReceiveCount for a message exceeds the
+	//    maxReceiveCount for a queue, Amazon SQS moves the message to the dead-letter-queue.
+	//
+	//    * RedriveAllowPolicy – The string that includes the parameters for the
+	//    permissions for the dead-letter queue redrive permission and which source
+	//    queues can specify dead-letter queues as a JSON object. The parameters
+	//    are as follows: redrivePermission – The permission type that defines
+	//    which source queues can specify the current queue as the dead-letter queue.
+	//    Valid values are: allowAll – (Default) Any source queues in this Amazon
+	//    Web Services account in the same Region can specify this queue as the
+	//    dead-letter queue. denyAll – No source queues can specify this queue
+	//    as the dead-letter queue. byQueue – Only queues specified by the sourceQueueArns
+	//    parameter can specify this queue as the dead-letter queue. sourceQueueArns
+	//    – The Amazon Resource Names (ARN)s of the source queues that can specify
+	//    this queue as the dead-letter queue and redrive messages. You can specify
+	//    this parameter only when the redrivePermission parameter is set to byQueue.
+	//    You can specify up to 10 source queue ARNs. To allow more than 10 source
+	//    queues to specify dead-letter queues, set the redrivePermission parameter
+	//    to allowAll.
+	//
+	// The dead-letter queue of a FIFO queue must also be a FIFO queue. Similarly,
+	// the dead-letter queue of a standard queue must also be a standard queue.
 	//
 	// The following attributes apply only to server-side-encryption (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html):
 	//
@@ -4971,25 +5007,42 @@ type SetQueueAttributesInput struct {
 	//    which a ReceiveMessage action waits for a message to arrive. Valid values:
 	//    An integer from 0 to 20 (seconds). Default: 0.
 	//
-	//    * RedrivePolicy – The string that includes the parameters for the dead-letter
-	//    queue functionality of the source queue as a JSON object. For more information
-	//    about the redrive policy and dead-letter queues, see Using Amazon SQS
-	//    Dead-Letter Queues (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
-	//    in the Amazon SQS Developer Guide. deadLetterTargetArn – The Amazon
-	//    Resource Name (ARN) of the dead-letter queue to which Amazon SQS moves
-	//    messages after the value of maxReceiveCount is exceeded. maxReceiveCount
-	//    – The number of times a message is delivered to the source queue before
-	//    being moved to the dead-letter queue. When the ReceiveCount for a message
-	//    exceeds the maxReceiveCount for a queue, Amazon SQS moves the message
-	//    to the dead-letter-queue. The dead-letter queue of a FIFO queue must also
-	//    be a FIFO queue. Similarly, the dead-letter queue of a standard queue
-	//    must also be a standard queue.
-	//
 	//    * VisibilityTimeout – The visibility timeout for the queue, in seconds.
 	//    Valid values: An integer from 0 to 43,200 (12 hours). Default: 30. For
 	//    more information about the visibility timeout, see Visibility Timeout
 	//    (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)
 	//    in the Amazon SQS Developer Guide.
+	//
+	// The following attributes apply only to dead-letter queues: (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html)
+	//
+	//    * RedrivePolicy – The string that includes the parameters for the dead-letter
+	//    queue functionality of the source queue as a JSON object. The parameters
+	//    are as follows: deadLetterTargetArn – The Amazon Resource Name (ARN)
+	//    of the dead-letter queue to which Amazon SQS moves messages after the
+	//    value of maxReceiveCount is exceeded. maxReceiveCount – The number of
+	//    times a message is delivered to the source queue before being moved to
+	//    the dead-letter queue. When the ReceiveCount for a message exceeds the
+	//    maxReceiveCount for a queue, Amazon SQS moves the message to the dead-letter-queue.
+	//
+	//    * RedriveAllowPolicy – The string that includes the parameters for the
+	//    permissions for the dead-letter queue redrive permission and which source
+	//    queues can specify dead-letter queues as a JSON object. The parameters
+	//    are as follows: redrivePermission – The permission type that defines
+	//    which source queues can specify the current queue as the dead-letter queue.
+	//    Valid values are: allowAll – (Default) Any source queues in this Amazon
+	//    Web Services account in the same Region can specify this queue as the
+	//    dead-letter queue. denyAll – No source queues can specify this queue
+	//    as the dead-letter queue. byQueue – Only queues specified by the sourceQueueArns
+	//    parameter can specify this queue as the dead-letter queue. sourceQueueArns
+	//    – The Amazon Resource Names (ARN)s of the source queues that can specify
+	//    this queue as the dead-letter queue and redrive messages. You can specify
+	//    this parameter only when the redrivePermission parameter is set to byQueue.
+	//    You can specify up to 10 source queue ARNs. To allow more than 10 source
+	//    queues to specify dead-letter queues, set the redrivePermission parameter
+	//    to allowAll.
+	//
+	// The dead-letter queue of a FIFO queue must also be a FIFO queue. Similarly,
+	// the dead-letter queue of a standard queue must also be a standard queue.
 	//
 	// The following attributes apply only to server-side-encryption (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html):
 	//
@@ -5362,6 +5415,9 @@ const (
 
 	// QueueAttributeNameFifoThroughputLimit is a QueueAttributeName enum value
 	QueueAttributeNameFifoThroughputLimit = "FifoThroughputLimit"
+
+	// QueueAttributeNameRedriveAllowPolicy is a QueueAttributeName enum value
+	QueueAttributeNameRedriveAllowPolicy = "RedriveAllowPolicy"
 )
 
 // QueueAttributeName_Values returns all elements of the QueueAttributeName enum
@@ -5387,5 +5443,6 @@ func QueueAttributeName_Values() []string {
 		QueueAttributeNameKmsDataKeyReusePeriodSeconds,
 		QueueAttributeNameDeduplicationScope,
 		QueueAttributeNameFifoThroughputLimit,
+		QueueAttributeNameRedriveAllowPolicy,
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -116,7 +116,7 @@ github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/cli
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs
-# github.com/aws/aws-sdk-go v1.40.10
+# github.com/aws/aws-sdk-go v1.40.38
 ## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn


### PR DESCRIPTION
~This is unconditionally enabled.~

~There is an IPv4-equivlanet ["HttpEndpoint" field](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateInstanceMetadataOptions.html#API_LaunchTemplateInstanceMetadataOptions_Contents) that defaults to enabled and we dont expose a way to disable it.~

~HttpProtocolIpv6 defaults to disabled, so to have it match the same behavior of HttpEndpoint we hardcode it to enabled.~

Since we dont allow the ipv4 endpoint to be disabled, I dont think we need to expose a new API field to allow this to be overridden either.~

~I chose not to expose it through the model since any kops upgrade to include this functionality will always have other LaunchTemplate changes that will prompt a new LT version to be written which will include this change, so we dont need to find and detect any necessary LT updates for this field.~


This now enables the IPv6 endpoint whenever IPv6AddressCount is > 0