### PR TITLE
Automated cherry pick of #12289: Include kops- prefix in external-dns TXT record
#12288: Fix docs for external-dns provider

### DIFF
--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -211,7 +211,7 @@ func precreateDNS(ctx context.Context, cluster *kops.Cluster, cloud fi.Cloud) er
 		} else {
 			changeset.Add(rrs.New(dnsHostname, []string{PlaceholderIP}, PlaceholderTTL, rrstype.A))
 			if cluster.Spec.ExternalDNS.Provider == kops.ExternalDNSProviderExternalDNS {
-				changeset.Add(rrs.New(dnsHostname, []string{fmt.Sprintf("\"heritage=external-dns,external-dns/owner=%s\"", cluster.GetClusterName())}, PlaceholderTTL, rrstype.TXT))
+				changeset.Add(rrs.New(dnsHostname, []string{fmt.Sprintf("\"heritage=external-dns,external-dns/owner=kops-%s\"", cluster.GetClusterName())}, PlaceholderTTL, rrstype.TXT))
 			}
 		}
 


### PR DESCRIPTION
Cherry pick of #12289 #12288 on release-1.22.

#12289: Include kops- prefix in external-dns TXT record
#12288: Fix docs for external-dns provider

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.