### PR TITLE
Add capacity-optimized-prioritized as a valid spot allocation strategy

### DIFF
--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -191,10 +191,17 @@ const (
 	SpotAllocationStrategyDiversified = "diversified"
 	// SpotAllocationStrategyCapacityOptimized indicates a capacity optimized strategy
 	SpotAllocationStrategyCapacityOptimized = "capacity-optimized"
+	// SpotAllocationStrategyCapacityOptimizedPrioritized indicates a capacity optimized prioritized strategy
+	SpotAllocationStrategyCapacityOptimizedPrioritized = "capacity-optimized-prioritized"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies
-var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified, SpotAllocationStrategyCapacityOptimized}
+var SpotAllocationStrategies = []string{
+	SpotAllocationStrategyLowestPrices,
+	SpotAllocationStrategyDiversified,
+	SpotAllocationStrategyCapacityOptimized,
+	SpotAllocationStrategyCapacityOptimizedPrioritized,
+}
 
 // InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)
 type InstanceMetadataOptions struct {


### PR DESCRIPTION
There are [four spot allocation strategies](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotOptions.html) supported in AWS. We already had support for the first three, and this PR adds the last missing one.

(Edit: fix link oopsie)