### PR TITLE
Update Amazon Linux 2 documentation to mention the 5.10 kernel

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -55,7 +55,7 @@ The following table provides the support status for various distros with regards
 
 ### Amazon Linux 2
 
-Amazon Linux 2 is based on Kernel version **4.14** which fixes some of the bugs present in RHEL/CentOS 7 and effects are less visible, but it's still quite old.
+Amazon Linux 2 has variants using Kernel versions 4.14 and 5.10. Be sure to use the 5.10 images as specified in the image filter below. More information is available in the [AWS Documentation](https://aws.amazon.com/amazon-linux-2/faqs/).
 
 For kOps versions 1.16 and 1.17, the only supported Docker version is `18.06.3`. Newer versions of Docker cannot be installed due to missing dependencies for `container-selinux`. This issue is fixed in kOps **1.18**.
 
@@ -65,7 +65,7 @@ Available images can be listed using:
 aws ec2 describe-images --region us-east-1 --output table \
   --owners 137112412989 \
   --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
-  --filters "Name=name,Values=amzn2-ami-hvm-2*-x86_64-gp2"
+  --filters "Name=name,Values=amzn2-ami-kernel-5.10-hvm-2*-x86_64-gp2"
 ```
 
 ### Debian 10 (Buster)

--- a/docs/releases/1.22-NOTES.md
+++ b/docs/releases/1.22-NOTES.md
@@ -161,6 +161,8 @@ For file assets, it means adding an explicit path as shown below:
 
 * Cilium now supports the wireguard protocol for transparent encryption.
 
+* Amazon Linux 2 users are encouraged to use the AMIs based on the 5.10 Linux kernel. See [the documentation](../operations/images.md#amazon-linux-2) for more information.
+
 # Full change list since 1.21.0 release
 
 ## 1.22.0-alpha.1 to 1.22.0-alpha.2


### PR DESCRIPTION
ref: https://github.com/kubernetes/kops/issues/12429
ref: https://github.com/kubernetes/test-infra/pull/23764

/hold to see the results of https://testgrid.k8s.io/kops-distros#kops-aws-distro-imageamazonlinux2 and the grid jobs.