### PR TITLE
Fix controller defaults for both bootstrap tokens and ipv6

### DIFF
--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -157,13 +157,17 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 	}
 
 	if len(kcm.Controllers) == 0 {
+		var changes []string
 		// @check if the node authorization is enabled and if so enable the tokencleaner controller (disabled by default)
 		// This is responsible for cleaning up bootstrap tokens which have expired
 		if fi.BoolValue(clusterSpec.KubeAPIServer.EnableBootstrapAuthToken) {
-			kcm.Controllers = []string{"*", "tokencleaner"}
+			changes = append(changes, "tokencleaner")
 		}
 		if clusterSpec.PodCIDRFromCloud {
-			kcm.Controllers = []string{"*", "-nodeipam"}
+			changes = append(changes, "-nodeipam")
+		}
+		if len(changes) != 0 {
+			kcm.Controllers = append([]string{"*"}, changes...)
 		}
 	}
 


### PR DESCRIPTION
The previous logic would override the controller slice in each
condition, instead of building it up.
