### PR TITLE
GCE: Fix subnet deletion

### DIFF
--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -48,10 +48,6 @@ const (
 	typeDNSRecord            = "DNSRecord"
 )
 
-// Maximum number of `-` separated tokens in a name
-// Example: nodeport-external-to-node-ipv6
-const maxPrefixTokens = 5
-
 func ListResourcesGCE(gceCloud gce.GCECloud, clusterName string, region string) (map[string]*resources.Resource, error) {
 	if region == "" {
 		region = gceCloud.Region()
@@ -499,6 +495,10 @@ func (d *clusterDiscoveryGCE) listFirewallRules() ([]*resources.Resource, error)
 	}
 
 	for _, fr := range frs {
+		// Maximum number of `-` separated tokens in a name
+		// Example: nodeport-external-to-node-ipv6
+		maxPrefixTokens := 5
+
 		if !d.matchesClusterNameMultipart(fr.Name, maxPrefixTokens) {
 			continue
 		}


### PR DESCRIPTION
Subnets are created & owned for IPAlias mode.  We weren't deleting
them because of a bug deleting when there is a hyphen in the name (and
by default they are named after the region, which has a hyphen).
