### PR TITLE
Use EC2 and Metadata IPv6 endpoints in IPv6 mode for EBS CSI Driver

### DIFF
--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -295,6 +295,14 @@ spec:
             - --logtostderr
             - --v=2
           env:
+            {{- if IsIPv6Only }}
+            # TODO: Replace with "AWS_USE_DUALSTACK_ENDPOINT=true" when the relevant PR is merged:
+            # https://github.com/aws/aws-sdk-go/pull/3938
+            - name: AWS_EC2_ENDPOINT
+              value: https://api.ec2.{{ Region }}.aws
+            - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
+              value: IPv6
+            {{- end }}
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
             - name: CSI_NODE_NAME
@@ -435,6 +443,10 @@ spec:
             - "--extra-tags={{ CloudLabels }}"
             - --v=5
           env:
+            {{- if IsIPv6Only }}
+            - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
+              value: IPv6
+            {{- end }}
             - name: CSI_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
/cc @olemarkus @rifelpet 