### PR TITLE
Add support to configure Cilium CNI chaining

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -3585,6 +3585,15 @@ spec:
                         description: BPFRoot is not implemented and may be removed
                           in the future. Setting this has no effect.
                         type: string
+                      chainingMode:
+                        description: 'ChainingMode allows to use Cilium in combination
+                          with other CNI plugins. With Cilium CNI chaining, the base
+                          network connectivity and IP address management is managed
+                          by the non-Cilium CNI plugin, but Cilium attaches eBPF programs
+                          to the network devices created by the non-Cilium plugin
+                          to provide L3/L4 network visibility, policy enforcement
+                          and other advanced features. Default: none'
+                        type: string
                       clusterName:
                         description: ClusterName is the name of the cluster. It is
                           only relevant when building a mesh of clusters.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -299,6 +299,13 @@ type CiliumNetworkingSpec struct {
 	// BPFRoot is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	BPFRoot string `json:"bpfRoot,omitempty"`
+	// ChainingMode allows to use Cilium in combination with other CNI plugins.
+	// With Cilium CNI chaining, the base network connectivity and IP address management is managed
+	// by the non-Cilium CNI plugin, but Cilium attaches eBPF programs to the network devices created
+	// by the non-Cilium plugin to provide L3/L4 network visibility, policy enforcement and other advanced features.
+	// Setting this has no effect.
+	// Default: none
+	ChainingMode string `json:"chainingMode,omitempty"`
 	// ContainerRuntime is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	ContainerRuntime []string `json:"containerRuntime,omitempty"`

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -303,7 +303,6 @@ type CiliumNetworkingSpec struct {
 	// With Cilium CNI chaining, the base network connectivity and IP address management is managed
 	// by the non-Cilium CNI plugin, but Cilium attaches eBPF programs to the network devices created
 	// by the non-Cilium plugin to provide L3/L4 network visibility, policy enforcement and other advanced features.
-	// Setting this has no effect.
 	// Default: none
 	ChainingMode string `json:"chainingMode,omitempty"`
 	// ContainerRuntime is not implemented and may be removed in the future.

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -299,6 +299,13 @@ type CiliumNetworkingSpec struct {
 	// BPFRoot is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	BPFRoot string `json:"bpfRoot,omitempty"`
+	// ChainingMode allows to use Cilium in combination with other CNI plugins.
+	// With Cilium CNI chaining, the base network connectivity and IP address management is managed
+	// by the non-Cilium CNI plugin, but Cilium attaches eBPF programs to the network devices created
+	// by the non-Cilium plugin to provide L3/L4 network visibility, policy enforcement and other advanced features.
+	// Setting this has no effect.
+	// Default: none
+	ChainingMode string `json:"chainingMode,omitempty"`
 	// ContainerRuntime is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	ContainerRuntime []string `json:"containerRuntime,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -303,7 +303,6 @@ type CiliumNetworkingSpec struct {
 	// With Cilium CNI chaining, the base network connectivity and IP address management is managed
 	// by the non-Cilium CNI plugin, but Cilium attaches eBPF programs to the network devices created
 	// by the non-Cilium plugin to provide L3/L4 network visibility, policy enforcement and other advanced features.
-	// Setting this has no effect.
 	// Default: none
 	ChainingMode string `json:"chainingMode,omitempty"`
 	// ContainerRuntime is not implemented and may be removed in the future.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1803,6 +1803,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.AllowLocalhost = in.AllowLocalhost
 	out.AutoIpv6NodeRoutes = in.AutoIpv6NodeRoutes
 	out.BPFRoot = in.BPFRoot
+	out.ChainingMode = in.ChainingMode
 	out.ContainerRuntime = in.ContainerRuntime
 	out.ContainerRuntimeEndpoint = in.ContainerRuntimeEndpoint
 	out.Debug = in.Debug
@@ -1911,6 +1912,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.AllowLocalhost = in.AllowLocalhost
 	out.AutoIpv6NodeRoutes = in.AutoIpv6NodeRoutes
 	out.BPFRoot = in.BPFRoot
+	out.ChainingMode = in.ChainingMode
 	out.ContainerRuntime = in.ContainerRuntime
 	out.ContainerRuntimeEndpoint = in.ContainerRuntimeEndpoint
 	out.Debug = in.Debug

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -127,6 +127,10 @@ data:
   # backend and affinity maps. (default 65536)
   bpf-lb-map-max: "{{ .BPFLBMapMax }}"
 
+  {{ if .ChainingMode }}
+  cni-chaining-mode: "{{ .ChainingMode }}"
+  {{ end }}
+
   # enable-bpf-masquerade enables masquerading packets from endpoints leaving
   # the host with BPF instead of iptables. (default false)
   enable-bpf-masquerade: "{{ .EnableBPFMasquerade }}"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -139,6 +139,10 @@ data:
   # backend and affinity maps. (default 65536)
   bpf-lb-map-max: "{{ .BPFLBMapMax }}"
 
+  {{ if .ChainingMode }}
+  cni-chaining-mode: "{{ .ChainingMode }}"
+  {{ end }}
+
   # enable-bpf-masquerade enables masquerading packets from endpoints leaving
   # the host with BPF instead of iptables. (default false)
   enable-bpf-masquerade: "{{ .EnableBPFMasquerade }}"


### PR DESCRIPTION
CNI chaining allows using Cilium in combination with other CNI plugins.

With Cilium CNI chaining, the base network connectivity and IP address management is managed by the non-Cilium CNI plugin, but Cilium attaches eBPF programs to the network devices created by the non-Cilium plugin to provide L3/L4 network visibility, policy enforcement and other advanced features.
https://docs.cilium.io/en/v1.9/gettingstarted/cni-chaining/#cni-chaining

In our case, to be able to use the `HostPort` feature in our cluster, we need to enable the `portmap` plugin.