### PR TITLE
Recognize pending EC2 instances as needed deletion

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -394,7 +394,7 @@ func ListInstances(cloud fi.Cloud, clusterName string) ([]*resources.Resource, e
 					case "terminated", "shutting-down":
 						continue
 
-					case "running", "stopped":
+					case "running", "stopped", "pending":
 						// We need to delete
 						klog.V(4).Infof("instance %q has state=%q", id, stateName)
 


### PR DESCRIPTION
They should be deleted as they will presumably be running shortly.

Also, this function is used from `kops dump cluster` where presumably
instances are more likely to be pending.
