### PR TITLE
Automated cherry pick of #12385: Remove unneeded network related sysctls

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -150,18 +150,6 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
-	if b.Cluster.Spec.IsIPv6Only() {
-		sysctls = append(sysctls,
-			"net.ipv6.conf.all.forwarding=1",
-			"net.ipv6.conf.all.accept_ra=2",
-			"")
-	} else {
-		sysctls = append(sysctls,
-			"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
-			"net.ipv4.ip_forward=1",
-			"")
-	}
-
 	if params := b.NodeupConfig.SysctlParameters; len(params) > 0 {
 		sysctls = append(sysctls,
 			"# Custom sysctl parameters from instance group spec",


### PR DESCRIPTION
Cherry pick of #12385 on release-1.22.

#12385: Remove unneeded network related sysctls

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.