### PR TITLE
Add Cilium agent pod annotations support to improve personalization

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -4438,6 +4438,12 @@ spec:
                         items:
                           type: string
                         type: array
+                      agentPodAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: 'AgentPodAnnotations makes possible to add additional
+                          annotations to the cilium agent. Default: none'
+                        type: object
                       agentPrometheusPort:
                         description: AgentPrometheusPort is the port to listen to
                           for Prometheus metrics. Defaults to 9090.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -434,6 +434,9 @@ type CiliumNetworkingSpec struct {
 	// Nat6Range is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	Nat46Range string `json:"nat46Range,omitempty"`
+	// AgentPodAnnotations makes possible to add additional annotations to cilium agent.
+	// Default: none
+	AgentPodAnnotations map[string]string `json:"agentPodAnnotations,omitempty"`
 	// Pprof is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	Pprof bool `json:"pprof,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -434,6 +434,9 @@ type CiliumNetworkingSpec struct {
 	// Nat6Range is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	Nat46Range string `json:"nat46Range,omitempty"`
+	// AgentPodAnnotations makes possible to add additional annotations to the cilium agent.
+	// Default: none
+	AgentPodAnnotations map[string]string `json:"agentPodAnnotations,omitempty"`
 	// Pprof is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	Pprof bool `json:"pprof,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1849,6 +1849,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.LogstashProbeTimer = in.LogstashProbeTimer
 	out.DisableMasquerade = in.DisableMasquerade
 	out.Nat46Range = in.Nat46Range
+	out.AgentPodAnnotations = in.AgentPodAnnotations
 	out.Pprof = in.Pprof
 	out.PrefilterDevice = in.PrefilterDevice
 	out.PrometheusServeAddr = in.PrometheusServeAddr
@@ -1958,6 +1959,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.LogstashProbeTimer = in.LogstashProbeTimer
 	out.DisableMasquerade = in.DisableMasquerade
 	out.Nat46Range = in.Nat46Range
+	out.AgentPodAnnotations = in.AgentPodAnnotations
 	out.Pprof = in.Pprof
 	out.PrefilterDevice = in.PrefilterDevice
 	out.PrometheusServeAddr = in.PrometheusServeAddr

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -564,6 +564,13 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AgentPodAnnotations != nil {
+		in, out := &in.AgentPodAnnotations, &out.AgentPodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.EnableRemoteNodeIdentity != nil {
 		in, out := &in.EnableRemoteNodeIdentity, &out.EnableRemoteNodeIdentity
 		*out = new(bool)

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -434,6 +434,9 @@ type CiliumNetworkingSpec struct {
 	// Nat6Range is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	Nat46Range string `json:"nat46Range,omitempty"`
+	// AgentPodAnnotations makes possible to add additional annotations to the cilium agent.
+	// Default: none
+	AgentPodAnnotations map[string]string `json:"agentPodAnnotations,omitempty"`
 	// Pprof is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	Pprof bool `json:"pprof,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1849,6 +1849,7 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.LogstashProbeTimer = in.LogstashProbeTimer
 	out.DisableMasquerade = in.DisableMasquerade
 	out.Nat46Range = in.Nat46Range
+	out.AgentPodAnnotations = in.AgentPodAnnotations
 	out.Pprof = in.Pprof
 	out.PrefilterDevice = in.PrefilterDevice
 	out.PrometheusServeAddr = in.PrometheusServeAddr
@@ -1958,6 +1959,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 	out.LogstashProbeTimer = in.LogstashProbeTimer
 	out.DisableMasquerade = in.DisableMasquerade
 	out.Nat46Range = in.Nat46Range
+	out.AgentPodAnnotations = in.AgentPodAnnotations
 	out.Pprof = in.Pprof
 	out.PrefilterDevice = in.PrefilterDevice
 	out.PrometheusServeAddr = in.PrometheusServeAddr

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -564,6 +564,13 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AgentPodAnnotations != nil {
+		in, out := &in.AgentPodAnnotations, &out.AgentPodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.EnableRemoteNodeIdentity != nil {
 		in, out := &in.EnableRemoteNodeIdentity, &out.EnableRemoteNodeIdentity
 		*out = new(bool)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -641,6 +641,13 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AgentPodAnnotations != nil {
+		in, out := &in.AgentPodAnnotations, &out.AgentPodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.EnableRemoteNodeIdentity != nil {
 		in, out := &in.EnableRemoteNodeIdentity, &out.EnableRemoteNodeIdentity
 		*out = new(bool)

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -555,6 +555,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
         {{ end }}
+{{- with .AgentPodAnnotations }}
+        {{- . | nindent 8 }}
+{{- end }}
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -587,6 +587,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
         {{ end }}
+{{- with .AgentPodAnnotations }}
+        {{- . | nindent 8 }}
+{{- end }}
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -84,6 +84,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	}
 
 	sprigTxtFuncMap := sprig.TxtFuncMap()
+	dest["nindent"] = sprigTxtFuncMap["nindent"]
 	dest["indent"] = sprigTxtFuncMap["indent"]
 	dest["contains"] = sprigTxtFuncMap["contains"]
 	dest["trimPrefix"] = sprigTxtFuncMap["trimPrefix"]


### PR DESCRIPTION
Annotations is pretty useful when you need third-party tool to add additional behavior
for a k8s resource.
Lots of auto-discovery tools are based on this annotations.