### PR TITLE
Add kubescheduler.config.k8s.io/v1beta2 for k8s 1.22+

### DIFF
--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -104,7 +104,9 @@ func (b *KubeSchedulerBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 	{
 		var config *SchedulerConfig
-		if b.IsKubernetesGTE("1.19") {
+		if b.IsKubernetesGTE("1.22") {
+			config = NewSchedulerConfig("kubescheduler.config.k8s.io/v1beta2")
+		} else if b.IsKubernetesGTE("1.19") {
 			config = NewSchedulerConfig("kubescheduler.config.k8s.io/v1beta1")
 		} else {
 			config = NewSchedulerConfig("kubescheduler.config.k8s.io/v1alpha2")


### PR DESCRIPTION
Ref: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/785-scheduler-component-config-api/README.md

Hopefully fixes:
https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-grid-scenario-ipv6-conformance/1445174305280233472/artifacts/cluster-info/kube-system/kube-scheduler-ip-172-20-43-37.eu-west-1.compute.internal/logs.txt
> E1005 00:04:12.105552       1 run.go:120] "command failed" err="no kind \"KubeSchedulerConfiguration\" is registered for version \"kubescheduler.config.k8s.io/v1beta1\" in scheme \"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme/scheme.go:30\""
