### PR TITLE
Automated cherry pick of #12463: Bump CAS images

### DIFF
--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -44,13 +44,13 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 		if err == nil {
 			switch v.Minor {
 			case 22:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.0"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.1"
 			case 21:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1"
 			case 20:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.1"
 			case 19:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.1"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.2"
 			case 18:
 				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.18.3"
 			case 17:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
     balanceSimilarNodeGroups: false
     enabled: true
     expander: random
-    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
+    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s
     scaleDownUtilizationThreshold: "0.5"

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 1299b049a099f57974cd698ac89222abbb41bdd249e7d4f33bce4ca753eda424
+    manifestHash: d402b56db4f6f601708ef366cef3105966fd20a2aedcb5adc2c3c88baba5e0c9
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -312,7 +312,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/cluster-autoscaler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
+        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
     balanceSimilarNodeGroups: false
     enabled: true
     expander: random
-    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
+    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s
     scaleDownUtilizationThreshold: "0.5"

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: f7e1e3dde3b3bf5baba2ccc79ed7e154559e8a5f7c320feca0821ec2b2f799ad
+    manifestHash: c02fbd808dd04643da3df92e4ed84cb370deb7fc9a2b58150f36d5fd28600f70
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -308,7 +308,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
+        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     balanceSimilarNodeGroups: false
     enabled: true
     expander: random
-    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
+    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s
     scaleDownUtilizationThreshold: "0.5"

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: f7e1e3dde3b3bf5baba2ccc79ed7e154559e8a5f7c320feca0821ec2b2f799ad
+    manifestHash: c02fbd808dd04643da3df92e4ed84cb370deb7fc9a2b58150f36d5fd28600f70
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -308,7 +308,7 @@ spec:
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
+        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Cherry pick of #12463 on release-1.22.

#12463: Bump CAS images

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```