### PR TITLE
Spotinst: Get instance types from `mixedInstancesPolicy` field

### DIFF
--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -544,6 +544,11 @@ func (b *SpotInstanceGroupModelBuilder) buildLaunchSpec(c *fi.ModelBuilderContex
 		}
 	}
 
+	policy := ig.Spec.MixedInstancesPolicy
+	if len(launchSpec.InstanceTypes) == 0 && policy != nil && len(policy.Instances) > 0 {
+		launchSpec.InstanceTypes = policy.Instances
+	}
+
 	// Capacity.
 	minSize, maxSize := b.buildCapacity(ig)
 	ocean.MinSize = fi.Int64(fi.Int64Value(ocean.MinSize) + fi.Int64Value(minSize))


### PR DESCRIPTION
This PR adds the ability for the Spot builder to set the instance types that will be used by Ocean Launch Spec depending on the value set in the `mixedInstancesPolicy.instances` field.