### PR TITLE
Make dns-controller delete placeholder addresses for IPv6 cluster

### DIFF
--- a/dns-controller/pkg/dns/dnscontroller.go
+++ b/dns-controller/pkg/dns/dnscontroller.go
@@ -299,6 +299,31 @@ func (c *DNSController) runOnce() error {
 		}
 	}
 
+	// Look for records of wrong record type.
+	for k := range newValueMap {
+		switch k.RecordType {
+		case RecordTypeA:
+			k.RecordType = RecordTypeAAAA
+		case RecordTypeAAAA:
+			k.RecordType = RecordTypeA
+		default:
+			continue
+		}
+
+		if c.StopRequested() {
+			return fmt.Errorf("stop requested")
+		}
+
+		newValues := newValueMap[k]
+		if newValues == nil {
+			err := op.deleteRecords(k)
+			if err != nil {
+				klog.Infof("error deleting records for %s: %v", k, err)
+				errors = append(errors, err)
+			}
+		}
+	}
+
 	// Look for deleted hostnames
 	for k := range oldValueMap {
 		if c.StopRequested() {


### PR DESCRIPTION
On an IPv6 cluster, the internal domain records for api and kops-controller had two records, an A record with the placeholder address and the correct AAAA record for the single control plane node.

Fix dns-controller to remove A records for domains that only have AAAA records (and vice versa).
