### PR TITLE
Automated cherry pick of #12431: Mount cgroupv2 for cilium at a custom location

### DIFF
--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 561acbb6fc8947695eb062473e9aa2297a9350fea1508d0939189940f48a5b32
+    manifestHash: 33c1ebadd038227fbca2acb94063b076d63d0c2fd750b1744839d9d741acb07c
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -35,7 +35,7 @@ data:
   bpf-nat-global-max: "524288"
   bpf-neigh-global-max: "524288"
   bpf-policy-map-max: "16384"
-  cgroup-root: /sys/fs/cgroup/unified
+  cgroup-root: /run/cilium/cgroupv2
   cluster-name: default
   container-runtime: none
   debug: "false"
@@ -508,7 +508,7 @@ spec:
         - mountPath: /sys/fs/bpf
           mountPropagation: HostToContainer
           name: bpf-maps
-        - mountPath: /sys/fs/cgroup/unified
+        - mountPath: /run/cilium/cgroupv2
           mountPropagation: HostToContainer
           name: cilium-cgroup
         - mountPath: /var/run/cilium
@@ -534,8 +534,8 @@ spec:
           type: DirectoryOrCreate
         name: cni-path
       - hostPath:
-          path: /sys/fs/cgroup/unified
-          type: DirectoryOrCreate
+          path: /run/cilium/cgroupv2
+          type: Directory
         name: cilium-cgroup
       - hostPath:
           path: /etc/cni/net.d

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 215a45b620ee9eb02bf3e22ba5a4a5bbd678b6dd2473ad9adc06baac1c1fbecb
+    manifestHash: a9cdd10f3fdd52e32d0228bc377bfd524c18dfd46a9c678af17b22519dcf27e5
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -35,7 +35,7 @@ data:
   bpf-nat-global-max: "524288"
   bpf-neigh-global-max: "524288"
   bpf-policy-map-max: "16384"
-  cgroup-root: /sys/fs/cgroup/unified
+  cgroup-root: /run/cilium/cgroupv2
   cluster-name: default
   container-runtime: none
   debug: "false"
@@ -508,7 +508,7 @@ spec:
         - mountPath: /sys/fs/bpf
           mountPropagation: HostToContainer
           name: bpf-maps
-        - mountPath: /sys/fs/cgroup/unified
+        - mountPath: /run/cilium/cgroupv2
           mountPropagation: HostToContainer
           name: cilium-cgroup
         - mountPath: /var/run/cilium
@@ -534,8 +534,8 @@ spec:
           type: DirectoryOrCreate
         name: cni-path
       - hostPath:
-          path: /sys/fs/cgroup/unified
-          type: DirectoryOrCreate
+          path: /run/cilium/cgroupv2
+          type: Directory
         name: cilium-cgroup
       - hostPath:
           path: /etc/cni/net.d

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: a27941351ef6ecb7bee109b5cbd773a7e8bde30626d1cfb1fef8bdcfcb55b38b
+    manifestHash: 712830ece49b2a47039e61eaf3d7a91631768660c46d648d36fbdd1d83389188
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -37,7 +37,7 @@ data:
   bpf-nat-global-max: "524288"
   bpf-neigh-global-max: "524288"
   bpf-policy-map-max: "16384"
-  cgroup-root: /sys/fs/cgroup/unified
+  cgroup-root: /run/cilium/cgroupv2
   cluster-name: default
   container-runtime: none
   debug: "false"
@@ -528,7 +528,7 @@ spec:
         - mountPath: /sys/fs/bpf
           mountPropagation: HostToContainer
           name: bpf-maps
-        - mountPath: /sys/fs/cgroup/unified
+        - mountPath: /run/cilium/cgroupv2
           mountPropagation: HostToContainer
           name: cilium-cgroup
         - mountPath: /var/run/cilium
@@ -554,8 +554,8 @@ spec:
           type: DirectoryOrCreate
         name: cni-path
       - hostPath:
