### PR TITLE
Allow kops-controller to be scheduled onto unready control plane nodes

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bc861d55793afb4599e5a92af886b474f8ac1a9fa7331d4ee133e203a6bc02c6
+    manifestHash: 213a95ccafd932702dacb49154fe2a3acb4fd1b8cbb0aaf8020ade4ec202f360
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 947941bb27d7b1abccdf1c304046e2269922feb63a14b6cc597b9d3461e964b0
+    manifestHash: 854ff63c437e184acb03dbc6ce43bf63d71f56d03e4660e1d610aac7f4031fc0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ce49dfb1a33dec454b462f4370a7479428bfdc0e569957c894b9e5b57cc8f05e
+    manifestHash: 47254077453c68a28ff0e46e59ce1fd680fb0c3c0d8877cfc912a65950d2e746
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2729009114fa5a1eb5ab85abe6272606468e55c2c40cdc3a12fba0c0d2370d4a
+    manifestHash: e0deedc5a298239ea1274507de1daf3e49d2680f59db542382fad0542fd93299
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6613b03dd6ef041b4c669a8f1d3d52fc171729a978431ddee0637aa7abb141be
+    manifestHash: 4abdee4bf7e648c166fe63785ac592cfa63dd8a196555f7705b080e745037a0b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 87ccb2dc413b4f46aaf46dc0c71bb5e8b3f36d2ed44d26e1ec2c84747c310c86
+    manifestHash: ab0265aad65b25351b33b7e003f5790073c5c9b51ba67a4609e82633a29914fd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4b3f789f167a2c11b9432a0fae0df797bea3b6f0cab911c583bdf00cd9bb49ac
+    manifestHash: bc862641fda898000155d4ca179608834d8bf612239c5e797c5ad2db07249910
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2fb6ba9d4ada4c4ade36c583a79908395cd798df8fbed854af7ab3ef0346e89f
+    manifestHash: c28c14d5d2d7fa878d6e608bcac063d4295d14de4f2a80a97519777e23bc4b01
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8daf35b1007c346a38eb503d33ab457853fcbd93ba0db6f0bb030d3d6cbff6e6
+    manifestHash: 00f10026f71e0367cf65cab53adebbecf5d6575fb03514b42860c1f0e32461b2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f333e3a2baeacb3658a3dcaffb45c67329737e625478ae8325d96b23d4d70792
+    manifestHash: 24ad6357417f5ece9842769f8c108aac1cb30bf98199596ac99f54288ca89b4b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -66,12 +66,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cdee2943ea97d2c6e0a886650565154028bcde2fa6b4bd14e7457122a295e798
+    manifestHash: 025f1f698e5296f2448b88e57403b5d5275fc0769347ffcbe60e82787c4f29ad
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 380a796a8b614a7093556436a7144ae3ff60b1cf6260ab1e924f425a81549248
+    manifestHash: 546e6d8cf8b4742bd27223316f9d76957124ecd025e53066632d546ed5944796
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/minimal-json/data/aws_s3_bucket_object_minimal-json.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-json/data/aws_s3_bucket_object_minimal-json.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5424433845a11783e6a010b5952882226ba3353efee79993287c512d09aacd2a
+    manifestHash: 9496d6ee8029be17b1e9458edb096ea5c7389b558ef1864ccaff80f12a15fe7c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-json/data/aws_s3_bucket_object_minimal-json.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-json/data/aws_s3_bucket_object_minimal-json.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c104d1d5a5811c2e4ef3bbb4f50d00e14818cba43a290b9b7605bc74d2cfb374
+    manifestHash: 0086003e047a685e69e476fcc142d3bb07ea0dba30bd6432f4a838774b230d7b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ec6e2f25faa3336cdf8daae6b0460269b8b8f04d0927aace750e4cb669f20c33
+    manifestHash: 1d967e8bc003e889a20323ccf2ef683e252a33454529e9587cd43dd618e7423f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -66,12 +66,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ca21100ff40ec22a7493ccb4624aec8a3544bb2335988be77aefe4f63a8080da
+    manifestHash: af2566e1b57034593d79872ff9825e3dc2d0df57e94872c7041335de7fc47cfc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -66,12 +66,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2a1bedc31e7214c196bf963cc3f884121d732b48a46db9dbfc3200364ec31225
+    manifestHash: e6b41f00b75cab32fda7c50c711d8e5bea15548cbe60b0ec6a05c9f42fe9180d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7df9bebfcfe6c53dbe01a26a252f2181cd4a4f36a7c77acaae460f5409f1b67b
+    manifestHash: 59e475abb4a5deb285fb01ab6da4a40ba6117b0166e0f748cddfc188e45161fd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7df9bebfcfe6c53dbe01a26a252f2181cd4a4f36a7c77acaae460f5409f1b67b
+    manifestHash: 59e475abb4a5deb285fb01ab6da4a40ba6117b0166e0f748cddfc188e45161fd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 364a69838b26d26253aa55195068a74149c97a9c2ac228c83f7c61da9fc04a86
+    manifestHash: 8d184b01726efeca25b68d66aa66433b503291b9e5ee1eb9c90380a8e515d18e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61dda80f9691fc245d3877febc2a3e8292b73f0b25f805bdb7aa1f2b99cca4ce
+    manifestHash: d6be186799a6cc2b8c24a1a0422e19fd7877652c649e8d9974011ce0ed634ab0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b45a68a34b6b03a800bd7772a9bbd62dda674662cadc3495acf9af075222cdce
+    manifestHash: 3b0fe6c08f8a0b513cfdda8d90a188196090791ada9fb11278019f5f756a2c44
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 87ef256448629b14cf21a2b136461597bb4e3bbee3e0e4b5a3d9ab91996c8da9
+    manifestHash: 09d4c21256867d39720d5d9ea649c9fd28410569c62034b33896275a41bbf8b2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b519003736c1bd75dc3cde82eb752a16f92b5df460153a2a6a3b46b1dffa9b1a
+    manifestHash: 860a3656de8f7aed31abfac3c82bdb0437c524589e36858b8c54fe5ebc1aeb43
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0ba0ef258e206327f1d125376d80028cc8768f6595a301bef10d0b2d3dc90014
+    manifestHash: 58a7102fbc1961485ad52be1f0f3ba13e819d17b4fd90887d52effd5423a50ba
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bbf70afc9e1231d85d3eab9326f83012a7061bb27d5396c8b483cb17448866b7
+    manifestHash: 9219ec59b2edf20076c5bbf498e37a091aa278a73e5e0d371294e328ee289072
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -66,12 +66,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 20434c0843ff1c519b5fae0cb066590e7d4222bf5cc54ac26f5cd4b6953894b2
+    manifestHash: 98170d49627f42d59983e1f92935127800f549c21958824d44c9a2ba9b107451
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fc52b25362c9509a9a0093ccabd0edfc83dc5b05c5ba17198490097f1f418f5e
+    manifestHash: 92fda553280a60b2b1fb862f45959e2458d6706b4db1609f1b16d816429fc4bf
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9ece2dd82db825bedc6e3a3fb0c9830de693408da1099dab3244fec3c78bb270
+    manifestHash: 125d5cef1b62ba9bf3b44761a4740661f7d5d286825ec958f1634fe98365b264
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7e24054284caf82dec43739c3fddfdc7fb58d88bc5c09a28bc11bffbb884c3b4
+    manifestHash: 5f805f168b3ed92c385afdbea50ec81b65a0620fa4c756914713a7c2b35c855a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0972104056a057cbdce0024ba13296195e3aa87a1662327eb6d30286cf091e9d
+    manifestHash: a1e33499970c338c35e8865d95124f7b543a081c41c3fad247ac248ab328f489
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9f0b43577c590bf69f052daea16b0af712fd6d9eb75c7e60963b1ab0e9904a94
+    manifestHash: ecbc930dc4c1ba19fb93e5d27815178f815d4dcd9a14da5323c7f5f9b3a3c6e7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a83d695741287203e12b1b83c1bf451fe78d28705d26d3bdf7d1c332ff29ca02
+    manifestHash: 83d08ba36d16727b6e6e0ae1736f84e5c8c47347b042c83af021f9d79dca3218
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1e83133bfe7e5d2c4124f5a109a0a98e9a2b63e69e656e1251cbbab8f67acf56
+    manifestHash: ad7d86c0cf860a7005ff206ea95d60524983ad7655fcec7dcead887334f5800c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a6aff77ee80022cc03966747706389266b473ac17af127c48b5bc6339ed09042
+    manifestHash: 6a93e4194cf6114b5634a757e8d2471160f458cb8198a391f4e30e0be8f5dbe6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 05eb1c527361a625ad1a90200d3166ccaea69b00a4661b2a0fc4f1c0f5d135f5
+    manifestHash: 9da1ffdf784b9de349bb51191f9467375f50bce6236b968d7be3cb782d857554
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -39,12 +39,7 @@ spec:
     spec:
       priorityClassName: system-node-critical
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       nodeSelector:
         node-role.kubernetes.io/master: ""
         kops.k8s.io/kops-controller-pki: ""

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b235a1551668b13ba96779362540d61f7aef96f0cd4b856dc99bb4ab1774e07
+    manifestHash: f5b875a343067de8fb7cd3d5fd49959067763a69b0d86524f57b873f2083e6d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b235a1551668b13ba96779362540d61f7aef96f0cd4b856dc99bb4ab1774e07
+    manifestHash: f5b875a343067de8fb7cd3d5fd49959067763a69b0d86524f57b873f2083e6d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b235a1551668b13ba96779362540d61f7aef96f0cd4b856dc99bb4ab1774e07
+    manifestHash: f5b875a343067de8fb7cd3d5fd49959067763a69b0d86524f57b873f2083e6d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b235a1551668b13ba96779362540d61f7aef96f0cd4b856dc99bb4ab1774e07
+    manifestHash: f5b875a343067de8fb7cd3d5fd49959067763a69b0d86524f57b873f2083e6d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -66,12 +66,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: be0cb32b2e7c036399e9e4dfd213c79e0f58f4aff563beb23e2b1070f1444d69
+    manifestHash: a06d613e996ac954fb38768d7250d17419f7d7a0b791927f53148442b2de1f9f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: be0cb32b2e7c036399e9e4dfd213c79e0f58f4aff563beb23e2b1070f1444d69
+    manifestHash: a06d613e996ac954fb38768d7250d17419f7d7a0b791927f53148442b2de1f9f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b235a1551668b13ba96779362540d61f7aef96f0cd4b856dc99bb4ab1774e07
+    manifestHash: f5b875a343067de8fb7cd3d5fd49959067763a69b0d86524f57b873f2083e6d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: be0cb32b2e7c036399e9e4dfd213c79e0f58f4aff563beb23e2b1070f1444d69
+    manifestHash: a06d613e996ac954fb38768d7250d17419f7d7a0b791927f53148442b2de1f9f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b235a1551668b13ba96779362540d61f7aef96f0cd4b856dc99bb4ab1774e07
+    manifestHash: f5b875a343067de8fb7cd3d5fd49959067763a69b0d86524f57b873f2083e6d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b235a1551668b13ba96779362540d61f7aef96f0cd4b856dc99bb4ab1774e07
+    manifestHash: f5b875a343067de8fb7cd3d5fd49959067763a69b0d86524f57b873f2083e6d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -68,12 +68,7 @@ spec:
       priorityClassName: system-node-critical
       serviceAccount: kops-controller
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-        operator: Exists
+      - operator: Exists
       volumes:
       - configMap:
           name: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b235a1551668b13ba96779362540d61f7aef96f0cd4b856dc99bb4ab1774e07
+    manifestHash: f5b875a343067de8fb7cd3d5fd49959067763a69b0d86524f57b873f2083e6d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b235a1551668b13ba96779362540d61f7aef96f0cd4b856dc99bb4ab1774e07
+    manifestHash: f5b875a343067de8fb7cd3d5fd49959067763a69b0d86524f57b873f2083e6d2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:


### PR DESCRIPTION
Some [upgrade tests](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k121-ko121-to-klatest-kolatest/1438334330005884928) are failing and during troubleshooting I noticed [kops-controller never got scheduled](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k121-ko121-to-klatest-kolatest/1438334330005884928/artifacts/15.223.115.49/kubelet.log) which meant [the other nodes couldn't join the cluster](https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k121-ko121-to-klatest-kolatest/1438334330005884928/artifacts/) because the control plane node had the `node.kubernetes.io/not-ready` taint (in the upgrade case, we lose DNS access to the API so we cant get k8s resources dumped but in [other tests](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-grid-cilium-rhel8-k22-containerd/1438294568381452288/artifacts/cluster-info/nodes.yaml) we can see the similar issue and the nodes reveal the not-ready taint is due to CNI issues).


This should improve the time for new clusters to validate by a bit.

