### PR TITLE
Cleanup ClusterSpec code

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -939,12 +939,10 @@ spec:
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     enableEtcdTLS:
-                      description: EnableEtcdTLS indicates the etcd service should
-                        use TLS between peers and clients
+                      description: EnableEtcdTLS is unused.
                       type: boolean
                     enableTLSAuth:
-                      description: EnableTLSAuth indicates client and peer TLS auth
-                        should be enforced
+                      description: EnableTLSAuth is unused.
                       type: boolean
                     etcdMembers:
                       description: Members stores the configurations for each member

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -359,39 +359,10 @@ func (c *NodeupModelContext) IsKubernetesLT(version string) bool {
 	return !c.IsKubernetesGTE(version)
 }
 
-// UseEtcdTLS checks if the etcd cluster has TLS enabled bool
-func (c *NodeupModelContext) UseEtcdTLS() bool {
-	// @note: because we enforce that 'both' have to be enabled for TLS we only need to check one here.
-	for _, x := range c.Cluster.Spec.EtcdClusters {
-		if x.EnableEtcdTLS {
-			return true
-		}
-	}
-
-	return false
-}
-
 // UseVolumeMounts is used to check if we have volume mounts enabled as we need to
 // insert requires and afters in various places
 func (c *NodeupModelContext) UseVolumeMounts() bool {
 	return len(c.NodeupConfig.VolumeMounts) > 0
-}
-
-// UseEtcdTLSAuth checks the peer-auth is set in both cluster
-// @NOTE: in retrospect i think we should have consolidated the common config in the wrapper struct; it
-// feels weird we set things like version, tls etc per cluster since they both have to be the same.
-func (c *NodeupModelContext) UseEtcdTLSAuth() bool {
-	if !c.UseEtcdTLS() {
-		return false
-	}
-
-	for _, x := range c.Cluster.Spec.EtcdClusters {
-		if x.EnableTLSAuth {
-			return true
-		}
-	}
-
-	return false
 }
 
 // UseKopsControllerForNodeBootstrap checks if nodeup should use kops-controller to bootstrap.

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -552,10 +552,6 @@ const (
 	EtcdProviderTypeManager EtcdProviderType = "Manager"
 )
 
