### PR TITLE
Support BYO IPv6

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
+++ b/upup/pkg/fi/cloudup/awstasks/vpcamazonipv6cidrblock.go
@@ -138,6 +138,8 @@ func findVPCIPv6CIDR(cloud awsup.AWSCloud, vpcID *string) (*string, error) {
 		return nil, err
 	}
 
+	var byoIPv6CidrBlock *string
+
 	for _, association := range vpc.Ipv6CidrBlockAssociationSet {
 		if association == nil || association.Ipv6CidrBlockState == nil {
 			continue
@@ -151,7 +153,11 @@ func findVPCIPv6CIDR(cloud awsup.AWSCloud, vpcID *string) (*string, error) {
 		if aws.StringValue(association.Ipv6Pool) == "Amazon" {
 			return association.Ipv6CidrBlock, nil
 		}
+
+		if byoIPv6CidrBlock == nil {
+			byoIPv6CidrBlock = association.Ipv6CidrBlock
+		}
 	}
 
-	return nil, nil
+	return byoIPv6CidrBlock, nil
 }


### PR DESCRIPTION
While AWS currently only supports one IPv6 CIDR per VPC, the API allows for more. So I coded this to prefer the Amazon-provided association. We could alternatively just take the first one.