### PR TITLE
Automated cherry pick of #12560: Add capacity-optimized-prioritized as a valid spot allocation

### DIFF
--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -193,10 +193,17 @@ const (
 	SpotAllocationStrategyDiversified = "diversified"
 	// SpotAllocationStrategyCapacityOptimized indicates a capacity optimized strategy
 	SpotAllocationStrategyCapacityOptimized = "capacity-optimized"
+	// SpotAllocationStrategyCapacityOptimizedPrioritized indicates a capacity optimized prioritized strategy
+	SpotAllocationStrategyCapacityOptimizedPrioritized = "capacity-optimized-prioritized"
 )
 
 // SpotAllocationStrategies is a collection of supported strategies
-var SpotAllocationStrategies = []string{SpotAllocationStrategyLowestPrices, SpotAllocationStrategyDiversified, SpotAllocationStrategyCapacityOptimized}
+var SpotAllocationStrategies = []string{
+	SpotAllocationStrategyLowestPrices,
+	SpotAllocationStrategyDiversified,
+	SpotAllocationStrategyCapacityOptimized,
+	SpotAllocationStrategyCapacityOptimizedPrioritized,
+}
 
 // InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)
 type InstanceMetadataOptions struct {


### PR DESCRIPTION
Cherry pick of #12560 on release-1.22.

#12560: Add capacity-optimized-prioritized as a valid spot allocation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.