### PR TITLE
Automated cherry pick of #12322: Add support for writing lists of terraform literals

### DIFF
--- a/docs/releases/1.22-NOTES.md
+++ b/docs/releases/1.22-NOTES.md
@@ -69,6 +69,9 @@ kOps can now provision instances with nvidia GPUs and configure it for container
 
 # Required actions
 
+* Terraform support now requires Terraform >=0.15.0.
+  Users on older versions must follow Terraform's recommended upgrade path of applying one minor version at a time prior to running `kops update cluster --target terraform`.
+
 * The kOps Terraform support now renders managed files through the Terraform configuration instead 
   of writing them to S3 directly. If, after upgrading kOps and applying a new Terraform plan,
   you subsequently downgrade to an earlier version of kOps, the generated plan will delete these

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -4396,11 +4396,18 @@ spec:
                     description: TerraformSpec allows us to specify terraform config
                       in an extensible way
                     properties:
+                      filesProviderExtraConfig:
+                        additionalProperties:
+                          type: string
+                        description: FilesProviderExtraConfig contains key/value pairs
+                          to add to the terraform provider block used for managed
+                          files
+                        type: object
                       providerExtraConfig:
                         additionalProperties:
                           type: string
                         description: ProviderExtraConfig contains key/value pairs
-                          to add to the rendered terraform "provider" block
+                          to add to the main terraform provider block
                         type: object
                     type: object
                 type: object

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -694,8 +694,10 @@ func (t *TargetSpec) IsEmpty() bool {
 
 // TerraformSpec allows us to specify terraform config in an extensible way
 type TerraformSpec struct {
-	// ProviderExtraConfig contains key/value pairs to add to the rendered terraform "provider" block
+	// ProviderExtraConfig contains key/value pairs to add to the main terraform provider block
 	ProviderExtraConfig *map[string]string `json:"providerExtraConfig,omitempty"`
+	// FilesProviderExtraConfig contains key/value pairs to add to the terraform provider block used for managed files
+	FilesProviderExtraConfig *map[string]string `json:"filesProviderExtraConfig,omitempty"`
 }
 
 func (t *TerraformSpec) IsEmpty() bool {

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -677,8 +677,10 @@ func (t *TargetSpec) IsEmpty() bool {
 
 // TerraformSpec allows us to specify terraform config in an extensible way
 type TerraformSpec struct {
-	// ProviderExtraConfig contains key/value pairs to add to the rendered terraform "provider" block
+	// ProviderExtraConfig contains key/value pairs to add to the main terraform provider block
 	ProviderExtraConfig *map[string]string `json:"providerExtraConfig,omitempty"`
+	// FilesProviderExtraConfig contains key/value pairs to add to the terraform provider block used for managed files
+	FilesProviderExtraConfig *map[string]string `json:"filesProviderExtraConfig,omitempty"`
 }
 
 func (t *TerraformSpec) IsEmpty() bool {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6756,6 +6756,7 @@ func Convert_kops_TargetSpec_To_v1alpha2_TargetSpec(in *kops.TargetSpec, out *Ta
 
 func autoConvert_v1alpha2_TerraformSpec_To_kops_TerraformSpec(in *TerraformSpec, out *kops.TerraformSpec, s conversion.Scope) error {
 	out.ProviderExtraConfig = in.ProviderExtraConfig
+	out.FilesProviderExtraConfig = in.FilesProviderExtraConfig
 	return nil
 }
 
@@ -6766,6 +6767,7 @@ func Convert_v1alpha2_TerraformSpec_To_kops_TerraformSpec(in *TerraformSpec, out
 
 func autoConvert_kops_TerraformSpec_To_v1alpha2_TerraformSpec(in *kops.TerraformSpec, out *TerraformSpec, s conversion.Scope) error {
 	out.ProviderExtraConfig = in.ProviderExtraConfig
+	out.FilesProviderExtraConfig = in.FilesProviderExtraConfig
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4699,6 +4699,17 @@ func (in *TerraformSpec) DeepCopyInto(out *TerraformSpec) {
 			}
 		}
 	}
+	if in.FilesProviderExtraConfig != nil {
+		in, out := &in.FilesProviderExtraConfig, &out.FilesProviderExtraConfig
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4881,6 +4881,17 @@ func (in *TerraformSpec) DeepCopyInto(out *TerraformSpec) {
 			}
 		}
 	}
+	if in.FilesProviderExtraConfig != nil {
+		in, out := &in.FilesProviderExtraConfig, &out.FilesProviderExtraConfig
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
+		}
+	}
 	return
 }
 

--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -559,6 +564,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -566,6 +572,7 @@ resource "aws_s3_bucket_object" "discovery-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -573,6 +580,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -580,6 +588,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -587,6 +596,7 @@ resource "aws_s3_bucket_object" "keys-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -594,6 +604,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -601,6 +612,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -608,6 +620,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -615,6 +628,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -622,6 +636,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-aws-load-balancer-co
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -629,6 +644,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -636,6 +652,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-certmanager-io-k8s-1
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/certmanager.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -643,6 +660,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -650,6 +668,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -657,6 +676,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -664,6 +684,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -671,6 +692,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -678,6 +700,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -685,6 +708,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -692,6 +716,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -699,6 +724,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -892,11 +918,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-bastionuserdata-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -768,6 +773,7 @@ resource "aws_s3_bucket_object" "bastionuserdata-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -775,6 +781,7 @@ resource "aws_s3_bucket_object" "bastionuserdata-example-com-addons-core-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -782,6 +789,7 @@ resource "aws_s3_bucket_object" "bastionuserdata-example-com-addons-coredns-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -789,6 +797,7 @@ resource "aws_s3_bucket_object" "bastionuserdata-example-com-addons-dns-controll
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -796,6 +805,7 @@ resource "aws_s3_bucket_object" "bastionuserdata-example-com-addons-kops-control
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -803,6 +813,7 @@ resource "aws_s3_bucket_object" "bastionuserdata-example-com-addons-kubelet-api-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -810,6 +821,7 @@ resource "aws_s3_bucket_object" "bastionuserdata-example-com-addons-limit-range-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -817,6 +829,7 @@ resource "aws_s3_bucket_object" "bastionuserdata-example-com-addons-storage-aws-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -824,6 +837,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -831,6 +845,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -838,6 +853,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -845,6 +861,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -852,6 +869,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -859,6 +877,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -866,6 +885,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -873,6 +893,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-bastion" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-bastion_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/igconfig/bastion/bastion/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -880,6 +901,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -887,6 +909,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/bastionuserdata.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1215,11 +1238,12 @@ resource "aws_vpc_dhcp_options_association" "bastionuserdata-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -220,6 +220,12 @@ spec:
     name: us-east-1a-utility
     type: Utility
     zone: us-test-1a
+  target:
+    terraform:
+      filesProviderExtraConfig:
+        profile: foo
+      providerExtraConfig:
+        max_retries: "10"
   topology:
     dns:
       type: Public

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -67,6 +67,12 @@ spec:
   sshAccess:
   - 1.1.1.1/32
   sshKeyName: ""
+  target:
+    terraform:
+      providerExtraConfig:
+        max_retries: "10"
+      filesProviderExtraConfig:
+        profile: "foo"
   topology:
     masters: public
     nodes: public

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -67,6 +67,12 @@ spec:
   sshAccess:
   - 1.1.1.1/32
   sshKeyName: ""
+  target:
+    terraform:
+      providerExtraConfig:
+        max_retries: "10"
+      filesProviderExtraConfig:
+        profile: "foo"
   topology:
     masters: public
     nodes: public

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -92,7 +92,14 @@ output "vpc_id" {
 }
 
 provider "aws" {
-  region = "us-test-1"
+  region      = "us-test-1"
+  max_retries = "10"
+}
+
+provider "aws" {
+  alias   = "files"
+  region  = "us-test-1"
+  profile = "foo"
 }
 
 resource "aws_autoscaling_group" "master-us-test-1a-masters-complex-example-com" {
@@ -679,6 +686,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/complex.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -686,6 +694,7 @@ resource "aws_s3_bucket_object" "complex-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/complex.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -693,6 +702,7 @@ resource "aws_s3_bucket_object" "complex-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_complex.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/complex.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -700,6 +710,7 @@ resource "aws_s3_bucket_object" "complex-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_complex.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/complex.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -707,6 +718,7 @@ resource "aws_s3_bucket_object" "complex-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/complex.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -714,6 +726,7 @@ resource "aws_s3_bucket_object" "complex-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/complex.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -721,6 +734,7 @@ resource "aws_s3_bucket_object" "complex-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_complex.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/complex.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -728,6 +742,7 @@ resource "aws_s3_bucket_object" "complex-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_complex.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/complex.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -735,6 +750,7 @@ resource "aws_s3_bucket_object" "complex-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_complex.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/complex.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -742,6 +758,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/complex.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -749,6 +766,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/complex.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -756,6 +774,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/complex.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -763,6 +782,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/complex.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -770,6 +790,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/complex.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -777,6 +798,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/complex.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -784,6 +806,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/complex.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -791,6 +814,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/complex.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1129,11 +1153,12 @@ resource "aws_vpc_ipv4_cidr_block_association" "cidr-10-2-0-0--16" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-compress-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -474,6 +479,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/compress.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -481,6 +487,7 @@ resource "aws_s3_bucket_object" "compress-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/compress.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -488,6 +495,7 @@ resource "aws_s3_bucket_object" "compress-example-com-addons-core-addons-k8s-io"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_compress.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/compress.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -495,6 +503,7 @@ resource "aws_s3_bucket_object" "compress-example-com-addons-coredns-addons-k8s-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_compress.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/compress.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -502,6 +511,7 @@ resource "aws_s3_bucket_object" "compress-example-com-addons-dns-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/compress.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -509,6 +519,7 @@ resource "aws_s3_bucket_object" "compress-example-com-addons-kops-controller-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/compress.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -516,6 +527,7 @@ resource "aws_s3_bucket_object" "compress-example-com-addons-kubelet-api-rbac-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_compress.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/compress.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -523,6 +535,7 @@ resource "aws_s3_bucket_object" "compress-example-com-addons-limit-range-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_compress.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/compress.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -530,6 +543,7 @@ resource "aws_s3_bucket_object" "compress-example-com-addons-storage-aws-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_compress.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/compress.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -537,6 +551,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/compress.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -544,6 +559,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/compress.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -551,6 +567,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/compress.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -558,6 +575,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/compress.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -565,6 +583,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/compress.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -572,6 +591,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/compress.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -579,6 +599,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/compress.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -586,6 +607,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/compress.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -779,11 +801,12 @@ resource "aws_vpc_dhcp_options_association" "compress-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/digit/kubernetes.tf
+++ b/tests/integration/update_cluster/digit/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-123-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -558,6 +563,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/123.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -565,6 +571,7 @@ resource "aws_s3_bucket_object" "discovery-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/123.example.com/.well-known/openid-configuration"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -572,6 +579,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/123.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -579,6 +587,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/123.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -586,6 +595,7 @@ resource "aws_s3_bucket_object" "keys-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/123.example.com/openid/v1/jwks"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -593,6 +603,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/123.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -600,6 +611,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/123.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -607,6 +619,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/123.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -614,6 +627,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/123.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -621,6 +635,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/123.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -628,6 +643,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/123.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -635,6 +651,7 @@ resource "aws_s3_bucket_object" "prefix_123-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/123.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -642,6 +659,7 @@ resource "aws_s3_bucket_object" "prefix_123-example-com-addons-core-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_123.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/123.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -649,6 +667,7 @@ resource "aws_s3_bucket_object" "prefix_123-example-com-addons-coredns-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_123.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/123.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -656,6 +675,7 @@ resource "aws_s3_bucket_object" "prefix_123-example-com-addons-dns-controller-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/123.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -663,6 +683,7 @@ resource "aws_s3_bucket_object" "prefix_123-example-com-addons-kops-controller-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/123.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -670,6 +691,7 @@ resource "aws_s3_bucket_object" "prefix_123-example-com-addons-kubelet-api-rbac-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_123.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/123.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -677,6 +699,7 @@ resource "aws_s3_bucket_object" "prefix_123-example-com-addons-limit-range-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_123.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/123.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -684,6 +707,7 @@ resource "aws_s3_bucket_object" "prefix_123-example-com-addons-storage-aws-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_123.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/123.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -877,11 +901,12 @@ resource "aws_vpc_dhcp_options_association" "prefix_123-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -70,6 +70,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-existing-iam-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -798,6 +803,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "tests/existing-iam.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -805,6 +811,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "tests/existing-iam.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -812,6 +819,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "tests/existing-iam.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -819,6 +827,7 @@ resource "aws_s3_bucket_object" "existing-iam-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content")
   key                    = "tests/existing-iam.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -826,6 +835,7 @@ resource "aws_s3_bucket_object" "existing-iam-example-com-addons-core-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existing-iam.example.com-addons-core.addons.k8s.io_content")
   key                    = "tests/existing-iam.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -833,6 +843,7 @@ resource "aws_s3_bucket_object" "existing-iam-example-com-addons-coredns-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existing-iam.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/existing-iam.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -840,6 +851,7 @@ resource "aws_s3_bucket_object" "existing-iam-example-com-addons-dns-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/existing-iam.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -847,6 +859,7 @@ resource "aws_s3_bucket_object" "existing-iam-example-com-addons-kops-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "tests/existing-iam.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -854,6 +867,7 @@ resource "aws_s3_bucket_object" "existing-iam-example-com-addons-kubelet-api-rba
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existing-iam.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "tests/existing-iam.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -861,6 +875,7 @@ resource "aws_s3_bucket_object" "existing-iam-example-com-addons-limit-range-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existing-iam.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "tests/existing-iam.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -868,6 +883,7 @@ resource "aws_s3_bucket_object" "existing-iam-example-com-addons-storage-aws-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existing-iam.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "tests/existing-iam.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -875,6 +891,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "tests/existing-iam.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -882,6 +899,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "tests/existing-iam.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -889,6 +907,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "tests/existing-iam.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -896,6 +915,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "tests/existing-iam.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -903,6 +923,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "tests/existing-iam.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -910,6 +931,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1b" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1b_content")
   key                    = "tests/existing-iam.example.com/igconfig/master/master-us-test-1b/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -917,6 +939,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1c" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1c_content")
   key                    = "tests/existing-iam.example.com/igconfig/master/master-us-test-1c/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -924,6 +947,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "tests/existing-iam.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1145,11 +1169,12 @@ resource "aws_vpc_dhcp_options_association" "existing-iam-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -90,6 +90,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-existingsg-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -910,6 +915,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/existingsg.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -917,6 +923,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/existingsg.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -924,6 +931,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/existingsg.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -931,6 +939,7 @@ resource "aws_s3_bucket_object" "existingsg-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/existingsg.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -938,6 +947,7 @@ resource "aws_s3_bucket_object" "existingsg-example-com-addons-core-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existingsg.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/existingsg.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -945,6 +955,7 @@ resource "aws_s3_bucket_object" "existingsg-example-com-addons-coredns-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existingsg.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/existingsg.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -952,6 +963,7 @@ resource "aws_s3_bucket_object" "existingsg-example-com-addons-dns-controller-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/existingsg.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -959,6 +971,7 @@ resource "aws_s3_bucket_object" "existingsg-example-com-addons-kops-controller-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/existingsg.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -966,6 +979,7 @@ resource "aws_s3_bucket_object" "existingsg-example-com-addons-kubelet-api-rbac-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existingsg.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/existingsg.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -973,6 +987,7 @@ resource "aws_s3_bucket_object" "existingsg-example-com-addons-limit-range-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existingsg.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/existingsg.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -980,6 +995,7 @@ resource "aws_s3_bucket_object" "existingsg-example-com-addons-storage-aws-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_existingsg.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/existingsg.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -987,6 +1003,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/existingsg.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -994,6 +1011,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/existingsg.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1001,6 +1019,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/existingsg.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1008,6 +1027,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/existingsg.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1015,6 +1035,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/existingsg.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1022,6 +1043,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1b" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1b_content")
   key                    = "clusters.example.com/existingsg.example.com/igconfig/master/master-us-test-1b/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1029,6 +1051,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1c" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1c_content")
   key                    = "clusters.example.com/existingsg.example.com/igconfig/master/master-us-test-1c/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1036,6 +1059,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/existingsg.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1516,11 +1540,12 @@ resource "aws_vpc_dhcp_options_association" "existingsg-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/external_dns/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -486,6 +491,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -493,6 +499,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -500,6 +507,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -507,6 +515,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -514,6 +523,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -521,6 +531,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -528,6 +539,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -535,6 +547,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -542,6 +555,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -549,6 +563,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -556,6 +571,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-external-dns-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/external-dns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -563,6 +579,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -570,6 +587,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -577,6 +595,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -584,6 +603,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -591,6 +611,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -598,6 +619,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -791,11 +813,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
@@ -100,6 +100,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -533,6 +538,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -540,6 +546,7 @@ resource "aws_s3_bucket_object" "discovery-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -547,6 +554,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -554,6 +562,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -561,6 +570,7 @@ resource "aws_s3_bucket_object" "keys-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -568,6 +578,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -575,6 +586,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -582,6 +594,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -589,6 +602,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -596,6 +610,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -603,6 +618,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -610,6 +626,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -617,6 +634,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-external-dns-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/external-dns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -624,6 +642,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -631,6 +650,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -638,6 +658,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -645,6 +666,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -652,6 +674,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -659,6 +682,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -852,11 +876,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-externallb-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -490,6 +495,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/externallb.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -497,6 +503,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/externallb.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -504,6 +511,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/externallb.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -511,6 +519,7 @@ resource "aws_s3_bucket_object" "externallb-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/externallb.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -518,6 +527,7 @@ resource "aws_s3_bucket_object" "externallb-example-com-addons-core-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externallb.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/externallb.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -525,6 +535,7 @@ resource "aws_s3_bucket_object" "externallb-example-com-addons-coredns-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externallb.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/externallb.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -532,6 +543,7 @@ resource "aws_s3_bucket_object" "externallb-example-com-addons-dns-controller-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/externallb.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -539,6 +551,7 @@ resource "aws_s3_bucket_object" "externallb-example-com-addons-kops-controller-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/externallb.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -546,6 +559,7 @@ resource "aws_s3_bucket_object" "externallb-example-com-addons-kubelet-api-rbac-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externallb.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/externallb.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -553,6 +567,7 @@ resource "aws_s3_bucket_object" "externallb-example-com-addons-limit-range-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externallb.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/externallb.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -560,6 +575,7 @@ resource "aws_s3_bucket_object" "externallb-example-com-addons-storage-aws-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externallb.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/externallb.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -567,6 +583,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/externallb.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -574,6 +591,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/externallb.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -581,6 +599,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/externallb.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -588,6 +607,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/externallb.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -595,6 +615,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/externallb.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -602,6 +623,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/externallb.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -795,11 +817,12 @@ resource "aws_vpc_dhcp_options_association" "externallb-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-externalpolicies-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -587,6 +592,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/externalpolicies.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -594,6 +600,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/externalpolicies.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -601,6 +608,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/externalpolicies.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -608,6 +616,7 @@ resource "aws_s3_bucket_object" "externalpolicies-example-com-addons-bootstrap" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/externalpolicies.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -615,6 +624,7 @@ resource "aws_s3_bucket_object" "externalpolicies-example-com-addons-core-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externalpolicies.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/externalpolicies.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -622,6 +632,7 @@ resource "aws_s3_bucket_object" "externalpolicies-example-com-addons-coredns-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externalpolicies.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/externalpolicies.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -629,6 +640,7 @@ resource "aws_s3_bucket_object" "externalpolicies-example-com-addons-dns-control
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/externalpolicies.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -636,6 +648,7 @@ resource "aws_s3_bucket_object" "externalpolicies-example-com-addons-kops-contro
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/externalpolicies.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -643,6 +656,7 @@ resource "aws_s3_bucket_object" "externalpolicies-example-com-addons-kubelet-api
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/externalpolicies.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -650,6 +664,7 @@ resource "aws_s3_bucket_object" "externalpolicies-example-com-addons-limit-range
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externalpolicies.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/externalpolicies.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -657,6 +672,7 @@ resource "aws_s3_bucket_object" "externalpolicies-example-com-addons-storage-aws
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_externalpolicies.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/externalpolicies.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -664,6 +680,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/externalpolicies.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -671,6 +688,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/externalpolicies.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -678,6 +696,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/externalpolicies.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -685,6 +704,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/externalpolicies.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -692,6 +712,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/externalpolicies.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -699,6 +720,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/externalpolicies.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -987,11 +1009,12 @@ resource "aws_vpc_dhcp_options_association" "externalpolicies-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -90,6 +90,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-ha-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -870,6 +875,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "tests/ha.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -877,6 +883,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "tests/ha.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -884,6 +891,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "tests/ha.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -891,6 +899,7 @@ resource "aws_s3_bucket_object" "ha-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content")
   key                    = "tests/ha.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -898,6 +907,7 @@ resource "aws_s3_bucket_object" "ha-example-com-addons-core-addons-k8s-io" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha.example.com-addons-core.addons.k8s.io_content")
   key                    = "tests/ha.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -905,6 +915,7 @@ resource "aws_s3_bucket_object" "ha-example-com-addons-coredns-addons-k8s-io-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/ha.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -912,6 +923,7 @@ resource "aws_s3_bucket_object" "ha-example-com-addons-dns-controller-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/ha.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -919,6 +931,7 @@ resource "aws_s3_bucket_object" "ha-example-com-addons-kops-controller-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "tests/ha.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -926,6 +939,7 @@ resource "aws_s3_bucket_object" "ha-example-com-addons-kubelet-api-rbac-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "tests/ha.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -933,6 +947,7 @@ resource "aws_s3_bucket_object" "ha-example-com-addons-limit-range-addons-k8s-io
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "tests/ha.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -940,6 +955,7 @@ resource "aws_s3_bucket_object" "ha-example-com-addons-storage-aws-addons-k8s-io
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "tests/ha.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -947,6 +963,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "tests/ha.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -954,6 +971,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "tests/ha.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -961,6 +979,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "tests/ha.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -968,6 +987,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "tests/ha.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -975,6 +995,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "tests/ha.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -982,6 +1003,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1b" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1b_content")
   key                    = "tests/ha.example.com/igconfig/master/master-us-test-1b/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -989,6 +1011,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1c" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1c_content")
   key                    = "tests/ha.example.com/igconfig/master/master-us-test-1c/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -996,6 +1019,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "tests/ha.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1217,11 +1241,12 @@ resource "aws_vpc_dhcp_options_association" "ha-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -21,10 +21,16 @@ provider "google" {
   region  = "us-test1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "tests/ha-gce.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -32,6 +38,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "tests/ha-gce.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -39,6 +46,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "tests/ha-gce.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -46,6 +54,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content")
   key                    = "tests/ha-gce.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -53,6 +62,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-core-addons-k8s-io" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-core.addons.k8s.io_content")
   key                    = "tests/ha-gce.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -60,6 +70,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-coredns-addons-k8s-io
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/ha-gce.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -67,6 +78,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-dns-controller-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/ha-gce.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -74,6 +86,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-kops-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "tests/ha-gce.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -81,6 +94,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-kubelet-api-rbac-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "tests/ha-gce.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -88,6 +102,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-limit-range-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "tests/ha-gce.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -95,6 +110,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-metadata-proxy-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content")
   key                    = "tests/ha-gce.example.com/addons/metadata-proxy.addons.k8s.io/v0.1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -102,6 +118,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-rbac-addons-k8s-io-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-rbac.addons.k8s.io-k8s-1.8_content")
   key                    = "tests/ha-gce.example.com/addons/rbac.addons.k8s.io/k8s-1.8.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -109,6 +126,7 @@ resource "aws_s3_bucket_object" "ha-gce-example-com-addons-storage-gce-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_ha-gce.example.com-addons-storage-gce.addons.k8s.io-v1.7.0_content")
   key                    = "tests/ha-gce.example.com/addons/storage-gce.addons.k8s.io/v1.7.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -116,6 +134,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "tests/ha-gce.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -123,6 +142,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "tests/ha-gce.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -130,6 +150,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "tests/ha-gce.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -137,6 +158,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "tests/ha-gce.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -144,6 +166,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test1-a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test1-a_content")
   key                    = "tests/ha-gce.example.com/igconfig/master/master-us-test1-a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -151,6 +174,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test1-b" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test1-b_content")
   key                    = "tests/ha-gce.example.com/igconfig/master/master-us-test1-b/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -158,6 +182,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test1-c" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test1-c_content")
   key                    = "tests/ha-gce.example.com/igconfig/master/master-us-test1-c/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -165,6 +190,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "tests/ha-gce.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -744,7 +770,7 @@ resource "google_compute_network" "default" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -558,6 +563,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -565,6 +571,7 @@ resource "aws_s3_bucket_object" "discovery-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -572,6 +579,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -579,6 +587,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -586,6 +595,7 @@ resource "aws_s3_bucket_object" "keys-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -593,6 +603,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -600,6 +611,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -607,6 +619,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -614,6 +627,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -621,6 +635,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -628,6 +643,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -635,6 +651,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -642,6 +659,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -649,6 +667,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -656,6 +675,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -663,6 +683,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -670,6 +691,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -677,6 +699,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -684,6 +707,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -877,11 +901,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -45,6 +45,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_eip" "us-test-1a-lifecyclephases-example-com" {
   tags = {
     "KubernetesCluster"                                 = "lifecyclephases.example.com"
@@ -175,11 +180,12 @@ resource "aws_vpc_dhcp_options_association" "lifecyclephases-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
@@ -150,6 +150,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -663,6 +668,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -670,6 +676,7 @@ resource "aws_s3_bucket_object" "discovery-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -677,6 +684,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -684,6 +692,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -691,6 +700,7 @@ resource "aws_s3_bucket_object" "keys-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -698,6 +708,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -705,6 +716,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -712,6 +724,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -719,6 +732,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -726,6 +740,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-aws-cloud-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content")
   key                    = "clusters.example.com/minimal.example.com/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -733,6 +748,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-aws-ebs-csi-driver-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content")
   key                    = "clusters.example.com/minimal.example.com/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -740,6 +756,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-aws-load-balancer-co
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -747,6 +764,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -754,6 +772,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-certmanager-io-k8s-1
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/certmanager.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -761,6 +780,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-cluster-autoscaler-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content")
   key                    = "clusters.example.com/minimal.example.com/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -768,6 +788,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -775,6 +796,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -782,6 +804,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -789,6 +812,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -796,6 +820,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -803,6 +828,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -810,6 +836,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-networking-amazon-vp
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -817,6 +844,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-node-termination-han
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content")
   key                    = "clusters.example.com/minimal.example.com/addons/node-termination-handler.aws/k8s-1.11.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -824,6 +852,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-snapshot-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content")
   key                    = "clusters.example.com/minimal.example.com/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -831,6 +860,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -838,6 +868,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -845,6 +876,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1047,11 +1079,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -486,6 +491,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -493,6 +499,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -500,6 +507,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -507,6 +515,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -514,6 +523,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -521,6 +531,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -528,6 +539,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -535,6 +547,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-aws-cloud-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content")
   key                    = "clusters.example.com/minimal.example.com/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -542,6 +555,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-aws-ebs-csi-driver-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content")
   key                    = "clusters.example.com/minimal.example.com/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -549,6 +563,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-aws-load-balancer-co
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -556,6 +571,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -563,6 +579,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-certmanager-io-k8s-1
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/certmanager.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -570,6 +587,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-cluster-autoscaler-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content")
   key                    = "clusters.example.com/minimal.example.com/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -577,6 +595,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -584,6 +603,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -591,6 +611,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -598,6 +619,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -605,6 +627,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -612,6 +635,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -619,6 +643,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-networking-amazon-vp
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -626,6 +651,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-node-termination-han
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content")
   key                    = "clusters.example.com/minimal.example.com/addons/node-termination-handler.aws/k8s-1.11.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -633,6 +659,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-snapshot-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content")
   key                    = "clusters.example.com/minimal.example.com/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -640,6 +667,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -647,6 +675,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -654,6 +683,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -856,11 +886,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -486,6 +491,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -493,6 +499,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -500,6 +507,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -507,6 +515,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -514,6 +523,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -521,6 +531,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -528,6 +539,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -535,6 +547,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-aws-ebs-csi-driver-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content")
   key                    = "clusters.example.com/minimal.example.com/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -542,6 +555,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-aws-load-balancer-co
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -549,6 +563,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -556,6 +571,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-certmanager-io-k8s-1
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/certmanager.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -563,6 +579,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-cluster-autoscaler-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content")
   key                    = "clusters.example.com/minimal.example.com/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -570,6 +587,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -577,6 +595,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -584,6 +603,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -591,6 +611,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -598,6 +619,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -605,6 +627,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -612,6 +635,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-networking-amazon-vp
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -619,6 +643,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-node-termination-han
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-node-termination-handler.aws-k8s-1.11_content")
   key                    = "clusters.example.com/minimal.example.com/addons/node-termination-handler.aws/k8s-1.11.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -626,6 +651,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-snapshot-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content")
   key                    = "clusters.example.com/minimal.example.com/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -633,6 +659,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -640,6 +667,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -647,6 +675,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -849,11 +878,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -482,6 +487,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -489,6 +495,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -496,6 +503,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -503,6 +511,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -510,6 +519,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -517,6 +527,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -524,6 +535,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -531,6 +543,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -538,6 +551,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -545,6 +559,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -552,6 +567,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -559,6 +575,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -566,6 +583,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -573,6 +591,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -580,6 +599,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -587,6 +607,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -594,6 +615,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -787,11 +809,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-ipv6-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -551,6 +556,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -558,6 +564,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -565,6 +572,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -572,6 +580,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -579,6 +588,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -586,6 +596,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -593,6 +604,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -600,6 +612,7 @@ resource "aws_s3_bucket_object" "minimal-ipv6-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -607,6 +620,7 @@ resource "aws_s3_bucket_object" "minimal-ipv6-example-com-addons-core-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -614,6 +628,7 @@ resource "aws_s3_bucket_object" "minimal-ipv6-example-com-addons-coredns-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -621,6 +636,7 @@ resource "aws_s3_bucket_object" "minimal-ipv6-example-com-addons-dns-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -628,6 +644,7 @@ resource "aws_s3_bucket_object" "minimal-ipv6-example-com-addons-kops-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -635,6 +652,7 @@ resource "aws_s3_bucket_object" "minimal-ipv6-example-com-addons-kubelet-api-rba
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -642,6 +660,7 @@ resource "aws_s3_bucket_object" "minimal-ipv6-example-com-addons-limit-range-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -649,6 +668,7 @@ resource "aws_s3_bucket_object" "minimal-ipv6-example-com-addons-storage-aws-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -656,6 +676,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -663,6 +684,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal-ipv6.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -922,11 +944,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-ipv6-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-warmpool-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -486,6 +491,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -493,6 +499,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -500,6 +507,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -507,6 +515,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -514,6 +523,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -521,6 +531,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -528,6 +539,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -535,6 +547,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-aws-ebs-csi
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -542,6 +555,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-bootstrap" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -549,6 +563,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-core-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -556,6 +571,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-coredns-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -563,6 +579,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-dns-control
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -570,6 +587,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-kops-contro
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -577,6 +595,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-kubelet-api
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -584,6 +603,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-limit-range
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -591,6 +611,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-networking-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/networking.cilium.io/k8s-1.16-v1.10.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -598,6 +619,7 @@ resource "aws_s3_bucket_object" "minimal-warmpool-example-com-addons-storage-aws
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -605,6 +627,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -612,6 +635,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal-warmpool.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -805,11 +829,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-warmpool-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -486,6 +491,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -493,6 +499,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -500,6 +507,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -507,6 +515,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -514,6 +523,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -521,6 +531,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -528,6 +539,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -535,6 +547,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -542,6 +555,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -549,6 +563,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -556,6 +571,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -563,6 +579,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -570,6 +587,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -577,6 +595,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -584,6 +603,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -591,6 +611,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -598,6 +619,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -791,11 +813,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -21,10 +21,16 @@ provider "google" {
   region  = "us-test1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "tests/minimal-gce.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -32,6 +38,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "tests/minimal-gce.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -39,6 +46,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "tests/minimal-gce.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -46,6 +54,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "tests/minimal-gce.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -53,6 +62,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "tests/minimal-gce.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -60,6 +70,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "tests/minimal-gce.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -67,6 +78,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "tests/minimal-gce.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -74,6 +86,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content")
   key                    = "tests/minimal-gce.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -81,6 +94,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-core-addons-k8s-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-core.addons.k8s.io_content")
   key                    = "tests/minimal-gce.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -88,6 +102,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-coredns-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/minimal-gce.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -95,6 +110,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-dns-controller-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/minimal-gce.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -102,6 +118,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-kops-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "tests/minimal-gce.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -109,6 +126,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-kubelet-api-rbac
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "tests/minimal-gce.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -116,6 +134,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-limit-range-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "tests/minimal-gce.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -123,6 +142,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-metadata-proxy-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content")
   key                    = "tests/minimal-gce.example.com/addons/metadata-proxy.addons.k8s.io/v0.1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -130,6 +150,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-rbac-addons-k8s-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-rbac.addons.k8s.io-k8s-1.8_content")
   key                    = "tests/minimal-gce.example.com/addons/rbac.addons.k8s.io/k8s-1.8.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -137,6 +158,7 @@ resource "aws_s3_bucket_object" "minimal-gce-example-com-addons-storage-gce-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce.example.com-addons-storage-gce.addons.k8s.io-v1.7.0_content")
   key                    = "tests/minimal-gce.example.com/addons/storage-gce.addons.k8s.io/v1.7.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -144,6 +166,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test1-a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test1-a_content")
   key                    = "tests/minimal-gce.example.com/igconfig/master/master-us-test1-a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -151,6 +174,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "tests/minimal-gce.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -559,7 +583,7 @@ resource "google_compute_network" "default" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -21,10 +21,16 @@ provider "google" {
   region  = "us-test1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "tests/minimal-gce-private.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -32,6 +38,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "tests/minimal-gce-private.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -39,6 +46,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "tests/minimal-gce-private.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -46,6 +54,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "tests/minimal-gce-private.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -53,6 +62,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "tests/minimal-gce-private.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -60,6 +70,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "tests/minimal-gce-private.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -67,6 +78,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "tests/minimal-gce-private.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -74,6 +86,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-bootstra
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content")
   key                    = "tests/minimal-gce-private.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -81,6 +94,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-core-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-core.addons.k8s.io_content")
   key                    = "tests/minimal-gce-private.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -88,6 +102,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-coredns-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/minimal-gce-private.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -95,6 +110,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-dns-cont
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "tests/minimal-gce-private.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -102,6 +118,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-kops-con
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "tests/minimal-gce-private.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -109,6 +126,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-kubelet-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "tests/minimal-gce-private.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -116,6 +134,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-limit-ra
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "tests/minimal-gce-private.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -123,6 +142,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-metadata
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content")
   key                    = "tests/minimal-gce-private.example.com/addons/metadata-proxy.addons.k8s.io/v0.1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -130,6 +150,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-rbac.addons.k8s.io-k8s-1.8_content")
   key                    = "tests/minimal-gce-private.example.com/addons/rbac.addons.k8s.io/k8s-1.8.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -137,6 +158,7 @@ resource "aws_s3_bucket_object" "minimal-gce-private-example-com-addons-storage-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-storage-gce.addons.k8s.io-v1.7.0_content")
   key                    = "tests/minimal-gce-private.example.com/addons/storage-gce.addons.k8s.io/v1.7.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -144,6 +166,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test1-a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test1-a_content")
   key                    = "tests/minimal-gce-private.example.com/igconfig/master/master-us-test1-a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -151,6 +174,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "tests/minimal-gce-private.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -568,7 +592,7 @@ resource "google_compute_router_nat" "nat-minimal-gce-private-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     google = {
       "source"  = "hashicorp/google"

