### PR TITLE
Allow arbitrary length terraform literals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gophercloud/gophercloud v0.18.0
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/hashicorp/hcl/v2 v2.10.0
+	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/hashicorp/vault/api v1.1.0
 	github.com/jacksontj/memberlistmesh v0.0.0-20190905163944-93462b9d2bb7
 	github.com/jetstack/cert-manager v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.10.0 h1:1S1UnuhDGlv3gRFV4+0EdwB+znNP5HmcGbIqwnSCByg=
-github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
+github.com/hashicorp/hcl/v2 v2.10.1 h1:h4Xx4fsrRE26ohAk/1iGF/JBqRQbyUqu5Lvj60U54ys=
+github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -789,7 +789,7 @@ github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
+github.com/hashicorp/hcl/v2 v2.10.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=

--- a/upup/pkg/fi/cloudup/terraform/hcl2_test.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl2_test.go
@@ -119,18 +119,20 @@ func TestWriteLiteral(t *testing.T) {
 	}{
 		{
 			name:     "string",
-			literal:  &terraformWriter.Literal{Value: "value"},
+			literal:  terraformWriter.LiteralFromStringValue("value"),
 			expected: `foo = "value"`,
 		},
 		{
-			name: "traversal",
-			literal: &terraformWriter.Literal{
-				ResourceType: "type",
-				ResourceName: "name",
-				ResourceProp: "prop",
-			},
+			name:     "traversal",
+			literal:  terraformWriter.LiteralProperty("type", "name", "prop"),
 			expected: "foo = type.name.prop",
 		},
+		{
+			name:     "provider alias",
+			literal:  terraformWriter.LiteralTokens("aws", "files"),
+			expected: "foo = aws.files",
+		},
+
 		{
 			name:     "file",
 			literal:  terraformWriter.LiteralFunctionExpression("file", []string{"\"${path.module}/foo\""}),
@@ -164,9 +166,7 @@ func TestWriteLiteralList(t *testing.T) {
 			name: "one literal",
 			literals: []*terraformWriter.Literal{
 				{
-					ResourceType: "type",
-					ResourceName: "name",
-					ResourceProp: "prop",
+					Tokens: []string{"type", "name", "prop"},
 				},
 			},
 			expected: "foo = [type.name.prop]",
@@ -175,14 +175,10 @@ func TestWriteLiteralList(t *testing.T) {
 			name: "two literals",
 			literals: []*terraformWriter.Literal{
 				{
-					ResourceType: "type1",
-					ResourceName: "name1",
-					ResourceProp: "prop1",
+					Tokens: []string{"type1", "name1", "prop1"},
 				},
 				{
-					ResourceType: "type2",
-					ResourceName: "name2",
-					ResourceProp: "prop2",
+					Tokens: []string{"type2", "name2", "prop2"},
 				},
 			},
 			expected: "foo = [type1.name1.prop1, type2.name2.prop2]",
@@ -191,9 +187,7 @@ func TestWriteLiteralList(t *testing.T) {
 			name: "one traversal literal, one string literal",
 			literals: []*terraformWriter.Literal{
 				{
-					ResourceType: "type",
-					ResourceName: "name",
-					ResourceProp: "prop",
+					Tokens: []string{"type", "name", "prop"},
 				},
 				{
 					Value: "foobar",

--- a/upup/pkg/fi/cloudup/terraformWriter/literal.go
+++ b/upup/pkg/fi/cloudup/terraformWriter/literal.go
@@ -31,12 +31,9 @@ type Literal struct {
 	// "${}" interpolation is supported.
 	Value string `cty:"value"`
 
-	// ResourceType represents the type of a resource in a literal reference
-	ResourceType string `cty:"resource_type"`
-	// ResourceName represents the name of a resource in a literal reference
-	ResourceName string `cty:"resource_name"`
-	// ResourceProp represents the property of a resource in a literal reference
-	ResourceProp string `cty:"resource_prop"`
+	// Tokens are portions of a literal reference joined by periods.
+	// example: {"aws_vpc", "foo", "id"}
+	Tokens []string `cty:"tokens"`
 
 	// FnName represents the name of a terraform function.
 	FnName string `cty:"fn_name"`
@@ -67,10 +64,16 @@ func LiteralProperty(resourceType, resourceName, prop string) *Literal {
 	tfName := sanitizeName(resourceName)
 	expr := "${" + resourceType + "." + tfName + "." + prop + "}"
 	return &Literal{
-		Value:        expr,
-		ResourceType: resourceType,
-		ResourceName: tfName,
-		ResourceProp: prop,
+		Value:  expr,
+		Tokens: []string{resourceType, tfName, prop},
+	}
+}
+
+func LiteralTokens(tokens ...string) *Literal {
+	expr := "${" + strings.Join(tokens, ".") + "}"
+	return &Literal{
+		Value:  expr,
+		Tokens: tokens,
 	}
 }
 

--- a/vendor/github.com/hashicorp/hcl/v2/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/hcl/v2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # HCL Changelog
 
+## v2.10.1 (July 21, 2021)
+
+* dynblock: Decode unknown dynamic blocks in order to obtain any diagnostics even though the decoded value is not used ([#476](https://github.com/hashicorp/hcl/pull/476))
+* hclsyntax: Calling functions is now more robust in the face of an incorrectly-implemented function which returns a `function.ArgError` whose argument index is out of range for the length of the arguments. Previously this would often lead to a panic, but now it'll return a less-precice error message instead. Functions that return out-of-bounds argument indices still ought to be fixed so that the resulting error diagnostics can be as precise as possible. ([#472](https://github.com/hashicorp/hcl/pull/472))
+* hclsyntax: Ensure marks on unknown values are maintained when processing string templates. ([#478](https://github.com/hashicorp/hcl/pull/478))
+* hcl: Improved error messages for various common error situtions in `hcl.Index` and `hcl.GetAttr`. These are part of the implementation of indexing and attribute lookup in the native syntax expression language too, so the new error messages will apply to problems using those operators. ([#474](https://github.com/hashicorp/hcl/pull/474))
+
 ## v2.10.0 (April 20, 2021)
 
 ### Enhancements

--- a/vendor/github.com/hashicorp/hcl/v2/hclsyntax/expression_template.go
+++ b/vendor/github.com/hashicorp/hcl/v2/hclsyntax/expression_template.go
@@ -48,6 +48,12 @@ func (e *TemplateExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) 
 			continue
 		}
 
+		// Unmark the part and merge its marks into the set
+		unmarkedVal, partMarks := partVal.Unmark()
+		for k, v := range partMarks {
+			marks[k] = v
+		}
+
 		if !partVal.IsKnown() {
 			// If any part is unknown then the result as a whole must be
 			// unknown too. We'll keep on processing the rest of the parts
@@ -57,7 +63,7 @@ func (e *TemplateExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) 
 			continue
 		}
 
-		strVal, err := convert.Convert(partVal, cty.String)
+		strVal, err := convert.Convert(unmarkedVal, cty.String)
 		if err != nil {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -74,13 +80,7 @@ func (e *TemplateExpr) Value(ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) 
 			continue
 		}
 
-		// Unmark the part and merge its marks into the set
-		unmarked, partMarks := strVal.Unmark()
-		for k, v := range partMarks {
-			marks[k] = v
-		}
-
-		buf.WriteString(unmarked.AsString())
+		buf.WriteString(strVal.AsString())
 	}
 
 	var ret cty.Value

--- a/vendor/github.com/hashicorp/hcl/v2/hclsyntax/parser.go
+++ b/vendor/github.com/hashicorp/hcl/v2/hclsyntax/parser.go
@@ -1661,7 +1661,7 @@ func (p *parser) parseQuotedStringLiteral() (string, hcl.Range, hcl.Diagnostics)
 
 	var diags hcl.Diagnostics
 	ret := &bytes.Buffer{}
-	var cQuote Token
+	var endRange hcl.Range
 
 Token:
 	for {
@@ -1669,7 +1669,7 @@ Token:
 		switch tok.Type {
 
 		case TokenCQuote:
-			cQuote = tok
+			endRange = tok.Range
 			break Token
 
 		case TokenQuotedLit:
@@ -1712,6 +1712,7 @@ Token:
 				Subject:  &tok.Range,
 				Context:  hcl.RangeBetween(oQuote.Range, tok.Range).Ptr(),
 			})
+			endRange = tok.Range
 			break Token
 
 		default:
@@ -1724,13 +1725,14 @@ Token:
 				Context:  hcl.RangeBetween(oQuote.Range, tok.Range).Ptr(),
 			})
 			p.recover(TokenCQuote)
+			endRange = tok.Range
 			break Token
 
 		}
 
 	}
 
-	return ret.String(), hcl.RangeBetween(oQuote.Range, cQuote.Range), diags
+	return ret.String(), hcl.RangeBetween(oQuote.Range, endRange), diags
 }
 
 // ParseStringLiteralToken processes the given token, which must be either a

--- a/vendor/github.com/hashicorp/hcl/v2/hclsyntax/spec.md
+++ b/vendor/github.com/hashicorp/hcl/v2/hclsyntax/spec.md
@@ -293,18 +293,20 @@ Between the open and closing delimiters of these sequences, newline sequences
 are ignored as whitespace.
 
 There is a syntax ambiguity between _for expressions_ and collection values
-whose first element is a reference to a variable named `for`. The
-_for expression_ interpretation has priority, so to produce a tuple whose
-first element is the value of a variable named `for`, or an object with a
-key named `for`, use parentheses to disambiguate:
+whose first element starts with an identifier named `for`. The _for expression_
+interpretation has priority, so to write a key literally named `for`
+or an expression derived from a variable named `for` you must use parentheses
+or quotes to disambiguate:
 
 - `[for, foo, baz]` is a syntax error.
 - `[(for), foo, baz]` is a tuple whose first element is the value of variable
   `for`.
-- `{for: 1, baz: 2}` is a syntax error.
-- `{(for): 1, baz: 2}` is an object with an attribute literally named `for`.
-- `{baz: 2, for: 1}` is equivalent to the previous example, and resolves the
+- `{for = 1, baz = 2}` is a syntax error.
+- `{"for" = 1, baz = 2}` is an object with an attribute literally named `for`.
+- `{baz = 2, for = 1}` is equivalent to the previous example, and resolves the
   ambiguity by reordering.
+- `{(for) = 1, baz = 2}` is an object with a key with the same value as the
+  variable `for`.
 
 ### Template Expressions
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -463,7 +463,7 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hashicorp/hcl/v2 v2.10.0
+# github.com/hashicorp/hcl/v2 v2.10.1
 ## explicit
 github.com/hashicorp/hcl/v2
 github.com/hashicorp/hcl/v2/ext/customdecode


### PR DESCRIPTION
[Terraform provider aliases](https://www.terraform.io/docs/language/providers/configuration.html#selecting-alternate-provider-configurations) are referenced with two "tokens": `aws.files`

This adds support for literal references with an arbitrary number of tokens for eventual use by a provider alias in aws_s3_bucket_object resources.