### PR TITLE
[cilium] Add support for bpf-lb-sock-hostns-only field

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -4478,6 +4478,13 @@ spec:
                         description: 'BPFLBMapMax is the maximum number of entries
                           in bpf lb service, backend and affinity maps. Default: 65536'
                         type: integer
+                      bpfLBSockHostNSOnly:
+                        description: 'BPFLBSockHostNSOnly enables skipping socket
+                          LB for services when inside a pod namespace, in favor of
+                          service LB at the pod interface. Socket LB is still used
+                          when in the host namespace. Required by service mesh (e.g.,
+                          Istio, Linkerd). Default: false'
+                        type: boolean
                       bpfNATGlobalMax:
                         description: 'BPFNATGlobalMax is the the maximum number of
                           entries in the BPF NAT table. Default: 524288'

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -491,6 +491,11 @@ type CiliumNetworkingSpec struct {
 	// BPFLBMapMax is the maximum number of entries in bpf lb service, backend and affinity maps.
 	// Default: 65536
 	BPFLBMapMax int `json:"bpfLBMapMax,omitempty"`
+	// BPFLBSockHostNSOnly enables skipping socket LB for services when inside a pod namespace,
+	// in favor of service LB at the pod interface. Socket LB is still used when in the host namespace.
+	// Required by service mesh (e.g., Istio, Linkerd).
+	// Default: false
+	BPFLBSockHostNSOnly bool `json:"bpfLBSockHostNSOnly,omitempty"`
 	// PreallocateBPFMaps reduces the per-packet latency at the expense of up-front memory allocation.
 	// Default: true
 	PreallocateBPFMaps bool `json:"preallocateBPFMaps,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -500,6 +500,11 @@ type CiliumNetworkingSpec struct {
 	// BPFLBMapMax is the maximum number of entries in bpf lb service, backend and affinity maps.
 	// Default: 65536
 	BPFLBMapMax int `json:"bpfLBMapMax,omitempty"`
+	// BPFLBSockHostNSOnly enables skipping socket LB for services when inside a pod namespace,
+	// in favor of service LB at the pod interface. Socket LB is still used when in the host namespace.
+	// Required by service mesh (e.g., Istio, Linkerd).
+	// Default: false
+	BPFLBSockHostNSOnly bool `json:"bpfLBSockHostNSOnly,omitempty"`
 	// PreallocateBPFMaps reduces the per-packet latency at the expense of up-front memory allocation.
 	// Default: true
 	PreallocateBPFMaps bool `json:"preallocateBPFMaps,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1868,6 +1868,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.BPFNeighGlobalMax = in.BPFNeighGlobalMax
 	out.BPFPolicyMapMax = in.BPFPolicyMapMax
 	out.BPFLBMapMax = in.BPFLBMapMax
+	out.BPFLBSockHostNSOnly = in.BPFLBSockHostNSOnly
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
 	out.ClusterName = in.ClusterName
@@ -1978,6 +1979,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.BPFNeighGlobalMax = in.BPFNeighGlobalMax
 	out.BPFPolicyMapMax = in.BPFPolicyMapMax
 	out.BPFLBMapMax = in.BPFLBMapMax
+	out.BPFLBSockHostNSOnly = in.BPFLBSockHostNSOnly
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
 	out.ClusterName = in.ClusterName

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -480,6 +480,11 @@ type CiliumNetworkingSpec struct {
 	// BPFLBMapMax is the maximum number of entries in bpf lb service, backend and affinity maps.
 	// Default: 65536
 	BPFLBMapMax int `json:"bpfLBMapMax,omitempty"`
+	// BPFLBSockHostNSOnly enables skipping socket LB for services when inside a pod namespace,
+	// in favor of service LB at the pod interface. Socket LB is still used when in the host namespace.
+	// Required by service mesh (e.g., Istio, Linkerd).
+	// Default: false
+	BPFLBSockHostNSOnly bool `json:"bpfLBSockHostNSOnly,omitempty"`
 	// PreallocateBPFMaps reduces the per-packet latency at the expense of up-front memory allocation.
 	// Default: true
 	PreallocateBPFMaps bool `json:"preallocateBPFMaps,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1816,6 +1816,7 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.BPFNeighGlobalMax = in.BPFNeighGlobalMax
 	out.BPFPolicyMapMax = in.BPFPolicyMapMax
 	out.BPFLBMapMax = in.BPFLBMapMax
+	out.BPFLBSockHostNSOnly = in.BPFLBSockHostNSOnly
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
 	out.ClusterName = in.ClusterName
@@ -1926,6 +1927,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 	out.BPFNeighGlobalMax = in.BPFNeighGlobalMax
 	out.BPFPolicyMapMax = in.BPFPolicyMapMax
 	out.BPFLBMapMax = in.BPFLBMapMax
+	out.BPFLBSockHostNSOnly = in.BPFLBSockHostNSOnly
 	out.PreallocateBPFMaps = in.PreallocateBPFMaps
 	out.SidecarIstioProxyImage = in.SidecarIstioProxyImage
 	out.ClusterName = in.ClusterName

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 1703cd96b5c8d24e70cc30e81b011e9f6392a2df4e3a714bccb03b0a9a824f0e
+    manifestHash: 047215d10823af9a1bb696a4b0daaeb790b9c708986d7a97d989053f5b052cbf
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -32,6 +32,7 @@ data:
   bpf-lb-algorithm: random
   bpf-lb-maglev-table-size: "16381"
   bpf-lb-map-max: "65536"
+  bpf-lb-sock-hostns-only: "false"
   bpf-nat-global-max: "524288"
   bpf-neigh-global-max: "524288"
   bpf-policy-map-max: "16384"

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 96198c21b885265a89a7374b685d06154fe36741c890b38f932a759073bdc82f
+    manifestHash: 52cdf5be5f19ea68efe3b18efe980717dc9081f8ef73df495d83784ae0d83720
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -32,6 +32,7 @@ data:
   bpf-lb-algorithm: random
   bpf-lb-maglev-table-size: "16381"
   bpf-lb-map-max: "65536"
+  bpf-lb-sock-hostns-only: "false"
   bpf-nat-global-max: "524288"
   bpf-neigh-global-max: "524288"
   bpf-policy-map-max: "16384"

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: b0d700920b53b105c93ca2d6bd1c9ca5fcdab045f8e5b4d88f4893be71752c55
+    manifestHash: 0d3773e9dcb3b00b570e6cd5b327fa74aaa7f90ea290afb7703c631f65088fe6
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -34,6 +34,7 @@ data:
   bpf-lb-algorithm: random
   bpf-lb-maglev-table-size: "16381"
   bpf-lb-map-max: "65536"
+  bpf-lb-sock-hostns-only: "false"
   bpf-nat-global-max: "524288"
   bpf-neigh-global-max: "524288"
   bpf-policy-map-max: "16384"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -140,6 +140,11 @@ data:
   # backend and affinity maps. (default 65536)
   bpf-lb-map-max: "{{ .BPFLBMapMax }}"
 
+  # bpf-lb-sock-hostns-only enables skipping socket LB for services when inside a pod namespace,
+  # in favor of service LB at the pod interface. Socket LB is still used when in the host namespace.
+  # Required by service mesh (e.g., Istio, Linkerd). (default false)
+  bpf-lb-sock-hostns-only: "{{ .BPFLBSockHostNSOnly }}"
+
   {{ if .ChainingMode }}
   cni-chaining-mode: "{{ .ChainingMode }}"
   {{ end }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: a8676c7ed851ffa9059350f44530cc6a89e79abf6e2395a0655c9ec950e543e2
+    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: a8676c7ed851ffa9059350f44530cc6a89e79abf6e2395a0655c9ec950e543e2
+    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: a8676c7ed851ffa9059350f44530cc6a89e79abf6e2395a0655c9ec950e543e2
+    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -75,7 +75,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: a8676c7ed851ffa9059350f44530cc6a89e79abf6e2395a0655c9ec950e543e2
+    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: a8676c7ed851ffa9059350f44530cc6a89e79abf6e2395a0655c9ec950e543e2
+    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
This is a needed configuration option for users that want to combine
Cilium alongside with a ServiceMesh. Cilium by default will LB requests
at CNI layer meaning that the Sidecars of ServiceMesh Proxy are not able
to apply LB by themselves thus loosing the capability of applying their
features for traffic management.

Ref issue: https://github.com/istio/istio/issues/35531

Signed-off-by: dntosas <ntosas@gmail.com>