### PR TITLE
Make AWS CCM NodeIPFamilies configurable

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -343,6 +343,12 @@ spec:
                   multizone:
                     description: GCE cloud-config options
                     type: boolean
+                  nodeIPFamilies:
+                    description: NodeIPFamilies controls the IP families reported
+                      for each node (AWS only).
+                    items:
+                      type: string
+                    type: array
                   nodeInstancePrefix:
                     type: string
                   nodeTags:

--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -107,6 +107,7 @@ go_test(
         "//pkg/assets:go_default_library",
         "//pkg/client/simple/vfsclientset:go_default_library",
         "//pkg/configbuilder:go_default_library",
+        "//pkg/diff:go_default_library",
         "//pkg/flagbuilder:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -102,8 +102,8 @@ func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
 		if cloudConfig.ElbSecurityGroup != nil {
 			lines = append(lines, "ElbSecurityGroup = "+*cloudConfig.ElbSecurityGroup)
 		}
-		if b.Cluster.Spec.IsIPv6Only() {
-			lines = append(lines, "NodeIPFamilies = ipv6")
+		for _, family := range cloudConfig.NodeIPFamilies {
+			lines = append(lines, "NodeIPFamilies = "+family)
 		}
 	case "openstack":
 		osc := cloudConfig.Openstack

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -839,6 +839,8 @@ type CloudConfiguration struct {
 	Multizone          *bool   `json:"multizone,omitempty"`
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
+	// NodeIPFamilies controls the IP families reported for each node (AWS only).
+	NodeIPFamilies []string `json:"nodeIPFamilies,omitempty"`
 	// GCEServiceAccount specifies the service account with which the GCE VM runs
 	GCEServiceAccount string `json:"gceServiceAccount,omitempty"`
 	// AWS cloud-config options

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -838,6 +838,8 @@ type CloudConfiguration struct {
 	Multizone          *bool   `json:"multizone,omitempty"`
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
+	// NodeIPFamilies controls the IP families reported for each node (AWS only).
+	NodeIPFamilies []string `json:"nodeIPFamilies,omitempty"`
 	// GCEServiceAccount specifies the service account with which the GCE VM runs
 	GCEServiceAccount string `json:"gceServiceAccount,omitempty"`
 	// AWS cloud-config options

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2021,6 +2021,7 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.NodeIPFamilies = in.NodeIPFamilies
 	out.GCEServiceAccount = in.GCEServiceAccount
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.ElbSecurityGroup = in.ElbSecurityGroup
@@ -2073,6 +2074,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha2_CloudConfiguration(in *kops
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.NodeIPFamilies = in.NodeIPFamilies
 	out.GCEServiceAccount = in.GCEServiceAccount
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.ElbSecurityGroup = in.ElbSecurityGroup

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -624,6 +624,11 @@ func (in *CloudConfiguration) DeepCopyInto(out *CloudConfiguration) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NodeIPFamilies != nil {
+		in, out := &in.NodeIPFamilies, &out.NodeIPFamilies
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.DisableSecurityGroupIngress != nil {
 		in, out := &in.DisableSecurityGroupIngress, &out.DisableSecurityGroupIngress
 		*out = new(bool)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -708,6 +708,11 @@ func (in *CloudConfiguration) DeepCopyInto(out *CloudConfiguration) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NodeIPFamilies != nil {
+		in, out := &in.NodeIPFamilies, &out.NodeIPFamilies
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.DisableSecurityGroupIngress != nil {
 		in, out := &in.DisableSecurityGroupIngress, &out.DisableSecurityGroupIngress
 		*out = new(bool)

--- a/pkg/model/components/cloudconfiguration.go
+++ b/pkg/model/components/cloudconfiguration.go
@@ -52,5 +52,9 @@ func (b *CloudConfigurationOptionsBuilder) BuildOptions(o interface{}) error {
 		c.ManageStorageClasses = manage
 	}
 
+	if clusterSpec.IsIPv6Only() && len(c.NodeIPFamilies) == 0 {
+		c.NodeIPFamilies = []string{"ipv6", "ipv4"}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Default to IPv6 + IPv4 but allow setting IPv6 or IPv4 only.

/cc @olemarkus @johngmyers 