### PR TITLE
Resolve /64#N CIDRs at Find time out of existing VPC assignment

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -114,6 +114,15 @@ func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
 		}
 		e.IPv6CIDR = subnetIPv6CIDR
 	}
+	if actual.IPv6CIDR != nil && strings.HasPrefix(aws.StringValue(e.IPv6CIDR), "/") {
+		cidr, err := findVPCIPv6CIDR(c.Cloud.(awsup.AWSCloud), e.VPC.ID)
+		if err == nil && cidr != nil {
+			subnetIPv6CIDR, err := calculateSubnetCIDR(cidr, e.IPv6CIDR)
+			if err == nil {
+				e.IPv6CIDR = subnetIPv6CIDR
+			}
+		}
+	}
 
 	// Prevent spurious changes
 	actual.Lifecycle = e.Lifecycle // Not materialized in AWS


### PR DESCRIPTION
/kind bug

```
W1023 16:02:19.966565   69808 executor.go:139] error running task "Subnet/eu-central-1a.REDACTED" (9m55s remaining to succeed): Subnet.IPv6CIDR: Forbidden: field is immutable: old="2a0a:2b00:20:1::/64" new="/64#1"
W1023 16:02:19.966598   69808 executor.go:139] error running task "Subnet/eu-central-1b.REDACTED" (9m55s remaining to succeed): Subnet.IPv6CIDR: Forbidden: field is immutable: old="2a0a:2b00:20:2::/64" new="/64#2"

```
