### PR TITLE
Revert "Remove unneeded network related sysctls"

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -150,6 +150,18 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
+	if b.Cluster.Spec.IsIPv6Only() {
+		sysctls = append(sysctls,
+			"net.ipv6.conf.all.forwarding=1",
+			"net.ipv6.conf.all.accept_ra=2",
+			"")
+	} else {
+		sysctls = append(sysctls,
+			"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
+			"net.ipv4.ip_forward=1",
+			"")
+	}
+
 	if params := b.NodeupConfig.SysctlParameters; len(params) > 0 {
 		sysctls = append(sysctls,
 			"# Custom sysctl parameters from instance group spec",


### PR DESCRIPTION
This reverts commit ce08ec68dfb5bdf2c74d61dfd008c5fa671ef200.

Removing these sysctls broke a number of CNIs (weave, aws vpc, and canal), and possibly breaks configurations we do not test as well.

The accept_ra sysctls can be removed in a followup.