--- a/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-k8s-local" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -486,6 +491,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.k8s.local/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -493,6 +499,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.k8s.local/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -500,6 +507,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.k8s.local/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -507,6 +515,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.k8s.local/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -514,6 +523,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.k8s.local/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -521,6 +531,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.k8s.local/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -528,6 +539,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.k8s.local/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -535,6 +547,7 @@ resource "aws_s3_bucket_object" "minimal-k8s-local-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.k8s.local/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -542,6 +555,7 @@ resource "aws_s3_bucket_object" "minimal-k8s-local-addons-core-addons-k8s-io" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.k8s.local-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.k8s.local/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -549,6 +563,7 @@ resource "aws_s3_bucket_object" "minimal-k8s-local-addons-coredns-addons-k8s-io-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.k8s.local/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -556,6 +571,7 @@ resource "aws_s3_bucket_object" "minimal-k8s-local-addons-dns-controller-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.k8s.local/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -563,6 +579,7 @@ resource "aws_s3_bucket_object" "minimal-k8s-local-addons-kops-controller-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.k8s.local/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -570,6 +587,7 @@ resource "aws_s3_bucket_object" "minimal-k8s-local-addons-kubelet-api-rbac-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.k8s.local-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.k8s.local/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -577,6 +595,7 @@ resource "aws_s3_bucket_object" "minimal-k8s-local-addons-limit-range-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.k8s.local-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.k8s.local/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -584,6 +603,7 @@ resource "aws_s3_bucket_object" "minimal-k8s-local-addons-storage-aws-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.k8s.local-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.k8s.local/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -591,6 +611,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.k8s.local/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -598,6 +619,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.k8s.local/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -791,11 +813,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-k8s-local" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -90,6 +90,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-mixedinstances-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -887,6 +892,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/mixedinstances.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -894,6 +900,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/mixedinstances.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -901,6 +908,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/mixedinstances.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -908,6 +916,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/mixedinstances.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -915,6 +924,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/mixedinstances.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -922,6 +932,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/mixedinstances.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -929,6 +940,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/mixedinstances.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -936,6 +948,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -943,6 +956,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-core-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -950,6 +964,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-coredns-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -957,6 +972,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-dns-controlle
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -964,6 +980,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-kops-controll
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -971,6 +988,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-kubelet-api-r
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -978,6 +996,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-limit-range-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -985,6 +1004,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-storage-aws-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -992,6 +1012,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/mixedinstances.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -999,6 +1020,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1b" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1b_content")
   key                    = "clusters.example.com/mixedinstances.example.com/igconfig/master/master-us-test-1b/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1006,6 +1028,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1c" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1c_content")
   key                    = "clusters.example.com/mixedinstances.example.com/igconfig/master/master-us-test-1c/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1013,6 +1036,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/mixedinstances.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1234,11 +1258,12 @@ resource "aws_vpc_dhcp_options_association" "mixedinstances-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -90,6 +90,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-mixedinstances-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -888,6 +893,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/mixedinstances.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -895,6 +901,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/mixedinstances.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -902,6 +909,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/mixedinstances.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -909,6 +917,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/mixedinstances.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -916,6 +925,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/mixedinstances.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -923,6 +933,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/mixedinstances.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -930,6 +941,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/mixedinstances.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -937,6 +949,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -944,6 +957,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-core-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -951,6 +965,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-coredns-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -958,6 +973,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-dns-controlle
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -965,6 +981,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-kops-controll
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -972,6 +989,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-kubelet-api-r
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -979,6 +997,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-limit-range-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -986,6 +1005,7 @@ resource "aws_s3_bucket_object" "mixedinstances-example-com-addons-storage-aws-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_mixedinstances.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/mixedinstances.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -993,6 +1013,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/mixedinstances.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1000,6 +1021,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1b" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1b_content")
   key                    = "clusters.example.com/mixedinstances.example.com/igconfig/master/master-us-test-1b/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1007,6 +1029,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1c" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1c_content")
   key                    = "clusters.example.com/mixedinstances.example.com/igconfig/master/master-us-test-1c/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1014,6 +1037,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/mixedinstances.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1235,11 +1259,12 @@ resource "aws_vpc_dhcp_options_association" "mixedinstances-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
