### PR TITLE
Automated cherry pick of #12310: Bump aws ebs csi driver to 1.2.1

### DIFF
--- a/pkg/model/components/awsebscsidriver.go
+++ b/pkg/model/components/awsebscsidriver.go
@@ -48,7 +48,7 @@ func (b *AWSEBSCSIDriverOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == nil {
-		version := "v1.2.0"
+		version := "v1.2.1"
 		c.Version = fi.String(version)
 	}
 

--- a/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
+++ b/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
@@ -32,7 +32,7 @@ REPORT_DIR="${ARTIFACTS:-$(pwd)/_artifacts}/aws-ebs-csi-driver/"
 cd "$(mktemp -dt kops.XXXXXXXXX)"
 go get github.com/onsi/ginkgo/ginkgo
 
-git clone --branch v1.2.0 https://github.com/kubernetes-sigs/aws-ebs-csi-driver.git .
+git clone --branch v1.2.1 https://github.com/kubernetes-sigs/aws-ebs-csi-driver.git .
 
 # shellcheck disable=SC2164
 cd tests/e2e-kubernetes/

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.2.0
+    version: v1.2.1
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.2.0
+    version: v1.2.1
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.2.0
+      version: v1.2.1
     manageStorageClasses: true
   cloudControllerManager: {}
   cloudProvider: aws

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -308,7 +308,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +354,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +377,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +441,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -473,7 +473,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.2.0
+        app.kubernetes.io/version: v1.2.1
     spec:
       containers:
       - args:
@@ -488,7 +488,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -594,7 +594,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.2.0
+        app.kubernetes.io/version: v1.2.1
     spec:
       affinity:
         podAntiAffinity:
@@ -648,7 +648,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -797,7 +797,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -815,7 +815,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
 spec:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -84,7 +84,7 @@ spec:
       k8s-addon: aws-cloud-controller.addons.k8s.io
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: b3d70cf5c6c089ff60b0a1ceeb6fb309d0e38476391fe7c1f50564c03157016f
+    manifestHash: 0f183314a9c288ada6a75caafeb0cde5c1f16be289a336da1677149a38280c2a
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.2.0
+    version: v1.2.1
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.2.0
+    version: v1.2.1
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.2.0
+      version: v1.2.1
     manageStorageClasses: true
   cloudControllerManager: {}
   cloudProvider: aws

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -308,7 +308,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +354,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +377,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +441,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -473,7 +473,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.2.0
+        app.kubernetes.io/version: v1.2.1
     spec:
       containers:
       - args:
@@ -488,7 +488,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -594,7 +594,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.2.0
+        app.kubernetes.io/version: v1.2.1
     spec:
       affinity:
         podAntiAffinity:
@@ -644,7 +644,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -741,7 +741,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -759,7 +759,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
 spec:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -84,7 +84,7 @@ spec:
       k8s-addon: aws-cloud-controller.addons.k8s.io
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c53680c3dec3a0f6cb36b7be64d8038e2babeb8aab3caf0d0b2d65d60e7fb27
+    manifestHash: 6b1d4a16671bece0de709ce50beba5b90c504f6681ba77e6aa459e7c50a52916
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.2.0
+    version: v1.2.1
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.2.0
+    version: v1.2.1
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.2.0
+      version: v1.2.1
     manageStorageClasses: true
   cloudProvider: aws
   clusterAutoscaler:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -308,7 +308,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +354,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +377,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +441,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -473,7 +473,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.2.0
+        app.kubernetes.io/version: v1.2.1
     spec:
       containers:
       - args:
@@ -488,7 +488,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -594,7 +594,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.2.0
+        app.kubernetes.io/version: v1.2.1
     spec:
       affinity:
         podAntiAffinity:
@@ -644,7 +644,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -741,7 +741,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -759,7 +759,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
 spec:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -78,7 +78,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c53680c3dec3a0f6cb36b7be64d8038e2babeb8aab3caf0d0b2d65d60e7fb27
+    manifestHash: 6b1d4a16671bece0de709ce50beba5b90c504f6681ba77e6aa459e7c50a52916
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.2.0
+    version: v1.2.1
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.2.0
+    version: v1.2.1
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: jnrwGYGiEv/FWBTaQ/EPcLh801b3vEf7D4F3PVwRRPg=
+NodeupConfigHash: wMzxC2J+2fQle4swMnOsp6CHale02Q9EaudaIpKUJWs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -12,7 +12,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.2.0
+      version: v1.2.1
     manageStorageClasses: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -308,7 +308,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +354,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +377,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +441,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -473,7 +473,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.2.0
+        app.kubernetes.io/version: v1.2.1
     spec:
       containers:
       - args:
@@ -488,7 +488,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -594,7 +594,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.2.0
+        app.kubernetes.io/version: v1.2.1
     spec:
       affinity:
         podAntiAffinity:
@@ -644,7 +644,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+        image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -741,7 +741,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -759,7 +759,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.2.0
+    app.kubernetes.io/version: v1.2.1
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
 spec:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 42b8011f95e8ddb8cde0f4877a57a674413314384ce5dda48a2cd75b988526ff
+    manifestHash: e0857b227e3d27fa2253caea62726618edeaeaced04c0a8bcb661aaf8562fa52
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -66,7 +66,7 @@ containerdConfig:
   version: 1.4.9
 warmPoolImages:
 - k8s.gcr.io/kube-proxy:v1.21.0
-- k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0
+- k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1
 - k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
 - k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
 - quay.io/cilium/cilium:v1.10.3

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -53,7 +53,7 @@ spec:
       k8s-addon: aws-cloud-controller.addons.k8s.io
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 0c53680c3dec3a0f6cb36b7be64d8038e2babeb8aab3caf0d0b2d65d60e7fb27
+    manifestHash: 6b1d4a16671bece0de709ce50beba5b90c504f6681ba77e6aa459e7c50a52916
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #12310 on release-1.22.

#12310: Bump aws ebs csi driver to 1.2.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.