### PR TITLE
Add support for NodeAnnotations on an InstanceGroup

### DIFF
--- a/cmd/kops-controller/controllers/BUILD.bazel
+++ b/cmd/kops-controller/controllers/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "awsipam.go",
         "legacy_node_controller.go",
         "node_controller.go",
+        "types.go",
     ],
     importpath = "k8s.io/kops/cmd/kops-controller/controllers",
     visibility = ["//visibility:public"],

--- a/cmd/kops-controller/controllers/awsipam.go
+++ b/cmd/kops-controller/controllers/awsipam.go
@@ -164,7 +164,7 @@ type nodePatchSpec struct {
 	PodCIDRs []string `json:"podCIDRs,omitempty"`
 }
 
-// patchNodeLabels patches the node labels to set the specified labels
+// patchNodePodCIDRs patches the node's pod CIDRs to set the cidr
 func patchNodePodCIDRs(client *corev1client.CoreV1Client, ctx context.Context, node *corev1.Node, cidr string) error {
 	klog.Infof("assigning cidr %q to node %q", cidr, node.ObjectMeta.Name)
 	nodePatchSpec := &nodePatchSpec{

--- a/cmd/kops-controller/controllers/types.go
+++ b/cmd/kops-controller/controllers/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,30 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package nodeidentity
+package controllers
 
-import (
-	"context"
-
-	corev1 "k8s.io/api/core/v1"
-)
-
-type Identifier interface {
-	IdentifyNode(ctx context.Context, node *corev1.Node) (*Info, error)
-}
-
-type Info struct {
-	InstanceID  string
+type nodeMetadataUpdate struct {
 	Labels      map[string]string
 	Annotations map[string]string
 }
 
-type LegacyIdentifier interface {
-	IdentifyNode(ctx context.Context, node *corev1.Node) (*LegacyInfo, error)
-}
-
-type LegacyInfo struct {
-	InstanceID        string
-	InstanceGroup     string
-	InstanceLifecycle string
+func newMetadataUpdate() *nodeMetadataUpdate {
+	return &nodeMetadataUpdate{
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+	}
 }

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -715,6 +715,12 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              nodeAnnotations:
+                additionalProperties:
+                  type: string
+                description: NodeAnnotations indicates the kubernetes annotations
+                  for nodes in this instance group
+                type: object
               nodeLabels:
                 additionalProperties:
                   type: string

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -135,6 +135,8 @@ type InstanceGroupSpec struct {
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 	// CloudLabels defines additional tags or labels on cloud provider resources
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
+	// NodeAnnotations indicates the kubernetes annotations for nodes in this instance group
+	NodeAnnotations map[string]string `json:"nodeAnnotations,omitempty"`
 	// NodeLabels indicates the kubernetes labels for nodes in this instance group
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 	// FileAssets is a collection of file assets for this instance group

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -103,6 +103,8 @@ type InstanceGroupSpec struct {
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 	// CloudLabels defines additional tags or labels on cloud provider resources
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
+	// NodeAnnotations indicates the kubernetes annotations for nodes in this instance group
+	NodeAnnotations map[string]string `json:"nodeAnnotations,omitempty"`
 	// NodeLabels indicates the kubernetes labels for nodes in this instance group
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 	// FileAssets is a collection of file assets for this instance group

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4202,6 +4202,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
 	out.CloudLabels = in.CloudLabels
+	out.NodeAnnotations = in.NodeAnnotations
 	out.NodeLabels = in.NodeLabels
 	if in.FileAssets != nil {
 		in, out := &in.FileAssets, &out.FileAssets
@@ -4363,6 +4364,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
 	out.CloudLabels = in.CloudLabels
+	out.NodeAnnotations = in.NodeAnnotations
 	out.NodeLabels = in.NodeLabels
 	if in.FileAssets != nil {
 		in, out := &in.FileAssets, &out.FileAssets

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2246,6 +2246,13 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.NodeAnnotations != nil {
+		in, out := &in.NodeAnnotations, &out.NodeAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NodeLabels != nil {
 		in, out := &in.NodeLabels, &out.NodeLabels
 		*out = make(map[string]string, len(*in))

--- a/pkg/apis/kops/v1alpha3/instancegroup.go
+++ b/pkg/apis/kops/v1alpha3/instancegroup.go
@@ -100,6 +100,8 @@ type InstanceGroupSpec struct {
 	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 	// CloudLabels defines additional tags or labels on cloud provider resources
 	CloudLabels map[string]string `json:"cloudLabels,omitempty"`
+	// NodeAnnotations indicates the kubernetes annotations for nodes in this instance group
+	NodeAnnotations map[string]string `json:"nodeAnnotations,omitempty"`
 	// NodeLabels indicates the kubernetes labels for nodes in this instance group
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 	// FileAssets is a collection of file assets for this instance group

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -4112,6 +4112,7 @@ func autoConvert_v1alpha3_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
 	out.CloudLabels = in.CloudLabels
+	out.NodeAnnotations = in.NodeAnnotations
 	out.NodeLabels = in.NodeLabels
 	if in.FileAssets != nil {
 		in, out := &in.FileAssets, &out.FileAssets
@@ -4273,6 +4274,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha3_InstanceGroupSpec(in *kops.I
 	out.AssociatePublicIP = in.AssociatePublicIP
 	out.AdditionalSecurityGroups = in.AdditionalSecurityGroups
 	out.CloudLabels = in.CloudLabels
+	out.NodeAnnotations = in.NodeAnnotations
 	out.NodeLabels = in.NodeLabels
 	if in.FileAssets != nil {
 		in, out := &in.FileAssets, &out.FileAssets

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -2226,6 +2226,13 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.NodeAnnotations != nil {
+		in, out := &in.NodeAnnotations, &out.NodeAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NodeLabels != nil {
 		in, out := &in.NodeLabels, &out.NodeLabels
 		*out = make(map[string]string, len(*in))

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -233,6 +233,62 @@ func TestValidBootDevice(t *testing.T) {
 	}
 }
 
+func TestValidNodeAnnotations(t *testing.T) {
+	grid := []struct {
+		key      string
+		value    string
+		expected []string
+	}{
+		{
+			key:   "subdomain.domain.tld",
+			value: "the-value",
+		},
+		{
+			key:   "subdomain.domain.tld/foo",
+			value: "the-value",
+		},
+		{
+			key:   "subdomain.domain.tld/FOO",
+			value: "the-value",
+		},
+		{
+			key:   "subdomain.domain.tld/foo_-.BaR",
+			value: "the-value",
+		},
+		{
+			key:      "subdomain.domain.tld/foo/bar",
+			value:    "the-value",
+			expected: []string{"Invalid value::spec.nodeAnnotations"},
+		},
+		{
+			key:      "SUBdomain.domain.tld/foo",
+			value:    "the-value",
+			expected: []string{"Invalid value::spec.nodeAnnotations"},
+		},
+		{
+			key:      "subdomain.domain.tld/-foo",
+			value:    "the-value",
+			expected: []string{"Invalid value::spec.nodeAnnotations"},
+		},
+	}
+
+	for _, g := range grid {
+		ig := &kops.InstanceGroup{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "some-ig",
+			},
+			Spec: kops.InstanceGroupSpec{
+				Role: "Node",
+			},
+		}
+		ig.Spec.NodeAnnotations = map[string]string{
+			g.key: g.value,
+		}
+		errs := ValidateInstanceGroup(ig, nil)
+		testErrors(t, g.key, errs, g.expected)
+	}
+}
+
 func TestValidNodeLabels(t *testing.T) {
 
 	grid := []struct {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2384,6 +2384,13 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.NodeAnnotations != nil {
+		in, out := &in.NodeAnnotations, &out.NodeAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NodeLabels != nil {
 		in, out := &in.NodeLabels, &out.NodeLabels
 		*out = make(map[string]string, len(*in))

--- a/pkg/model/azuremodel/context.go
+++ b/pkg/model/azuremodel/context.go
@@ -82,8 +82,9 @@ func (c *AzureModelContext) NameForLoadBalancer() string {
 // doesn't allow "/" in tag keys.
 func (c *AzureModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) map[string]*string {
 	const (
-		clusterNodeTemplateLabel = "k8s.io_cluster_node-template_label_"
-		clusterNodeTemplateTaint = "k8s.io_cluster_node-template_taint_"
+		clusterNodeTemplateLabel      = "k8s.io_cluster_node-template_label_"
+		clusterNodeTemplateAnnotation = "k8s.io_cluster_node-template_annotation_"
+		clusterNodeTemplateTaint      = "k8s.io_cluster_node-template_taint_"
 	)
 
 	labels := make(map[string]string)
@@ -97,8 +98,17 @@ func (c *AzureModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) ma
 		labels[k] = v
 	}
 
-	// Apply labels for cluster node labels.
+	// Apply labels for cluster node annotations.
 	i := 0
+	for k, v := range ig.Spec.NodeAnnotations {
+		// Store the label key in the tag value
+		// so that we don't need to espace "/" in the label key.
+		labels[fmt.Sprintf("%s%d", clusterNodeTemplateAnnotation, i)] = fmt.Sprintf("%s=%s", k, v)
+		i++
+	}
+
+	// Apply labels for cluster node labels.
+	i = 0
 	for k, v := range ig.Spec.NodeLabels {
 		// Store the label key in the tag value
 		// so that we don't need to espace "/" in the label key.

--- a/pkg/model/azuremodel/context_test.go
+++ b/pkg/model/azuremodel/context_test.go
@@ -37,6 +37,9 @@ func TestCloudTagsForInstanceGroup(t *testing.T) {
 	ig.Spec.NodeLabels = map[string]string{
 		"node_label/key": "node_label_value",
 	}
+	ig.Spec.NodeAnnotations = map[string]string{
+		"node_annotation/key": "node_annotation_value",
+	}
 	ig.Spec.Taints = []string{
 		"taint_key=taint_value",
 	}
@@ -47,6 +50,7 @@ func TestCloudTagsForInstanceGroup(t *testing.T) {
 		"ig_label_key":                                 fi.String("ig_label_value"),
 		"test_label":                                   fi.String("from_ig"),
 		"k8s.io_cluster_node-template_label_0":         fi.String("node_label/key=node_label_value"),
+		"k8s.io_cluster_node-template_annotation_0":    fi.String("node_annotation/key=node_annotation_value"),
 		"k8s.io_cluster_node-template_taint_taint_key": fi.String("taint_value"),
 		"k8s.io_role_node":                             fi.String("1"),
 		"kops.k8s.io_instancegroup":                    fi.String("nodes"),

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -153,6 +153,11 @@ func (b *KopsModelContext) CloudTagsForInstanceGroup(ig *kops.InstanceGroup) (ma
 		labels[nodeidentityaws.ClusterAutoscalerNodeTemplateLabel+k] = v
 	}
 
+	// Apply labels for cluster autoscaler node annotations
+	for k, v := range ig.Spec.NodeAnnotations {
+		labels[nodeidentityaws.ClusterAutoscalerNodeTemplateAnnotation+k] = v
+	}
+
 	// Apply labels for cluster autoscaler node taints
 	for _, v := range ig.Spec.Taints {
 		splits := strings.SplitN(v, "=", 2)

--- a/pkg/nodeidentity/aws/identify.go
+++ b/pkg/nodeidentity/aws/identify.go
@@ -40,6 +40,8 @@ const (
 	CloudTagInstanceGroupName = "kops.k8s.io/instancegroup"
 	// ClusterAutoscalerNodeTemplateLabel is the prefix used on node labels when copying to cloud tags.
 	ClusterAutoscalerNodeTemplateLabel = "k8s.io/cluster-autoscaler/node-template/label/"
+	// ClusterAutoscalerNodeTemplateAnnotation is the prefix used on node annotations when copying to cloud tags.
+	ClusterAutoscalerNodeTemplateAnnotation = "k8s.io/cluster-autoscaler/node-template/annotation/"
 	// The expiration time of nodeidentity.Info cache.
 	cacheTTL = 60 * time.Minute
 )
@@ -141,13 +143,17 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 	}
 
 	info := &nodeidentity.Info{
-		InstanceID: instanceID,
-		Labels:     labels,
+		InstanceID:  instanceID,
+		Labels:      labels,
+		Annotations: map[string]string{},
 	}
 
 	for _, tag := range instance.Tags {
-		if strings.HasPrefix(aws.StringValue(tag.Key), ClusterAutoscalerNodeTemplateLabel) {
-			info.Labels[strings.TrimPrefix(aws.StringValue(tag.Key), ClusterAutoscalerNodeTemplateLabel)] = aws.StringValue(tag.Value)
+		k := aws.StringValue(tag.Key)
+		if strings.HasPrefix(k, ClusterAutoscalerNodeTemplateLabel) {
+			info.Labels[strings.TrimPrefix(k, ClusterAutoscalerNodeTemplateLabel)] = aws.StringValue(tag.Value)
+		} else if strings.HasPrefix(k, ClusterAutoscalerNodeTemplateAnnotation) {
+			info.Annotations[strings.TrimPrefix(k, ClusterAutoscalerNodeTemplateAnnotation)] = aws.StringValue(tag.Value)
 		}
 	}
 


### PR DESCRIPTION
NodeAnnotations are propagated onto the 'annotations' field in the Node's metadata.

Fixes #12172

Signed-off-by: Jeroen van Erp <jeroen@hierynomus.com>