### PR TITLE
Remove unneeded network related sysctls

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -150,18 +150,6 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
-	if b.Cluster.Spec.IsIPv6Only() {
-		sysctls = append(sysctls,
-			"net.ipv6.conf.all.forwarding=1",
-			"net.ipv6.conf.all.accept_ra=2",
-			"")
-	} else {
-		sysctls = append(sysctls,
-			"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
-			"net.ipv4.ip_forward=1",
-			"")
-	}
-
 	if params := b.NodeupConfig.SysctlParameters; len(params) > 0 {
 		sysctls = append(sysctls,
 			"# Custom sysctl parameters from instance group spec",


### PR DESCRIPTION
The ipv4 and ipv6 forwarding is usually set by default. Also, seems that the original reason behind adding it is gone.
`net.ipv6.conf.all.accept_ra` is not working as expected and is mostly ignored.

/cc @olemarkus 