-var SupportedEtcdProviderTypes = []string{
-	string(EtcdProviderTypeManager),
-}
-
 // EtcdClusterSpec is the etcd cluster specification
 type EtcdClusterSpec struct {
 	// Name is the name of the etcd cluster (main, events etc)

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -565,9 +565,9 @@ type EtcdClusterSpec struct {
 	Provider EtcdProviderType `json:"provider,omitempty"`
 	// Members stores the configurations for each member of the cluster (including the data volume)
 	Members []EtcdMemberSpec `json:"etcdMembers,omitempty"`
-	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
+	// EnableEtcdTLS is unused.
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
-	// EnableTLSAuth indicates client and peer TLS auth should be enforced
+	// EnableTLSAuth is unused.
 	EnableTLSAuth bool `json:"enableTLSAuth,omitempty"`
 	// Version is the version of etcd to run.
 	Version string `json:"version,omitempty"`

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -563,9 +563,9 @@ type EtcdClusterSpec struct {
 	Provider EtcdProviderType `json:"provider,omitempty"`
 	// Members stores the configurations for each member of the cluster (including the data volume)
 	Members []EtcdMemberSpec `json:"etcdMembers,omitempty"`
-	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
+	// EnableEtcdTLS is unused.
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
-	// EnableTLSAuth indicates client and peer TLS auth should be enforced
+	// EnableTLSAuth is unused.
 	EnableTLSAuth bool `json:"enableTLSAuth,omitempty"`
 	// Version is the version of etcd to run.
 	Version string `json:"version,omitempty"`

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -563,9 +563,9 @@ type EtcdClusterSpec struct {
 	Provider EtcdProviderType `json:"provider,omitempty"`
 	// Members stores the configurations for each member of the cluster (including the data volume)
 	Members []EtcdMemberSpec `json:"etcdMembers,omitempty"`
-	// EnableEtcdTLS indicates the etcd service should use TLS between peers and clients
+	// EnableEtcdTLS is unused.
 	EnableEtcdTLS bool `json:"enableEtcdTLS,omitempty"`
-	// EnableTLSAuth indicates client and peer TLS auth should be enforced
+	// EnableTLSAuth is unused.
 	EnableTLSAuth bool `json:"enableTLSAuth,omitempty"`
 	// Version is the version of etcd to run.
 	Version string `json:"version,omitempty"`

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -201,7 +201,6 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 				allErrs = append(allErrs, validateEtcdClusterSpec(etcdCluster, c, fieldEtcdClusters.Index(i))...)
 			}
 			allErrs = append(allErrs, validateEtcdBackupStore(spec.EtcdClusters, fieldEtcdClusters)...)
-			allErrs = append(allErrs, validateEtcdTLS(spec.EtcdClusters, fieldEtcdClusters)...)
 			allErrs = append(allErrs, validateEtcdStorage(spec.EtcdClusters, fieldEtcdClusters)...)
 		}
 	}
@@ -1030,23 +1029,6 @@ func validateEtcdBackupStore(specs []kops.EtcdClusterSpec, fieldPath *field.Path
 			allErrs = append(allErrs, field.Forbidden(fieldPath.Index(0).Child("backupStore"), "the backup store must be unique for each etcd cluster"))
 		}
 		etcdBackupStore[x.Name] = true
-	}
-
-	return allErrs
-}
-
-// validateEtcdTLS checks the TLS settings for etcd are valid
-func validateEtcdTLS(specs []kops.EtcdClusterSpec, fieldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	var usingTLS int
-	for _, x := range specs {
-		if x.EnableEtcdTLS {
-			usingTLS++
-		}
-	}
-	// check both clusters are using tls if one is enabled
-	if usingTLS > 0 && usingTLS != len(specs) {
-		allErrs = append(allErrs, field.Forbidden(fieldPath.Index(0).Child("enableEtcdTLS"), "both etcd clusters must have TLS enabled or none at all"))
 	}
 
 	return allErrs

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1004,7 +1004,7 @@ func validateEtcdClusterSpec(spec kops.EtcdClusterSpec, c *kops.Cluster, fieldPa
 	}
 	if spec.Provider != "" {
 		value := string(spec.Provider)
-		allErrs = append(allErrs, IsValidValue(fieldPath.Child("provider"), &value, kops.SupportedEtcdProviderTypes)...)
+		allErrs = append(allErrs, IsValidValue(fieldPath.Child("provider"), &value, []string{string(kops.EtcdProviderTypeManager)})...)
 	}
 	if len(spec.Members) == 0 {
 		allErrs = append(allErrs, field.Required(fieldPath.Child("etcdMembers"), "No members defined in etcd cluster"))

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -224,10 +224,6 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 		}
 	}
 
-	if spec.IAM == nil || spec.IAM.Legacy {
-		allErrs = append(allErrs, field.Forbidden(fieldPath.Child("iam", "legacy"), "legacy IAM permissions are no longer supported"))
-	}
-
 	if spec.RollingUpdate != nil {
 		allErrs = append(allErrs, validateRollingUpdate(spec.RollingUpdate, fieldPath.Child("rollingUpdate"), false)...)
 	}
