### PR TITLE
Automated cherry pick of #12389: Add specific taints to dns-controller.

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 72ceaf7f3d033f2f5952dae8a15e841316f785de7c72be861a8f1a92d0a34d69
+    manifestHash: 6de1dca5e9fd89b3781f632bf74aee0a67d0416ca236ecc69811b39acb475271
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -62,7 +62,12 @@ spec:
         fsGroup: 10001
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
       volumes:
       - name: token-amazonaws-com
         projected:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 747da2871586a8accd3eae2d335dd7708eb5ec37397b7ef91360308cd2302a83
+    manifestHash: 9ed8f2ebf944f7bcb1c70dee2138e6c5792add9f406cdea4b7d698f43e70158d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3a9ef169a20b4b5b6ae15ab0d9f7e45b5c2d2c62bbcaab7eff7a6f68a9bc9fe6
+    manifestHash: 18b88eccffc711fc6f968b7e166187d67f2813f6e69f4fef1a3e87d57bd1d2e5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3380ffda384a67934f255af8515d5ee2c12f82e8647ce7d4a35fe7cb08141c2d
+    manifestHash: a9270f2b2ec75309dac50ccb3e31d64e0c71e8ed46cb4754e72c975380f46986
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f8992161ec6290f1daac9a8b9e9165d76636cf54fa18c8e839446558606cfd17
+    manifestHash: 1893570d7122c96f738a05ae0cdeadfb68f94b0a0d1d777edae2c03caac6abfd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 77d04b224d30727e21733cf87db85c32b24973a08d42fd8d9ea6453170a2fcb7
+    manifestHash: ed7a810cd370171f63bf9767f22d9aaf26e405dfb65ac352402088cff9398988
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5a66c9a04547a13daffc7a8205ce32a33e8aa1d8351700f2fd44b2d583498f24
+    manifestHash: 8a40656fb1df6b70f2349576daa69ddd4dc212c78a1c067487ebfd659f0b7c9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a23975fb5e21baa1a4c72f81b556b5ecdcb4b9b67a3351535c96884423d97651
+    manifestHash: 9066c95ac8179cf7e53477596429d4ea63be6225a4c1f2bb69950d60547875bb
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e89fdc090c3f83a880612902c60203b76ff6585fc6076653c3bddea744cb1ef8
+    manifestHash: 1bef58da6bbd857259561c3405fd8dfe7afa7b6e7f4892e617777e19a3bbc615
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0b8d89d14cc516c150b9446224474e39b7b89d15a22dd1459f960fc2d07bc0bc
+    manifestHash: de503fcb69ea337bed074f13417d5873035b43e6fa28509c633cfc473c58289f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4f5728585de2598f91ad3e93882a6aa49275d56dcb3112476fed031db45da835
+    manifestHash: eb67b2641c6a3e30f2f7b97f26d915981ad3fc6e60cba2d3ce1d1cd8ca5e7c8f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6d4e4031ae84ebd52b2f0a7b8cfaa83d22a9755e731c6afd6aa4b5a580ace863
+    manifestHash: 326a5316d78145e6bf7cec833d1be9df56e12877bca6bb8b9b883f353a2b27a6
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -63,7 +63,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 72ceaf7f3d033f2f5952dae8a15e841316f785de7c72be861a8f1a92d0a34d69
+    manifestHash: 6de1dca5e9fd89b3781f632bf74aee0a67d0416ca236ecc69811b39acb475271
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -62,7 +62,12 @@ spec:
         fsGroup: 10001
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
       volumes:
       - name: token-amazonaws-com
         projected:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f5043e79e6ad1edbb926c6ae6c258832dcf22077e8e5e3a35d0c575653592c98
