### PR TITLE
Automated cherry pick of #12573: Upgrade AWS VPC CNI to 1.9.3 w/ k8s 1.22 support

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -737,8 +737,6 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 
 		if c.CloudProvider != "aws" {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("amazonvpc"), "amazon-vpc-routed-eni networking is supported only in AWS"))
-		} else if cluster.IsKubernetesGTE("1.22") {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("amazonvpc"), "amazon-vpc-routed-eni networking is supported only for Kubernetes 1.21 and lower"))
 		}
 	}
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -82,7 +82,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f10cffef443c2f18c3cab72a44e64ca4342fde13a88a5ffcff4291e35450b25
+    manifestHash: 3522f8761e75814ac416ad7640e77303c489201144499610528a9c50b02185b0
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -4,7 +4,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 roleRef:
@@ -24,7 +28,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 rules:
@@ -33,14 +41,21 @@ rules:
   resources:
   - eniconfigs
   verbs:
-  - get
   - list
   - watch
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
+  - get
 - apiGroups:
   - ""
   resources:
   - pods
-  - namespaces
   verbs:
   - list
   - watch
@@ -65,13 +80,17 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -80,9 +99,14 @@ spec:
     kind: ENIConfig
     plural: eniconfigs
     singular: eniconfig
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 
@@ -94,7 +118,10 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -106,6 +133,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/instance: aws-vpc-cni
+        app.kubernetes.io/name: aws-node
         k8s-app: aws-node
     spec:
       affinity:
@@ -136,14 +165,17 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.3
         imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 60
+          timeoutSeconds: 5
         name: aws-node
         ports:
         - containerPort: 61678
@@ -153,7 +185,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 1
+          timeoutSeconds: 5
         resources:
           requests:
             cpu: 10m
@@ -179,7 +214,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.3
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -188,6 +223,7 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
+      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:
@@ -224,7 +260,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
   namespace: kube-system

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -82,7 +82,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f10cffef443c2f18c3cab72a44e64ca4342fde13a88a5ffcff4291e35450b25
+    manifestHash: 3522f8761e75814ac416ad7640e77303c489201144499610528a9c50b02185b0
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -4,7 +4,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 roleRef:
@@ -24,7 +28,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 rules:
@@ -33,14 +41,21 @@ rules:
   resources:
   - eniconfigs
   verbs:
-  - get
   - list
   - watch
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
+  - get
 - apiGroups:
   - ""
   resources:
   - pods
-  - namespaces
   verbs:
   - list
   - watch
@@ -65,13 +80,17 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -80,9 +99,14 @@ spec:
     kind: ENIConfig
     plural: eniconfigs
     singular: eniconfig
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 
@@ -94,7 +118,10 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -106,6 +133,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/instance: aws-vpc-cni
+        app.kubernetes.io/name: aws-node
         k8s-app: aws-node
     spec:
       affinity:
@@ -136,14 +165,17 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.3
         imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 60
+          timeoutSeconds: 5
         name: aws-node
         ports:
         - containerPort: 61678
@@ -153,7 +185,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 1
+          timeoutSeconds: 5
         resources:
           requests:
             cpu: 10m
@@ -179,7 +214,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.3
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -188,6 +223,7 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
+      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:
@@ -224,7 +260,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
   namespace: kube-system

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -82,7 +82,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 3f10cffef443c2f18c3cab72a44e64ca4342fde13a88a5ffcff4291e35450b25
+    manifestHash: 3522f8761e75814ac416ad7640e77303c489201144499610528a9c50b02185b0
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -4,7 +4,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 roleRef:
@@ -24,7 +28,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 rules:
@@ -33,14 +41,21 @@ rules:
   resources:
   - eniconfigs
   verbs:
-  - get
   - list
   - watch
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
+  - get
 - apiGroups:
   - ""
   resources:
   - pods
-  - namespaces
   verbs:
   - list
   - watch
@@ -65,13 +80,17 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -80,9 +99,14 @@ spec:
     kind: ENIConfig
     plural: eniconfigs
     singular: eniconfig
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 
@@ -94,7 +118,10 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -106,6 +133,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/instance: aws-vpc-cni
+        app.kubernetes.io/name: aws-node
         k8s-app: aws-node
     spec:
       affinity:
@@ -136,14 +165,17 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.3
         imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 60
+          timeoutSeconds: 5
         name: aws-node
         ports:
         - containerPort: 61678
