### PR TITLE
Automated cherry pick of #12104: Fix cluster spec typo in CCM integration tests
#12291: Default to latest staging image for AWS CCM

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -73,5 +73,24 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		return fmt.Errorf("no networking mode set")
 	}
 
+	if eccm.Image == "" {
+		var tag string
+		switch b.KubernetesVersion.Minor {
+		case 18:
+			tag = "v1.18.0-alpha.1"
+		case 19:
+			tag = "v1.19.0-alpha.1"
+		case 20:
+			tag = "v1.20.0-alpha.0"
+		case 21:
+			tag = "v1.21.0-alpha.0"
+		default:
+			// There is no latest tag, so default to the latest that exists
+			// See https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/provider-aws/cloud-controller-manager
+			tag = "v1.22.0-alpha.0"
+		}
+		eccm.Image = fmt.Sprintf("k8s.gcr.io/provider-aws/cloud-controller-manager:%v", tag)
+	}
+
 	return nil
 }

--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -74,22 +74,21 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 	}
 
 	if eccm.Image == "" {
-		var tag string
+		// See https://us.gcr.io/k8s-artifacts-prod/provider-aws/cloud-controller-manager
 		switch b.KubernetesVersion.Minor {
 		case 18:
-			tag = "v1.18.0-alpha.1"
+			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.18.0-alpha.1"
 		case 19:
-			tag = "v1.19.0-alpha.1"
+			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.19.0-alpha.1"
 		case 20:
-			tag = "v1.20.0-alpha.0"
+			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.20.0-alpha.0"
 		case 21:
-			tag = "v1.21.0-alpha.0"
+			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0"
+		case 22:
+			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.22.0-alpha.0"
 		default:
-			// There is no latest tag, so default to the latest that exists
-			// See https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/provider-aws/cloud-controller-manager
-			tag = "v1.22.0-alpha.0"
+			eccm.Image = "gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest"
 		}
-		eccm.Image = fmt.Sprintf("k8s.gcr.io/provider-aws/cloud-controller-manager:%v", tag)
 	}
 
 	return nil

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -24,6 +24,7 @@ spec:
     clusterCIDR: 172.20.0.0/16
     clusterName: minimal.example.com
     configureCloudRoutes: false
+    image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
   cloudProvider: aws
   clusterAutoscaler:
     awsUseStaticInstanceList: false

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -18,7 +18,12 @@ spec:
       enabled: true
       version: v1.2.1
     manageStorageClasses: true
-  cloudControllerManager: {}
+  cloudControllerManager:
+    allocateNodeCIDRs: true
+    cloudProvider: aws
+    clusterCIDR: 172.20.0.0/16
+    clusterName: minimal.example.com
+    configureCloudRoutes: false
   cloudProvider: aws
   clusterAutoscaler:
     awsUseStaticInstanceList: false

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -22,6 +22,10 @@ spec:
       - args:
         - --v=2
         - --cloud-provider=aws
+        - --cluster-name=minimal.example.com
+        - --cluster-cidr=172.20.0.0/16
+        - --allocate-node-cidrs=true
+        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         env:
         - name: KUBERNETES_SERVICE_HOST

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -34,7 +34,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-cloud-controller-manager.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest
+        image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -78,7 +78,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 920c4484d1da9b60e389307e2c2884d1c1ddd5495a6f316ed962ac273111cbb9
+    manifestHash: 724a83ac5cd64f9c68dd69ecf91492e42e931c2404216875335e2915b039a7f9
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/in-v1alpha2.yaml
@@ -17,7 +17,7 @@ spec:
     awsEBSCSIDriver:
       enabled: true
   cloudControllerManager:
-    provider: aws
+    cloudProvider: aws
   cloudProvider: aws
   configBase: memfs://clusters.example.com/minimal.example.com
   etcdClusters:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -24,6 +24,7 @@ spec:
     clusterCIDR: 172.20.0.0/16
     clusterName: minimal.example.com
     configureCloudRoutes: false
