### PR TITLE
Revert "Enable ipv6 forwarding and router announcements"

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -150,17 +150,10 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
-	if b.Cluster.Spec.IsIPv6Only() {
-		sysctls = append(sysctls,
-			"net.ipv6.conf.all.forwarding=1",
-			"net.ipv6.conf.all.accept_ra=2",
-			"")
-	} else {
-		sysctls = append(sysctls,
-			"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
-			"net.ipv4.ip_forward=1",
-			"")
-	}
+	sysctls = append(sysctls,
+		"# Prevent docker from changing iptables: https://github.com/kubernetes/kubernetes/issues/40182",
+		"net.ipv4.ip_forward=1",
+		"")
 
 	if params := b.NodeupConfig.SysctlParameters; len(params) > 0 {
 		sysctls = append(sysctls,


### PR DESCRIPTION
`net.ipv6.conf.all.forwarding=1` is not needed with Calico and Cilium (the only supported IPv6 CNIs)
`net.ipv6.conf.all.accept_ra=2` is a big mess that is conflicting with systemd-networkd on Ubuntu and in general, not working.

This reverts commit ab596a49

/cc @olemarkus @rifelpet 