@@ -256,6 +252,10 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 	}
 
 	if spec.IAM != nil {
+		if spec.IAM.Legacy {
+			allErrs = append(allErrs, field.Forbidden(fieldPath.Child("iam", "legacy"), "legacy IAM permissions are no longer supported"))
+		}
+
 		if len(spec.IAM.ServiceAccountExternalPermissions) > 0 {
 			if spec.ServiceAccountIssuerDiscovery == nil || !spec.ServiceAccountIssuerDiscovery.EnableAWSOIDCProvider {
 				allErrs = append(allErrs, field.Forbidden(fieldPath.Child("iam", "serviceAccountExternalPermissions"), "serviceAccountExternalPermissions requires AWS OIDC Provider to be enabled"))

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -444,7 +444,6 @@ func Test_Validate_AdditionalPolicies(t *testing.T) {
 					},
 				},
 			},
-			IAM: &kops.IAMSpec{},
 		}
 		errs := validateClusterSpec(clusterSpec, &kops.Cluster{Spec: *clusterSpec}, field.NewPath("spec"))
 		testErrors(t, g.Input, errs, g.ExpectedErrors)

--- a/pkg/model/alimodel/policy_builder.go
+++ b/pkg/model/alimodel/policy_builder.go
@@ -168,7 +168,7 @@ func (b *PolicyBuilder) BuildAlicloudPolicyMaster() (*Policy, error) {
 		return nil, fmt.Errorf("failed to generate Alicloud RAM OSS access statements: %v", err)
 	}
 
-	if b.Cluster.Spec.IAM.AllowContainerRegistry {
+	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {
 		addCRPermissions(p)
 	}
 
@@ -190,7 +190,7 @@ func (b *PolicyBuilder) BuildAlicloudPolicyNode() (*Policy, error) {
 		return nil, fmt.Errorf("failed to generate Alicloud RAM OSS access statements: %v", err)
 	}
 
-	if b.Cluster.Spec.IAM.AllowContainerRegistry {
+	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {
 		addCRPermissions(p)
 	}
 

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -141,15 +141,11 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 	c.EtcdServersOverrides = nil
 
 	for _, etcdCluster := range clusterSpec.EtcdClusters {
-		protocol := "http"
-		if etcdCluster.EnableEtcdTLS {
-			protocol = "https"
-		}
 		switch etcdCluster.Name {
 		case "main":
-			c.EtcdServers = append(c.EtcdServers, protocol+"://127.0.0.1:4001")
+			c.EtcdServers = append(c.EtcdServers, "https://127.0.0.1:4001")
 		case "events":
-			c.EtcdServersOverrides = append(c.EtcdServersOverrides, "/events#"+protocol+"://127.0.0.1:4002")
+			c.EtcdServersOverrides = append(c.EtcdServersOverrides, "/events#https://127.0.0.1:4002")
 		}
 	}
 

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -17,9 +17,6 @@ limitations under the License.
 package components
 
 import (
-	"fmt"
-	"strings"
-
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi/loader"
 )
@@ -43,10 +40,6 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 
 	for i := range spec.EtcdClusters {
 		c := &spec.EtcdClusters[i]
-		if c.Provider == "" {
-			c.Provider = kops.EtcdProviderTypeManager
-		}
-
 		// Ensure the version is set
 		if c.Version == "" {
 			// We run the k8s-recommended versions of etcd
@@ -57,12 +50,6 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 			} else {
 				c.Version = DefaultEtcd3Version_1_17
 			}
-		}
-
-		// We make sure that etcd v3 is used
-		version := strings.TrimPrefix(c.Version, "v")
-		if !strings.HasPrefix(version, "3.") {
-			return fmt.Errorf("unexpected etcd version %q", c.Version)
 		}
 	}
 

--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -64,9 +64,6 @@ func (b *EtcdOptionsBuilder) BuildOptions(o interface{}) error {
 		if !strings.HasPrefix(version, "3.") {
 			return fmt.Errorf("unexpected etcd version %q", c.Version)
 		}
-
-		c.EnableEtcdTLS = true
-		c.EnableTLSAuth = true
 	}
 
 	return nil

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -310,17 +310,6 @@ func (b *KopsModelContext) UseNetworkLoadBalancer() bool {
 	return b.Cluster.Spec.API.LoadBalancer.Class == kops.LoadBalancerClassNetwork
 }
 
-// UseEtcdTLS checks to see if etcd tls is enabled
-func (b *KopsModelContext) UseEtcdTLS() bool {
-	for _, x := range b.Cluster.Spec.EtcdClusters {
-		if x.EnableEtcdTLS {
-			return true
-		}
-	}
-
-	return false
-}
-
 // UseSSHKey returns true if SSHKeyName from the cluster spec is set to a nonempty string
 // or there is an SSH public key provisioned in the key store.
 func (b *KopsModelContext) UseSSHKey() bool {

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -298,7 +298,7 @@ func (r *NodeRoleAPIServer) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		addKMSIAMPolicies(p, stringorslice.Slice(b.KMSKeys))
 	}
 
-	if b.Cluster.Spec.IAM.AllowContainerRegistry {
+	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {
 		addECRPermissions(p)
 	}
 
@@ -365,7 +365,7 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		}
 	}
 
