### PR TITLE
Automated cherry pick of #12410: Run verify-cloudformation in host network
#12411: Upgrade cnf-lint to 0.54.2

### DIFF
--- a/hack/verify-cloudformation.sh
+++ b/hack/verify-cloudformation.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 . "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-TAG=v0.52.0
+TAG=v0.54.2
 IMAGE="cfn-python-lint:${TAG}"
 
 # There is no official docker image so build it locally

--- a/hack/verify-cloudformation.sh
+++ b/hack/verify-cloudformation.sh
@@ -32,7 +32,7 @@ function docker_build() {
 
 docker image inspect "${IMAGE}" >/dev/null 2>&1 || docker_build
 
-docker run --rm -v "${KOPS_ROOT}:/${KOPS_ROOT}" -v "${KOPS_ROOT}/hack/.cfnlintrc.yaml:/root/.cfnlintrc" "${IMAGE}" "/${KOPS_ROOT}/tests/integration/update_cluster/**/cloudformation.json"
+docker run --rm --network host -v "${KOPS_ROOT}:/${KOPS_ROOT}" -v "${KOPS_ROOT}/hack/.cfnlintrc.yaml:/root/.cfnlintrc" "${IMAGE}" "/${KOPS_ROOT}/tests/integration/update_cluster/**/cloudformation.json"
 RC=$?
 
 if [ $RC != 0 ]; then


### PR DESCRIPTION
Cherry pick of #12410 #12411 on release-1.22.

#12410: Run verify-cloudformation in host network
#12411: Upgrade cnf-lint to 0.54.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.