### PR TITLE
Automated cherry pick of #12258: Set NodeIPFamilies in ipv6 mode
#12305: Make AWS CCM NodeIPFamilies configurable

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -343,6 +343,12 @@ spec:
                   multizone:
                     description: GCE cloud-config options
                     type: boolean
+                  nodeIPFamilies:
+                    description: NodeIPFamilies controls the IP families reported
+                      for each node (AWS only).
+                    items:
+                      type: string
+                    type: array
                   nodeInstancePrefix:
                     type: string
                   nodeTags:

--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -109,6 +109,7 @@ go_test(
         "//pkg/assets:go_default_library",
         "//pkg/client/simple/vfsclientset:go_default_library",
         "//pkg/configbuilder:go_default_library",
+        "//pkg/diff:go_default_library",
         "//pkg/flagbuilder:go_default_library",
         "//pkg/pki:go_default_library",
         "//pkg/testutils:go_default_library",

--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -102,8 +102,8 @@ func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
 		if cloudConfig.ElbSecurityGroup != nil {
 			lines = append(lines, "ElbSecurityGroup = "+*cloudConfig.ElbSecurityGroup)
 		}
-		if b.Cluster.Spec.IsIPv6Only() {
-			lines = append(lines, "NodeIPFamilies = ipv6")
+		for _, family := range cloudConfig.NodeIPFamilies {
+			lines = append(lines, "NodeIPFamilies = "+family)
 		}
 	case "openstack":
 		osc := cloudConfig.Openstack

--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -102,6 +102,9 @@ func (b *CloudConfigBuilder) Build(c *fi.ModelBuilderContext) error {
 		if cloudConfig.ElbSecurityGroup != nil {
 			lines = append(lines, "ElbSecurityGroup = "+*cloudConfig.ElbSecurityGroup)
 		}
+		if b.Cluster.Spec.IsIPv6Only() {
+			lines = append(lines, "NodeIPFamilies = ipv6")
+		}
 	case "openstack":
 		osc := cloudConfig.Openstack
 		if osc == nil {

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -837,6 +837,8 @@ type CloudConfiguration struct {
 	Multizone          *bool   `json:"multizone,omitempty"`
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
+	// NodeIPFamilies controls the IP families reported for each node (AWS only).
+	NodeIPFamilies []string `json:"nodeIPFamilies,omitempty"`
 	// GCEServiceAccount specifies the service account with which the GCE VM runs
 	GCEServiceAccount string `json:"gceServiceAccount,omitempty"`
 	// AWS cloud-config options

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -836,6 +836,8 @@ type CloudConfiguration struct {
 	Multizone          *bool   `json:"multizone,omitempty"`
 	NodeTags           *string `json:"nodeTags,omitempty"`
 	NodeInstancePrefix *string `json:"nodeInstancePrefix,omitempty"`
+	// NodeIPFamilies controls the IP families reported for each node (AWS only).
+	NodeIPFamilies []string `json:"nodeIPFamilies,omitempty"`
 	// GCEServiceAccount specifies the service account with which the GCE VM runs
 	GCEServiceAccount string `json:"gceServiceAccount,omitempty"`
 	// AWS cloud-config options

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2021,6 +2021,7 @@ func autoConvert_v1alpha2_CloudConfiguration_To_kops_CloudConfiguration(in *Clou
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.NodeIPFamilies = in.NodeIPFamilies
 	out.GCEServiceAccount = in.GCEServiceAccount
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.ElbSecurityGroup = in.ElbSecurityGroup
@@ -2073,6 +2074,7 @@ func autoConvert_kops_CloudConfiguration_To_v1alpha2_CloudConfiguration(in *kops
 	out.Multizone = in.Multizone
 	out.NodeTags = in.NodeTags
 	out.NodeInstancePrefix = in.NodeInstancePrefix
+	out.NodeIPFamilies = in.NodeIPFamilies
 	out.GCEServiceAccount = in.GCEServiceAccount
 	out.DisableSecurityGroupIngress = in.DisableSecurityGroupIngress
 	out.ElbSecurityGroup = in.ElbSecurityGroup

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -624,6 +624,11 @@ func (in *CloudConfiguration) DeepCopyInto(out *CloudConfiguration) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NodeIPFamilies != nil {
+		in, out := &in.NodeIPFamilies, &out.NodeIPFamilies
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.DisableSecurityGroupIngress != nil {
 		in, out := &in.DisableSecurityGroupIngress, &out.DisableSecurityGroupIngress
 		*out = new(bool)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -708,6 +708,11 @@ func (in *CloudConfiguration) DeepCopyInto(out *CloudConfiguration) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NodeIPFamilies != nil {
+		in, out := &in.NodeIPFamilies, &out.NodeIPFamilies
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.DisableSecurityGroupIngress != nil {
 		in, out := &in.DisableSecurityGroupIngress, &out.DisableSecurityGroupIngress
 		*out = new(bool)

--- a/pkg/model/components/cloudconfiguration.go
+++ b/pkg/model/components/cloudconfiguration.go
@@ -52,5 +52,9 @@ func (b *CloudConfigurationOptionsBuilder) BuildOptions(o interface{}) error {
 		c.ManageStorageClasses = manage
 	}
 
+	if clusterSpec.IsIPv6Only() && len(c.NodeIPFamilies) == 0 {
+		c.NodeIPFamilies = []string{"ipv6", "ipv4"}
+	}
+
 	return nil
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -27,6 +27,7 @@ spec:
         - --allocate-node-cidrs=true
         - --configure-cloud-routes=false
         - --use-service-account-credentials=true
+        - --cloud-config=/etc/kubernetes/cloud.config
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
@@ -41,6 +42,9 @@ spec:
           requests:
             cpu: 200m
         volumeMounts:
+        - mountPath: /etc/kubernetes/cloud.config
+          name: cloudconfig
+          readOnly: true
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
           readOnly: true
@@ -58,6 +62,10 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:
+      - hostPath:
+          path: /etc/kubernetes/cloud.config
+          type: ""
+        name: cloudconfig
       - name: token-amazonaws-com
         projected:
           defaultMode: 420

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -78,7 +78,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 724a83ac5cd64f9c68dd69ecf91492e42e931c2404216875335e2915b039a7f9
+    manifestHash: 21f67dfab1631085a7bf58b0627a53350c996ee471971ed02326893a3ba9b988
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -27,6 +27,7 @@ spec:
         - --allocate-node-cidrs=true
         - --configure-cloud-routes=false
         - --use-service-account-credentials=true
+        - --cloud-config=/etc/kubernetes/cloud.config
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
@@ -36,6 +37,10 @@ spec:
         resources:
           requests:
             cpu: 200m
+        volumeMounts:
+        - mountPath: /etc/kubernetes/cloud.config
+          name: cloudconfig
+          readOnly: true
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -47,6 +52,11 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/cloud.config
+          type: ""
+        name: cloudconfig
   updateStrategy:
     type: RollingUpdate
 

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -78,7 +78,7 @@ spec:
       role.kubernetes.io/networking: "1"
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: fc84bbdf31ebd7ffa65127033e1250f8e9af8290319ce7c36ec3691833970936
+    manifestHash: 1d3a554dad2c3190ab871ed36d310499783e89dbf355fc128e7e6a69d06d075d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -40,8 +40,17 @@ spec:
         resources:
           requests:
             cpu: 200m
+        volumeMounts:
+        - mountPath: /etc/kubernetes/cloud.config
+          name: cloudconfig
+          readOnly: true
       hostNetwork: true
       priorityClassName: system-cluster-critical
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/cloud.config
+          type: ""
+        name: cloudconfig
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -356,6 +356,8 @@ func (tf *TemplateFunctions) CloudControllerConfigArgv() ([]string, error) {
 		argv = append(argv, fmt.Sprintf("--use-service-account-credentials=%t", true))
 	}
 
+	argv = append(argv, "--cloud-config=/etc/kubernetes/cloud.config")
+
 	return argv, nil
 }
 

--- a/upup/pkg/fi/cloudup/template_functions_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_test.go
@@ -42,6 +42,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--v=2",
 				"--cloud-provider=openstack",
 				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 		{
@@ -58,6 +59,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--v=3",
 				"--cloud-provider=openstack",
 				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 		{
@@ -74,6 +76,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--v=3",
 				"--cloud-provider=openstack",
 				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 		{
@@ -100,6 +103,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--cloud-provider=openstack",
 				"--cluster-name=k8s",
 				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 		{
@@ -115,6 +119,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--v=2",
 				"--cloud-provider=openstack",
 				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 		{
@@ -130,6 +135,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--cloud-provider=openstack",
 				"--cluster-cidr=10.0.0.0/24",
 				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 		{
@@ -145,6 +151,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--cloud-provider=openstack",
 				"--allocate-node-cidrs=true",
 				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 		{
@@ -160,6 +167,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--cloud-provider=openstack",
 				"--configure-cloud-routes=true",
 				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 		{
@@ -175,6 +183,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--cloud-provider=openstack",
 				"--cidr-allocator-type=RangeAllocator",
 				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 		{
@@ -189,6 +198,7 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				"--v=2",
 				"--cloud-provider=openstack",
 				"--use-service-account-credentials=false",
+				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},
 	}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -27,6 +27,7 @@ spec:
         - --allocate-node-cidrs=true
         - --configure-cloud-routes=false
         - --use-service-account-credentials=true
+        - --cloud-config=/etc/kubernetes/cloud.config
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
@@ -36,6 +37,10 @@ spec:
         resources:
           requests:
             cpu: 200m
+        volumeMounts:
+        - mountPath: /etc/kubernetes/cloud.config
+          name: cloudconfig
+          readOnly: true
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -47,6 +52,11 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/cloud.config
+          type: ""
+        name: cloudconfig
   updateStrategy:
     type: RollingUpdate
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 44082fd8458970b2f65afe24a523c5866353ea1ab87eeb9f33ee9077425af1b8
+    manifestHash: ef8dfd3eea151466da553999bd400f52f5017a6dc2b94e53ad8368600c6384c7
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #12258 #12305 on release-1.22.

#12258: Set NodeIPFamilies in ipv6 mode
#12305: Make AWS CCM NodeIPFamilies configurable

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.