### PR TITLE
GCE: When using calico, need to open up ipip protocol

### DIFF
--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -408,3 +408,8 @@ func (b *KopsModelContext) UseServiceAccountExternalPermissions() bool {
 	return b.Cluster.Spec.IAM != nil &&
 		fi.BoolValue(b.Cluster.Spec.IAM.UseServiceAccountExternalPermissions)
 }
+
+// NetworkingIsCalico returns true if we are using calico networking
+func (b *KopsModelContext) NetworkingIsCalico() bool {
+	return b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.Calico != nil
+}

--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -38,6 +38,12 @@ var _ fi.ModelBuilder = &FirewallModelBuilder{}
 func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	klog.Warningf("TODO: Harmonize gcemodel with awsmodel for firewall - GCE model is way too open")
 
+	allProtocols := []string{"tcp", "udp", "icmp", "esp", "ah", "sctp"}
+
+	if b.NetworkingIsCalico() {
+		allProtocols = append(allProtocols, "ipip")
+	}
+
 	// Allow all traffic from nodes -> nodes
 	{
 		t := &gcetasks.FirewallRule{
@@ -46,7 +52,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Network:    b.LinkToNetwork(),
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
 			TargetTags: []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
-			Allowed:    []string{"tcp", "udp", "icmp", "esp", "ah", "sctp"},
+			Allowed:    allProtocols,
 		}
 		c.AddTask(t)
 	}
@@ -59,7 +65,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Network:    b.LinkToNetwork(),
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
 			TargetTags: []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
-			Allowed:    []string{"tcp", "udp", "icmp", "esp", "ah", "sctp"},
+			Allowed:    allProtocols,
 		}
 		c.AddTask(t)
 	}
@@ -72,7 +78,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Network:    b.LinkToNetwork(),
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
 			TargetTags: []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
-			Allowed:    []string{"tcp", "udp", "icmp", "esp", "ah", "sctp"},
+			Allowed:    allProtocols,
 		}
 		c.AddTask(t)
 	}
@@ -103,7 +109,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Network:      b.LinkToNetwork(),
 			SourceRanges: []string{b.Cluster.Spec.PodCIDR},
 			TargetTags:   []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
-			Allowed:      []string{"tcp", "udp", "icmp", "esp", "ah", "sctp"},
+			Allowed:      allProtocols,
 		})
 	}
 


### PR DESCRIPTION
We need to open up the ipip protocol, which wasn't previously enabled.

Future work could construct the firewall rules in a common library,
and then adapt them to the various clouds.