+++ b/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-nthsqsresources-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -578,6 +583,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -585,6 +591,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -592,6 +599,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -599,6 +607,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -606,6 +615,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -613,6 +623,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -620,6 +631,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -627,6 +639,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -634,6 +647,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -641,6 +655,7 @@ resource "aws_s3_bucket_object" "nthsqsresources-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -648,6 +663,7 @@ resource "aws_s3_bucket_object" "nthsqsresources-example-com-addons-core-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -655,6 +671,7 @@ resource "aws_s3_bucket_object" "nthsqsresources-example-com-addons-coredns-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -662,6 +679,7 @@ resource "aws_s3_bucket_object" "nthsqsresources-example-com-addons-dns-controll
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -669,6 +687,7 @@ resource "aws_s3_bucket_object" "nthsqsresources-example-com-addons-kops-control
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -676,6 +695,7 @@ resource "aws_s3_bucket_object" "nthsqsresources-example-com-addons-kubelet-api-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -683,6 +703,7 @@ resource "aws_s3_bucket_object" "nthsqsresources-example-com-addons-limit-range-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -690,6 +711,7 @@ resource "aws_s3_bucket_object" "nthsqsresources-example-com-addons-node-termina
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-node-termination-handler.aws-k8s-1.11_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/addons/node-termination-handler.aws/k8s-1.11.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -697,6 +719,7 @@ resource "aws_s3_bucket_object" "nthsqsresources-example-com-addons-storage-aws-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/nthsqsresources.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -901,11 +924,12 @@ resource "aws_vpc_dhcp_options_association" "nthsqsresources-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/nvidia/kubernetes.tf
+++ b/tests/integration/update_cluster/nvidia/kubernetes.tf
@@ -80,6 +80,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -494,6 +499,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -501,6 +507,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -508,6 +515,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -515,6 +523,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -522,6 +531,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -529,6 +539,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -536,6 +547,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -543,6 +555,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -550,6 +563,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -557,6 +571,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -564,6 +579,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -571,6 +587,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -578,6 +595,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -585,6 +603,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -592,6 +611,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-nvidia-addons-k8s-io
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-nvidia.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/nvidia.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -599,6 +619,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -606,6 +627,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -613,6 +635,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -806,11 +829,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -105,6 +105,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-private-shared-ip-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -744,6 +749,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -751,6 +757,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -758,6 +765,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -765,6 +773,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -772,6 +781,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -779,6 +789,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -786,6 +797,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -793,6 +805,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -800,6 +813,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -807,6 +821,7 @@ resource "aws_s3_bucket_object" "private-shared-ip-example-com-addons-bootstrap"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -814,6 +829,7 @@ resource "aws_s3_bucket_object" "private-shared-ip-example-com-addons-core-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -821,6 +837,7 @@ resource "aws_s3_bucket_object" "private-shared-ip-example-com-addons-coredns-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -828,6 +845,7 @@ resource "aws_s3_bucket_object" "private-shared-ip-example-com-addons-dns-contro
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -835,6 +853,7 @@ resource "aws_s3_bucket_object" "private-shared-ip-example-com-addons-kops-contr
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -842,6 +861,7 @@ resource "aws_s3_bucket_object" "private-shared-ip-example-com-addons-kubelet-ap
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -849,6 +869,7 @@ resource "aws_s3_bucket_object" "private-shared-ip-example-com-addons-limit-rang
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -856,6 +877,7 @@ resource "aws_s3_bucket_object" "private-shared-ip-example-com-addons-storage-aw
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/private-shared-ip.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1157,11 +1179,12 @@ resource "aws_subnet" "utility-us-test-1a-private-shared-ip-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -100,6 +100,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-private-shared-subnet-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -681,6 +686,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -688,6 +694,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -695,6 +702,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -702,6 +710,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -709,6 +718,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -716,6 +726,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -723,6 +734,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -730,6 +742,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -737,6 +750,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -744,6 +758,7 @@ resource "aws_s3_bucket_object" "private-shared-subnet-example-com-addons-bootst
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -751,6 +766,7 @@ resource "aws_s3_bucket_object" "private-shared-subnet-example-com-addons-core-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -758,6 +774,7 @@ resource "aws_s3_bucket_object" "private-shared-subnet-example-com-addons-coredn
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -765,6 +782,7 @@ resource "aws_s3_bucket_object" "private-shared-subnet-example-com-addons-dns-co
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -772,6 +790,7 @@ resource "aws_s3_bucket_object" "private-shared-subnet-example-com-addons-kops-c
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -779,6 +798,7 @@ resource "aws_s3_bucket_object" "private-shared-subnet-example-com-addons-kubele
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -786,6 +806,7 @@ resource "aws_s3_bucket_object" "private-shared-subnet-example-com-addons-limit-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -793,6 +814,7 @@ resource "aws_s3_bucket_object" "private-shared-subnet-example-com-addons-storag
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/private-shared-subnet.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1068,11 +1090,12 @@ resource "aws_security_group_rule" "icmp-pmtu-api-elb-0-0-0-0--0" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privatecalico-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -767,6 +772,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privatecalico.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -774,6 +780,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privatecalico.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -781,6 +788,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privatecalico.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -788,6 +796,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privatecalico.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -795,6 +804,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privatecalico.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -802,6 +812,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privatecalico.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -809,6 +820,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privatecalico.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -816,6 +828,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privatecalico.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -823,6 +836,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privatecalico.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -830,6 +844,7 @@ resource "aws_s3_bucket_object" "privatecalico-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privatecalico.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -837,6 +852,7 @@ resource "aws_s3_bucket_object" "privatecalico-example-com-addons-core-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecalico.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privatecalico.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -844,6 +860,7 @@ resource "aws_s3_bucket_object" "privatecalico-example-com-addons-coredns-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecalico.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatecalico.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -851,6 +868,7 @@ resource "aws_s3_bucket_object" "privatecalico-example-com-addons-dns-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatecalico.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -858,6 +876,7 @@ resource "aws_s3_bucket_object" "privatecalico-example-com-addons-kops-controlle
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privatecalico.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -865,6 +884,7 @@ resource "aws_s3_bucket_object" "privatecalico-example-com-addons-kubelet-api-rb
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecalico.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privatecalico.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -872,6 +892,7 @@ resource "aws_s3_bucket_object" "privatecalico-example-com-addons-limit-range-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecalico.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privatecalico.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -879,6 +900,7 @@ resource "aws_s3_bucket_object" "privatecalico-example-com-addons-networking-pro
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.16_content")
   key                    = "clusters.example.com/privatecalico.example.com/addons/networking.projectcalico.org/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -886,6 +908,7 @@ resource "aws_s3_bucket_object" "privatecalico-example-com-addons-storage-aws-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecalico.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privatecalico.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1223,11 +1246,12 @@ resource "aws_vpc_dhcp_options_association" "privatecalico-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privatecanal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -767,6 +772,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privatecanal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -774,6 +780,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privatecanal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -781,6 +788,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privatecanal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -788,6 +796,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privatecanal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -795,6 +804,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privatecanal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -802,6 +812,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privatecanal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -809,6 +820,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privatecanal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -816,6 +828,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privatecanal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -823,6 +836,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privatecanal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -830,6 +844,7 @@ resource "aws_s3_bucket_object" "privatecanal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privatecanal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -837,6 +852,7 @@ resource "aws_s3_bucket_object" "privatecanal-example-com-addons-core-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecanal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privatecanal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -844,6 +860,7 @@ resource "aws_s3_bucket_object" "privatecanal-example-com-addons-coredns-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecanal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatecanal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -851,6 +868,7 @@ resource "aws_s3_bucket_object" "privatecanal-example-com-addons-dns-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatecanal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -858,6 +876,7 @@ resource "aws_s3_bucket_object" "privatecanal-example-com-addons-kops-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privatecanal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -865,6 +884,7 @@ resource "aws_s3_bucket_object" "privatecanal-example-com-addons-kubelet-api-rba
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecanal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privatecanal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -872,6 +892,7 @@ resource "aws_s3_bucket_object" "privatecanal-example-com-addons-limit-range-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecanal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privatecanal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -879,6 +900,7 @@ resource "aws_s3_bucket_object" "privatecanal-example-com-addons-networking-proj
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.16_content")
   key                    = "clusters.example.com/privatecanal.example.com/addons/networking.projectcalico.org.canal/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -886,6 +908,7 @@ resource "aws_s3_bucket_object" "privatecanal-example-com-addons-storage-aws-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecanal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privatecanal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1214,11 +1237,12 @@ resource "aws_vpc_dhcp_options_association" "privatecanal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privatecilium-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -767,6 +772,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privatecilium.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -774,6 +780,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privatecilium.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -781,6 +788,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privatecilium.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -788,6 +796,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privatecilium.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -795,6 +804,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privatecilium.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -802,6 +812,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privatecilium.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -809,6 +820,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privatecilium.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -816,6 +828,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privatecilium.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -823,6 +836,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privatecilium.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -830,6 +844,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -837,6 +852,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-core-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -844,6 +860,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-coredns-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -851,6 +868,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-dns-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -858,6 +876,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-kops-controlle
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -865,6 +884,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-kubelet-api-rb
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -872,6 +892,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-limit-range-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -879,6 +900,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-networking-cil
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/networking.cilium.io/k8s-1.16-v1.10.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -886,6 +908,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-storage-aws-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1214,11 +1237,12 @@ resource "aws_vpc_dhcp_options_association" "privatecilium-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privatecilium-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -767,6 +772,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privatecilium.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -774,6 +780,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privatecilium.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -781,6 +788,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privatecilium.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -788,6 +796,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privatecilium.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -795,6 +804,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privatecilium.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -802,6 +812,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privatecilium.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -809,6 +820,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privatecilium.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -816,6 +828,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privatecilium.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -823,6 +836,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privatecilium.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -830,6 +844,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -837,6 +852,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-core-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -844,6 +860,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-dns-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -851,6 +868,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-kops-controlle
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -858,6 +876,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-kube-dns-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-kube-dns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -865,6 +884,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-kubelet-api-rb
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -872,6 +892,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-limit-range-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -879,6 +900,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-networking-cil
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/networking.cilium.io/k8s-1.12-v1.8.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -886,6 +908,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-rbac-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-rbac.addons.k8s.io-k8s-1.8_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/rbac.addons.k8s.io/k8s-1.8.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -893,6 +916,7 @@ resource "aws_s3_bucket_object" "privatecilium-example-com-addons-storage-aws-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatecilium.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privatecilium.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1221,11 +1245,12 @@ resource "aws_vpc_dhcp_options_association" "privatecilium-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privateciliumadvanced-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -783,6 +788,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -790,6 +796,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-cilium" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-cilium_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -797,6 +804,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -804,6 +812,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -811,6 +820,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -818,6 +828,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-cilium" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-cilium_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/manifests/etcd/cilium.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -825,6 +836,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -832,6 +844,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -839,6 +852,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -846,6 +860,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -853,6 +868,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -860,6 +876,7 @@ resource "aws_s3_bucket_object" "privateciliumadvanced-example-com-addons-bootst
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -867,6 +884,7 @@ resource "aws_s3_bucket_object" "privateciliumadvanced-example-com-addons-core-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -874,6 +892,7 @@ resource "aws_s3_bucket_object" "privateciliumadvanced-example-com-addons-coredn
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -881,6 +900,7 @@ resource "aws_s3_bucket_object" "privateciliumadvanced-example-com-addons-dns-co
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -888,6 +908,7 @@ resource "aws_s3_bucket_object" "privateciliumadvanced-example-com-addons-kops-c
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -895,6 +916,7 @@ resource "aws_s3_bucket_object" "privateciliumadvanced-example-com-addons-kubele
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -902,6 +924,7 @@ resource "aws_s3_bucket_object" "privateciliumadvanced-example-com-addons-limit-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -909,6 +932,7 @@ resource "aws_s3_bucket_object" "privateciliumadvanced-example-com-addons-networ
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/networking.cilium.io/k8s-1.16-v1.10.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -916,6 +940,7 @@ resource "aws_s3_bucket_object" "privateciliumadvanced-example-com-addons-storag
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privateciliumadvanced.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1244,11 +1269,12 @@ resource "aws_vpc_dhcp_options_association" "privateciliumadvanced-example-com" 
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privatedns1-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -852,6 +857,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privatedns1.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -859,6 +865,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privatedns1.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -866,6 +873,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privatedns1.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -873,6 +881,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privatedns1.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -880,6 +889,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privatedns1.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -887,6 +897,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privatedns1.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -894,6 +905,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privatedns1.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -901,6 +913,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privatedns1.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -908,6 +921,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privatedns1.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -915,6 +929,7 @@ resource "aws_s3_bucket_object" "privatedns1-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privatedns1.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -922,6 +937,7 @@ resource "aws_s3_bucket_object" "privatedns1-example-com-addons-core-addons-k8s-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns1.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privatedns1.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -929,6 +945,7 @@ resource "aws_s3_bucket_object" "privatedns1-example-com-addons-coredns-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns1.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatedns1.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -936,6 +953,7 @@ resource "aws_s3_bucket_object" "privatedns1-example-com-addons-dns-controller-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatedns1.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -943,6 +961,7 @@ resource "aws_s3_bucket_object" "privatedns1-example-com-addons-kops-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privatedns1.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -950,6 +969,7 @@ resource "aws_s3_bucket_object" "privatedns1-example-com-addons-kubelet-api-rbac
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns1.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privatedns1.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -957,6 +977,7 @@ resource "aws_s3_bucket_object" "privatedns1-example-com-addons-limit-range-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns1.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privatedns1.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -964,6 +985,7 @@ resource "aws_s3_bucket_object" "privatedns1-example-com-addons-networking-weave
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns1.example.com-addons-networking.weave-k8s-1.12_content")
   key                    = "clusters.example.com/privatedns1.example.com/addons/networking.weave/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -971,6 +993,7 @@ resource "aws_s3_bucket_object" "privatedns1-example-com-addons-storage-aws-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns1.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privatedns1.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1317,11 +1340,12 @@ resource "aws_vpc_dhcp_options_association" "privatedns1-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -105,6 +105,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privatedns2-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -753,6 +758,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privatedns2.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -760,6 +766,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privatedns2.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -767,6 +774,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privatedns2.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -774,6 +782,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privatedns2.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -781,6 +790,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privatedns2.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -788,6 +798,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privatedns2.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -795,6 +806,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privatedns2.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -802,6 +814,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privatedns2.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -809,6 +822,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privatedns2.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -816,6 +830,7 @@ resource "aws_s3_bucket_object" "privatedns2-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privatedns2.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -823,6 +838,7 @@ resource "aws_s3_bucket_object" "privatedns2-example-com-addons-core-addons-k8s-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns2.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privatedns2.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -830,6 +846,7 @@ resource "aws_s3_bucket_object" "privatedns2-example-com-addons-coredns-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns2.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatedns2.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -837,6 +854,7 @@ resource "aws_s3_bucket_object" "privatedns2-example-com-addons-dns-controller-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatedns2.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -844,6 +862,7 @@ resource "aws_s3_bucket_object" "privatedns2-example-com-addons-kops-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privatedns2.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -851,6 +870,7 @@ resource "aws_s3_bucket_object" "privatedns2-example-com-addons-kubelet-api-rbac
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns2.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privatedns2.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -858,6 +878,7 @@ resource "aws_s3_bucket_object" "privatedns2-example-com-addons-limit-range-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns2.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privatedns2.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -865,6 +886,7 @@ resource "aws_s3_bucket_object" "privatedns2-example-com-addons-storage-aws-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatedns2.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privatedns2.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1166,11 +1188,12 @@ resource "aws_subnet" "utility-us-test-1a-privatedns2-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privateflannel-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -767,6 +772,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privateflannel.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -774,6 +780,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privateflannel.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -781,6 +788,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privateflannel.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -788,6 +796,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privateflannel.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -795,6 +804,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privateflannel.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -802,6 +812,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privateflannel.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -809,6 +820,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privateflannel.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -816,6 +828,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privateflannel.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -823,6 +836,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privateflannel.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -830,6 +844,7 @@ resource "aws_s3_bucket_object" "privateflannel-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privateflannel.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -837,6 +852,7 @@ resource "aws_s3_bucket_object" "privateflannel-example-com-addons-core-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateflannel.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privateflannel.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -844,6 +860,7 @@ resource "aws_s3_bucket_object" "privateflannel-example-com-addons-coredns-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateflannel.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privateflannel.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -851,6 +868,7 @@ resource "aws_s3_bucket_object" "privateflannel-example-com-addons-dns-controlle
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privateflannel.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -858,6 +876,7 @@ resource "aws_s3_bucket_object" "privateflannel-example-com-addons-kops-controll
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privateflannel.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -865,6 +884,7 @@ resource "aws_s3_bucket_object" "privateflannel-example-com-addons-kubelet-api-r
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateflannel.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privateflannel.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -872,6 +892,7 @@ resource "aws_s3_bucket_object" "privateflannel-example-com-addons-limit-range-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateflannel.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privateflannel.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -879,6 +900,7 @@ resource "aws_s3_bucket_object" "privateflannel-example-com-addons-networking-fl
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateflannel.example.com-addons-networking.flannel-k8s-1.12_content")
   key                    = "clusters.example.com/privateflannel.example.com/addons/networking.flannel/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -886,6 +908,7 @@ resource "aws_s3_bucket_object" "privateflannel-example-com-addons-storage-aws-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateflannel.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privateflannel.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1214,11 +1237,12 @@ resource "aws_vpc_dhcp_options_association" "privateflannel-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -125,6 +125,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privatekopeio-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -789,6 +794,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privatekopeio.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -796,6 +802,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privatekopeio.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -803,6 +810,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privatekopeio.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -810,6 +818,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privatekopeio.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -817,6 +826,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privatekopeio.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -824,6 +834,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privatekopeio.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -831,6 +842,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privatekopeio.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -838,6 +850,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privatekopeio.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -845,6 +858,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privatekopeio.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -852,6 +866,7 @@ resource "aws_s3_bucket_object" "privatekopeio-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privatekopeio.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -859,6 +874,7 @@ resource "aws_s3_bucket_object" "privatekopeio-example-com-addons-core-addons-k8
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatekopeio.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privatekopeio.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -866,6 +882,7 @@ resource "aws_s3_bucket_object" "privatekopeio-example-com-addons-coredns-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatekopeio.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatekopeio.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -873,6 +890,7 @@ resource "aws_s3_bucket_object" "privatekopeio-example-com-addons-dns-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatekopeio.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -880,6 +898,7 @@ resource "aws_s3_bucket_object" "privatekopeio-example-com-addons-kops-controlle
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privatekopeio.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -887,6 +906,7 @@ resource "aws_s3_bucket_object" "privatekopeio-example-com-addons-kubelet-api-rb
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privatekopeio.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -894,6 +914,7 @@ resource "aws_s3_bucket_object" "privatekopeio-example-com-addons-limit-range-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatekopeio.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privatekopeio.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -901,6 +922,7 @@ resource "aws_s3_bucket_object" "privatekopeio-example-com-addons-networking-kop
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatekopeio.example.com-addons-networking.kope.io-k8s-1.12_content")
   key                    = "clusters.example.com/privatekopeio.example.com/addons/networking.kope.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -908,6 +930,7 @@ resource "aws_s3_bucket_object" "privatekopeio-example-com-addons-storage-aws-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privatekopeio.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privatekopeio.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1262,11 +1285,12 @@ resource "aws_vpc_dhcp_options_association" "privatekopeio-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -110,6 +110,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-privateweave-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -767,6 +772,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/privateweave.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -774,6 +780,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/privateweave.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -781,6 +788,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/privateweave.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -788,6 +796,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/privateweave.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -795,6 +804,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/privateweave.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -802,6 +812,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/privateweave.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -809,6 +820,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/privateweave.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -816,6 +828,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/privateweave.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -823,6 +836,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/privateweave.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -830,6 +844,7 @@ resource "aws_s3_bucket_object" "privateweave-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/privateweave.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -837,6 +852,7 @@ resource "aws_s3_bucket_object" "privateweave-example-com-addons-core-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateweave.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/privateweave.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -844,6 +860,7 @@ resource "aws_s3_bucket_object" "privateweave-example-com-addons-coredns-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateweave.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privateweave.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -851,6 +868,7 @@ resource "aws_s3_bucket_object" "privateweave-example-com-addons-dns-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/privateweave.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -858,6 +876,7 @@ resource "aws_s3_bucket_object" "privateweave-example-com-addons-kops-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/privateweave.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -865,6 +884,7 @@ resource "aws_s3_bucket_object" "privateweave-example-com-addons-kubelet-api-rba
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateweave.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/privateweave.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -872,6 +892,7 @@ resource "aws_s3_bucket_object" "privateweave-example-com-addons-limit-range-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateweave.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/privateweave.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -879,6 +900,7 @@ resource "aws_s3_bucket_object" "privateweave-example-com-addons-networking-weav
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateweave.example.com-addons-networking.weave-k8s-1.12_content")
   key                    = "clusters.example.com/privateweave.example.com/addons/networking.weave/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -886,6 +908,7 @@ resource "aws_s3_bucket_object" "privateweave-example-com-addons-storage-aws-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_privateweave.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/privateweave.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1214,11 +1237,12 @@ resource "aws_vpc_dhcp_options_association" "privateweave-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -100,6 +100,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -533,6 +538,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -540,6 +546,7 @@ resource "aws_s3_bucket_object" "discovery-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -547,6 +554,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -554,6 +562,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -561,6 +570,7 @@ resource "aws_s3_bucket_object" "keys-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -568,6 +578,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -575,6 +586,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -582,6 +594,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -589,6 +602,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -596,6 +610,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -603,6 +618,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -610,6 +626,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -617,6 +634,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -624,6 +642,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kube-dns-addons-k8s-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kube-dns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kube-dns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -631,6 +650,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -638,6 +658,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -645,6 +666,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -652,6 +674,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -659,6 +682,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -852,11 +876,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -75,6 +75,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedsubnet-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -445,6 +450,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -452,6 +458,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -459,6 +466,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -466,6 +474,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -473,6 +482,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -480,6 +490,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -487,6 +498,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -494,6 +506,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -501,6 +514,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -508,6 +522,7 @@ resource "aws_s3_bucket_object" "sharedsubnet-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -515,6 +530,7 @@ resource "aws_s3_bucket_object" "sharedsubnet-example-com-addons-core-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -522,6 +538,7 @@ resource "aws_s3_bucket_object" "sharedsubnet-example-com-addons-coredns-addons-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -529,6 +546,7 @@ resource "aws_s3_bucket_object" "sharedsubnet-example-com-addons-dns-controller-
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -536,6 +554,7 @@ resource "aws_s3_bucket_object" "sharedsubnet-example-com-addons-kops-controller
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -543,6 +562,7 @@ resource "aws_s3_bucket_object" "sharedsubnet-example-com-addons-kubelet-api-rba
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -550,6 +570,7 @@ resource "aws_s3_bucket_object" "sharedsubnet-example-com-addons-limit-range-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -557,6 +578,7 @@ resource "aws_s3_bucket_object" "sharedsubnet-example-com-addons-storage-aws-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/sharedsubnet.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -709,11 +731,12 @@ resource "aws_security_group_rule" "from-nodes-sharedsubnet-example-com-ingress-
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -75,6 +75,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-sharedvpc-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -472,6 +477,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/sharedvpc.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -479,6 +485,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/sharedvpc.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -486,6 +493,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/sharedvpc.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -493,6 +501,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/sharedvpc.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -500,6 +509,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/sharedvpc.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -507,6 +517,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/sharedvpc.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -514,6 +525,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/sharedvpc.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -521,6 +533,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/sharedvpc.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -528,6 +541,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/sharedvpc.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -535,6 +549,7 @@ resource "aws_s3_bucket_object" "sharedvpc-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/sharedvpc.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -542,6 +557,7 @@ resource "aws_s3_bucket_object" "sharedvpc-example-com-addons-core-addons-k8s-io
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedvpc.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/sharedvpc.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -549,6 +565,7 @@ resource "aws_s3_bucket_object" "sharedvpc-example-com-addons-coredns-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedvpc.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/sharedvpc.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -556,6 +573,7 @@ resource "aws_s3_bucket_object" "sharedvpc-example-com-addons-dns-controller-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/sharedvpc.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -563,6 +581,7 @@ resource "aws_s3_bucket_object" "sharedvpc-example-com-addons-kops-controller-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/sharedvpc.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -570,6 +589,7 @@ resource "aws_s3_bucket_object" "sharedvpc-example-com-addons-kubelet-api-rbac-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/sharedvpc.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -577,6 +597,7 @@ resource "aws_s3_bucket_object" "sharedvpc-example-com-addons-limit-range-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedvpc.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/sharedvpc.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -584,6 +605,7 @@ resource "aws_s3_bucket_object" "sharedvpc-example-com-addons-storage-aws-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_sharedvpc.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/sharedvpc.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -750,11 +772,12 @@ resource "aws_subnet" "us-test-1a-sharedvpc-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -105,6 +105,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "bastion-unmanaged-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -686,6 +691,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/unmanaged.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -693,6 +699,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/unmanaged.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -700,6 +707,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/unmanaged.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -707,6 +715,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/unmanaged.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -714,6 +723,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/unmanaged.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -721,6 +731,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/unmanaged.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -728,6 +739,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/unmanaged.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -735,6 +747,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/unmanaged.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -742,6 +755,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/unmanaged.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -749,6 +763,7 @@ resource "aws_s3_bucket_object" "unmanaged-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/unmanaged.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -756,6 +771,7 @@ resource "aws_s3_bucket_object" "unmanaged-example-com-addons-core-addons-k8s-io
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_unmanaged.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/unmanaged.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -763,6 +779,7 @@ resource "aws_s3_bucket_object" "unmanaged-example-com-addons-coredns-addons-k8s
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_unmanaged.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/unmanaged.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -770,6 +787,7 @@ resource "aws_s3_bucket_object" "unmanaged-example-com-addons-dns-controller-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/unmanaged.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -777,6 +795,7 @@ resource "aws_s3_bucket_object" "unmanaged-example-com-addons-kops-controller-ad
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/unmanaged.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -784,6 +803,7 @@ resource "aws_s3_bucket_object" "unmanaged-example-com-addons-kubelet-api-rbac-a
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_unmanaged.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/unmanaged.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -791,6 +811,7 @@ resource "aws_s3_bucket_object" "unmanaged-example-com-addons-limit-range-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_unmanaged.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/unmanaged.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -798,6 +819,7 @@ resource "aws_s3_bucket_object" "unmanaged-example-com-addons-storage-aws-addons
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_unmanaged.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/unmanaged.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -1125,11 +1147,12 @@ resource "aws_subnet" "utility-us-test-1b-unmanaged-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -90,6 +90,11 @@ provider "aws" {
   region = "us-test-1"
 }
 
