### PR TITLE
Automated cherry pick of #12486: Add kubescheduler.config.k8s.io/v1beta2 for k8s 1.22+

### DIFF
--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -104,7 +104,9 @@ func (b *KubeSchedulerBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 	{
 		var config *SchedulerConfig
-		if b.IsKubernetesGTE("1.19") {
+		if b.IsKubernetesGTE("1.22") {
+			config = NewSchedulerConfig("kubescheduler.config.k8s.io/v1beta2")
+		} else if b.IsKubernetesGTE("1.19") {
 			config = NewSchedulerConfig("kubescheduler.config.k8s.io/v1beta1")
 		} else if b.IsKubernetesGTE("1.18") {
 			config = NewSchedulerConfig("kubescheduler.config.k8s.io/v1alpha2")


### PR DESCRIPTION
Cherry pick of #12486 on release-1.22.

#12486: Add kubescheduler.config.k8s.io/v1beta2 for k8s 1.22+

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.