### PR TITLE
Skip load balancer test in IPv6 clusters

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -19,6 +19,8 @@ package tester
 import (
 	"regexp"
 	"strings"
+
+	"k8s.io/kops/upup/pkg/fi/utils"
 )
 
 const (
@@ -74,6 +76,12 @@ func (t *Tester) setSkipRegexFlag() error {
 		// this test assumes the cluster runs COS but kOps uses Ubuntu by default
 		// ref: https://github.com/kubernetes/test-infra/pull/22190
 		skipRegex += "|should.be.mountable.when.non-attachable"
+	}
+
+	if cluster.Spec.CloudProvider == "aws" && utils.IsIPv6CIDR(cluster.Spec.NonMasqueradeCIDR) {
+		// AWS VPC Classic ELBs are IPv4 only
+		// ref: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-internet-facing-load-balancers.html#internet-facing-ip-addresses
+		skipRegex += "|should.not.disrupt.a.cloud.load-balancer.s.connectivity.during.rollout"
 	}
 
 	// Ensure it is valid regex


### PR DESCRIPTION
This skips the last failure on the ipv6 calico jobs: https://testgrid.k8s.io/kops-misc#kops-grid-scenario-ipv6-calico