### PR TITLE
Fix addon-resource-tracking e2e scenario

### DIFF
--- a/tests/e2e/scenarios/addon-resource-tracking/run-test.sh
+++ b/tests/e2e/scenarios/addon-resource-tracking/run-test.sh
@@ -42,7 +42,7 @@ ${KUBETEST2} \
 haveds
 
 # Upgrade to a version that should adopt existing resources and apply the change below
-KOPS=$(kops-acquire-latest)
+kops-acquire-latest
 
 cp "${KOPS}" "${WORKSPACE}/kops"
 


### PR DESCRIPTION
See https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/12156/pull-e2e-kops-addon-resource-tracking/1446251135265411072/build-log.txt

The output of this function is the output of acquiring the latest kops version, not the path to the acquired version. See the value of `--kops-binary-path`:

> kubetest2 kops -v=2 --cloud-provider=aws --cluster-name=e2e-8f6cf1d295-e5e21.test-cncf-aws.k8s.io --kops-root=/home/prow/go/src/k8s.io/kops --admin-access= --env=KOPS_FEATURE_FLAGS=SpecOverrideFlag '--kops-binary-path=hack/install-bazelisk.sh


See also:
https://github.com/kubernetes/kops/blob/eb883bb149963899b33187ea1b2768fe740331f4/tests/e2e/scenarios/keypair-rotation/run-test.sh#L20