@@ -153,7 +185,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 1
+          timeoutSeconds: 5
         resources:
           requests:
             cpu: 10m
@@ -179,7 +214,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.3
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -188,6 +223,7 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
+      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:
@@ -224,7 +260,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
   namespace: kube-system

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,242 +1,278 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.9/config/v1.9/aws-k8s-cni.yaml
+# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.9/aws-k8s-cni.yaml
 
 ---
-"apiVersion": "rbac.authorization.k8s.io/v1"
-"kind": "ClusterRoleBinding"
-"metadata":
-  "name": "aws-node"
-"roleRef":
-  "apiGroup": "rbac.authorization.k8s.io"
-  "kind": "ClusterRole"
-  "name": "aws-node"
-"subjects":
-- "kind": "ServiceAccount"
-  "name": "aws-node"
-  "namespace": "kube-system"
+# Source: aws-vpc-cni/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-node
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.9.3"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+  - kind: ServiceAccount
+    name: aws-node
+    namespace: kube-system
 ---
-"apiVersion": "rbac.authorization.k8s.io/v1"
-"kind": "ClusterRole"
-"metadata":
-  "name": "aws-node"
-"rules":
-- "apiGroups":
-  - "crd.k8s.amazonaws.com"
-  "resources":
-  - "eniconfigs"
-  "verbs":
-  - "get"
-  - "list"
-  - "watch"
-- "apiGroups":
-  - ""
-  "resources":
-  - "pods"
-  - "namespaces"
-  "verbs":
-  - "list"
-  - "watch"
-  - "get"
-- "apiGroups":
-  - ""
-  "resources":
-  - "nodes"
-  "verbs":
-  - "list"
-  - "watch"
-  - "get"
-  - "update"
-- "apiGroups":
-  - "extensions"
-  - "apps"
-  "resources":
-  - "*"
-  "verbs":
-  - "list"
-  - "watch"
+# Source: aws-vpc-cni/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-node
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.9.3"
+rules:
+  - apiGroups:
+      - crd.k8s.amazonaws.com
+    resources:
+      - eniconfigs
+    verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs: ["list", "watch", "get", "update"]
+  - apiGroups: ["extensions", "apps"]
+    resources:
+      - '*'
+    verbs: ["list", "watch"]
 ---
-"apiVersion": "apiextensions.k8s.io/v1beta1"
-"kind": "CustomResourceDefinition"
-"metadata":
-  "name": "eniconfigs.crd.k8s.amazonaws.com"
-"spec":
-  "group": "crd.k8s.amazonaws.com"
-  "names":
-    "kind": "ENIConfig"
-    "plural": "eniconfigs"
-    "singular": "eniconfig"
-  "scope": "Cluster"
-  "versions":
-  - "name": "v1alpha1"
-    "served": true
-    "storage": true
+# Source: aws-vpc-cni/templates/customresourcedefinition.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: eniconfigs.crd.k8s.amazonaws.com
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.9.3"
+spec:
+  scope: Cluster
+  group: crd.k8s.amazonaws.com
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+  names:
+    plural: eniconfigs
+    singular: eniconfig
+    kind: ENIConfig
 ---
