### PR TITLE
Spotinst: Support for RI commitments

### DIFF
--- a/docs/getting_started/spot-ocean.md
+++ b/docs/getting_started/spot-ocean.md
@@ -151,6 +151,7 @@ metadata:
 |---|---|---|
 | `spotinst.io/spot-percentage` | Specify the percentage of Spot instances that should spin up from the target capacity. | `100` |
 | `spotinst.io/utilize-reserved-instances` | Specify whether reserved instances should be utilized. | `true` |
+| `spotinst.io/utilize-commitments` | Specify whether reserved instance commitments should be utilized. | none |
 | `spotinst.io/fallback-to-ondemand` | Specify whether fallback to on-demand instances should be enabled. | `true` |
 | `spotinst.io/draining-timeout` | Specify a period of time, in seconds, after a node is marked for termination during which on running pods remains active. | none |
 | `spotinst.io/grace-period` | Specify a period of time, in seconds, that Ocean should wait before applying instance health checks. | none |

--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -53,6 +53,10 @@ const (
 	// utilized.
 	SpotInstanceGroupLabelUtilizeReservedInstances = "spotinst.io/utilize-reserved-instances"
 
+	// SpotInstanceGroupLabelUtilizeCommitments is the metadata label used
+	// on the instance group to specify whether commitments should be utilized.
+	SpotInstanceGroupLabelUtilizeCommitments = "spotinst.io/utilize-commitments"
+
 	// SpotInstanceGroupLabelFallbackToOnDemand is the metadata label used on the
 	// instance group to specify whether fallback to on-demand instances should
 	// be enabled.
@@ -218,6 +222,12 @@ func (b *SpotInstanceGroupModelBuilder) buildElastigroup(c *fi.ModelBuilderConte
 				return err
 			}
 
+		case SpotInstanceGroupLabelUtilizeCommitments:
+			group.UtilizeCommitments, err = parseBool(v)
+			if err != nil {
+				return err
+			}
+
 		case SpotInstanceGroupLabelFallbackToOnDemand:
 			group.FallbackToOnDemand, err = parseBool(v)
 			if err != nil {
@@ -376,6 +386,12 @@ func (b *SpotInstanceGroupModelBuilder) buildOcean(c *fi.ModelBuilderContext, ig
 		switch k {
 		case SpotInstanceGroupLabelUtilizeReservedInstances:
 			ocean.UtilizeReservedInstances, err = parseBool(v)
+			if err != nil {
+				return err
+			}
+
+		case SpotInstanceGroupLabelUtilizeCommitments:
+			ocean.UtilizeCommitments, err = parseBool(v)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR introduces a new metadata label; `spotinst.io/utilize-commitments: true`. With this label, Elastigroup / Ocean will use RI commitments first when provisioning new nodes.