### PR TITLE
Use MasterInternalName for gossip cluster SA issuer

### DIFF
--- a/pkg/model/components/BUILD.bazel
+++ b/pkg/model/components/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/util:go_default_library",
         "//pkg/assets:go_default_library",
-        "//pkg/dns:go_default_library",
         "//pkg/k8sversion:go_default_library",
         "//pkg/wellknownports:go_default_library",
         "//upup/pkg/fi:go_default_library",

--- a/pkg/model/components/discovery.go
+++ b/pkg/model/components/discovery.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/loader"
 	"k8s.io/kops/util/pkg/vfs"
@@ -83,9 +82,7 @@ func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
 				return fmt.Errorf("locationStore=%q is of unexpected type %T", store, base)
 			}
 		} else {
-			if dns.IsGossipHostname(clusterSpec.MasterInternalName) {
-				serviceAccountIssuer = "https://kubernetes.default"
-			} else if supportsPublicJWKS(clusterSpec) {
+			if supportsPublicJWKS(clusterSpec) {
 				serviceAccountIssuer = "https://" + clusterSpec.MasterPublicName
 			} else {
 				serviceAccountIssuer = "https://" + clusterSpec.MasterInternalName

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
@@ -178,8 +178,8 @@ kubeAPIServer:
   requestheaderUsernameHeaders:
   - X-Remote-User
   securePort: 443
-  serviceAccountIssuer: https://kubernetes.default
-  serviceAccountJWKSURI: https://kubernetes.default/openid/v1/jwks
+  serviceAccountIssuer: https://api.internal.minimal.k8s.local
+  serviceAccountJWKSURI: https://api.internal.minimal.k8s.local/openid/v1/jwks
   serviceClusterIPRange: 100.64.0.0/13
   storageBackend: etcd3
 kubeControllerManager:
@@ -244,7 +244,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.k8s.local
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: m2l73Z2ZTSfhaFMqWrGVDU1JFskZDHBE4kShP/WV0dw=
+NodeupConfigHash: E3XByTEqoq24u0RUuiwk1z9v1aOJSZG1QOl/WsD9Tdw=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -88,8 +88,8 @@ spec:
     requestheaderUsernameHeaders:
     - X-Remote-User
     securePort: 443
-    serviceAccountIssuer: https://kubernetes.default
-    serviceAccountJWKSURI: https://kubernetes.default/openid/v1/jwks
+    serviceAccountIssuer: https://api.internal.minimal.k8s.local
+    serviceAccountJWKSURI: https://api.internal.minimal.k8s.local/openid/v1/jwks
     serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   kubeControllerManager:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -38,8 +38,8 @@ APIServerConfig:
     requestheaderUsernameHeaders:
     - X-Remote-User
     securePort: 443
-    serviceAccountIssuer: https://kubernetes.default
-    serviceAccountJWKSURI: https://kubernetes.default/openid/v1/jwks
+    serviceAccountIssuer: https://api.internal.minimal.k8s.local
+    serviceAccountJWKSURI: https://api.internal.minimal.k8s.local/openid/v1/jwks
     serviceClusterIPRange: 100.64.0.0/13
     storageBackend: etcd3
   ServiceAccountPublicKeys: |


### PR DESCRIPTION
This reverts https://github.com/kubernetes/kops/pull/11470 introduced earlier in 1.22 that resulted in existing service account tokens becoming invalid after a kops upgrade. Now gossip clusters will continue to use the the master internal name, as was the case in kops <=1.21

As discussed during office hours today

FYI @zetaab this will result in _another_ token invalidation if `serviceAccountIssuer` isn't set in the cluster spec while upgrading from an earlier 1.22 pre-release.