+provider "aws" {
+  alias  = "files"
+  region = "us-test-1"
+}
+
 resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com" {
   enabled_metrics = ["GroupDesiredCapacity", "GroupInServiceInstances", "GroupMaxSize", "GroupMinSize", "GroupPendingInstances", "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
   launch_template {
@@ -507,6 +512,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_cluster-completed.spec_content")
   key                    = "clusters.example.com/minimal.example.com/cluster-completed.spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -514,6 +520,7 @@ resource "aws_s3_bucket_object" "discovery-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -521,6 +528,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-events_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/events/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -528,6 +536,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_etcd-cluster-spec-main_content")
   key                    = "clusters.example.com/minimal.example.com/backups/etcd/main/control/etcd-cluster-spec"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -535,6 +544,7 @@ resource "aws_s3_bucket_object" "keys-json" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -542,6 +552,7 @@ resource "aws_s3_bucket_object" "kops-version-txt" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_kops-version.txt_content")
   key                    = "clusters.example.com/minimal.example.com/kops-version.txt"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -549,6 +560,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-events" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-events_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/events.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -556,6 +568,7 @@ resource "aws_s3_bucket_object" "manifests-etcdmanager-main" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-etcdmanager-main_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/etcd/main.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -563,6 +576,7 @@ resource "aws_s3_bucket_object" "manifests-static-kube-apiserver-healthcheck" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content")
   key                    = "clusters.example.com/minimal.example.com/manifests/static/kube-apiserver-healthcheck.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -570,6 +584,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content")
   key                    = "clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -577,6 +592,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-core-addons-k8s-io" 
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-core.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/core.addons.k8s.io/v1.4.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -584,6 +600,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-coredns-addons-k8s-i
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/coredns.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -591,6 +608,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-dns-controller-addon
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content")
   key                    = "clusters.example.com/minimal.example.com/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -598,6 +616,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kops-controller-addo
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -605,6 +624,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-kubelet-api-rbac-add
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-kubelet-api.rbac.addons.k8s.io-k8s-1.9_content")
   key                    = "clusters.example.com/minimal.example.com/addons/kubelet-api.rbac.addons.k8s.io/k8s-1.9.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -612,6 +632,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-limit-range-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-limit-range.addons.k8s.io_content")
   key                    = "clusters.example.com/minimal.example.com/addons/limit-range.addons.k8s.io/v1.5.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -619,6 +640,7 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_minimal.example.com-addons-storage-aws.addons.k8s.io-v1.15.0_content")
   key                    = "clusters.example.com/minimal.example.com/addons/storage-aws.addons.k8s.io/v1.15.0.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -626,6 +648,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-master-us-test-1a" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/master/master-us-test-1a/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -633,6 +656,7 @@ resource "aws_s3_bucket_object" "nodeupconfig-nodes" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-nodes_content")
   key                    = "clusters.example.com/minimal.example.com/igconfig/node/nodes/nodeupconfig.yaml"
