### PR TITLE
Automated cherry pick of #12403: Upgrade terraform to 1.0.7

### DIFF
--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -21,7 +21,7 @@ set -o pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 # Terraform versions
-TF_TAG=1.0.5
+TF_TAG=1.0.7
 
 PROVIDER_CACHE="${KOPS_ROOT}/.cache/terraform"
 

--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -30,7 +30,7 @@ while IFS= read -r -d '' -u 3 test_dir; do
   [ -f "${test_dir}/kubernetes.tf" ] || [ -f "${test_dir}/kubernetes.tf.json" ] || continue
   echo -e "${test_dir}\n"
 
-  docker run --rm -e "TF_PLUGIN_CACHE_DIR=${PROVIDER_CACHE}" -v "${PROVIDER_CACHE}:${PROVIDER_CACHE}" -v "${test_dir}":"${test_dir}" -w "${test_dir}" --entrypoint=sh hashicorp/terraform:${TF_TAG} -c '/bin/terraform init -upgrade >/dev/null && /bin/terraform validate' || RC=$?
+  docker run --rm --network host -e "TF_PLUGIN_CACHE_DIR=${PROVIDER_CACHE}" -v "${PROVIDER_CACHE}:${PROVIDER_CACHE}" -v "${test_dir}":"${test_dir}" -w "${test_dir}" --entrypoint=sh hashicorp/terraform:${TF_TAG} -c '/bin/terraform init -upgrade >/dev/null && /bin/terraform validate' || RC=$?
 done 3< <(find "${KOPS_ROOT}/tests/integration/update_cluster" -maxdepth 1 -type d -print0)
 
 if [ $RC != 0 ]; then


### PR DESCRIPTION
Cherry pick of #12403 on release-1.22.

#12403: Upgrade terraform to 1.0.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```