### PR TITLE
Use secure port for kube-scheduler liveness probe

### DIFF
--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -225,9 +225,10 @@ func (b *KubeSchedulerBuilder) buildPod(kubeScheduler *kops.KubeSchedulerConfig)
 		LivenessProbe: &v1.Probe{
 			Handler: v1.Handler{
 				HTTPGet: &v1.HTTPGetAction{
-					Host: "127.0.0.1",
-					Path: "/healthz",
-					Port: intstr.FromInt(10251),
+					Host:   "127.0.0.1",
+					Path:   "/healthz",
+					Port:   intstr.FromInt(10259),
+					Scheme: "HTTPS",
 				},
 			},
 			InitialDelaySeconds: 15,

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
@@ -29,7 +29,8 @@ contents: |
         httpGet:
           host: 127.0.0.1
           path: /healthz
-          port: 10251
+          port: 10259
+          scheme: HTTPS
         initialDelaySeconds: 15
         timeoutSeconds: 15
       name: kube-scheduler

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
@@ -29,7 +29,8 @@ contents: |
         httpGet:
           host: 127.0.0.1
           path: /healthz
-          port: 10251
+          port: 10259
+          scheme: HTTPS
         initialDelaySeconds: 15
         timeoutSeconds: 15
       name: kube-scheduler

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
@@ -29,7 +29,8 @@ contents: |
         httpGet:
           host: 127.0.0.1
           path: /healthz
-          port: 10251
+          port: 10259
+          scheme: HTTPS
         initialDelaySeconds: 15
         timeoutSeconds: 15
       name: kube-scheduler


### PR DESCRIPTION
current prow jobs using CI builds of k8s are failing due to kube-scheduler failing its liveness probe.

* [kube-scheduler logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-misc-arm64-ci/1438208727294414848/artifacts/ip-172-20-62-200.eu-central-1.compute.internal/kube-scheduler.log)
* [kubelet logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-misc-arm64-ci/1438208727294414848/artifacts/ip-172-20-62-200.eu-central-1.compute.internal/journal.log)

`Sep 15 18:36:03.679849 ip-172-20-62-200 kubelet[4522]: I0915 18:36:03.679821    4522 prober.go:116] "Probe failed" probeType="Liveness" pod="kube-system/kube-scheduler-ip-172-20-62-200.eu-central-1.compute.internal" podUID=ec8d3987a3e988962372ae26c45e2e4c containerName="kube-scheduler" probeResult=failure output="Get \"http://127.0.0.1:10251/healthz\": dial tcp 127.0.0.1:10251: connect: connection refused"`

ref: https://github.com/kubernetes/kubernetes/pull/96345