### PR TITLE
Automated cherry pick of #12298: Add IPv6 IMDS terraform support

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -396,6 +396,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -477,6 +478,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -894,7 +896,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -486,6 +486,7 @@ resource "aws_launch_template" "bastion-bastionuserdata-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -562,6 +563,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-bastionuserdata-exampl
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -643,6 +645,7 @@ resource "aws_launch_template" "nodes-bastionuserdata-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1216,7 +1219,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -1883,7 +1883,7 @@
           ],
           "Version": "2012-10-17"
         },
-        "PermissionsBoundary": "arn:aws:iam:00000000000:policy/boundaries",
+        "PermissionsBoundary": "arn:aws:iam::000000000000:policy/boundaries",
         "Tags": [
           {
             "Key": "KubernetesCluster",
@@ -1924,7 +1924,7 @@
           ],
           "Version": "2012-10-17"
         },
-        "PermissionsBoundary": "arn:aws:iam:00000000000:policy/boundaries",
+        "PermissionsBoundary": "arn:aws:iam::000000000000:policy/boundaries",
         "Tags": [
           {
             "Key": "KubernetesCluster",

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -68,7 +68,7 @@ spec:
     provider: dns-controller
   iam:
     legacy: false
-    permissionsBoundary: arn:aws:iam:00000000000:policy/boundaries
+    permissionsBoundary: arn:aws:iam::000000000000:policy/boundaries
   keyStore: memfs://clusters.example.com/complex.example.com/pki
   kubeAPIServer:
     allowPrivileged: true

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -37,7 +37,7 @@ spec:
       name: a
     name: events
   iam:
-    permissionsBoundary: arn:aws:iam:00000000000:policy/boundaries
+    permissionsBoundary: arn:aws:iam::000000000000:policy/boundaries
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
     auditWebhookBatchThrottleQps: 3.14

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -37,7 +37,7 @@ spec:
       name: a
     name: events
   iam:
-    permissionsBoundary: arn:aws:iam:00000000000:policy/boundaries
+    permissionsBoundary: arn:aws:iam::000000000000:policy/boundaries
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
     auditWebhookBatchThrottleQps: 3.14

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -368,6 +368,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "required"
   }
@@ -467,6 +468,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1131,7 +1133,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -295,7 +295,7 @@ resource "aws_iam_instance_profile" "nodes-complex-example-com" {
 resource "aws_iam_role" "masters-complex-example-com" {
   assume_role_policy   = file("${path.module}/data/aws_iam_role_masters.complex.example.com_policy")
   name                 = "masters.complex.example.com"
-  permissions_boundary = "arn:aws:iam:00000000000:policy/boundaries"
+  permissions_boundary = "arn:aws:iam::000000000000:policy/boundaries"
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "masters.complex.example.com"
@@ -308,7 +308,7 @@ resource "aws_iam_role" "masters-complex-example-com" {
 resource "aws_iam_role" "nodes-complex-example-com" {
   assume_role_policy   = file("${path.module}/data/aws_iam_role_nodes.complex.example.com_policy")
   name                 = "nodes.complex.example.com"
-  permissions_boundary = "arn:aws:iam:00000000000:policy/boundaries"
+  permissions_boundary = "arn:aws:iam::000000000000:policy/boundaries"
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "nodes.complex.example.com"

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -312,6 +312,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-compress-example-com" 
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -392,6 +393,7 @@ resource "aws_launch_template" "nodes-compress-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -781,7 +783,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/digit/kubernetes.tf
+++ b/tests/integration/update_cluster/digit/kubernetes.tf
@@ -395,6 +395,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-123-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -476,6 +477,7 @@ resource "aws_launch_template" "nodes-123-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -879,7 +881,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -453,6 +453,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existing-iam-example-c
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -538,6 +539,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existing-iam-example-c
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -623,6 +625,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existing-iam-example-c
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -704,6 +707,7 @@ resource "aws_launch_template" "nodes-existing-iam-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1145,7 +1149,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -554,6 +554,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-existingsg-example-com
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -639,6 +640,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-existingsg-example-com
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -724,6 +726,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-existingsg-example-com
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -805,6 +808,7 @@ resource "aws_launch_template" "nodes-existingsg-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1516,7 +1520,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/external_dns/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns/kubernetes.tf
@@ -323,6 +323,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -404,6 +405,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -793,7 +795,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
@@ -370,6 +370,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -451,6 +452,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -854,7 +856,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -327,6 +327,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externallb-example-com
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -408,6 +409,7 @@ resource "aws_launch_template" "nodes-externallb-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -797,7 +799,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -399,6 +399,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-externalpolicies-examp
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -486,6 +487,7 @@ resource "aws_launch_template" "nodes-externalpolicies-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -989,7 +991,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -525,6 +525,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-ha-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -610,6 +611,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-ha-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -695,6 +697,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-ha-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -776,6 +779,7 @@ resource "aws_launch_template" "nodes-ha-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1217,7 +1221,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -395,6 +395,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -476,6 +477,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -879,7 +881,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -179,7 +179,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
@@ -500,6 +500,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -581,6 +582,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1049,7 +1051,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
@@ -323,6 +323,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -404,6 +405,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -858,7 +860,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons/kubernetes.tf
@@ -323,6 +323,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -404,6 +405,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -851,7 +853,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -319,6 +319,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -400,6 +401,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -789,7 +791,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -324,6 +324,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-ipv6-example-c
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -405,6 +406,7 @@ resource "aws_launch_template" "nodes-minimal-ipv6-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "enabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -924,7 +926,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
+++ b/tests/integration/update_cluster/minimal-json/kubernetes.tf.json
@@ -369,7 +369,8 @@
         "metadata_options": {
           "http_endpoint": "enabled",
           "http_put_response_hop_limit": 1,
-          "http_tokens": "optional"
+          "http_tokens": "optional",
+          "http_protocol_ipv6": "disabled"
         },
         "monitoring": [
           {
@@ -463,7 +464,8 @@
         "metadata_options": {
           "http_endpoint": "enabled",
           "http_put_response_hop_limit": 1,
-          "http_tokens": "optional"
+          "http_tokens": "optional",
+          "http_protocol_ipv6": "disabled"
         },
         "monitoring": [
           {
@@ -854,7 +856,7 @@
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "\u003e= 2.46.0"
+        "version": "\u003e= 3.59.0"
       }
     },
     "required_version": "\u003e= 0.12.26"

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -323,6 +323,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-warmpool-examp
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -404,6 +405,7 @@ resource "aws_launch_template" "nodes-minimal-warmpool-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -807,7 +809,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -323,6 +323,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -404,6 +405,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -793,7 +795,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
@@ -323,6 +323,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-k8s-local" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -404,6 +405,7 @@ resource "aws_launch_template" "nodes-minimal-k8s-local" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -793,7 +795,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -542,6 +542,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -627,6 +628,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -712,6 +714,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -793,6 +796,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1234,7 +1238,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -543,6 +543,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-mixedinstances-example
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -628,6 +629,7 @@ resource "aws_launch_template" "master-us-test-1b-masters-mixedinstances-example
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -713,6 +715,7 @@ resource "aws_launch_template" "master-us-test-1c-masters-mixedinstances-example
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -794,6 +797,7 @@ resource "aws_launch_template" "nodes-mixedinstances-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1235,7 +1239,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
+++ b/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
@@ -409,6 +409,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-nthsqsresources-exampl
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -493,6 +494,7 @@ resource "aws_launch_template" "nodes-nthsqsresources-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -903,7 +905,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/nvidia/kubernetes.tf
+++ b/tests/integration/update_cluster/nvidia/kubernetes.tf
@@ -328,6 +328,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -409,6 +410,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -808,7 +810,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -463,6 +463,7 @@ resource "aws_launch_template" "bastion-private-shared-ip-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -538,6 +539,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-ip-exam
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -619,6 +621,7 @@ resource "aws_launch_template" "nodes-private-shared-ip-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1158,7 +1161,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -458,6 +458,7 @@ resource "aws_launch_template" "bastion-private-shared-subnet-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -533,6 +534,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-private-shared-subnet-
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -614,6 +616,7 @@ resource "aws_launch_template" "nodes-private-shared-subnet-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1069,7 +1072,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -486,6 +486,7 @@ resource "aws_launch_template" "bastion-privatecalico-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -561,6 +562,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecalico-example-
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -642,6 +644,7 @@ resource "aws_launch_template" "nodes-privatecalico-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1224,7 +1227,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -486,6 +486,7 @@ resource "aws_launch_template" "bastion-privatecanal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -561,6 +562,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecanal-example-c
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -642,6 +644,7 @@ resource "aws_launch_template" "nodes-privatecanal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1215,7 +1218,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -486,6 +486,7 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -561,6 +562,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -642,6 +644,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1215,7 +1218,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -486,6 +486,7 @@ resource "aws_launch_template" "bastion-privatecilium-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -561,6 +562,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatecilium-example-
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -642,6 +644,7 @@ resource "aws_launch_template" "nodes-privatecilium-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1222,7 +1225,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -502,6 +502,7 @@ resource "aws_launch_template" "bastion-privateciliumadvanced-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -577,6 +578,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateciliumadvanced-
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -658,6 +660,7 @@ resource "aws_launch_template" "nodes-privateciliumadvanced-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1245,7 +1248,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -542,6 +542,7 @@ resource "aws_launch_template" "bastion-privatedns1-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -623,6 +624,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns1-example-co
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -710,6 +712,7 @@ resource "aws_launch_template" "nodes-privatedns1-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1318,7 +1321,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -472,6 +472,7 @@ resource "aws_launch_template" "bastion-privatedns2-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -547,6 +548,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatedns2-example-co
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -628,6 +630,7 @@ resource "aws_launch_template" "nodes-privatedns2-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1167,7 +1170,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -486,6 +486,7 @@ resource "aws_launch_template" "bastion-privateflannel-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -561,6 +562,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateflannel-example
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -642,6 +644,7 @@ resource "aws_launch_template" "nodes-privateflannel-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1215,7 +1218,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -492,6 +492,7 @@ resource "aws_launch_template" "bastion-privatekopeio-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -567,6 +568,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privatekopeio-example-
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -648,6 +650,7 @@ resource "aws_launch_template" "nodes-privatekopeio-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1263,7 +1266,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -486,6 +486,7 @@ resource "aws_launch_template" "bastion-privateweave-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -561,6 +562,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-privateweave-example-c
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -642,6 +644,7 @@ resource "aws_launch_template" "nodes-privateweave-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1215,7 +1218,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -370,6 +370,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -451,6 +452,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -854,7 +856,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -309,6 +309,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedsubnet-example-c
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -390,6 +391,7 @@ resource "aws_launch_template" "nodes-sharedsubnet-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -711,7 +713,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -309,6 +309,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-sharedvpc-example-com"
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -390,6 +391,7 @@ resource "aws_launch_template" "nodes-sharedvpc-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -752,7 +754,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -463,6 +463,7 @@ resource "aws_launch_template" "bastion-unmanaged-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -538,6 +539,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-unmanaged-example-com"
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -619,6 +621,7 @@ resource "aws_launch_template" "nodes-unmanaged-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -1126,7 +1129,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -344,6 +344,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -425,6 +426,7 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
   }
   metadata_options {
     http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
     http_put_response_hop_limit = 1
     http_tokens                 = "optional"
   }
@@ -828,7 +830,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -250,7 +250,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }
@@ -324,7 +324,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform.go
@@ -123,6 +123,8 @@ type terraformLaunchTemplateInstanceMetadata struct {
 	HTTPPutResponseHopLimit *int64 `json:"http_put_response_hop_limit,omitempty" cty:"http_put_response_hop_limit"`
 	// HTTPTokens is the state of token usage for your instance metadata requests.
 	HTTPTokens *string `json:"http_tokens,omitempty" cty:"http_tokens"`
+	// HTTPProtocolIPv6 enables the IPv6 instance metadata endpoint
+	HTTPProtocolIPv6 *string `json:"http_protocol_ipv6,omitempty" cty:"http_protocol_ipv6"`
 }
 
 type terraformLaunchTemplate struct {
@@ -199,6 +201,7 @@ func (t *LaunchTemplate) RenderTerraform(target *terraform.TerraformTarget, a, e
 			HTTPEndpoint:            fi.String("enabled"),
 			HTTPTokens:              e.HTTPTokens,
 			HTTPPutResponseHopLimit: e.HTTPPutResponseHopLimit,
+			HTTPProtocolIPv6:        e.HTTPProtocolIPv6,
 		},
 		NetworkInterfaces: []*terraformLaunchTemplateNetworkInterface{
 			{

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -98,7 +98,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }
@@ -184,7 +184,7 @@ terraform {
   required_providers {
     aws = {
       "source"  = "hashicorp/aws"
-      "version" = ">= 3.34.0"
+      "version" = ">= 3.59.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -109,7 +109,7 @@ func (t *TerraformTarget) finishHCL2() error {
 	} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
 		writeMap(requiredProvidersBody, "aws", map[string]cty.Value{
 			"source":  cty.StringVal("hashicorp/aws"),
-			"version": cty.StringVal(">= 3.34.0"),
+			"version": cty.StringVal(">= 3.59.0"),
 		})
 		if featureflag.Spotinst.Enabled() {
 			writeMap(requiredProvidersBody, "spotinst", map[string]cty.Value{

--- a/upup/pkg/fi/cloudup/terraform/target_json.go
+++ b/upup/pkg/fi/cloudup/terraform/target_json.go
@@ -91,7 +91,7 @@ func (t *TerraformTarget) finishJSON() error {
 	} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
 		requiredProviderAWS := make(map[string]interface{})
 		requiredProviderAWS["source"] = "hashicorp/aws"
-		requiredProviderAWS["version"] = ">= 2.46.0"
+		requiredProviderAWS["version"] = ">= 3.59.0"
 		for k, v := range tfGetProviderExtraConfig(t.clusterSpecTarget) {
 			requiredProviderAWS[k] = v
 		}


### PR DESCRIPTION
Cherry pick of #12298 on release-1.22.

#12298: Add IPv6 IMDS terraform support

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```