### PR TITLE
Have toolbox dump include contents of /etc/hosts

### DIFF
--- a/pkg/dump/dumper.go
+++ b/pkg/dump/dumper.go
@@ -285,6 +285,10 @@ func (n *logDumperNode) dump(ctx context.Context) []error {
 		}
 	}
 
+	if err := n.shellToFile(ctx, "cat /etc/hosts", filepath.Join(n.dir, "etchosts")); err != nil {
+		errors = append(errors, err)
+	}
+
 	return errors
 }
 


### PR DESCRIPTION
This should help troubleshoot DNS issues in gossip clusters.

For example, [this GCE job](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-grid-gce-cilium-u2004-k22-docker/1442007600894840832) is failing to validate because nodes arent joining the cluster. [kubelet logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-grid-gce-cilium-u2004-k22-docker/1442007600894840832/artifacts/34.106.20.139/kubelet.log) on an unjoined node report not being able to resolve the API DNS record. [protokube logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-grid-gce-cilium-u2004-k22-docker/1442007600894840832/artifacts/34.106.20.139/protokube.log) on the same node report updating /etc/hosts but it will be easier to troubleshoot if we can see the final contents of /etc/hosts.