-"apiVersion": "apps/v1"
-"kind": "DaemonSet"
-"metadata":
-  "labels":
-    "k8s-app": "aws-node"
-  "name": "aws-node"
-  "namespace": "kube-system"
-"spec":
-  "selector":
-    "matchLabels":
-      "k8s-app": "aws-node"
-  "template":
-    "metadata":
-      "labels":
-        "k8s-app": "aws-node"
-    "spec":
-      "affinity":
-        "nodeAffinity":
-          "requiredDuringSchedulingIgnoredDuringExecution":
-            "nodeSelectorTerms":
-            - "matchExpressions":
-              - "key": "kubernetes.io/os"
-                "operator": "In"
-                "values":
-                - "linux"
-              - "key": "kubernetes.io/arch"
-                "operator": "In"
-                "values":
-                - "amd64"
-                - "arm64"
-              - "key": "eks.amazonaws.com/compute-type"
-                "operator": "NotIn"
-                "values":
-                - "fargate"
-      "containers":
-      - "env":
-        {{- range $name, $value := AmazonVpcEnvVars }}
-        - "name": "{{ $name }}"
-          "value": "{{ $value }}"
-        {{- end }}
-        # The below envs are commented-out on purpose and replaced by the above range. 
-        # See https://github.com/kubernetes/kops/issues/11144 for more context.
-        # - "name": "ADDITIONAL_ENI_TAGS"
-        #   "value": "{}"
-        # - "name": "AWS_VPC_CNI_NODE_PORT_SUPPORT"
-        #   "value": "true"
-        # - "name": "AWS_VPC_ENI_MTU"
-        #   "value": "9001"
-        # - "name": "AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER"
-        #   "value": "false"
-        # - "name": "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG"
-        #   "value": "false"
-        # - "name": "AWS_VPC_K8S_CNI_EXTERNALSNAT"
-        #   "value": "false"
-        # - "name": "AWS_VPC_K8S_CNI_LOGLEVEL"
-        #   "value": "DEBUG"
-        # - "name": "AWS_VPC_K8S_CNI_LOG_FILE"
-        #   "value": "/host/var/log/aws-routed-eni/ipamd.log"
-        # - "name": "AWS_VPC_K8S_CNI_RANDOMIZESNAT"
-        #   "value": "prng"
-        # - "name": "AWS_VPC_K8S_CNI_VETHPREFIX"
-        #   "value": "eni"
-        # - "name": "AWS_VPC_K8S_PLUGIN_LOG_FILE"
-        #   "value": "/var/log/aws-routed-eni/plugin.log"
-        # - "name": "AWS_VPC_K8S_PLUGIN_LOG_LEVEL"
-        #   "value": "DEBUG"
-        # - "name": "DISABLE_INTROSPECTION"
-        #   "value": "false"
-        # - "name": "DISABLE_METRICS"
-        #   "value": "false"
-        # - "name": "ENABLE_POD_ENI"
-        #   "value": "false"
-        # - "name": "ENABLE_PREFIX_DELEGATION"
-        #   "value": "false"
-        - "name": "MY_NODE_NAME"
-          "valueFrom":
-            "fieldRef":
-              "fieldPath": "spec.nodeName"
-        # - "name": "WARM_ENI_TARGET"
-        #   "value": "1"
-        # - "name": "WARM_PREFIX_TARGET"
-        #   "value": "1"
-        - "name": "CLUSTER_NAME"
-          "value": "{{ ClusterName }}"
-        "image": "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0" }}"
-        "imagePullPolicy": "Always"
-        "livenessProbe":
-          "exec":
-            "command":
-            - "/app/grpc-health-probe"
-            - "-addr=:50051"
-          "initialDelaySeconds": 60
-        "name": "aws-node"
-        "ports":
-        - "containerPort": 61678
-          "name": "metrics"
-        "readinessProbe":
-          "exec":
-            "command":
-            - "/app/grpc-health-probe"
-            - "-addr=:50051"
-          "initialDelaySeconds": 1
-        "resources":
-          "requests":
-            "cpu": "10m"
-        "securityContext":
-          "capabilities":
-            "add":
-            - "NET_ADMIN"
-        "volumeMounts":
-        - "mountPath": "/host/opt/cni/bin"
-          "name": "cni-bin-dir"
-        - "mountPath": "/host/etc/cni/net.d"
-          "name": "cni-net-dir"
-        - "mountPath": "/host/var/log/aws-routed-eni"
-          "name": "log-dir"
-        - "mountPath": "/var/run/aws-node"
-          "name": "run-dir"
-        - "mountPath": "/var/run/dockershim.sock"
-          "name": "dockershim"
-        - "mountPath": "/run/xtables.lock"
-          "name": "xtables-lock"
-      "hostNetwork": true
-      "initContainers":
-      - "env":
-        - "name": "DISABLE_TCP_EARLY_DEMUX"
-          "value": "false"
-        "image": "{{- or .Networking.AmazonVPC.InitImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0" }}"
-        "imagePullPolicy": "Always"
-        "name": "aws-vpc-cni-init"
-        "securityContext":
-          "privileged": true
-        "volumeMounts":
-        - "mountPath": "/host/opt/cni/bin"
-          "name": "cni-bin-dir"
-      "priorityClassName": "system-node-critical"
-      "serviceAccountName": "aws-node"
-      "terminationGracePeriodSeconds": 10
-      "tolerations":
-      - "operator": "Exists"
-      "volumes":
-      - "hostPath":
-          "path": "/opt/cni/bin"
-        "name": "cni-bin-dir"
-      - "hostPath":
-          "path": "/etc/cni/net.d"
-        "name": "cni-net-dir"
-      - "hostPath":
-          "path": "{{ if eq .ContainerRuntime "containerd" }}/run/containerd/containerd.sock{{ else }}/var/run/dockershim.sock{{ end }}"
-        "name": "dockershim"
-      - "hostPath":
-          "path": "/run/xtables.lock"
-        "name": "xtables-lock"
-      - "hostPath":
-          "path": "/var/log/aws-routed-eni"
-          "type": "DirectoryOrCreate"
-        "name": "log-dir"
-      - "hostPath":
-          "path": "/var/run/aws-node"
-          "type": "DirectoryOrCreate"
-        "name": "run-dir"
-  "updateStrategy":
-    "type": "OnDelete"
+# Source: aws-vpc-cni/templates/daemonset.yaml
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.9.3"
+spec:
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      k8s-app: aws-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aws-node
+        app.kubernetes.io/instance: aws-vpc-cni
+        k8s-app: aws-node
+    spec:
+      priorityClassName: "system-node-critical"
+      serviceAccountName: aws-node
+      hostNetwork: true
+      initContainers:
+      - name: aws-vpc-cni-init
+        image: "{{- or .Networking.AmazonVPC.InitImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.3" }}"
+        imagePullPolicy: Always
+        env:
+          - name: DISABLE_TCP_EARLY_DEMUX
+            value: "false"
+        securityContext:
+            privileged: true
+        volumeMounts:
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
+
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - operator: Exists
+      securityContext:
+        {}
+      containers:
+        - name: aws-node
+          image: "{{- or .Networking.AmazonVPC.ImageName "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.3" }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 61678
+              name: metrics
+          livenessProbe:
+            exec:
+              command:
+              - /app/grpc-health-probe
+              - -addr=:50051
+              - -connect-timeout=2s
+              - -rpc-timeout=2s
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - /app/grpc-health-probe
+              - -addr=:50051
+              - -connect-timeout=2s
+              - -rpc-timeout=2s
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+          env:
+            {{- range $name, $value := AmazonVpcEnvVars }}
+            - "name": "{{ $name }}"
+              "value": "{{ $value }}"
+            {{- end }}
+            # The below envs are commented-out on purpose and replaced by the above range.
+            # See https://github.com/kubernetes/kops/issues/11144 for more context
+            # - name: ADDITIONAL_ENI_TAGS
+            #   value: "{}"
+            # - name: AWS_VPC_CNI_NODE_PORT_SUPPORT
+            #   value: "true"
+            # - name: AWS_VPC_ENI_MTU
+            #   value: "9001"
+            # - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
+            #   value: "false"
+            # - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
+            #   value: "false"
+            # - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
+            #   value: "false"
+            # - name: AWS_VPC_K8S_CNI_LOGLEVEL
+            #   value: "DEBUG"
+            # - name: AWS_VPC_K8S_CNI_LOG_FILE
+            #   value: "/host/var/log/aws-routed-eni/ipamd.log"
+            # - name: AWS_VPC_K8S_CNI_RANDOMIZESNAT
+            #   value: "prng"
+            # - name: AWS_VPC_K8S_CNI_VETHPREFIX
+            #   value: "eni"
+            # - name: AWS_VPC_K8S_PLUGIN_LOG_FILE
+            #   value: "/var/log/aws-routed-eni/plugin.log"
+            # - name: AWS_VPC_K8S_PLUGIN_LOG_LEVEL
+            #   value: "DEBUG"
+            # - name: DISABLE_INTROSPECTION
+            #   value: "false"
+            # - name: DISABLE_METRICS
+            #   value: "false"
+            # - name: DISABLE_NETWORK_RESOURCE_PROVISIONING
+            #   value: "false"
+            # - name: ENABLE_IPv4
+            #   value: "true"
+            # - name: ENABLE_IPv6
+            #   value: "false"
+            # - name: ENABLE_POD_ENI
+            #   value: "false"
+            # - name: ENABLE_PREFIX_DELEGATION
+            #   value: "false"
+            # - name: WARM_ENI_TARGET
+            #   value: "1"
+            # - name: WARM_PREFIX_TARGET
+            #   value: "1"
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "CLUSTER_NAME"
+              value: "{{ ClusterName }}"
+          resources:
+            requests:
+              cpu: 10m
+          securityContext:
+            capabilities:
+              add:
+              - NET_ADMIN
+          volumeMounts:
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
+          - mountPath: /host/etc/cni/net.d
+            name: cni-net-dir
+          - mountPath: /host/var/log/aws-routed-eni
+            name: log-dir
+          - mountPath: /var/run/aws-node
+            name: run-dir
+          - mountPath: /var/run/dockershim.sock
+            name: dockershim
+          - mountPath: /run/xtables.lock
+            name: xtables-lock
+      volumes:
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: dockershim
+        hostPath:
+          path: "{{ if eq .ContainerRuntime "containerd" }}/run/containerd/containerd.sock{{ else }}/var/run/dockershim.sock{{ end }}"
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+      - name: log-dir
+        hostPath:
+          path: /var/log/aws-routed-eni
+          type: DirectoryOrCreate
+      - name: run-dir
+        hostPath:
+          path: /var/run/aws-node
+          type: DirectoryOrCreate
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
 ---
