### PR TITLE
GCE: Don't create utility subnets in private topology

### DIFF
--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -52,9 +52,6 @@ spec:
   - name: us-test1
     region: us-test1
     type: Private
-  - name: utility-us-test1
-    region: us-test1
-    type: Utility
   topology:
     bastion:
       bastionPublicName: bastion.private.example.com


### PR DESCRIPTION
We don't need them on GCE, and in fact we don't support them with IP Alias.
