### PR TITLE
Automated cherry pick of #12303: Bump snapshot-controller to 4.2.1

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -90,7 +90,7 @@ spec:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: fe892771413f88df11a130f49be362a93a2ee33c9dc6ed14712ec53316b41493
+    manifestHash: 7629abf66390989fa8529a3e7ef2274cc6d0169957d28ce36c7ebf59d6af7191
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1197,7 +1197,7 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.0
+        image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
       nodeSelector:
@@ -1234,7 +1234,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.2.0
+        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.2.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -90,7 +90,7 @@ spec:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: fe892771413f88df11a130f49be362a93a2ee33c9dc6ed14712ec53316b41493
+    manifestHash: 7629abf66390989fa8529a3e7ef2274cc6d0169957d28ce36c7ebf59d6af7191
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1197,7 +1197,7 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.0
+        image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
       nodeSelector:
@@ -1234,7 +1234,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.2.0
+        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.2.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -84,7 +84,7 @@ spec:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: fe892771413f88df11a130f49be362a93a2ee33c9dc6ed14712ec53316b41493
+    manifestHash: 7629abf66390989fa8529a3e7ef2274cc6d0169957d28ce36c7ebf59d6af7191
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1197,7 +1197,7 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.0
+        image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
       nodeSelector:
@@ -1234,7 +1234,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.2.0
+        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.2.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
+++ b/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
@@ -756,7 +756,7 @@ spec:
       serviceAccount: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.0
+          image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.1
           args:
             - "--v=5"
             - "--leader-election=true"
@@ -787,7 +787,7 @@ spec:
     spec:
       containers:
       - name: snapshot-validation
-        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.2.0
+        image: k8s.gcr.io/sig-storage/snapshot-validation-webhook:v4.2.1
         imagePullPolicy: IfNotPresent
         args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key']
         ports:


### PR DESCRIPTION
Cherry pick of #12303 on release-1.22.

#12303: Bump snapshot-controller to 4.2.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.