### PR TITLE
Automated cherry pick of #12437: Make it possible to set CAS max-node-provision-time

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -603,6 +603,10 @@ spec:
                     description: 'Image is the docker container used. Default: the
                       latest supported image for the specified kubernetes version.'
                     type: string
+                  maxNodeProvisionTime:
+                    description: MaxNodeProvisionTime determines how long CAS will
+                      wait for a node to join the cluster.
+                    type: string
                   memoryRequest:
                     anyOf:
                     - type: integer

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -991,6 +991,8 @@ type ClusterAutoscalerConfig struct {
 	// CPURequest of cluster autoscaler container.
 	// Default: 100m
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MaxNodeProvisionTime determines how long CAS will wait for a node to join the cluster.
+	MaxNodeProvisionTime string `json:"maxNodeProvisionTime,omitempty"`
 }
 
 // MetricsServerConfig determines the metrics server configuration.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -990,6 +990,8 @@ type ClusterAutoscalerConfig struct {
 	// CPURequest of cluster autoscaler container.
 	// Default: 100m
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
+	// MaxNodeProvisionTime determines how long CAS will wait for a node to join the cluster.
+	MaxNodeProvisionTime string `json:"maxNodeProvisionTime,omitempty"`
 }
 
 // MetricsServerConfig determines the metrics server configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2227,6 +2227,7 @@ func autoConvert_v1alpha2_ClusterAutoscalerConfig_To_kops_ClusterAutoscalerConfi
 	out.Image = in.Image
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
+	out.MaxNodeProvisionTime = in.MaxNodeProvisionTime
 	return nil
 }
 
@@ -2248,6 +2249,7 @@ func autoConvert_kops_ClusterAutoscalerConfig_To_v1alpha2_ClusterAutoscalerConfi
 	out.Image = in.Image
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
+	out.MaxNodeProvisionTime = in.MaxNodeProvisionTime
 	return nil
 }
 

--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -89,6 +89,9 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 	if cas.ScaleDownDelayAfterAdd == nil {
 		cas.ScaleDownDelayAfterAdd = fi.String("10m0s")
 	}
+	if cas.MaxNodeProvisionTime == "" {
+		cas.MaxNodeProvisionTime = "15m0s"
+	}
 
 	return nil
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -32,6 +32,7 @@ spec:
     enabled: true
     expander: random
     image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
+    maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s
     scaleDownUtilizationThreshold: "0.5"

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: d402b56db4f6f601708ef366cef3105966fd20a2aedcb5adc2c3c88baba5e0c9
+    manifestHash: e9e6f6bf84e258ed32878bb654ceab2083d3bf3ee5f2e42e272e13e4be1ea512
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -303,6 +303,7 @@ spec:
         - --skip-nodes-with-system-pods=true
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
+        - --max-node-provision-time=15m0s
         - --stderrthreshold=info
         - --v=2
         env:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -32,6 +32,7 @@ spec:
     enabled: true
     expander: random
     image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
+    maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s
     scaleDownUtilizationThreshold: "0.5"

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: c02fbd808dd04643da3df92e4ed84cb370deb7fc9a2b58150f36d5fd28600f70
+    manifestHash: 42629d9eebd31eca3d7eec866262390546b664b21e97ac87d43ee653bf8cc447
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -303,6 +303,7 @@ spec:
         - --skip-nodes-with-system-pods=true
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
+        - --max-node-provision-time=15m0s
         - --stderrthreshold=info
         - --v=2
         env:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,7 @@ spec:
     enabled: true
     expander: random
     image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
+    maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s
     scaleDownUtilizationThreshold: "0.5"

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: c02fbd808dd04643da3df92e4ed84cb370deb7fc9a2b58150f36d5fd28600f70
+    manifestHash: 42629d9eebd31eca3d7eec866262390546b664b21e97ac87d43ee653bf8cc447
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -303,6 +303,7 @@ spec:
         - --skip-nodes-with-system-pods=true
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
+        - --max-node-provision-time=15m0s
         - --stderrthreshold=info
         - --v=2
         env:

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -296,6 +296,7 @@ spec:
             - --skip-nodes-with-system-pods={{ .SkipNodesWithSystemPods }}
             - --scale-down-delay-after-add={{ .ScaleDownDelayAfterAdd }}
             - --new-pod-scale-up-delay={{ .NewPodScaleUpDelay }}
+            - --max-node-provision-time={{ .MaxNodeProvisionTime }}
             - --stderrthreshold=info
             - --v=2
           env:


### PR DESCRIPTION
Cherry pick of #12437 on release-1.22.

#12437: Make it possible to set CAS max-node-provision-time

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```