-"apiVersion": "v1"
-"kind": "ServiceAccount"
-"metadata":
-  "name": "aws-node"
-  "namespace": "kube-system"
-...
+# Source: aws-vpc-cni/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-node
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.9.3"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 43248639361134d8a3bd94098b9b0bb8a9209088c2b85dbb2af9594a236ea83c
+    manifestHash: 75da98966cc04594813596f6bcd22fa34987f3ac91c44803659729c0c759f462
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -4,7 +4,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 roleRef:
@@ -24,7 +28,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 rules:
@@ -33,14 +41,21 @@ rules:
   resources:
   - eniconfigs
   verbs:
-  - get
   - list
   - watch
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
+  - get
 - apiGroups:
   - ""
   resources:
   - pods
-  - namespaces
   verbs:
   - list
   - watch
@@ -65,13 +80,17 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -80,9 +99,14 @@ spec:
     kind: ENIConfig
     plural: eniconfigs
     singular: eniconfig
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 
@@ -94,7 +118,10 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -106,6 +133,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/instance: aws-vpc-cni
+        app.kubernetes.io/name: aws-node
         k8s-app: aws-node
     spec:
       affinity:
@@ -140,14 +169,17 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.3
         imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 60
+          timeoutSeconds: 5
         name: aws-node
         ports:
         - containerPort: 61678
