### PR TITLE
dns-controller: Treat IPv6 node addresses as both internal and external

### DIFF
--- a/dns-controller/pkg/watchers/node.go
+++ b/dns-controller/pkg/watchers/node.go
@@ -165,7 +165,7 @@ func (c *NodeController) updateNodeRecords(node *v1.Node) string {
 
 	// node/<name>/external -> ExternalIP
 	for _, a := range node.Status.Addresses {
-		if a.Type != v1.NodeExternalIP {
+		if a.Type != v1.NodeExternalIP && (a.Type != v1.NodeInternalIP || !utils.IsIPv6IP(a.Address)) {
 			continue
 		}
 		var recordType dns.RecordType = dns.RecordTypeA


### PR DESCRIPTION
This will cause clusters with IPv6 on control plane nodes to expose the APIServer on both IPv4 and IPv6.