### PR TITLE
Remove unnecessary sysctl "net.ipv6.conf.all.accept_ra=2"

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -152,8 +152,8 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	if b.Cluster.Spec.IsIPv6Only() {
 		sysctls = append(sysctls,
+			"# Enable IPv6 forwarding for network plugins that don't do it themselves",
 			"net.ipv6.conf.all.forwarding=1",
-			"net.ipv6.conf.all.accept_ra=2",
 			"")
 	} else {
 		sysctls = append(sysctls,


### PR DESCRIPTION
`net.ipv6.conf.all.accept_ra=2` is unnecessary and possibly conflicting with `syststemd-networkd`.

xRef: https://github.com/systemd/systemd/issues/13061