### PR TITLE
[DigitalOcean] Incorporate existing vpc support for kops

### DIFF
--- a/pkg/model/domodel/droplets.go
+++ b/pkg/model/domodel/droplets.go
@@ -17,7 +17,6 @@ limitations under the License.
 package domodel
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -81,10 +80,8 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 			droplet.Tags = append(droplet.Tags, do.TagKubernetesInstanceGroup+":"+ig.Name)
 		}
 
-		fmt.Printf("Checking network id = %s \n", d.Cluster.Spec.NetworkID)
 		if d.Cluster.Spec.NetworkID != "" {
 			droplet.VPC = fi.String(d.Cluster.Spec.NetworkID)
-			fmt.Printf("Droplet info = %v \n", droplet)
 		}
 
 		userData, err := d.BootstrapScriptBuilder.ResourceNodeUp(c, ig)

--- a/pkg/model/domodel/droplets.go
+++ b/pkg/model/domodel/droplets.go
@@ -17,6 +17,7 @@ limitations under the License.
 package domodel
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -60,14 +61,12 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 			Name:      fi.String(name),
 			Lifecycle: d.Lifecycle,
 
-			// during alpha support we only allow 1 region
-			// validation for only 1 region is done at this point
+			// kops do supports allow only 1 region
 			Region: fi.String(d.Cluster.Spec.Subnets[0].Region),
 			Size:   fi.String(ig.Spec.MachineType),
 			Image:  fi.String(ig.Spec.Image),
 			SSHKey: fi.String(sshKeyFingerPrint),
-
-			Tags: []string{clusterTag},
+			Tags:   []string{clusterTag},
 		}
 
 		if ig.IsMaster() {
@@ -80,6 +79,12 @@ func (d *DropletBuilder) Build(c *fi.ModelBuilderContext) error {
 			droplet.Tags = append(droplet.Tags, do.TagKubernetesInstanceGroup+":"+ig.Name)
 		} else {
 			droplet.Tags = append(droplet.Tags, do.TagKubernetesInstanceGroup+":"+ig.Name)
+		}
+
+		fmt.Printf("Checking network id = %s \n", d.Cluster.Spec.NetworkID)
+		if d.Cluster.Spec.NetworkID != "" {
+			droplet.VPC = fi.String(d.Cluster.Spec.NetworkID)
+			fmt.Printf("Droplet info = %v \n", droplet)
 		}
 
 		userData, err := d.BootstrapScriptBuilder.ResourceNodeUp(c, ig)

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -154,8 +154,7 @@ func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {
 			Tags:     e.Tags,
 			VPCUUID:  fi.StringValue(e.VPC),
 			UserData: userData,
-
-			SSHKeys: []godo.DropletCreateSSHKey{{Fingerprint: fi.StringValue(e.SSHKey)}},
+			SSHKeys:  []godo.DropletCreateSSHKey{{Fingerprint: fi.StringValue(e.SSHKey)}},
 		})
 
 		if err != nil {

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -39,6 +39,7 @@ type Droplet struct {
 	Size     *string
 	Image    *string
 	SSHKey   *string
+	VPC      *string
 	Tags     []string
 	Count    int
 	UserData fi.Resource
@@ -83,6 +84,7 @@ func (d *Droplet) Find(c *fi.Context) (*Droplet, error) {
 		Tags:      foundDroplet.Tags,
 		SSHKey:    d.SSHKey,   // TODO: get from droplet or ignore change
 		UserData:  d.UserData, // TODO: get from droplet or ignore change
+		VPC:       fi.String(foundDroplet.VPCUUID),
 		Lifecycle: d.Lifecycle,
 	}, nil
 }
@@ -150,8 +152,10 @@ func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {
 			Size:     fi.StringValue(e.Size),
 			Image:    godo.DropletCreateImage{Slug: fi.StringValue(e.Image)},
 			Tags:     e.Tags,
+			VPCUUID:  fi.StringValue(e.VPC),
 			UserData: userData,
-			SSHKeys:  []godo.DropletCreateSSHKey{{Fingerprint: fi.StringValue(e.SSHKey)}},
+
+			SSHKeys: []godo.DropletCreateSSHKey{{Fingerprint: fi.StringValue(e.SSHKey)}},
 		})
 
 		if err != nil {


### PR DESCRIPTION
This PR introduces minor changes to create KOPS DO cluster in an existing VPC.
It uses the `--vpc` flag that already exists to pass the vpc uuid where the droplets must be created.

Example:
./kops create cluster --cloud=digitalocean --name=dev1.example.co.in --vpc=af287488-862e-46c7-a783-5e5fa89cb256 --networking=cilium --zones=tor1 --ssh-public-key=~/.ssh/id_rsa_github.pub

Tested to make sure the droplets are created in the vpc specified.

Next steps, may include additional support for creating new vpc as part of the kops create cluster option.