### PR TITLE
Remove critical-pod scheduler annotation.

### DIFF
--- a/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/awsiam/tasks-kube-apiserver.yaml
@@ -27,7 +27,6 @@ contents: |
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
       kubectl.kubernetes.io/default-container: kube-apiserver
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-apiserver

--- a/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/dedicated-apiserver/tasks-kube-apiserver.yaml
@@ -6,7 +6,6 @@ contents: |
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
       kubectl.kubernetes.io/default-container: kube-apiserver
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-apiserver

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
@@ -6,7 +6,6 @@ contents: |
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
       kubectl.kubernetes.io/default-container: kube-apiserver
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-apiserver

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
@@ -2,8 +2,6 @@ contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-controller-manager

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
@@ -2,8 +2,6 @@ contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-proxy

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
@@ -2,8 +2,6 @@ contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-scheduler

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-amd64.yaml
@@ -6,7 +6,6 @@ contents: |
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
       kubectl.kubernetes.io/default-container: kube-apiserver
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-apiserver

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-apiserver-arm64.yaml
@@ -6,7 +6,6 @@ contents: |
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
       kubectl.kubernetes.io/default-container: kube-apiserver
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-apiserver

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-amd64.yaml
@@ -2,8 +2,6 @@ contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-controller-manager

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-controller-manager-arm64.yaml
@@ -2,8 +2,6 @@ contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-controller-manager

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-amd64.yaml
@@ -2,8 +2,6 @@ contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-proxy

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-arm64.yaml
@@ -2,8 +2,6 @@ contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-proxy

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-amd64.yaml
@@ -2,8 +2,6 @@ contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-scheduler

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-scheduler-arm64.yaml
@@ -2,8 +2,6 @@ contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-scheduler

--- a/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/without-etcd-events/tasks-kube-apiserver.yaml
@@ -6,7 +6,6 @@ contents: |
       dns.alpha.kubernetes.io/external: api.minimal.example.com
       dns.alpha.kubernetes.io/internal: api.internal.minimal.example.com
       kubectl.kubernetes.io/default-container: kube-apiserver
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: kube-apiserver

--- a/pkg/kubemanifest/critical.go
+++ b/pkg/kubemanifest/critical.go
@@ -22,11 +22,6 @@ import (
 
 // MarkPodAsCritical adds the required annotations for a pod to be considered critical
 func MarkPodAsCritical(pod *v1.Pod) {
-	if pod.ObjectMeta.Annotations == nil {
-		pod.ObjectMeta.Annotations = make(map[string]string)
-	}
-	pod.ObjectMeta.Annotations["scheduler.alpha.kubernetes.io/critical-pod"] = ""
-
 	toleration := v1.Toleration{
 		Key:      "CriticalAddonsOnly",
 		Operator: v1.TolerationOpExists,

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -63,8 +63,6 @@ Contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: etcd-manager-events
@@ -133,8 +131,6 @@ Contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: etcd-manager-main

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -63,8 +63,6 @@ Contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: etcd-manager-events
@@ -136,8 +134,6 @@ Contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: etcd-manager-main

--- a/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
@@ -63,8 +63,6 @@ Contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: etcd-manager-events
@@ -134,8 +132,6 @@ Contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: etcd-manager-main

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -63,8 +63,6 @@ Contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: etcd-manager-events
@@ -142,8 +140,6 @@ Contents: |
   apiVersion: v1
   kind: Pod
   metadata:
-    annotations:
-      scheduler.alpha.kubernetes.io/critical-pod: ""
     creationTimestamp: null
     labels:
       k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-cilium_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-cilium_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-cilium

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-events

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
   creationTimestamp: null
   labels:
     k8s-app: etcd-manager-main


### PR DESCRIPTION
This is no longer recognized in all supported k8s versions (1.16+)

https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals

> the scheduler.alpha.kubernetes.io/critical-pod annotation is removed. Pod priority (spec.priorityClassName) should be used instead to mark pods as critical.

There are still references to this in addon manifests but we can debate between removing them now vs when they're removed upstream.