### PR TITLE
Better logging in setLifecycleOverride

### DIFF
--- a/upup/pkg/fi/task.go
+++ b/upup/pkg/fi/task.go
@@ -107,7 +107,6 @@ func (c *ModelBuilderContext) setLifecycleOverride(task Task) Task {
 	// TODO - so that we can return an error here, rather than just returning.
 	// certain tasks have not implemented HasLifecycle interface
 	typeName := TypeNameForTask(task)
-	klog.V(8).Infof("testing task %q", typeName)
 
 	// typeName can be values like "InternetGateway"
 	value, ok := c.LifecycleOverrides[typeName]
@@ -118,7 +117,7 @@ func (c *ModelBuilderContext) setLifecycleOverride(task Task) Task {
 			return task
 		}
 
-		klog.Warningf("overriding task %s, lifecycle %s", task, value)
+		klog.Infof("overriding task %s, lifecycle %s", task, value)
 		hl.SetLifecycle(value)
 	}
 


### PR DESCRIPTION
Remove the log message at V(8), it doesn't include any real
signal.  This method also gets called a lot!

Also differentiate between the expected and unexpected cases when a
task implements/does not implement HasLifecycle.
