### PR TITLE
kops-controller: register coordination scheme

### DIFF
--- a/cmd/kops-controller/BUILD.bazel
+++ b/cmd/kops-controller/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/nodeidentity/openstack:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//upup/pkg/fi/cloudup/gce/tpm/gcetpmverifier:go_default_library",
+        "//vendor/k8s.io/api/coordination/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -167,6 +168,10 @@ func main() {
 func buildScheme() error {
 	if err := corev1.AddToScheme(scheme); err != nil {
 		return fmt.Errorf("error registering corev1: %v", err)
+	}
+	// Needed so that the leader-election system can post events
+	if err := coordinationv1.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("error registering coordinationv1: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Otherwise we log an error message because we can't discover the GVK
when reporting the leader-election events.