-          path: /sys/fs/cgroup/unified
-          type: DirectoryOrCreate
+          path: /run/cilium/cgroupv2
+          type: Directory
         name: cilium-cgroup
       - hostPath:
           path: /etc/cni/net.d

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -228,7 +228,7 @@ data:
   # enable-l7-proxy enables L7 proxy for L7 policy enforcement. (default true)
   enable-l7-proxy: "{{ .EnableL7Proxy }}"
 
-  cgroup-root: /sys/fs/cgroup/unified
+  cgroup-root: /run/cilium/cgroupv2
 
   {{ if WithDefaultBool .Hubble.Enabled false }}
   # Enable Hubble gRPC service.
@@ -757,7 +757,7 @@ spec:
           name: bpf-maps
           mountPropagation: HostToContainer
         # Required to mount cgroup filesystem from the host to cilium agent pod
-        - mountPath: /sys/fs/cgroup/unified
+        - mountPath: /run/cilium/cgroupv2
           name: cilium-cgroup
           mountPropagation: HostToContainer
         - mountPath: /var/run/cilium
@@ -793,8 +793,8 @@ spec:
         name: cni-path
       # To keep state between restarts / upgrades for cgroup2 filesystem
       - hostPath:
-          path: /sys/fs/cgroup/unified
-          type: DirectoryOrCreate
+          path: /run/cilium/cgroupv2
+          type: Directory
         name: cilium-cgroup
       # To install cilium cni configuration in the host
       - hostPath:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -241,7 +241,7 @@ data:
   # enable-l7-proxy enables L7 proxy for L7 policy enforcement. (default true)
   enable-l7-proxy: "{{ .EnableL7Proxy }}"
 
-  cgroup-root: /sys/fs/cgroup/unified
+  cgroup-root: /run/cilium/cgroupv2
 
   {{ if WithDefaultBool .Hubble.Enabled false }}
   # Enable Hubble gRPC service.
@@ -791,7 +791,7 @@ spec:
           name: bpf-maps
           mountPropagation: HostToContainer
          # Required to mount cgroup filesystem from the host to cilium agent pod
-        - mountPath: /sys/fs/cgroup/unified
+        - mountPath: /run/cilium/cgroupv2
           name: cilium-cgroup
           mountPropagation: HostToContainer
         - mountPath: /var/run/cilium
@@ -827,8 +827,8 @@ spec:
         name: cni-path
       # To keep state between restarts / upgrades for cgroup2 filesystem
       - hostPath:
-          path: /sys/fs/cgroup/unified
-          type: DirectoryOrCreate
+          path: /run/cilium/cgroupv2
+          type: Directory
         name: cilium-cgroup
         # To install cilium cni configuration in the host
       - hostPath:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -53,7 +53,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 3308ec4fa8e2ca93d839d9fb1e683be766f066f1764eb010f53b12e2df047a92
+    manifestHash: d3b4eb6aa680eb0a4e30cc5491bd27769aeb718b7539d7a8531e32c5e34042a8
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -59,7 +59,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 3308ec4fa8e2ca93d839d9fb1e683be766f066f1764eb010f53b12e2df047a92
+    manifestHash: d3b4eb6aa680eb0a4e30cc5491bd27769aeb718b7539d7a8531e32c5e34042a8
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -53,7 +53,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 3308ec4fa8e2ca93d839d9fb1e683be766f066f1764eb010f53b12e2df047a92
+    manifestHash: d3b4eb6aa680eb0a4e30cc5491bd27769aeb718b7539d7a8531e32c5e34042a8
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -65,7 +65,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 3308ec4fa8e2ca93d839d9fb1e683be766f066f1764eb010f53b12e2df047a92
+    manifestHash: d3b4eb6aa680eb0a4e30cc5491bd27769aeb718b7539d7a8531e32c5e34042a8
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -59,7 +59,7 @@ spec:
       k8s-addon: storage-aws.addons.k8s.io
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 3308ec4fa8e2ca93d839d9fb1e683be766f066f1764eb010f53b12e2df047a92
+    manifestHash: d3b4eb6aa680eb0a4e30cc5491bd27769aeb718b7539d7a8531e32c5e34042a8
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #12431 on release-1.22.

#12431: Mount cgroupv2 for cilium at a custom location

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```