### PR TITLE
Upgrade tests - cleanup previous cluster with newer kops version

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -30,6 +30,15 @@ if [[ "$K8S_VERSION_B" == "latest" ]]; then
 fi
 
 export KOPS_BASE_URL
+
+echo "Cleaning up any leaked resources from previous cluster"
+KOPS_BASE_URL=$(kops-base-from-marker "${KOPS_VERSION_B}")
+KOPS_BASE_URL_B="${KOPS_BASE_URL}"
+KOPS_B=$(kops-download-from-base)
+${KUBETEST2} \
+		--down \
+		--kops-binary-path="${KOPS_B}" || echo "kubetest2 down failed"
+
 KOPS_BASE_URL=$(kops-base-from-marker "${KOPS_VERSION_A}")
 KOPS_A=$(kops-download-from-base)
 KOPS="${KOPS_A}"
@@ -47,8 +56,7 @@ KUBECONFIG_A=$(mktemp -t kops.XXXXXXXXX)
 # Verify kubeconfig-a
 kubectl get nodes -owide --kubeconfig="${KUBECONFIG_A}"
 
-KOPS_BASE_URL=$(kops-base-from-marker "${KOPS_VERSION_B}")
-KOPS_B=$(kops-download-from-base)
+KOPS_BASE_URL="${KOPS_BASE_URL_B}"
 
 KOPS="${KOPS_B}"
 


### PR DESCRIPTION
This way if any additional VFS files are introduced in newer kops versions, the files can be cleaned up without having the older kops version fail to recognize the orphaned files.

Should fix https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-upgrade-k121-ko121-to-klatest-kolatest/1450957748761006080#1:build-log.txt%3A199