### PR TITLE
Allow aws-iam-authenticator to be scheduled onto dedicated apiserver nodes

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -129,11 +129,15 @@ spec:
 
       # run on each master node
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        {{ APIServerNodeRole }}: ""
       priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/api-server
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
 

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -101,6 +101,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["GetNodeInstanceGroups"] = tf.GetNodeInstanceGroups
 	dest["HasHighlyAvailableControlPlane"] = tf.HasHighlyAvailableControlPlane
 	dest["ControlPlaneControllerReplicas"] = tf.ControlPlaneControllerReplicas
+	dest["APIServerNodeRole"] = tf.APIServerNodeRole
 
 	dest["CloudTags"] = tf.CloudTagsForInstanceGroup
 	dest["KubeDNS"] = func() *kops.KubeDNSConfig {
@@ -297,6 +298,13 @@ func (tf *TemplateFunctions) ControlPlaneControllerReplicas() int {
 		return 2
 	}
 	return 1
+}
+
+func (tf *TemplateFunctions) APIServerNodeRole() string {
+	if featureflag.APIServerNodes.Enabled() {
+		return "node-role.kubernetes.io/api-server"
+	}
+	return "node-role.kubernetes.io/master"
 }
 
 // HasHighlyAvailableControlPlane returns true of the cluster has more than one control plane node. False otherwise.

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/authentication.aws-k8s-1.12.yaml
@@ -189,6 +189,10 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/api-server
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       volumes:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 7fab0163a43a38470011072ed69967e28c8d6acf5f47ad9c82f437878f78eb77
+    manifestHash: e560afb9c07a966239a54546698ff2ce489b26cbc51db6508914fc68cfb8b599
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
Also adding the CCM toleration to match dns-controller in https://github.com/kubernetes/kops/pull/12389

Fixes #12390