### PR TITLE
Stop skipping snapshot fields tests in EBS CSI e2e

### DIFF
--- a/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
+++ b/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
@@ -37,5 +37,4 @@ git clone --branch v1.4.0 https://github.com/kubernetes-sigs/aws-ebs-csi-driver.
 # shellcheck disable=SC2164
 cd tests/e2e-kubernetes/
 
-# Skipping disruptive and flakes caused by https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/911
-ginkgo --nodes=25 ./... -- -cluster-tag="${CLUSTER_NAME}" -ginkgo.skip="\[Disruptive\]|should.check.snapshot.fields" -report-dir="${REPORT_DIR}" -gce-zone="${ZONE}"
+ginkgo --nodes=25 ./... -- -cluster-tag="${CLUSTER_NAME}" -ginkgo.skip="\[Disruptive\]" -report-dir="${REPORT_DIR}" -gce-zone="${ZONE}"

--- a/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
+++ b/tests/e2e/scenarios/aws-ebs-csi/run-test.sh
@@ -22,6 +22,7 @@ kops-acquire-latest
 OVERRIDES="${OVERRIDES-} --override=cluster.spec.cloudConfig.awsEBSCSIDriver.enabled=true"
 OVERRIDES="$OVERRIDES --override=cluster.spec.snapshotController.enabled=true"
 OVERRIDES="$OVERRIDES --override=cluster.spec.certManager.enabled=true"
+OVERRIDES="$OVERRIDES --master-size=t3.medium --node-size=c5.large"
 
 kops-up
 


### PR DESCRIPTION
the linked issue's PR was merged into 1.22 so we'll see if we can stop skipping these tests

