### PR TITLE
Fix parsing of kops toolbox dump yaml output

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/kops v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc
 	sigs.k8s.io/kubetest2 v0.0.0-20210423234514-1c731a5d2283
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace k8s.io/kops => ../../.

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -17,7 +17,6 @@ limitations under the License.
 package deployer
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -26,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/resources"
 	"sigs.k8s.io/kubetest2/pkg/exec"
+	"sigs.k8s.io/yaml"
 )
 
 func (d *deployer) DumpClusterLogs() error {
@@ -111,13 +111,15 @@ func (d *deployer) dumpClusterInfoSSH() error {
 		"--ssh-user", d.SSHUser,
 		"-o", "yaml",
 	}
+	klog.Info(strings.Join(toolboxDumpArgs, " "))
+
 	cmd := exec.Command(toolboxDumpArgs[0], toolboxDumpArgs[1:]...)
 	dumpOutput, err := exec.Output(cmd)
 	if err != nil {
 		return err
 	}
 	var dump *resources.Dump
-	err = json.Unmarshal(dumpOutput, dump)
+	err = yaml.Unmarshal(dumpOutput, dump)
 	if err != nil {
 		return err
 	}
@@ -134,6 +136,8 @@ func (d *deployer) dumpClusterInfoSSH() error {
 		"-o", "yaml",
 		"--output-directory", "/tmp/cluster-info",
 	}
+	klog.Info(strings.Join(sshArgs, " "))
+
 	cmd = exec.Command(sshArgs[0], sshArgs[1:]...)
 	if err := cmd.Run(); err != nil {
 		return err
@@ -143,6 +147,8 @@ func (d *deployer) dumpClusterInfoSSH() error {
 		fmt.Sprintf("%v:/tmp/cluster-info", sshURL),
 		path.Join(d.ArtifactsDir, "cluster-info"),
 	}
+	klog.Info(strings.Join(scpArgs, " "))
+
 	cmd = exec.Command(scpArgs[0], scpArgs[1:]...)
 	if err := cmd.Run(); err != nil {
 		return err
@@ -152,6 +158,8 @@ func (d *deployer) dumpClusterInfoSSH() error {
 		"ssh", "-i", d.SSHPrivateKeyPath, sshURL,
 		"rm", "-rf", "/tmp/cluster-info",
 	}
+	klog.Info(strings.Join(rmArgs, " "))
+
 	cmd = exec.Command(rmArgs[0], rmArgs[1:]...)
 	if err := cmd.Run(); err != nil {
 		return err


### PR DESCRIPTION
The output is in yaml, not json. Should fix [this](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k121-ko121-to-klatest-kolatest/1439904914728816640#1:build-log.txt%3A11798) error.

`W0920 11:33:33.229371    5232 down.go:34] Dumping cluster logs at the start of Down() failed: invalid character 'i' looking for beginning of value`

Also add logging to help troubleshoot which command is failing