### PR TITLE
Automated cherry pick of #12464: Don't ignore channel value in toolbox template

### DIFF
--- a/cmd/kops/toolbox_template.go
+++ b/cmd/kops/toolbox_template.go
@@ -163,7 +163,7 @@ func runToolBoxTemplate(f *util.Factory, out io.Writer, options *toolboxTemplate
 		}
 	}
 
-	channelLocation := ""
+	channelLocation := options.channel
 	if channelLocation == "" {
 		channelLocation = kopsapi.DefaultChannel
 	}


### PR DESCRIPTION
Cherry pick of #12464 on release-1.20.

#12464: Don't ignore channel value in toolbox template

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.