### PR TITLE
Automated cherry pick of #12357: Recognize pending EC2 instances as needed deletion

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -394,7 +394,7 @@ func ListInstances(cloud fi.Cloud, clusterName string) ([]*resources.Resource, e
 					case "terminated", "shutting-down":
 						continue
 
-					case "running", "stopped":
+					case "running", "stopped", "pending":
 						// We need to delete
 						klog.V(4).Infof("instance %q has state=%q", id, stateName)
 


### PR DESCRIPTION
Cherry pick of #12357 on release-1.22.

#12357: Recognize pending EC2 instances as needed deletion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.