-	if b.Cluster.Spec.IAM.AllowContainerRegistry {
+	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {
 		addECRPermissions(p)
 	}
 
@@ -395,7 +395,7 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
 	}
 
-	if b.Cluster.Spec.IAM.AllowContainerRegistry {
+	if b.Cluster.Spec.IAM != nil && b.Cluster.Spec.IAM.AllowContainerRegistry {
 		addECRPermissions(p)
 	}
 

--- a/pkg/testutils/cluster.go
+++ b/pkg/testutils/cluster.go
@@ -47,8 +47,6 @@ func BuildMinimalCluster(clusterName string) *kops.Cluster {
 		},
 	}
 
-	c.Spec.IAM = &kops.IAMSpec{}
-
 	c.Spec.Networking = &kops.NetworkingSpec{}
 
 	c.Spec.NetworkCIDR = "172.20.0.0/16"

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,8 +31,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -41,8 +39,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -35,7 +35,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -43,7 +42,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/bastionuserdata.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -46,8 +46,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/complex.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a
@@ -56,8 +54,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/complex.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -50,7 +50,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/complex.example.com/backups/etcd/events
@@ -58,7 +57,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/compress.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/compress.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/compress.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/123.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/123.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/123.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -35,7 +35,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: c
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/existing-iam.example.com/backups/etcd/events
@@ -47,7 +46,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: c
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://tests/existing-iam.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a
@@ -41,8 +39,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/existing-iam.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -30,8 +30,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/existingsg.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a
@@ -44,8 +42,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -38,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: c
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/existingsg.example.com/backups/etcd/events
@@ -50,7 +49,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: c
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: external-dns

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: external-dns

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/externallb.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/externallb.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/externallb.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -39,7 +39,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/events
@@ -47,7 +46,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -35,8 +35,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -45,8 +43,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/externalpolicies.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://tests/ha.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a
@@ -41,8 +39,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/ha.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: a

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -35,7 +35,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: c
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/ha.example.com/backups/etcd/events
@@ -47,7 +46,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: c
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://tests/ha-gce.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"
@@ -41,8 +39,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/ha-gce.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -35,7 +35,6 @@ spec:
     - instanceGroup: master-us-test1-c
       name: "3"
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/ha-gce.example.com/backups/etcd/events
@@ -47,7 +46,6 @@ spec:
     - instanceGroup: master-us-test1-c
       name: "3"
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/ipv6-cloudipam/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -54,7 +54,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -62,7 +61,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -50,8 +50,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -60,8 +58,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -54,7 +54,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -62,7 +61,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -50,8 +50,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -60,8 +58,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -43,8 +43,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -53,8 +51,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -47,7 +47,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -55,7 +54,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -41,8 +39,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -35,7 +35,6 @@ spec:
       volumeThroughput: 125
       volumeType: gp3
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -45,7 +44,6 @@ spec:
       volumeSize: 20
       volumeType: gp3
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal-ipv6.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -28,8 +28,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -38,8 +36,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -32,7 +32,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal-warmpool.example.com/backups/etcd/events
@@ -40,7 +39,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/minimal-gce.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/minimal-gce-private.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test1-a
       name: "1"
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://tests/minimal-gce-private.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://tests/minimal-gce-private.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -26,8 +26,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.k8s.local/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -36,8 +34,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -30,7 +30,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.k8s.local/backups/etcd/events
@@ -38,7 +37,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -41,8 +39,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -35,7 +35,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
@@ -47,7 +46,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -41,8 +39,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -35,7 +35,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/mixedinstances.example.com/backups/etcd/events
@@ -47,7 +46,6 @@ spec:
     - instanceGroup: master-us-test-1c
       name: us-test-1c
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -34,7 +34,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -42,7 +41,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -30,8 +30,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -40,8 +38,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-ip.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/private-shared-subnet.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privatecalico.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatecalico.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatecalico.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatecanal.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privatecanal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatecanal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -42,7 +42,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.3
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
@@ -50,7 +49,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.3
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -38,8 +38,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -48,8 +46,6 @@ spec:
     version: 3.4.3
   - backups:
       backupStore: memfs://clusters.example.com/privatecilium.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -49,8 +45,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium
