### PR TITLE
gossip: support resolution of k8s.local names from pods

### DIFF
--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/api/coordination/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/k8s.io/klog/v2/klogr:go_default_library",

--- a/cmd/kops-controller/controllers/BUILD.bazel
+++ b/cmd/kops-controller/controllers/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/registry:go_default_library",
+        "//pkg/apis/kops/util:go_default_library",
+        "//pkg/ipaddr:go_default_library",
         "//pkg/kopscodecs:go_default_library",
         "//pkg/nodeidentity:go_default_library",
         "//pkg/nodelabels:go_default_library",
@@ -34,7 +36,9 @@ go_library(
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/builder:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/event:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager:go_default_library",
     ],
 )

--- a/cmd/kops-controller/controllers/BUILD.bazel
+++ b/cmd/kops-controller/controllers/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "awsipam.go",
+        "hosts_controller.go",
         "legacy_node_controller.go",
         "node_controller.go",
     ],
@@ -27,7 +28,9 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/dynamic:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime:go_default_library",

--- a/cmd/kops-controller/controllers/hosts_controller.go
+++ b/cmd/kops-controller/controllers/hosts_controller.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// HostsReconciler populates an /etc/hosts style file in the CoreDNS config map,
+// supporting in-pod resolution of our k8s.local entries.
+// Currently we only populate the apiserver internal record.
+type HostsReconciler struct {
+	// configMapID identifies the configmap we should update
+	configMapID types.NamespacedName
+
+	// hostnameInternalAPIServer is the DNS hostname we should populate for the internal apiserver record.
+	hostnameInternalAPIServer string
+
+	// client is the controller-runtime client
+	client client.Client
+
+	// log is a logr
+	log logr.Logger
+
+	// dynamicClient is a client-go client for patching ConfigMaps
+	dynamicClient dynamic.Interface
+
+	// lastUpdate holds the last value we updated, to reduce spurious updates.
+	lastUpdate *managedConfigMap
+}
+
+// NewHostsReconciler is the constructor for a HostsReconciler
+func NewHostsReconciler(mgr manager.Manager, configMapID types.NamespacedName, hostnameInternalAPIServer string) (*HostsReconciler, error) {
+	r := &HostsReconciler{
+		client:                    mgr.GetClient(),
+		log:                       ctrl.Log.WithName("controllers").WithName("Hosts"),
+		configMapID:               configMapID,
+		hostnameInternalAPIServer: hostnameInternalAPIServer,
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return nil, fmt.Errorf("error building dynamic client: %v", err)
+	}
+	r.dynamicClient = dynamicClient
+
+	return r, nil
+}
+
+// +kubebuilder:rbac:groups=,resources=nodes,verbs=get;list;watch
+
+// +kubebuilder:rbac:groups=,resources=configmaps,namespace=kube-system,resourceNames=coredns,verbs=get;patch
+
+// Reconcile is the main reconciler function that observes node changes.
+func (r *HostsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = r.log.WithValues("host", req.NamespacedName)
+
+	node := &corev1.Node{}
+	if err := r.client.Get(ctx, req.NamespacedName, node); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		klog.Warningf("unable to fetch node %s: %v", node.Name, err)
+		return ctrl.Result{}, err
+	}
+
+	controlPlaneLabels := client.HasLabels([]string{"node-role.kubernetes.io/control-plane"})
+	nodes := &corev1.NodeList{}
+	if err := r.client.List(ctx, nodes, controlPlaneLabels); err != nil {
+		klog.Warningf("unable to list nodes: %v", err)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, r.updateHosts(ctx, nodes)
+}
+
+func (r *HostsReconciler) updateHosts(ctx context.Context, nodes *corev1.NodeList) error {
+	addrToHosts := make(map[string][]string)
+
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+
+		for j := range node.Status.Addresses {
+			address := &node.Status.Addresses[j]
+
+			if address.Type == corev1.NodeInternalIP && address.Address != "" {
+				addrToHosts[address.Address] = append(addrToHosts[address.Address], r.hostnameInternalAPIServer)
+			}
+		}
+	}
+
+	return r.updateConfigMap(ctx, addrToHosts)
+}
+
+// managedConfigMap holds the fields we manage
+type managedConfigMap struct {
+	APIVersion string            `json:"apiVersion"`
+	Kind       string            `json:"kind"`
+	Data       map[string]string `json:"data"`
+}
+
+func (r *HostsReconciler) updateConfigMap(ctx context.Context, addrToHosts map[string][]string) error {
+	var block []string
+	for addr, hosts := range addrToHosts {
+		sort.Strings(hosts)
+		block = append(block, addr+"\t"+strings.Join(hosts, " "))
+	}
+	// Sort into a consistent order to minimize updates
+	sort.Strings(block)
+
+	hosts := strings.Join(block, "\n")
+
+	data := &managedConfigMap{}
+	data.APIVersion = "v1"  // Needed for some reason, even though it's in the resource path (?)
+	data.Kind = "ConfigMap" // Needed for some reason, even though it's in the resource path (?)
+	data.Data = map[string]string{"hosts": hosts}
+
+	if r.lastUpdate != nil && reflect.DeepEqual(r.lastUpdate, data) {
+		klog.Infof("skipping hosts configmap update (unchanged): %#v", data)
+		return nil
+	}
+
+	klog.Infof("patching hosts configmap: %#v", data)
+
+	configmapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	patch, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+
+	// It is strongly recommended for controllers to always "force" conflicts, since they might not be able to resolve or act on these conflicts.
+	force := true
+	patchOpts := metav1.PatchOptions{
+		FieldManager: "kops.k8s.io/hosts",
+		Force:        &force,
+	}
+	if _, err := r.dynamicClient.Resource(configmapGVR).Namespace(r.configMapID.Namespace).Patch(ctx, r.configMapID.Name, types.ApplyPatchType, patch, patchOpts); err != nil {
+		return fmt.Errorf("failed to patch configmap: %w", err)
+	}
+
+	r.lastUpdate = data
+
+	return nil
+}
+
+func (r *HostsReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		Complete(r)
+}

