### PR TITLE
gce: allow router to refer to network object

### DIFF
--- a/pkg/model/gcemodel/network.go
+++ b/pkg/model/gcemodel/network.go
@@ -82,7 +82,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			r := &gcetasks.Router{
 				Name:                          s(b.SafeObjectName("nat")),
 				Lifecycle:                     b.Lifecycle,
-				Network:                       s(b.LinkToNetwork().URL(b.Cluster.Spec.Project)),
+				Network:                       b.LinkToNetwork(),
 				Region:                        s(b.Region),
 				NATIPAllocationOption:         s(gcetasks.NATIPAllocationOptionAutoOnly),
 				SourceSubnetworkIPRangesToNAT: s(gcetasks.SourceSubnetworkIPRangesAll),

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -498,7 +498,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-private-example-c
 
 resource "google_compute_router" "nat-minimal-gce-private-example-com" {
   name    = "nat-minimal-gce-private-example-com"
-  network = "https://www.googleapis.com/compute/v1/projects/testproject/global/networks/default"
+  network = "default"
 }
 
 resource "google_compute_router_nat" "nat-minimal-gce-private-example-com" {


### PR DESCRIPTION
This allows for our execution model to work a little more smoothly.

Continuing to split out #12382