### PR TITLE
Automated cherry pick of #12540: Don't hard-code the SQS Queue ARN partition

### DIFF
--- a/pkg/model/awsmodel/nodeterminationhandler.go
+++ b/pkg/model/awsmodel/nodeterminationhandler.go
@@ -140,9 +140,10 @@ func (b *NodeTerminationHandlerBuilder) buildSQSQueue(c *fi.ModelBuilderContext)
 func (b *NodeTerminationHandlerBuilder) buildEventBridgeRules(c *fi.ModelBuilderContext) error {
 	clusterName := b.ClusterName()
 	queueName := model.QueueNamePrefix(clusterName) + "-nth"
+	partition := b.AWSPartition
 	region := b.Region
 	accountID := b.AWSAccountID
-	targetArn := "arn:aws:sqs:" + region + ":" + accountID + ":" + queueName
+	targetArn := "arn:" + partition + ":sqs:" + region + ":" + accountID + ":" + queueName
 
 	clusterNamePrefix := awsup.GetClusterName40(clusterName)
 	for _, event := range events {

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
@@ -984,7 +984,7 @@
         "Targets": [
           {
             "Id": "1",
-            "Arn": "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+            "Arn": "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
           }
         ]
       }
@@ -1004,7 +1004,7 @@
         "Targets": [
           {
             "Id": "1",
-            "Arn": "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+            "Arn": "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
           }
         ]
       }
@@ -1024,7 +1024,7 @@
         "Targets": [
           {
             "Id": "1",
-            "Arn": "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+            "Arn": "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
           }
         ]
       }
@@ -1044,7 +1044,7 @@
         "Targets": [
           {
             "Id": "1",
-            "Arn": "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+            "Arn": "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
           }
         ]
       }

--- a/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
+++ b/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
@@ -265,22 +265,22 @@ resource "aws_cloudwatch_event_rule" "nthsqsresources-longclustername-e-fkbaoh-S
 }
 
 resource "aws_cloudwatch_event_target" "nthsqsresources-longclustername-e-fkbaoh-ASGLifecycle-Target" {
-  arn  = "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+  arn  = "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
   rule = aws_cloudwatch_event_rule.nthsqsresources-longclustername-e-fkbaoh-ASGLifecycle.id
 }
 
 resource "aws_cloudwatch_event_target" "nthsqsresources-longclustername-e-fkbaoh-InstanceStateChange-Target" {
-  arn  = "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+  arn  = "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
   rule = aws_cloudwatch_event_rule.nthsqsresources-longclustername-e-fkbaoh-InstanceStateChange.id
 }
 
 resource "aws_cloudwatch_event_target" "nthsqsresources-longclustername-e-fkbaoh-RebalanceRecommendation-Target" {
-  arn  = "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+  arn  = "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
   rule = aws_cloudwatch_event_rule.nthsqsresources-longclustername-e-fkbaoh-RebalanceRecommendation.id
 }
 
 resource "aws_cloudwatch_event_target" "nthsqsresources-longclustername-e-fkbaoh-SpotInterruption-Target" {
-  arn  = "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+  arn  = "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
   rule = aws_cloudwatch_event_rule.nthsqsresources-longclustername-e-fkbaoh-SpotInterruption.id
 }
 


### PR DESCRIPTION
Cherry pick of #12540 on release-1.22.

#12540: Don't hard-code the SQS Queue ARN partition

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```