### PR TITLE
Automated cherry pick of #12300: Recognize Ubuntu 21.10 (Impish Indri)

### DIFF
--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -45,6 +45,7 @@ var (
 	DistributionUbuntu2004   = Distribution{packageFormat: "deb", project: "ubuntu", id: "focal", version: 20.04}
 	DistributionUbuntu2010   = Distribution{packageFormat: "deb", project: "ubuntu", id: "groovy", version: 20.10}
 	DistributionUbuntu2104   = Distribution{packageFormat: "deb", project: "ubuntu", id: "hirsute", version: 21.04}
+	DistributionUbuntu2110   = Distribution{packageFormat: "deb", project: "ubuntu", id: "impish", version: 21.10}
 	DistributionAmazonLinux2 = Distribution{packageFormat: "rpm", project: "amazonlinux2", id: "amazonlinux2", version: 0}
 	DistributionRhel7        = Distribution{packageFormat: "rpm", project: "rhel", id: "rhel7", version: 7}
 	DistributionCentos7      = Distribution{packageFormat: "rpm", project: "centos", id: "centos7", version: 7}

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -70,6 +70,8 @@ func FindDistribution(rootfs string) (Distribution, error) {
 		return DistributionUbuntu2010, nil
 	case "ubuntu-21.04":
 		return DistributionUbuntu2104, nil
+	case "ubuntu-21.10":
+		return DistributionUbuntu2110, nil
 	}
 
 	// Some distros have a more verbose VERSION_ID

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -115,6 +115,11 @@ func TestFindDistribution(t *testing.T) {
 			expected: DistributionUbuntu2104,
 		},
 		{
+			rootfs:   "ubuntu2110",
+			err:      nil,
+			expected: DistributionUbuntu2110,
+		},
+		{
 			rootfs:   "notfound",
 			err:      fmt.Errorf("reading /etc/os-release: open tests/notfound/etc/os-release: no such file or directory"),
 			expected: Distribution{},

--- a/util/pkg/distributions/tests/ubuntu2110/etc/os-release
+++ b/util/pkg/distributions/tests/ubuntu2110/etc/os-release
@@ -1,0 +1,12 @@
+PRETTY_NAME="Ubuntu Impish Indri"
+NAME="Ubuntu"
+VERSION_ID="21.10"
+VERSION="21.10 (Impish Indri)"
+VERSION_CODENAME=impish
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=impish


### PR DESCRIPTION
Cherry pick of #12300 on release-1.22.

#12300: Recognize Ubuntu 21.10 (Impish Indri)

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.