@@ -157,7 +189,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 1
+          timeoutSeconds: 5
         resources:
           requests:
             cpu: 10m
@@ -183,7 +218,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.3
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -192,6 +227,7 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
+      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:
@@ -228,7 +264,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
   namespace: kube-system

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 43248639361134d8a3bd94098b9b0bb8a9209088c2b85dbb2af9594a236ea83c
+    manifestHash: 75da98966cc04594813596f6bcd22fa34987f3ac91c44803659729c0c759f462
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -4,7 +4,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 roleRef:
@@ -24,7 +28,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
 rules:
@@ -33,14 +41,21 @@ rules:
   resources:
   - eniconfigs
   verbs:
-  - get
   - list
   - watch
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
+  - get
 - apiGroups:
   - ""
   resources:
   - pods
-  - namespaces
   verbs:
   - list
   - watch
@@ -65,13 +80,17 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
 spec:
@@ -80,9 +99,14 @@ spec:
     kind: ENIConfig
     plural: eniconfigs
     singular: eniconfig
+  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
 
@@ -94,7 +118,10 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -106,6 +133,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/instance: aws-vpc-cni
+        app.kubernetes.io/name: aws-node
         k8s-app: aws-node
     spec:
       affinity:
@@ -140,14 +169,17 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.9.3
         imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 60
+          timeoutSeconds: 5
         name: aws-node
         ports:
         - containerPort: 61678
@@ -157,7 +189,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
+            - -connect-timeout=2s
+            - -rpc-timeout=2s
           initialDelaySeconds: 1
+          timeoutSeconds: 5
         resources:
           requests:
             cpu: 10m
@@ -183,7 +218,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.0
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.9.3
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -192,6 +227,7 @@ spec:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir
       priorityClassName: system-node-critical
+      securityContext: {}
       serviceAccountName: aws-node
       terminationGracePeriodSeconds: 10
       tolerations:
@@ -228,7 +264,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.9.3
+    k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
   namespace: kube-system


### PR DESCRIPTION
Cherry pick of #12573 on release-1.22.

#12573: Upgrade AWS VPC CNI to 1.9.3 w/ k8s 1.22 support

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.