### PR TITLE
Disable CNP status updates by default

### DIFF
--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -14,6 +14,8 @@ This is a document to gather the release notes prior to the release.
 
 * Support for the Lyft CNI has been removed.
 
+* Cilium now has `disable-cnp-status-updates: true` by default. Set this to false if you rely on the CiliumNetworkPolicy status fields.
+
 # Required actions
 
 # Deprecations

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -4561,6 +4561,10 @@ spec:
                         description: Device is not implemented and may be removed
                           in the future. Setting this has no effect.
                         type: string
+                      disableCNPStatusUpdates:
+                        description: Determines if CNP NodeStatus updates will be
+                          sent to the Kubernetes api-server.
+                        type: boolean
                       disableConntrack:
                         description: DisableConntrack is not implemented and may be
                           removed in the future. Setting this has no effect.

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -567,6 +567,8 @@ type CiliumNetworkingSpec struct {
 	// CniBinPath is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	CniBinPath string `json:"cniBinPath,omitempty"`
+	// Determines if CNP NodeStatus updates will be sent to the Kubernetes api-server.
+	DisableCNPStatusUpdates *bool `json:"disableCNPStatusUpdates,omitempty"`
 }
 
 // HubbleSpec configures the Hubble service on the Cilium agent.

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -576,6 +576,8 @@ type CiliumNetworkingSpec struct {
 	// CniBinPath is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	CniBinPath string `json:"cniBinPath,omitempty"`
+	// Determines if CNP NodeStatus updates will be sent to the Kubernetes api-server.
+	DisableCNPStatusUpdates *bool `json:"disableCNPStatusUpdates,omitempty"`
 }
 
 // HubbleSpec configures the Hubble service on the Cilium agent.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1896,6 +1896,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.ReconfigureKubelet = in.ReconfigureKubelet
 	out.NodeInitBootstrapFile = in.NodeInitBootstrapFile
 	out.CniBinPath = in.CniBinPath
+	out.DisableCNPStatusUpdates = in.DisableCNPStatusUpdates
 	return nil
 }
 
@@ -2007,6 +2008,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 	out.ReconfigureKubelet = in.ReconfigureKubelet
 	out.NodeInitBootstrapFile = in.NodeInitBootstrapFile
 	out.CniBinPath = in.CniBinPath
