### PR TITLE
Automated cherry pick of #12424: protokube: don't try to connect to apiserver if not

### DIFF
--- a/protokube/pkg/protokube/kube_boot.go
+++ b/protokube/pkg/protokube/kube_boot.go
@@ -105,21 +105,24 @@ func (k *KubeBoot) Init(volumesProvider Volumes) {
 func (k *KubeBoot) RunSyncLoop() {
 	ctx := context.Background()
 
-	client, err := k.Kubernetes.KubernetesClient()
-	if err != nil {
-		panic(fmt.Sprintf("could not create kubernetes client: %v", err))
+	if k.Master {
+		client, err := k.Kubernetes.KubernetesClient()
+		if err != nil {
+			panic(fmt.Sprintf("could not create kubernetes client: %v", err))
+		}
+
+		klog.Info("polling for apiserver readiness")
+		for {
+			_, err = client.CoreV1().Namespaces().Get(ctx, "kube-system", metav1.GetOptions{})
+			if err == nil {
+				klog.Info("successfully connected to the apiserver")
+				break
+			}
+			klog.Infof("failed to connect to the apiserver (will sleep and retry): %v", err)
+			time.Sleep(5 * time.Second)
+		}
 	}
 
-	klog.Info("polling for apiserver readiness")
-	for {
-		_, err = client.CoreV1().Namespaces().Get(ctx, "kube-system", metav1.GetOptions{})
-		if err == nil {
-			klog.Info("successfully connected to the apiserver")
-			break
-		}
-		klog.Infof("failed to connect to the apiserver (will sleep and retry): %v", err)
-		time.Sleep(5 * time.Second)
-	}
 	for {
 		if err := k.syncOnce(ctx); err != nil {
 			klog.Warningf("error during attempt to bootstrap (will sleep and retry): %v", err)


### PR DESCRIPTION
Cherry pick of #12424 on release-1.22.

#12424: protokube: don't try to connect to apiserver if not

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```