### PR TITLE
Automated cherry pick of #12355: Only add IPv6 IAM permissions if using IPv6

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -287,7 +287,7 @@ func NewPolicy(clusterName string) *Policy {
 func (r *NodeRoleAPIServer) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	p := NewPolicy(b.Cluster.GetClusterName())
 
-	addNodeupPermissions(p, r.warmPool)
+	b.addNodeupPermissions(p, r.warmPool)
 
 	var err error
 	if p, err = b.AddS3Permissions(p); err != nil {
@@ -328,7 +328,7 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	p := NewPolicy(clusterName)
 
 	addEtcdManagerPermissions(p)
-	addNodeupPermissions(p, false)
+	b.addNodeupPermissions(p, false)
 
 	var err error
 	if p, err = b.AddS3Permissions(p); err != nil {
@@ -396,7 +396,7 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	p := NewPolicy(b.Cluster.GetClusterName())
 
-	addNodeupPermissions(p, r.enableLifecycleHookPermissions)
+	b.addNodeupPermissions(p, r.enableLifecycleHookPermissions)
 
 	var err error
 	if p, err = b.AddS3Permissions(p); err != nil {
@@ -771,7 +771,7 @@ func addCalicoSrcDstCheckPermissions(p *Policy) {
 	)
 }
 
-func addNodeupPermissions(p *Policy, enableHookSupport bool) {
+func (b *PolicyBuilder) addNodeupPermissions(p *Policy, enableHookSupport bool) {
 	addCertIAMPolicies(p)
 	addKMSGenerateRandomPolicies(p)
 	addASLifecyclePolicies(p, enableHookSupport)
@@ -779,6 +779,13 @@ func addNodeupPermissions(p *Policy, enableHookSupport bool) {
 		"ec2:DescribeInstances", // aws.go
 		"ec2:DescribeInstanceTypes",
 	)
+
+	if b.Cluster.Spec.PodCIDRFromCloud {
+		p.unconditionalAction.Insert(
+			"ec2:DescribeNetworkInterfaces",
+			"ec2:AssignIpv6Addresses",
+		)
+	}
 }
 
 func addEtcdManagerPermissions(p *Policy) {


### PR DESCRIPTION
Cherry pick of #12355 on release-1.22.

#12355: Only add IPv6 IAM permissions if using IPv6

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.