+	out.DisableCNPStatusUpdates = in.DisableCNPStatusUpdates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -581,6 +581,11 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(HubbleSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DisableCNPStatusUpdates != nil {
+		in, out := &in.DisableCNPStatusUpdates, &out.DisableCNPStatusUpdates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -556,6 +556,8 @@ type CiliumNetworkingSpec struct {
 	// CniBinPath is not implemented and may be removed in the future.
 	// Setting this has no effect.
 	CniBinPath string `json:"cniBinPath,omitempty"`
+	// Determines if CNP NodeStatus updates will be sent to the Kubernetes api-server.
+	DisableCNPStatusUpdates *bool `json:"disableCNPStatusUpdates,omitempty"`
 }
 
 // HubbleSpec configures the Hubble service on the Cilium agent.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1844,6 +1844,7 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	out.ReconfigureKubelet = in.ReconfigureKubelet
 	out.NodeInitBootstrapFile = in.NodeInitBootstrapFile
 	out.CniBinPath = in.CniBinPath
+	out.DisableCNPStatusUpdates = in.DisableCNPStatusUpdates
 	return nil
 }
 
@@ -1955,6 +1956,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 	out.ReconfigureKubelet = in.ReconfigureKubelet
 	out.NodeInitBootstrapFile = in.NodeInitBootstrapFile
 	out.CniBinPath = in.CniBinPath
+	out.DisableCNPStatusUpdates = in.DisableCNPStatusUpdates
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -582,6 +582,11 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(HubbleSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DisableCNPStatusUpdates != nil {
+		in, out := &in.DisableCNPStatusUpdates, &out.DisableCNPStatusUpdates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -658,6 +658,11 @@ func (in *CiliumNetworkingSpec) DeepCopyInto(out *CiliumNetworkingSpec) {
 		*out = new(HubbleSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DisableCNPStatusUpdates != nil {
+		in, out := &in.DisableCNPStatusUpdates, &out.DisableCNPStatusUpdates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -139,6 +139,10 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 		c.EnableL7Proxy = fi.Bool(true)
 	}
 
+	if c.DisableCNPStatusUpdates == nil {
+		c.DisableCNPStatusUpdates = fi.Bool(true)
+	}
+
 	if c.CPURequest == nil {
 		defaultCPURequest := resource.MustParse("25m")
 		c.CPURequest = &defaultCPURequest

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -184,6 +184,7 @@ spec:
       clusterName: default
       containerRuntimeLabels: none
       cpuRequest: 25m
+      disableCNPStatusUpdates: true
       disableMasquerade: false
       enableBPFMasquerade: false
       enableEndpointHealthChecking: true

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 047215d10823af9a1bb696a4b0daaeb790b9c708986d7a97d989053f5b052cbf
+    manifestHash: e189fc92d397104b4526baecfe33054943a6fd5279802196bfbef4ec749bde76
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -40,6 +40,7 @@ data:
   cluster-name: default
   container-runtime: none
   debug: "false"
+  disable-cnp-status-updates: "true"
   disable-endpoint-crd: "false"
   enable-bpf-masquerade: "false"
   enable-endpoint-health-checking: "true"

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -177,6 +177,7 @@ spec:
       clusterName: default
       containerRuntimeLabels: none
       cpuRequest: 25m
+      disableCNPStatusUpdates: true
       disableMasquerade: false
       enableBPFMasquerade: false
       enableEndpointHealthChecking: true

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 52cdf5be5f19ea68efe3b18efe980717dc9081f8ef73df495d83784ae0d83720
+    manifestHash: b953f6c7cf1b1e1e58115981b21cf5837f5b181a834c47fb51e884ea91b45c45
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -40,6 +40,7 @@ data:
   cluster-name: default
   container-runtime: none
   debug: "false"
+  disable-cnp-status-updates: "true"
   disable-endpoint-crd: "false"
   enable-bpf-masquerade: "false"
   enable-endpoint-health-checking: "true"

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -182,6 +182,7 @@ spec:
       clusterName: default
       containerRuntimeLabels: none
       cpuRequest: 25m
+      disableCNPStatusUpdates: true
       disableMasquerade: false
       enableBPFMasquerade: false
       enableEndpointHealthChecking: true

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -185,6 +185,7 @@ spec:
       clusterName: default
       containerRuntimeLabels: none
       cpuRequest: 25m
+      disableCNPStatusUpdates: true
       disableMasquerade: true
       enableBPFMasquerade: false
       enableEndpointHealthChecking: true

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 0d3773e9dcb3b00b570e6cd5b327fa74aaa7f90ea290afb7703c631f65088fe6
+    manifestHash: 12cfd585141014ba65ea2a1aec21f8012ac51e49466b35873c571bddf6b860db
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -42,6 +42,7 @@ data:
   cluster-name: default
   container-runtime: none
   debug: "false"
+  disable-cnp-status-updates: "true"
   disable-endpoint-crd: "false"
   enable-bpf-masquerade: "false"
   enable-endpoint-health-checking: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -255,6 +255,8 @@ data:
 
   cgroup-root: /run/cilium/cgroupv2
 
+  disable-cnp-status-updates: "{{ .DisableCNPStatusUpdates }}"
+
   {{ if WithDefaultBool .Hubble.Enabled false }}
   # Enable Hubble gRPC service.
   enable-hubble: "true"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
+    manifestHash: fb14b81c0d752392e5880b57adb1225d87fadd790edbcb15aecc54fd3d1d4835
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
+    manifestHash: fb14b81c0d752392e5880b57adb1225d87fadd790edbcb15aecc54fd3d1d4835
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
+    manifestHash: fb14b81c0d752392e5880b57adb1225d87fadd790edbcb15aecc54fd3d1d4835
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -75,7 +75,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
+    manifestHash: fb14b81c0d752392e5880b57adb1225d87fadd790edbcb15aecc54fd3d1d4835
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 2191286409f4b8ee73737c2134bb2bef5a23c5302224010f79b01e17b1bfd420
+    manifestHash: fb14b81c0d752392e5880b57adb1225d87fadd790edbcb15aecc54fd3d1d4835
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
This change was suggested by upstream to avoid ever-growing objects. See https://cilium.slack.com/archives/C53TG4J4R/p1634655498336400