+    manifestHash: 3bc80ac06a7492a9bf5adc34791348fe5957c515dce1a4d5ae10b9b864c1ce97
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e4802a79f17ed74aa9bf24f57669a26c5fe07f5ba2e431686fa8e5760da0f1e2
+    manifestHash: 5328b4c822ee40e3193fd38376e91e8a312a8e60b2138551a64d56006704cb8a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3d32bb53547006975d0f48368e9d89d7808c28c026dc324d7347a6f1f269b006
+    manifestHash: 17103aff69c41a29f61fa083208b1fd0ed6e8fe2508c93e6f716ea0e7573d9c7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6d4e4031ae84ebd52b2f0a7b8cfaa83d22a9755e731c6afd6aa4b5a580ace863
+    manifestHash: 326a5316d78145e6bf7cec833d1be9df56e12877bca6bb8b9b883f353a2b27a6
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -63,7 +63,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57ec44dab8cd34bde9a2b8255d6fc5ea1bf1f4b2aa68cf82b9eda021c3deeb5
+    manifestHash: c7cc5b0f22f1deb85e17211430e11a7aead8f765393571d298eb7fe21720f2cd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6d4e4031ae84ebd52b2f0a7b8cfaa83d22a9755e731c6afd6aa4b5a580ace863
+    manifestHash: 326a5316d78145e6bf7cec833d1be9df56e12877bca6bb8b9b883f353a2b27a6
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -63,7 +63,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 14f90e422580ef9b751efd05c7856943a3f4817a13679c5dfd78e7fe4152d903
+    manifestHash: d8a6c449955ff1d97e0c931dea57185656e73f1df77a445b482ad6c904f8c286
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 226acd92bf806a632dd59b270f2acd6c6e48a70ab8af406187dd959bca952ccd
+    manifestHash: 56805eedcb057272fe388d9882390778e7b3c0c5653ce4f860a9d5272dc520c0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -55,7 +55,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e800ff87140780c33252d466bd54d6a6b8c391f97c9c17d80c347d93dff90c99
+    manifestHash: 1aa5adc91929084e725d4b3646b83983b2236c0fa63a951d50e835be98416b26
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e800ff87140780c33252d466bd54d6a6b8c391f97c9c17d80c347d93dff90c99
+    manifestHash: 1aa5adc91929084e725d4b3646b83983b2236c0fa63a951d50e835be98416b26
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 092264f7bd693dbb882fe88dab8178b80ecf2fc35a1189aefd277bf3b1588584
+    manifestHash: 9031c106603cdf3f67392537ed30387291d06103a390b74e7f084d167ab0b3a0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8b153a2e0523f228810c00e7a475393d3624eb846871cf8f2d176cfa5dce0b9f
+    manifestHash: f4474e68e58cfbf0c43e3ebb7df20981f94c04aba251e3b9b5023ec90035e428
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3290bd9a317e60f2c79821842447ddfe5a5e3dee489b4ae8df3d76bf7b474771
+    manifestHash: 0e10dc37557f87d1688c7e0c1f498c295ca37807862726ab72336868cd9c9ed1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 113c75281b40d826386f82dcf1601176b5ddc4400923c982b57cb91ec87b9f5c
+    manifestHash: 1354ae2d64b05902382afa4ff98584879844244b3be1c98d6028cb8b63a9db32
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 49571bd856fd4062c98dfb26c3f3eb7db79cec9011f3aad6b7536ffbfeabe468
+    manifestHash: 5396ac3a5a91ceeca986db43313230d7e5cde5c7505656b5dbb3e83a88286da3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b0229bf88b6093dfe391a63541941e1b7e7b0254936289695051d970ecab4309
+    manifestHash: 58c17d7f876a270794b32a75a002d94062cd0f3043e614286a790fb0fd1a4bfe
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6dc9700cc7e24c453b820ac693fca269e0d38da147e12eedf1bc62227971bd41
+    manifestHash: a26540c5ddf111ece882eefd6d9e33774b9da4e1cf13d95bd92f8ac36652c3e3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -63,7 +63,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c6c4ccc2ffe13e512177b6c221a62aef2d52df3b8a89caa3c2bc91f60460eff3
+    manifestHash: 21535a8311a04140e54e25e0df06a65999da266578328afc72701aaa72f7d182
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0a49e982812861c7a441d347e158c7dfa4aa7e16c52b788d2e604f8aee4a19e8
+    manifestHash: eb5c42284c02de8daa9aa4666580cf3a359996c639784c2d7803a519bd473c6a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f3a8594431a30f4c37da9538673c19e2a2601ae4a622b74842a2f56ed613e429
+    manifestHash: 5e65a526bca86790177744514f71bf26512857a6a092df1f6b29bab70928576e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1d9f77e0621132e058679f20af3f1a6ea16e26162344cf9d252fb14514ecd4c1
+    manifestHash: 4e094c1b26dc2b90ee1c322f4dc81fa97f403c54b0c932ebdc9c9d0a249fc815
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: ad79b935b1e2383a31dde2168d7ebcdba7513d99c528dd335db3555a24026d41
+    manifestHash: f1102679c00842b04365dfe1586066ed2b1b67af8af54f08c828143772256be1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 65d213767dbe92f4b6905c7412aee6e0084611b810facded2a56cb0cf1e5dff1
+    manifestHash: 7e6b6e0c3d58a36312fb607ab05bb3ff1ae7bcc30cec9e34f5c560cdc5f48b9a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a610cd70816856eb4347d0e18b0a49f156b4cb254df4117b4ad9d1f97c6c4904
+    manifestHash: f5dbf3bdf081671f8cadbfa4da615e74e90f0924acb4a545b034232ca67b66bf
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 62093d3f1f3ccfee4a4c8ae9ae40f59feb7a8eeaf316a6ca12120cf0f5027667
+    manifestHash: c6c61bfeb957e8c51d55b479b21f48b4564eebe19b0ee70366690786766861e5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 72ceaf7f3d033f2f5952dae8a15e841316f785de7c72be861a8f1a92d0a34d69
+    manifestHash: 6de1dca5e9fd89b3781f632bf74aee0a67d0416ca236ecc69811b39acb475271
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -62,7 +62,12 @@ spec:
         fsGroup: 10001
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
       volumes:
       - name: token-amazonaws-com
         projected:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cfc744e5534528959f6a400a1ab85b7ca2fa5c537473eb2b66a28b030b812c39
