### PR TITLE
[kubelet] Add validation for cpuCFSQuotaPeriod after k8s>=1.20

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -649,6 +649,12 @@ func validateKubelet(k *kops.KubeletConfigSpec, c *kops.Cluster, kubeletPath *fi
 			allErrs = append(allErrs, IsValidValue(kubeletPath.Child("logFormat"), &k.LogFormat, []string{"text", "json"})...)
 		}
 
+		if k.CPUCFSQuotaPeriod != nil {
+			if c.IsKubernetesGTE("1.20") {
+				allErrs = append(allErrs, field.Forbidden(kubeletPath.Child("cpuCFSQuotaPeriod"), "cpuCFSQuotaPeriod has been removed on Kubernetes >=1.20"))
+			}
+		}
+
 	}
 	return allErrs
 }


### PR DESCRIPTION
This flag is removed from Kubelet starting from v1.20 of k8s so in here
we add a validation to prevent users from deploying a configuration which
breaks Kubelet and thus nodes from getting ready.

This setting can now only be set on [Kubelet config file.](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/)

Error msg:
```
kubelet[5122]: F0909 11:49:28.458628    5122 server.go:215] invalid configuration: cpuCFSQuotaPeriod {10ms}
```

Signed-off-by: dntosas <ntosas@gmail.com>