### PR TITLE
Fix typo in name of new 'UseServiceAccountExternalPermissions' variable.

### DIFF
--- a/docs/releases/1.22-NOTES.md
+++ b/docs/releases/1.22-NOTES.md
@@ -29,7 +29,7 @@ This can be enabled by adding the following to the Cluster spec:
 ```
 spec:
   iam:
-    useServiceAcountExternalPermissions: true
+    useServiceAccountExternalPermissions: true
 ```
 
 Currently this is only available using the AWS cloud provider.


### PR DESCRIPTION
I was reading the documentation and `acount` stood out to me.