### PR TITLE
Automated cherry pick of #12461: Remove unnecessary sysctl "net.ipv6.conf.all.accept_ra=2"

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -152,8 +152,8 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	if b.Cluster.Spec.IsIPv6Only() {
 		sysctls = append(sysctls,
+			"# Enable IPv6 forwarding for network plugins that don't do it themselves",
 			"net.ipv6.conf.all.forwarding=1",
-			"net.ipv6.conf.all.accept_ra=2",
 			"")
 	} else {
 		sysctls = append(sysctls,


### PR DESCRIPTION
Cherry pick of #12461 on release-1.22.

#12461: Remove unnecessary sysctl "net.ipv6.conf.all.accept_ra=2"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.