+  provider               = aws.files
   server_side_encryption = "AES256"
 }
 
@@ -826,11 +850,12 @@ resource "aws_vpc_dhcp_options_association" "minimal-example-com" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -701,7 +701,15 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 	case TargetTerraform:
 		checkExisting = false
 		outDir := c.OutDir
-		tf := terraform.NewTerraformTarget(cloud, project, outDir, cluster.Spec.Target)
+		var vfsProvider *vfs.TerraformProvider
+		if tfPath, ok := configBase.(vfs.TerraformPath); ok && featureflag.TerraformManagedFiles.Enabled() {
+			var err error
+			vfsProvider, err = tfPath.TerraformProvider()
+			if err != nil {
+				return err
+			}
+		}
+		tf := terraform.NewTerraformTarget(cloud, project, vfsProvider, outDir, cluster.Spec.Target)
 
 		// We include a few "util" variables in the TF output
 		if err := tf.AddOutputVariable("region", terraformWriter.LiteralFromStringValue(cloud.Region())); err != nil {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -246,11 +246,12 @@ resource "aws_autoscaling_group" "test" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }
@@ -320,11 +321,12 @@ resource "aws_autoscaling_group" "test1" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -94,11 +94,12 @@ resource "aws_launch_template" "test" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }
@@ -180,11 +181,12 @@ resource "aws_launch_template" "test" {
 }
 
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      "source"  = "hashicorp/aws"
-      "version" = ">= 3.59.0"
+      "configuration_aliases" = [aws.files]
+      "source"                = "hashicorp/aws"
+      "version"               = ">= 3.59.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/render_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/render_test.go
@@ -56,7 +56,7 @@ func doRenderTests(t *testing.T, method string, cases []*renderTest) {
 
 		switch method {
 		case "RenderTerraform":
-			target = terraform.NewTerraformTarget(cloud, "test", outdir, nil)
+			target = terraform.NewTerraformTarget(cloud, "test", nil, outdir, nil)
 			filename = "kubernetes.tf"
 		case "RenderCloudformation":
 			target = cloudformation.NewCloudformationTarget(cloud, "test", outdir)

--- a/upup/pkg/fi/cloudup/terraform/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/terraform/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/featureflag:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/terraformWriter:go_default_library",
+        "//util/pkg/vfs:go_default_library",
         "//vendor/github.com/hashicorp/hcl/v2:go_default_library",
         "//vendor/github.com/hashicorp/hcl/v2/hclsyntax:go_default_library",
         "//vendor/github.com/hashicorp/hcl/v2/hclwrite:go_default_library",

--- a/upup/pkg/fi/cloudup/terraform/hcl2_test.go
+++ b/upup/pkg/fi/cloudup/terraform/hcl2_test.go
@@ -211,6 +211,12 @@ func TestWriteLiteralList(t *testing.T) {
 }
 
 func TestWriteMap(t *testing.T) {
+	literalList := []*terraformWriter.Literal{
+		terraformWriter.LiteralTokens("aws", "files"),
+		terraformWriter.LiteralFromStringValue("foobar"),
+	}
+	literalListType, _ := gocty.ImpliedType(literalList)
+	literalListVal, _ := gocty.ToCtyValue(literalList, literalListType)
 	cases := []struct {
 		name     string
 		values   map[string]cty.Value
@@ -238,6 +244,16 @@ tags = {
 			expected: `
 tags = {
   "key1.k8s.local/foo" = "value1"
+}`,
+		},
+		{
+			name: "literal list",
+			values: map[string]cty.Value{
+				"foo": literalListVal,
+			},
+			expected: `
+tags = {
+  "foo" = [aws.files, "foobar"]
 }`,
 		},
 	}

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/terraformWriter"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 type TerraformTarget struct {
@@ -40,15 +41,17 @@ type TerraformTarget struct {
 	outDir string
 	// extra config to add to the provider block
 	clusterSpecTarget *kops.TargetSpec
+	filesProvider     *vfs.TerraformProvider
 }
 
-func NewTerraformTarget(cloud fi.Cloud, project string, outDir string, clusterSpecTarget *kops.TargetSpec) *TerraformTarget {
+func NewTerraformTarget(cloud fi.Cloud, project string, filesProvider *vfs.TerraformProvider, outDir string, clusterSpecTarget *kops.TargetSpec) *TerraformTarget {
 	target := TerraformTarget{
 		Cloud:   cloud,
 		Project: project,
 
 		outDir:            outDir,
 		clusterSpecTarget: clusterSpecTarget,
+		filesProvider:     filesProvider,
 	}
 	target.InitTerraformWriter()
 	return &target

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -75,8 +75,18 @@ func (t *TerraformTarget) ProcessDeletions() bool {
 func tfGetProviderExtraConfig(c *kops.TargetSpec) map[string]string {
 	if c != nil &&
 		c.Terraform != nil &&
-		c.Terraform.ProviderExtraConfig != nil {
+		c.Terraform.FilesProviderExtraConfig != nil {
 		return *c.Terraform.ProviderExtraConfig
+	}
+	return nil
+}
+
+// tfGetFilesProviderExtraConfig is a helper function to get extra config with safety checks on the pointers.
+func tfGetFilesProviderExtraConfig(c *kops.TargetSpec) map[string]string {
+	if c != nil &&
+		c.Terraform != nil &&
+		c.Terraform.FilesProviderExtraConfig != nil {
+		return *c.Terraform.FilesProviderExtraConfig
 	}
 	return nil
 }

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -53,6 +53,10 @@ func (t *TerraformTarget) finishHCL2() error {
 	}
 	rootBody.AppendNewline()
 
+	if err := t.writeFilesProvider(rootBody); err != nil {
+		return err
+	}
+
 	resourcesByType, err := t.GetResourcesByType()
 	if err != nil {
 		return err
@@ -172,5 +176,23 @@ func writeLocalsOutputs(body *hclwrite.Body, outputs map[string]terraformWriter.
 		existingOutputVars[tfName] = true
 		body.AppendNewline()
 	}
+	return nil
+}
+
+// writeFilesProvider adds the second provider definition for managed files
+func (t *TerraformTarget) writeFilesProvider(body *hclwrite.Body) error {
+	if t.filesProvider == nil {
+		return nil
+	}
+	providerBlock := body.AppendNewBlock("provider", []string{t.filesProvider.Name})
+	providerBody := providerBlock.Body()
+	providerBody.SetAttributeValue("alias", cty.StringVal("files"))
+	for k, v := range t.filesProvider.Arguments {
+		providerBody.SetAttributeValue(k, cty.StringVal(v))
+	}
+	for k, v := range tfGetFilesProviderExtraConfig(t.clusterSpecTarget) {
+		providerBody.SetAttributeValue(k, cty.StringVal(v))
+	}
+	body.AppendNewline()
 	return nil
 }

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -100,7 +100,7 @@ func (t *TerraformTarget) finishHCL2() error {
 
 	terraformBlock := rootBody.AppendNewBlock("terraform", []string{})
 	terraformBody := terraformBlock.Body()
-	terraformBody.SetAttributeValue("required_version", cty.StringVal(">= 0.12.26"))
+	terraformBody.SetAttributeValue("required_version", cty.StringVal(">= 0.15.0"))
 
 	requiredProvidersBlock := terraformBody.AppendNewBlock("required_providers", []string{})
 	requiredProvidersBody := requiredProvidersBlock.Body()
@@ -111,9 +111,19 @@ func (t *TerraformTarget) finishHCL2() error {
 			"version": cty.StringVal(">= 2.19.0"),
 		})
 	} else if t.Cloud.ProviderID() == kops.CloudProviderAWS {
+		configurationAliases := []*terraformWriter.Literal{terraformWriter.LiteralTokens("aws", "files")}
+		aliasesType, err := gocty.ImpliedType(configurationAliases)
+		if err != nil {
+			return err
+		}
+		aliasesVal, err := gocty.ToCtyValue(configurationAliases, aliasesType)
+		if err != nil {
+			return err
+		}
 		writeMap(requiredProvidersBody, "aws", map[string]cty.Value{
-			"source":  cty.StringVal("hashicorp/aws"),
-			"version": cty.StringVal(">= 3.59.0"),
+			"source":                cty.StringVal("hashicorp/aws"),
+			"version":               cty.StringVal(">= 3.59.0"),
+			"configuration_aliases": aliasesVal,
 		})
 		if featureflag.Spotinst.Enabled() {
 			writeMap(requiredProvidersBody, "spotinst", map[string]cty.Value{

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -204,11 +204,12 @@ func (p *MemFSPath) TerraformProvider() (*TerraformProvider, error) {
 }
 
 type terraformMemFSFile struct {
-	Bucket  string                   `json:"bucket" cty:"bucket"`
-	Key     string                   `json:"key" cty:"key"`
-	Content *terraformWriter.Literal `json:"content,omitempty" cty:"content"`
-	Acl     *string                  `json:"acl,omitempty" cty:"acl"`
-	SSE     string                   `json:"server_side_encryption,omitempty" cty:"server_side_encryption"`
+	Bucket   string                   `json:"bucket" cty:"bucket"`
+	Key      string                   `json:"key" cty:"key"`
+	Content  *terraformWriter.Literal `json:"content,omitempty" cty:"content"`
+	Acl      *string                  `json:"acl,omitempty" cty:"acl"`
+	SSE      string                   `json:"server_side_encryption,omitempty" cty:"server_side_encryption"`
+	Provider *terraformWriter.Literal `json:"provider,omitempty" cty:"provider"`
 }
 
 func (p *MemFSPath) RenderTerraform(w *terraformWriter.TerraformWriter, name string, data io.Reader, acl ACL) error {
@@ -232,11 +233,12 @@ func (p *MemFSPath) RenderTerraform(w *terraformWriter.TerraformWriter, name str
 	}
 
 	tf := &terraformMemFSFile{
-		Bucket:  "testingBucket",
-		Key:     p.location,
-		Content: content,
-		SSE:     "AES256",
-		Acl:     requestAcl,
+		Bucket:   "testingBucket",
+		Key:      p.location,
+		Content:  content,
+		SSE:      "AES256",
+		Acl:      requestAcl,
+		Provider: terraformWriter.LiteralTokens("aws", "files"),
 	}
 	return w.RenderResource("aws_s3_bucket_object", name, tf)
 }

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -194,6 +194,15 @@ func (p *MemFSPath) Location() string {
 
 // Terraform support for integration tests.
 
+func (p *MemFSPath) TerraformProvider() (*TerraformProvider, error) {
+	return &TerraformProvider{
+		Name: "aws",
+		Arguments: map[string]string{
+			"region": "us-test-1",
+		},
+	}, nil
+}
+
 type terraformMemFSFile struct {
 	Bucket  string                   `json:"bucket" cty:"bucket"`
 	Key     string                   `json:"key" cty:"key"`

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -87,6 +87,21 @@ func (p *S3Path) String() string {
 	return p.Path()
 }
 
+// TerraformProvider returns the provider name and necessary arguments
+func (p *S3Path) TerraformProvider() (*TerraformProvider, error) {
+	if err := p.ensureBucketDetails(); err != nil {
+		return nil, err
+	}
+
+	provider := &TerraformProvider{
+		Name: "aws",
+		Arguments: map[string]string{
+			"region": p.bucketDetails.region,
+		},
+	}
+	return provider, nil
+}
+
 func (p *S3Path) Remove() error {
 	client, err := p.client()
 	if err != nil {

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -518,11 +518,12 @@ func (p *S3Path) IsPublic() (bool, error) {
 }
 
 type terraformS3File struct {
-	Bucket  string                   `json:"bucket" cty:"bucket"`
-	Key     string                   `json:"key" cty:"key"`
-	Content *terraformWriter.Literal `json:"content,omitempty" cty:"content"`
-	Acl     *string                  `json:"acl,omitempty" cty:"acl"`
-	SSE     *string                  `json:"server_side_encryption,omitempty" cty:"server_side_encryption"`
+	Bucket   string                   `json:"bucket" cty:"bucket"`
+	Key      string                   `json:"key" cty:"key"`
+	Content  *terraformWriter.Literal `json:"content,omitempty" cty:"content"`
+	Acl      *string                  `json:"acl,omitempty" cty:"acl"`
+	SSE      *string                  `json:"server_side_encryption,omitempty" cty:"server_side_encryption"`
+	Provider *terraformWriter.Literal `json:"provider,omitempty" cty:"provider"`
 }
 
 func (p *S3Path) RenderTerraform(w *terraformWriter.TerraformWriter, name string, data io.Reader, acl ACL) error {
@@ -547,11 +548,12 @@ func (p *S3Path) RenderTerraform(w *terraformWriter.TerraformWriter, name string
 	}
 
 	tf := &terraformS3File{
-		Bucket:  p.Bucket(),
-		Key:     p.Key(),
-		Content: content,
-		SSE:     sse,
-		Acl:     requestACL,
+		Bucket:   p.Bucket(),
+		Key:      p.Key(),
+		Content:  content,
+		SSE:      sse,
+		Acl:      requestACL,
+		Provider: terraformWriter.LiteralTokens("aws", "files"),
 	}
 	return w.RenderResource("aws_s3_bucket_object", name, tf)
 }

--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -82,6 +82,17 @@ type TerraformPath interface {
 	Path
 	// RenderTerraform renders the file to a TerraformWriter.
 	RenderTerraform(writer *terraformWriter.TerraformWriter, name string, data io.Reader, acl ACL) error
+
+	// TerraformProvider returns provider information
+	TerraformProvider() (*TerraformProvider, error)
+}
+
+// TerraformProvider is a provider definition for a TerraformPath
+type TerraformProvider struct {
+	// Name is the name of the terraform provider
+	Name string
+	// Arguments are additional settings used in the provider definition
+	Arguments map[string]string
 }
 
 type HasHash interface {


### PR DESCRIPTION
Cherry pick of #12322 on release-1.22.

#12322: Add support for writing lists of terraform literals

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```