### PR TITLE
Replace klog flags with go-runner in k8s 1.23 

### DIFF
--- a/nodeup/pkg/model/tests/golden/minimal/cluster.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/cluster.yaml
@@ -30,7 +30,7 @@ spec:
   iam: {}
   kubelet:
     anonymousAuth: false
-  kubernetesVersion: v1.18.0
+  kubernetesVersion: v1.23.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
@@ -14,8 +14,11 @@ contents: |
   spec:
     containers:
     - args:
+      - --log-file=/var/log/kube-apiserver.log
+      - /usr/local/bin/kube-apiserver
       - --allow-privileged=true
       - --anonymous-auth=false
+      - --api-audiences=kubernetes.svc.default
       - --apiserver-count=1
       - --authorization-mode=AlwaysAllow
       - --bind-address=0.0.0.0
@@ -40,18 +43,18 @@ contents: |
       - --requestheader-group-headers=X-Remote-Group
       - --requestheader-username-headers=X-Remote-User
       - --secure-port=443
+      - --service-account-issuer=https://api.internal.minimal.example.com
+      - --service-account-jwks-uri=https://api.internal.minimal.example.com/openid/v1/jwks
       - --service-account-key-file=/srv/kubernetes/kube-apiserver/service-account.pub
+      - --service-account-signing-key-file=/srv/kubernetes/kube-apiserver/service-account.key
       - --service-cluster-ip-range=100.64.0.0/13
       - --storage-backend=etcd3
       - --tls-cert-file=/srv/kubernetes/kube-apiserver/server.crt
       - --tls-private-key-file=/srv/kubernetes/kube-apiserver/server.key
       - --v=2
-      - --logtostderr=false
-      - --alsologtostderr
-      - --log-file=/var/log/kube-apiserver.log
       command:
-      - /usr/local/bin/kube-apiserver
-      image: k8s.gcr.io/kube-apiserver:v1.18.0
+      - /go-runner
+      image: k8s.gcr.io/kube-apiserver:v1.23.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1
@@ -290,6 +293,20 @@ contents:
     type: server
 mode: "0600"
 path: /srv/kubernetes/kube-apiserver/server.key
+type: file
+---
+contents: |
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIBPQIBAAJBANiW3hfHTcKnxCig+uWhpVbOfH1pANKmXVSysPKgE80QSU4tZ6m4
+  9pAEeIMsvwvDMaLsb2v6JvXe0qvCmueU+/sCAwEAAQJBAKt/gmpHqP3qA3u8RA5R
+  2W6L360Z2Mnza1FmkI/9StCCkJGjuE5yDhxU4JcVnFyX/nMxm2ockEEQDqRSu7Oo
+  xTECIQD2QsUsgFL4FnXWzTclySJ6ajE4Cte3gSDOIvyMNMireQIhAOEnsV8UaSI+
+  ZyL7NMLzMPLCgtsrPnlamr8gdrEHf9ITAiEAxCCLbpTI/4LL2QZZrINTLVGT34Fr
+  Kl/yI5pjrrp/M2kCIQDfOktQyRuzJ8t5kzWsUxCkntS+FxHJn1rtQ3Jp8dV4oQIh
+  AOyiVWDyLZJvg7Y24Ycmp86BZjM9Wk/BfWpBXKnl9iDY
+  -----END RSA PRIVATE KEY-----
+mode: "0600"
+path: /srv/kubernetes/kube-apiserver/service-account.key
 type: file
 ---
 contents: |

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
@@ -10,6 +10,8 @@ contents: |
   spec:
     containers:
     - args:
+      - --log-file=/var/log/kube-controller-manager.log
+      - /usr/local/bin/kube-controller-manager
       - --allocate-node-cidrs=true
       - --attach-detach-reconcile-sync-period=1m0s
       - --authentication-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
@@ -21,6 +23,7 @@ contents: |
       - --cluster-signing-cert-file=/srv/kubernetes/kube-controller-manager/ca.crt
       - --cluster-signing-key-file=/srv/kubernetes/kube-controller-manager/ca.key
       - --configure-cloud-routes=true
+      - --feature-gates=CSIMigrationAWS=true
       - --flex-volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/
       - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig
       - --leader-elect=true
@@ -30,12 +33,9 @@ contents: |
       - --tls-private-key-file=/srv/kubernetes/kube-controller-manager/server.key
       - --use-service-account-credentials=true
       - --v=2
-      - --logtostderr=false
-      - --alsologtostderr
-      - --log-file=/var/log/kube-controller-manager.log
       command:
-      - /usr/local/bin/kube-controller-manager
-      image: k8s.gcr.io/kube-controller-manager:v1.18.0
+      - /go-runner
+      image: k8s.gcr.io/kube-controller-manager:v1.23.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
@@ -23,7 +23,7 @@ contents: |
       - --log-file=/var/log/kube-proxy.log
       command:
       - /usr/local/bin/kube-proxy
-      image: k8s.gcr.io/kube-proxy:v1.18.0
+      image: k8s.gcr.io/kube-proxy:v1.23.0
       name: kube-proxy
       resources:
         requests:

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
@@ -10,6 +10,8 @@ contents: |
   spec:
     containers:
     - args:
+      - --log-file=/var/log/kube-scheduler.log
+      - /usr/local/bin/kube-scheduler
       - --authentication-kubeconfig=/var/lib/kube-scheduler/kubeconfig
       - --authorization-kubeconfig=/var/lib/kube-scheduler/kubeconfig
       - --config=/var/lib/kube-scheduler/config.yaml
@@ -17,17 +19,15 @@ contents: |
       - --tls-cert-file=/srv/kubernetes/kube-scheduler/server.crt
       - --tls-private-key-file=/srv/kubernetes/kube-scheduler/server.key
       - --v=2
-      - --logtostderr=false
-      - --alsologtostderr
-      - --log-file=/var/log/kube-scheduler.log
       command:
-      - /usr/local/bin/kube-scheduler
-      image: k8s.gcr.io/kube-scheduler:v1.18.0
+      - /go-runner
+      image: k8s.gcr.io/kube-scheduler:v1.23.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1
           path: /healthz
-          port: 10251
+          port: 10259
+          scheme: HTTPS
         initialDelaySeconds: 15
         timeoutSeconds: 15
       name: kube-scheduler
@@ -95,7 +95,7 @@ path: /srv/kubernetes/kube-scheduler/server.key
 type: file
 ---
 contents: |
-  apiVersion: kubescheduler.config.k8s.io/v1alpha2
+  apiVersion: kubescheduler.config.k8s.io/v1beta2
   clientConnection:
     kubeconfig: /var/lib/kube-scheduler/kubeconfig
   kind: KubeSchedulerConfiguration


### PR DESCRIPTION
These flags have been deprecated, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components

Also observe the deprecation warnings currently emitted in our 1.23 prow jobs: https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-grid-scenario-ipv6-conformance/1445295102216900608/artifacts/cluster-info/kube-system/kube-scheduler-ip-172-20-61-191.eu-west-1.compute.internal/logs.txt