### PR TITLE
GCE: use chrony on Ubuntu + GCE

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -668,3 +668,8 @@ func (c *NodeupModelContext) InstallNvidiaRuntime() bool {
 		fi.BoolValue(c.NodeupConfig.NvidiaGPU.Enabled) &&
 		c.GPUVendor == architectures.GPUVendorNvidia
 }
+
+// RunningOnGCE returns true if we are running on GCE
+func (c *NodeupModelContext) RunningOnGCE() bool {
+	return kops.CloudProviderID(c.Cluster.Spec.CloudProvider) == kops.CloudProviderGCE
+}

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -59,7 +59,8 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	if b.Distribution.IsDebianFamily() {
-		if b.Distribution.IsUbuntu() {
+		// Ubuntu recommends systemd-timesyncd, but on ubuntu on GCE systemd-timesyncd is blocked (in favor of chrony)
+		if b.Distribution.IsUbuntu() && !b.RunningOnGCE() {
 			if ntpHost != "" {
 				c.AddTask(b.buildTimesyncdConf("/etc/systemd/timesyncd.conf", ntpHost))
 			}


### PR DESCRIPTION
Ubuntu on GCE has systemd-timesyncd masked, and recommends (and
preconfigures) chrony instead.