### PR TITLE
GCE: support egress specification

### DIFF
--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -513,7 +513,11 @@ resource "google_compute_router_nat" "nat-minimal-gce-private-example-com" {
   nat_ip_allocate_option             = "AUTO_ONLY"
   region                             = "us-test1"
   router                             = "nat-minimal-gce-private-example-com"
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name                    = google_compute_subnetwork.us-test1-minimal-gce-private-example-com.name
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
 }
 
 resource "google_compute_subnetwork" "us-test1-minimal-gce-private-example-com" {


### PR DESCRIPTION
Empty or "nat" now defaults to creating a per-subnet NAT router for
private topologies.  "external" will assume that egress is configured
outside of kOps.

Issue #12563