+    image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
   cloudProvider: aws
   clusterAutoscaler:
     awsUseStaticInstanceList: false

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -18,7 +18,12 @@ spec:
       enabled: true
       version: v1.2.1
     manageStorageClasses: true
-  cloudControllerManager: {}
+  cloudControllerManager:
+    allocateNodeCIDRs: true
+    cloudProvider: aws
+    clusterCIDR: 172.20.0.0/16
+    clusterName: minimal.example.com
+    configureCloudRoutes: false
   cloudProvider: aws
   clusterAutoscaler:
     awsUseStaticInstanceList: false

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -22,6 +22,10 @@ spec:
       - args:
         - --v=2
         - --cloud-provider=aws
+        - --cluster-name=minimal.example.com
+        - --cluster-cidr=172.20.0.0/16
+        - --allocate-node-cidrs=true
+        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         env:
         - name: KUBERNETES_SERVICE_HOST

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest
+        image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -78,7 +78,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: d03cdda8c8dc8cf3df62d94209cec9b7fe554616a99270882d0286906da569e8
+    manifestHash: fc84bbdf31ebd7ffa65127033e1250f8e9af8290319ce7c36ec3691833970936
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/many-addons-ccm/in-v1alpha2.yaml
@@ -17,7 +17,7 @@ spec:
     awsEBSCSIDriver:
       enabled: true
   cloudControllerManager:
-    provider: aws
+    cloudProvider: aws
   cloudProvider: aws
   configBase: memfs://clusters.example.com/minimal.example.com
   etcdClusters:

--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: aws-cloud-controller-manager
       containers:
       - name: aws-cloud-controller-manager
-        image: {{ if .ExternalCloudControllerManager.Image }}{{ .ExternalCloudControllerManager.Image }}{{ else }}gcr.io/k8s-staging-provider-aws/cloud-controller-manager:{{AWSCCMTag}}{{ end }}
+        image: {{ .ExternalCloudControllerManager.Image }}
         imagePullPolicy: IfNotPresent
         args:
 {{- range $arg := CloudControllerConfigArgv }}

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -128,7 +128,6 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 
 	// will return openstack external ccm image location for current kubernetes version
 	dest["OpenStackCCMTag"] = tf.OpenStackCCMTag
-	dest["AWSCCMTag"] = tf.AWSCCMTag
 	dest["ProxyEnv"] = tf.ProxyEnv
 
 	dest["KopsSystemEnv"] = tf.KopsSystemEnv
@@ -655,28 +654,6 @@ func (tf *TemplateFunctions) OpenStackCCMTag() string {
 		}
 	}
 	return tag
-}
-
-// AWSCCMTag returns the correct tag for the cloud controller manager based on
-// the Kubernetes Version
-func (tf *TemplateFunctions) AWSCCMTag() (string, error) {
-	var tag string
-	parsed, err := util.ParseKubernetesVersion(tf.Cluster.Spec.KubernetesVersion)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse Kubernetes version from cluster spec: %q", err)
-	}
-
-	// Update when we have stable releases
-	switch parsed.Minor {
-	case 18:
-		tag = "v1.18.0-alpha.1"
-	case 19:
-		tag = "v1.19.0-alpha.1"
-	default:
-		tag = "latest"
-	}
-
-	return tag, nil
 }
 
 // GetNodeInstanceGroups returns a map containing the defined instance groups of role "Node".

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -30,7 +30,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest
+        image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.20.0-alpha.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: c2b208761561c8596a3cb60ada550760756f85d1973a55510ce0df044c0f680d
+    manifestHash: 44082fd8458970b2f65afe24a523c5866353ea1ab87eeb9f33ee9077425af1b8
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #12104 #12291 on release-1.22.

#12104: Fix cluster spec typo in CCM integration tests
#12291: Default to latest staging image for AWS CCM

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.