+    manifestHash: 985f33f4c1608727c8d53fbb4dc464f361ad247b24e209f288201e31886dec83
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4d2919054d8185753628b588ab47b35f5166d95ef165415d33c9747d2e815f60
+    manifestHash: e630b44fe87c546566e4bda2af67b4b3843160ee23b0a84e3731efa1c9b4bd44
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 757230281ccb9545bb8cace0040629d96c827d31f7982ed784c187ce6393538d
+    manifestHash: 0d0c874e1e3c134e054e720341aa749ca7ad300106939150bd3bdbf9b101eacc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac8a05bfbba6be22e1586fef53788e6669cbb745c82e72e9028c9d08e147e513
+    manifestHash: 22d37110c8f60c3b04ba83eedaa5ef2d9d1013cacb1f7e9ad48d22757243af9b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -52,7 +52,12 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
 
 ---
 

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -25,7 +25,12 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
       nodeSelector:
         node-role.kubernetes.io/master: ""
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -37,7 +37,7 @@ spec:
         dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
 {{ end }}
     spec:
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: Exists

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0a17bbcd96393cb3658dd5f09195d3fe6a1bf78c1a7e5f975fd1c653c50d660
+    manifestHash: 5714bc1b354509fad4f8a17b422e170d81fc9fd4cd690acdc59eea77cdf6db18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0a17bbcd96393cb3658dd5f09195d3fe6a1bf78c1a7e5f975fd1c653c50d660
+    manifestHash: 5714bc1b354509fad4f8a17b422e170d81fc9fd4cd690acdc59eea77cdf6db18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0a17bbcd96393cb3658dd5f09195d3fe6a1bf78c1a7e5f975fd1c653c50d660
+    manifestHash: 5714bc1b354509fad4f8a17b422e170d81fc9fd4cd690acdc59eea77cdf6db18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0a17bbcd96393cb3658dd5f09195d3fe6a1bf78c1a7e5f975fd1c653c50d660
+    manifestHash: 5714bc1b354509fad4f8a17b422e170d81fc9fd4cd690acdc59eea77cdf6db18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -63,7 +63,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b75de985fe5bfc35ffd8e1d93566ca70e8e073277fc5e6ecac2f115e9d930f44
+    manifestHash: 06c00d67d2b89e430f1f883ec354c7e2a5d2e26d8502f4a8208bb8352bc5ddfd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b75de985fe5bfc35ffd8e1d93566ca70e8e073277fc5e6ecac2f115e9d930f44
+    manifestHash: 06c00d67d2b89e430f1f883ec354c7e2a5d2e26d8502f4a8208bb8352bc5ddfd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0a17bbcd96393cb3658dd5f09195d3fe6a1bf78c1a7e5f975fd1c653c50d660
+    manifestHash: 5714bc1b354509fad4f8a17b422e170d81fc9fd4cd690acdc59eea77cdf6db18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b75de985fe5bfc35ffd8e1d93566ca70e8e073277fc5e6ecac2f115e9d930f44
+    manifestHash: 06c00d67d2b89e430f1f883ec354c7e2a5d2e26d8502f4a8208bb8352bc5ddfd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0a17bbcd96393cb3658dd5f09195d3fe6a1bf78c1a7e5f975fd1c653c50d660
+    manifestHash: 5714bc1b354509fad4f8a17b422e170d81fc9fd4cd690acdc59eea77cdf6db18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -62,7 +62,12 @@ spec:
         fsGroup: 10001
       serviceAccount: dns-controller
       tolerations:
-      - operator: Exists
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
       volumes:
       - name: token-amazonaws-com
         projected:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0a17bbcd96393cb3658dd5f09195d3fe6a1bf78c1a7e5f975fd1c653c50d660
+    manifestHash: 5714bc1b354509fad4f8a17b422e170d81fc9fd4cd690acdc59eea77cdf6db18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 72ceaf7f3d033f2f5952dae8a15e841316f785de7c72be861a8f1a92d0a34d69
+    manifestHash: 6de1dca5e9fd89b3781f632bf74aee0a67d0416ca236ecc69811b39acb475271
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -65,7 +65,7 @@ spec:
       nodeSelector:
         kops.k8s.io/kops-controller-pki: ""
         node-role.kubernetes.io/master: ""
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0a17bbcd96393cb3658dd5f09195d3fe6a1bf78c1a7e5f975fd1c653c50d660
+    manifestHash: 5714bc1b354509fad4f8a17b422e170d81fc9fd4cd690acdc59eea77cdf6db18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f0a17bbcd96393cb3658dd5f09195d3fe6a1bf78c1a7e5f975fd1c653c50d660
+    manifestHash: 5714bc1b354509fad4f8a17b422e170d81fc9fd4cd690acdc59eea77cdf6db18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -35,7 +35,7 @@ spec:
       k8s-addon: limit-range.addons.k8s.io
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 11fc77d975790b13403bd9f035f2daa23ed4445d0d9d4107023d9c6103eabe85
+    manifestHash: 7934f73e3a3e56972beeb971f6cb30c5479cb97a6917a1d5c1628b06642ebc2a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #12389 on release-1.22.

#12389: Add specific taints to dns-controller.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.