### PR TITLE
Automated cherry pick of #12412: Allow adding more subnets to an NLB

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -460,7 +460,7 @@ func (e *NetworkLoadBalancer) Normalize() {
 	sort.Stable(OrderTargetGroupsByName(e.TargetGroups))
 }
 
-func (s *NetworkLoadBalancer) CheckChanges(a, e, changes *NetworkLoadBalancer) error {
+func (*NetworkLoadBalancer) CheckChanges(a, e, changes *NetworkLoadBalancer) error {
 	if a == nil {
 		if fi.StringValue(e.Name) == "" {
 			return fi.RequiredField("Name")
@@ -489,12 +489,12 @@ func (s *NetworkLoadBalancer) CheckChanges(a, e, changes *NetworkLoadBalancer) e
 		if len(changes.SubnetMappings) > 0 {
 			expectedSubnets := make(map[string]*string)
 			for _, s := range e.SubnetMappings {
-				//expectedSubnets[*s.Subnet.ID] = s
 				if s.AllocationID != nil {
 					expectedSubnets[*s.Subnet.ID] = s.AllocationID
-				}
-				if s.PrivateIPv4Address != nil {
+				} else if s.PrivateIPv4Address != nil {
 					expectedSubnets[*s.Subnet.ID] = s.PrivateIPv4Address
+				} else {
+					expectedSubnets[*s.Subnet.ID] = nil
 				}
 			}
 


### PR DESCRIPTION
Cherry pick of #12412 on release-1.22.

#12412: Allow adding more subnets to an NLB

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```