--- a/cmd/kops-controller/controllers/hosts_controller.go
+++ b/cmd/kops-controller/controllers/hosts_controller.go
@@ -26,15 +26,18 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/ipaddr"
+	"k8s.io/kops/pkg/nodelabels"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -45,8 +48,11 @@ type HostsReconciler struct {
 	// configMapID identifies the configmap we should update
 	configMapID types.NamespacedName
 
-	// hostnameInternalAPIServer is the DNS hostname we should populate for the internal apiserver record.
-	hostnameInternalAPIServer string
+	// roleControlPlaneHostnames lists the DNS hostnames we should populate for the (full) control-plane nodes.
+	roleControlPlaneHostnames []string
+
+	// roleAPIServerHostnames lists the DNS hostnames we should populate for apiserver-only nodes.
+	roleAPIServerHostnames []string
 
 	// client is the controller-runtime client
 	client client.Client
@@ -62,15 +68,20 @@ type HostsReconciler struct {
 
 	// addressFamilies holds the list of address families we should populate for internal IPs
 	addressFamilies map[ipaddr.Family]bool
+
+	// matchLabels is the set of labels we filter on; only nodes matching one of these labels will be considered
+	matchLabels []string
 }
 
 // NewHostsReconciler is the constructor for a HostsReconciler
-func NewHostsReconciler(mgr manager.Manager, configMapID types.NamespacedName, hostnameInternalAPIServer string, addressFamilies []ipaddr.Family) (*HostsReconciler, error) {
+func NewHostsReconciler(mgr manager.Manager, configMapID types.NamespacedName, roleControlPlaneHostnames []string, roleAPIServerHostnames []string, addressFamilies []ipaddr.Family) (*HostsReconciler, error) {
 	r := &HostsReconciler{
 		client:                    mgr.GetClient(),
 		log:                       ctrl.Log.WithName("controllers").WithName("Hosts"),
 		configMapID:               configMapID,
-		hostnameInternalAPIServer: hostnameInternalAPIServer,
+		roleControlPlaneHostnames: roleControlPlaneHostnames,
+		roleAPIServerHostnames:    roleAPIServerHostnames,
+		matchLabels:               []string{nodelabels.RoleLabelAPIServer16, nodelabels.RoleLabelControlPlane20},
 	}
 
 	r.addressFamilies = make(map[ipaddr.Family]bool)
@@ -93,32 +104,42 @@ func NewHostsReconciler(mgr manager.Manager, configMapID types.NamespacedName, h
 
 // Reconcile is the main reconciler function that observes node changes.
 func (r *HostsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = r.log.WithValues("host", req.NamespacedName)
-
-	node := &corev1.Node{}
-	if err := r.client.Get(ctx, req.NamespacedName, node); err != nil {
-		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		klog.Warningf("unable to fetch node %s: %v", node.Name, err)
-		return ctrl.Result{}, err
-	}
-
-	controlPlaneLabels := client.HasLabels([]string{"node-role.kubernetes.io/control-plane"})
-	nodes := &corev1.NodeList{}
-	if err := r.client.List(ctx, nodes, controlPlaneLabels); err != nil {
-		klog.Warningf("unable to list nodes: %v", err)
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, r.updateHosts(ctx, nodes)
-}
-
-func (r *HostsReconciler) updateHosts(ctx context.Context, nodes *corev1.NodeList) error {
 	addrToHosts := make(map[string][]string)
 
+	for _, label := range r.matchLabels {
+		nodes := &corev1.NodeList{}
+		if err := r.client.List(ctx, nodes, client.HasLabels([]string{label})); err != nil {
+			klog.Warningf("unable to list nodes with label %q: %v", label, err)
+			return ctrl.Result{}, err
+		}
+		if err := r.buildAddrToHosts(ctx, nodes, addrToHosts); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, r.updateConfigMap(ctx, addrToHosts)
+}
+
+func (r *HostsReconciler) buildAddrToHosts(ctx context.Context, nodes *corev1.NodeList, addrToHosts map[string][]string) error {
 	for i := range nodes.Items {
 		node := &nodes.Items[i]
+
+		role := util.GetNodeRole(node)
+
+		isRoleAPIServer := false
+		isRoleControlPlane := false
+
+		switch role {
+		case "apiserver":
+			isRoleAPIServer = true
+
+		case "control-plane", "master":
+			isRoleControlPlane = true
+
+		default:
+			klog.Warningf("ignoring node that should have been filtered by label selector: %v", node.Name)
+			continue
+		}
 
 		for j := range node.Status.Addresses {
 			address := &node.Status.Addresses[j]
@@ -138,25 +159,37 @@ func (r *HostsReconciler) updateHosts(ctx context.Context, nodes *corev1.NodeLis
 					continue
 				}
 
-				addrToHosts[address.Address] = append(addrToHosts[address.Address], r.hostnameInternalAPIServer)
+				if isRoleAPIServer {
+					addrToHosts[address.Address] = append(addrToHosts[address.Address], r.roleAPIServerHostnames...)
+				}
+				if isRoleControlPlane {
+					addrToHosts[address.Address] = append(addrToHosts[address.Address], r.roleControlPlaneHostnames...)
+				}
 			}
 		}
 	}
 
-	return r.updateConfigMap(ctx, addrToHosts)
+	return nil
 }
 
 // managedConfigMap holds the fields we manage
 type managedConfigMap struct {
-	APIVersion string            `json:"apiVersion"`
-	Kind       string            `json:"kind"`
-	Data       map[string]string `json:"data"`
+	APIVersion      string `json:"apiVersion"`
+	Kind            string `json:"kind"`
+	managedMetadata `json:"metadata"`
+
+	Data map[string]string `json:"data"`
+}
+
+type managedMetadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }
 
 func (r *HostsReconciler) updateConfigMap(ctx context.Context, addrToHosts map[string][]string) error {
 	var block []string
 	for addr, hosts := range addrToHosts {
-		sort.Strings(hosts)
+		hosts = normalizeStringSlice(hosts)
 		block = append(block, addr+"\t"+strings.Join(hosts, " "))
 	}
 	// Sort into a consistent order to minimize updates
@@ -165,10 +198,13 @@ func (r *HostsReconciler) updateConfigMap(ctx context.Context, addrToHosts map[s
 	hosts := strings.Join(block, "\n")
 
 	data := &managedConfigMap{}
-	data.APIVersion = "v1"  // Needed for some reason, even though it's in the resource path (?)
-	data.Kind = "ConfigMap" // Needed for some reason, even though it's in the resource path (?)
-	data.Data = map[string]string{"hosts": hosts}
+	// These fields are needed, even though they can be determined by looking at the path
+	data.APIVersion = "v1"
+	data.Kind = "ConfigMap"
+	data.Name = r.configMapID.Name
+	data.Namespace = r.configMapID.Namespace
 
+	data.Data = map[string]string{"hosts": hosts}
 	if r.lastUpdate != nil && reflect.DeepEqual(r.lastUpdate, data) {
 		klog.Infof("skipping hosts configmap update (unchanged): %#v", data)
 		return nil
@@ -198,8 +234,63 @@ func (r *HostsReconciler) updateConfigMap(ctx context.Context, addrToHosts map[s
 	return nil
 }
 
+// normalizeStringSlice returns a de-duplicated and sorted list of strings
+func normalizeStringSlice(in []string) []string {
+	if len(in) <= 1 {
+		return in
+	}
+
+	sort.Strings(in)
+	// Remove duplicates from sorted slice
+	out := make([]string, 0, len(in))
+	for i, s := range in {
+		if i == 0 || in[i-1] != s {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 func (r *HostsReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// We use a predicate to filter, ideally we would push-down the watch to filter by labels,
+	// but as we're watching all nodes anyway for the labelling controller, this isn't too bad.
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Node{}).
+		For(&corev1.Node{}, builder.WithPredicates(
+			&hostsPredicate{matchLabels: r.matchLabels},
+		)).
 		Complete(r)
+}
+
+// hostsPredicate filters watch events only to nodes of interest.
+type hostsPredicate struct {
+	matchLabels []string
+}
+
+func (p *hostsPredicate) isRelevant(obj *corev1.Node) bool {
+	for _, label := range p.matchLabels {
+		if _, found := obj.Labels[label]; found {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *hostsPredicate) Create(ev event.CreateEvent) bool {
+	return p.isRelevant(ev.Object.(*corev1.Node))
+}
+
+// Delete returns true if the Delete event should be processed
+func (p *hostsPredicate) Delete(ev event.DeleteEvent) bool {
+	return p.isRelevant(ev.Object.(*corev1.Node))
+}
+
+// Update returns true if the Update event should be processed
+func (p *hostsPredicate) Update(ev event.UpdateEvent) bool {
+	return p.isRelevant(ev.ObjectOld.(*corev1.Node)) || p.isRelevant(ev.ObjectNew.(*corev1.Node))
+}
+
+// Generic returns true if the Generic event should be processed
+func (p *hostsPredicate) Generic(ev event.GenericEvent) bool {
+	return p.isRelevant(ev.Object.(*corev1.Node))
 }

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -262,7 +262,7 @@ func addGossipController(mgr manager.Manager, opt *config.Options) error {
 		Name:      "coredns",
 	}
 
-	controller, err := controllers.NewHostsReconciler(mgr, configMapID, opt.Gossip.HostnameInternalAPIServer)
+	controller, err := controllers.NewHostsReconciler(mgr, configMapID, opt.Gossip.HostnameInternalAPIServer, opt.Gossip.InternalAddressFamilies)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -253,7 +253,7 @@ func addGossipController(mgr manager.Manager, opt *config.Options) error {
 		return nil
 	}
 
-	if opt.Gossip.HostnameInternalAPIServer == "" {
+	if len(opt.Gossip.RoleControlPlaneHostnames) == 0 && len(opt.Gossip.RoleAPIServerHostnames) == 0 {
 		return nil
 	}
 
@@ -262,7 +262,7 @@ func addGossipController(mgr manager.Manager, opt *config.Options) error {
 		Name:      "coredns",
 	}
 
-	controller, err := controllers.NewHostsReconciler(mgr, configMapID, opt.Gossip.HostnameInternalAPIServer, opt.Gossip.InternalAddressFamilies)
+	controller, err := controllers.NewHostsReconciler(mgr, configMapID, opt.Gossip.RoleControlPlaneHostnames, opt.Gossip.RoleAPIServerHostnames, opt.Gossip.InternalAddressFamilies)
 	if err != nil {
 		return err
 	}

--- a/cmd/kops-controller/pkg/config/BUILD.bazel
+++ b/cmd/kops-controller/pkg/config/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/kops/cmd/kops-controller/pkg/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ipaddr:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/gce/tpm:go_default_library",
     ],

--- a/cmd/kops-controller/pkg/config/options.go
+++ b/cmd/kops-controller/pkg/config/options.go
@@ -64,8 +64,11 @@ type ServerProviderOptions struct {
 
 // GossipOptions configures our support for gossip DNS (i.e. k8s.local)
 type GossipOptions struct {
-	// HostnameInternalAPIServer is the hostname for the internal apiserver.
-	HostnameInternalAPIServer string `json:"hostnameInternalAPIServer"`
+	// RoleControlPlaneHostnames lists the DNS hostnames we should populate for the (full) control-plane nodes.
+	RoleControlPlaneHostnames []string `json:"roleControlPlaneHostnames"`
+
+	// RoleAPIServerHostnames lists the DNS hostnames we should populate for apiserver-only nodes.
+	RoleAPIServerHostnames []string `json:"roleAPIServerHostnames"`
 
 	// InternalAddressFamilies holds the families of the internal addresses we should publish.
 	InternalAddressFamilies []ipaddr.Family `json:"internalAddressFamilies"`

--- a/cmd/kops-controller/pkg/config/options.go
+++ b/cmd/kops-controller/pkg/config/options.go
@@ -29,6 +29,8 @@ type Options struct {
 
 	// EnableCloudIPAM enables the cloud IPAM controller.
 	EnableCloudIPAM bool `json:"enableCloudIPAM,omitempty"`
+
+	Gossip *GossipOptions `json:"gossip,omitempty"`
 }
 
 func (o *Options) PopulateDefaults() {
@@ -57,4 +59,10 @@ type ServerOptions struct {
 type ServerProviderOptions struct {
 	AWS *awsup.AWSVerifierOptions  `json:"aws,omitempty"`
 	GCE *gcetpm.TPMVerifierOptions `json:"gce,omitempty"`
+}
+
+// GossipOptions configures our support for gossip DNS (i.e. k8s.local)
+type GossipOptions struct {
+	// HostnameInternalAPIServer is the hostname for the internal apiserver.
+	HostnameInternalAPIServer string `json:"hostnameInternalAPIServer"`
 }

--- a/cmd/kops-controller/pkg/config/options.go
+++ b/cmd/kops-controller/pkg/config/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"k8s.io/kops/pkg/ipaddr"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	gcetpm "k8s.io/kops/upup/pkg/fi/cloudup/gce/tpm"
 )
@@ -65,4 +66,7 @@ type ServerProviderOptions struct {
 type GossipOptions struct {
 	// HostnameInternalAPIServer is the hostname for the internal apiserver.
 	HostnameInternalAPIServer string `json:"hostnameInternalAPIServer"`
+
+	// InternalAddressFamilies holds the families of the internal addresses we should publish.
+	InternalAddressFamilies []ipaddr.Family `json:"internalAddressFamilies"`
 }

--- a/pkg/ipaddr/BUILD.bazel
+++ b/pkg/ipaddr/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["family.go"],
+    importpath = "k8s.io/kops/pkg/ipaddr",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/ipaddr/family.go
+++ b/pkg/ipaddr/family.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipaddr
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// Family is the IP address family (type) for an address; typically IPV4 or IPV6
+type Family string
+
+const (
+	FamilyIPV4 Family = "ipv4"
+	FamilyIPV6 Family = "ipv6"
+)
+
+// GetFamily returns the family for an IP.
+// IPv4-in-IPv6 addresses are treated as IPv6.
+func GetFamily(ip string) (Family, error) {
+	// Verify it is an IP (and not a host:port)
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return "", fmt.Errorf("cannot parse IP %q", ip)
+	}
+
+	// Check for ipv6 using colons; this is hacky but means we classify IPv4-in-IPv6 as v6
+	// Context: https://github.com/golang/go/issues/37921
+	family := FamilyIPV4
+	if strings.Contains(ip, ":") {
+		family = FamilyIPV6
+	}
+
+	return family, nil
+}

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e4297ef11985ee4a7c4e8707453a8d2c16bcb12eccc050adffac3e6ac2fb9a18
+    manifestHash: 262fb03230d0c4a72a9579736b4bc8fdf04e676b8e417790d08c14b4ff03198d
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e4297ef11985ee4a7c4e8707453a8d2c16bcb12eccc050adffac3e6ac2fb9a18
+    manifestHash: 262fb03230d0c4a72a9579736b4bc8fdf04e676b8e417790d08c14b4ff03198d
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e4297ef11985ee4a7c4e8707453a8d2c16bcb12eccc050adffac3e6ac2fb9a18
+    manifestHash: 262fb03230d0c4a72a9579736b4bc8fdf04e676b8e417790d08c14b4ff03198d
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e31327420b42b8d1b813625c65601166c52b054ae9ac95a57048d72e70b7033c
+    manifestHash: 63d09ebb456eb06d694bce805fda8888754e5250eb6a37c120146bbf6f655af4
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e31327420b42b8d1b813625c65601166c52b054ae9ac95a57048d72e70b7033c
+    manifestHash: 63d09ebb456eb06d694bce805fda8888754e5250eb6a37c120146bbf6f655af4
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e31327420b42b8d1b813625c65601166c52b054ae9ac95a57048d72e70b7033c
+    manifestHash: 63d09ebb456eb06d694bce805fda8888754e5250eb6a37c120146bbf6f655af4
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8c02a92c45fcae6cebd491fb57a7ba1d9f4df92b1b1a03cec8002c2374ad1a07
+    manifestHash: cbcbedeb8cabbc0323e24392d0fab033d4d34a48b58903c2e9314e246771d18b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cbcbedeb8cabbc0323e24392d0fab033d4d34a48b58903c2e9314e246771d18b
+    manifestHash: 723e6d0e2b354128538a4401b02de6bf6e40786acbdfda1df6d1879a1ba154c8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a2b7d85f845283e6a2e41036215e8b27c7808b199e0d613bcf3d1d40dd2f653b
+    manifestHash: 8c02a92c45fcae6cebd491fb57a7ba1d9f4df92b1b1a03cec8002c2374ad1a07
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 237badcf1d7899f372b94c7f6b3d7dbb0c48bc490d8cbbb9f8d90ed5e1ecb6b3
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -80,6 +80,10 @@ data:
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
         }
+        hosts /etc/coredns/hosts k8s.local {
+          ttl 30
+          fallthrough
+        }
         prometheus :9153
         forward . /etc/resolv.conf {
           max_concurrent 1000
@@ -200,9 +204,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"gossip":{"hostnameInternalAPIServer":"api.internal.minimal.k8s.local","internalAddressFamilies":["ipv4"]}}
+    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"gossip":{"roleControlPlaneHostnames":["api.internal.minimal.k8s.local","main.etcd.minimal.k8s.local","events.etcd.minimal.k8s.local","kops-controller.internal.minimal.k8s.local"],"roleAPIServerHostnames":null,"internalAddressFamilies":["ipv4"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"gossip":{"hostnameInternalAPIServer":"api.internal.minimal.k8s.local"}}
+    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"gossip":{"hostnameInternalAPIServer":"api.internal.minimal.k8s.local","internalAddressFamilies":["ipv4"]}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   config.yaml: |
-    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]}}
+    {"cloud":"aws","configBase":"memfs://clusters.example.com/minimal.k8s.local","server":{"Listen":":3988","provider":{"aws":{"nodesRoles":["nodes.minimal.k8s.local"],"Region":"us-test-1"}},"serverKeyPath":"/etc/kubernetes/kops-controller/pki/kops-controller.key","serverCertificatePath":"/etc/kubernetes/kops-controller/pki/kops-controller.crt","caBasePath":"/etc/kubernetes/kops-controller/pki","signingCAs":["kubernetes-ca"],"certNames":["kubelet","kubelet-server","kube-proxy"]},"gossip":{"hostnameInternalAPIServer":"api.internal.minimal.k8s.local"}}
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -185,6 +185,16 @@ rules:
   - leases
   verbs:
   - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - coredns
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - patch
 
 ---
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -200,9 +200,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -76,6 +76,12 @@ data:
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
         }
+    {{- if GossipDomains }}
+        hosts /etc/coredns/hosts {{ join GossipDomains " " }} {
+          ttl 30
+          fallthrough
+        }
+    {{- end }}
         prometheus :9153
         forward . {{ or (join KubeDNS.UpstreamNameservers " ") "/etc/resolv.conf" }} {
           max_concurrent 1000
@@ -192,9 +198,6 @@ spec:
         - name: config-volume
           configMap:
             name: coredns
-            items:
-            - key: Corefile
-              path: Corefile
 ---
 apiVersion: v1
 kind: Service

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -187,6 +187,17 @@ rules:
   - leases
   verbs:
   - create
+{{- if GossipDomains }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - patch
+  resourceNames: [ "coredns" ]
+{{- end }}
 
 ---
 

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/client/simple:go_default_library",
         "//pkg/dns:go_default_library",
         "//pkg/featureflag:go_default_library",
+        "//pkg/ipaddr:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/model/alimodel:go_default_library",
         "//pkg/model/awsmodel:go_default_library",

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/featureflag"
+	"k8s.io/kops/pkg/ipaddr"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/resources/spotinst"
 	"k8s.io/kops/pkg/wellknownports"
@@ -593,6 +594,11 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 	if dns.IsGossipHostname(cluster.Spec.MasterInternalName) {
 		config.Gossip = &kopscontrollerconfig.GossipOptions{
 			HostnameInternalAPIServer: cluster.Spec.MasterInternalName,
+		}
+		if cluster.Spec.IsIPv6Only() {
+			config.Gossip.InternalAddressFamilies = []ipaddr.Family{ipaddr.FamilyIPV6}
+		} else {
+			config.Gossip.InternalAddressFamilies = []ipaddr.Family{ipaddr.FamilyIPV4}
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/coredns.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/coredns.addons.k8s.io-k8s-1.12.yaml
@@ -209,9 +209,6 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          items:
-          - key: Corefile
-            path: Corefile
           name: coredns
         name: config-volume
 

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: a9df38695bacbb83a7e11814642d6edfc6291f9dc615c74124ee9a5a57998c0e
+    manifestHash: 73b69518aa4e49109f038213924a57beac385c57e0c9b96f72e6368000d160e7
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88ffe1a3752cf290450cc94bd53aea49a665e411dbf4cfe9c1a2cc5b027f12ef
+    manifestHash: 12b67f439637253329bf6fb2ee23b3ef65959621720c863263c13da8271bff89
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io


### PR DESCRIPTION
We add the hosts plugin to CoreDNS, and we populate a ConfigMap from
kops-controller (when in gossip mode).

This enables resolution of the internal apiserver DNS name from Pods,
even when gossip mode (k8s.local) is in use.  This should fix the
failing e2e tests which are assuming that the name in the JWT token is
resolvable from inside the cluster.

This is also a possible step towards a simpler gossip mode, now that
we have a central controller.
