### PR TITLE
Spotinst: Permission to create `bigdata.spot.io/bigdataenvironments`

### DIFF
--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -127,7 +127,7 @@ rules:
   verbs: ["get", "list"]
 - apiGroups: ["bigdata.spot.io"]
   resources: ["bigdataenvironments"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The PR updates the controller's cluster role to allow the creation of `bigdata.spot.io/bigdataenvironments` resources.