@@ -49,7 +47,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: cilium
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -32,8 +32,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privatedns1.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -42,8 +40,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatedns1.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -36,7 +36,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatedns1.example.com/backups/etcd/events
@@ -44,7 +43,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatedns2.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privatedns2.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatedns2.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privateflannel.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privateflannel.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privateflannel.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privatekopeio.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/privateweave.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privateweave.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/privateweave.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -36,8 +36,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -46,8 +44,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -40,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -48,7 +47,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/sharedsubnet.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/sharedvpc.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -29,8 +29,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/unmanaged.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -39,8 +37,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/unmanaged.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,7 +33,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/unmanaged.example.com/backups/etcd/events
@@ -41,7 +40,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: main
-    provider: Manager
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
@@ -39,7 +38,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-    provider: Manager
     version: 3.4.13
   externalDns:
     provider: dns-controller

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,8 +27,6 @@ spec:
   etcdClusters:
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/main
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
@@ -37,8 +35,6 @@ spec:
     version: 3.4.13
   - backups:
       backupStore: memfs://clusters.example.com/minimal.example.com/backups/etcd/events
-    enableEtcdTLS: true
-    enableTLSAuth: true
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -71,12 +71,10 @@ type TemplateFunctions struct {
 func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretStore) (err error) {
 	cluster := tf.Cluster
 
-	dest["EtcdScheme"] = tf.EtcdScheme
 	dest["SharedVPC"] = tf.SharedVPC
 	dest["ToJSON"] = tf.ToJSON
 	dest["ToYAML"] = tf.ToYAML
 	dest["UseBootstrapTokens"] = tf.UseBootstrapTokens
-	dest["UseEtcdTLS"] = tf.UseEtcdTLS
 	// Remember that we may be on a different arch from the target.  Hard-code for now.
 	dest["replace"] = func(s, find, replace string) string {
 		return strings.Replace(s, find, replace, -1)
@@ -278,15 +276,6 @@ func (tf *TemplateFunctions) ToYAML(data interface{}) string {
 	}
 
 	return string(encoded)
-}
-
-// EtcdScheme parses and grabs the protocol to the etcd cluster
-func (tf *TemplateFunctions) EtcdScheme() string {
-	if tf.UseEtcdTLS() {
-		return "https"
-	}
-
-	return "http"
 }
 
 // SharedVPC is a simple helper function which makes the templates for a shared VPC clearer


### PR DESCRIPTION
/kind cleanup

Enabling legacy IAM causes a validation failure, so stop treating the lack of an `IAM` field as defaulting to legacy IAM.

Etcd TLS and TLS Auth are always enabled in BuildOptions, so remove everything about their being disabled.

Etcd-manager is the only supported etcd provider, so remove code around supporting other providers. We leave in the API validation for that field.
