### PR TITLE
Skip SCTP e2e tests on cilium + k8s 1.23

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -49,19 +49,19 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|external.IP.is.not.assigned.to.a.node"
 		// https://github.com/cilium/cilium/issues/14287
 		skipRegex += "|same.port.number.but.different.protocols|same.hostPort.but.different.hostIP.and.protocol"
+		if strings.HasSuffix(cluster.Spec.KubernetesVersion, "v1.23.0") {
+			// Reassess after https://github.com/kubernetes/kubernetes/pull/102643 is merged
+			// ref:
+			// https://github.com/kubernetes/kubernetes/issues/96717
+			// https://github.com/cilium/cilium/issues/5719
+			skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
+		}
 	} else if networking.Calico != nil {
 		skipRegex += "|Services.*functioning.*NodePort"
 	} else if networking.Kuberouter != nil {
 		skipRegex += "|load-balancer|hairpin|affinity\\stimeout|service\\.kubernetes\\.io|CLOSE_WAIT"
 	} else if networking.Kubenet != nil {
 		skipRegex += "|Services.*affinity"
-	}
-
-	if strings.HasSuffix(cluster.Spec.KubernetesVersion, "v1.23.0-alpha.0") {
-		// This matches `k8s_version='latest'` in build_jobs.py
-		// TODO(rifelpet): Remove once the next 1.23 pre-release tag has been created
-		// ref: https://github.com/kubernetes/kubernetes/pull/104061
-		skipRegex += "|MetricsGrabber.should.grab.all.metrics.from.a.ControllerManager"
 	}
 
 	// Ensure it is valid regex


### PR DESCRIPTION
The SCTP tests in k8s 1.23 are currently failing in all cilium jobs (examples: [kops-warm-pool](https://testgrid.k8s.io/kops-misc#kops-warm-pool), [kops-grid-scenario-cilium10-amd64](https://testgrid.k8s.io/kops-misc#kops-grid-scenario-cilium10-amd64), [kops-aws-external-dns](https://testgrid.k8s.io/kops-misc#kops-aws-external-dns))

The cilium issue linked in the comments suggests that SCTP support is not yet supported, so we can skip them for now. There is also a k/k PR that cleans up the SCTP tests that we can keep an eye on and reevaluate whether we need this skip once it merges.

Also removing the MetricsGrabber skip now that the fix is in 1.23.0-alpha.2.
