### PR TITLE
Skip certain e2e tests in GCE

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -64,6 +64,18 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|Services.*affinity"
 	}
 
+	if cluster.Spec.CloudProvider == "gce" {
+		// Firewall tests expect a specific format for cluster and control plane host names
+		// which kOps does not match
+		// ref: https://github.com/kubernetes/kubernetes/blob/1bd00776b5d78828a065b5c21e7003accc308a06/test/e2e/framework/providers/gce/firewall.go#L92-L100
+		skipRegex += "|Firewall"
+		// kube-dns tests are not skipped automatically if a cluster uses CoreDNS instead
+		skipRegex += "|kube-dns"
+		// this test assumes the cluster runs COS but kOps uses Ubuntu by default
+		// ref: https://github.com/kubernetes/test-infra/pull/22190
+		skipRegex += "|should.be.mountable.when.non-attachable"
+	}
+
 	// Ensure it is valid regex
 	if _, err := regexp.Compile(skipRegex); err != nil {
 		return err


### PR DESCRIPTION
These tests will never work with how kOps configures GCE clusters, so skip them for now.

Using this job as a reference: https://testgrid.k8s.io/kops-gce#kops-grid-gce-u2004-k22-docker

These tests are already being skipped in the original GCE jobs: https://github.com/kubernetes/test-infra/blob/6f7377aa20ea5c7b0e1284c0934114d1849d6dcd/config/jobs/kubernetes/kops/kops-periodics-gce.yaml#L39