### PR TITLE
gce: open kops-controller port from nodes

### DIFF
--- a/pkg/model/gcemodel/BUILD.bazel
+++ b/pkg/model/gcemodel/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/model/defaults:go_default_library",
         "//pkg/model/iam:go_default_library",
         "//pkg/nodeidentity/gce:go_default_library",
+        "//pkg/wellknownports:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/gce:go_default_library",
         "//upup/pkg/fi/cloudup/gcetasks:go_default_library",

--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/wellknownports"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gcetasks"
 )
@@ -91,7 +92,10 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Network:    b.LinkToNetwork(),
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
 			TargetTags: []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
-			Allowed:    []string{"tcp:443", "tcp:4194"},
+			Allowed: []string{
+				fmt.Sprintf("tcp:%d", wellknownports.KubeAPIServer),
+				fmt.Sprintf("tcp:%d", wellknownports.KopsControllerPort),
+			},
 		}
 		c.AddTask(t)
 	}

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -17,6 +17,9 @@ limitations under the License.
 package wellknownports
 
 const (
+	// KubeAPIServer is the port where kube-apiserver listens.
+	KubeAPIServer = 443
+
 	// KopsControllerPort is the port where kops-controller listens.
 	KopsControllerPort = 3988
 

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -348,7 +348,7 @@ resource "google_compute_firewall" "node-to-master-ha-gce-example-com" {
     protocol = "tcp"
   }
   allow {
-    ports    = ["4194"]
+    ports    = ["3988"]
     protocol = "tcp"
   }
   disabled    = false

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -284,7 +284,7 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-example-com" {
     protocol = "tcp"
   }
   allow {
-    ports    = ["4194"]
+    ports    = ["3988"]
     protocol = "tcp"
   }
   disabled    = false

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -284,7 +284,7 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-private-example-c
     protocol = "tcp"
   }
   allow {
-    ports    = ["4194"]
+    ports    = ["3988"]
     protocol = "tcp"
   }
   disabled    = false


### PR DESCRIPTION
This is now needed in our nodeup bootstrap with vTPM on GCE.
    
Also remove the cadvisor port, it is no longer running on the control-plane nodes.
