### PR TITLE
Fix GCE router terraform reference

### DIFF
--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -512,7 +512,7 @@ resource "google_compute_router_nat" "nat-minimal-gce-private-example-com" {
   name                               = "nat-minimal-gce-private-example-com"
   nat_ip_allocate_option             = "AUTO_ONLY"
   region                             = "us-test1"
-  router                             = "nat-minimal-gce-private-example-com"
+  router                             = google_compute_router.nat-minimal-gce-private-example-com.name
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
   subnetwork {
     name                    = google_compute_subnetwork.us-test1-minimal-gce-private-example-com.name

--- a/upup/pkg/fi/cloudup/gcetasks/router.go
+++ b/upup/pkg/fi/cloudup/gcetasks/router.go
@@ -189,7 +189,7 @@ func (*Router) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Router) error {
 type terraformRouterNat struct {
 	Name                          *string                         `json:"name,omitempty" cty:"name"`
 	Region                        *string                         `json:"region,omitempty" cty:"region"`
-	Router                        *string                         `json:"router,omitempty" cty:"router"`
+	Router                        *terraformWriter.Literal        `json:"router,omitempty" cty:"router"`
 	NATIPAllocateOption           *string                         `json:"nat_ip_allocate_option,omitempty" cty:"nat_ip_allocate_option"`
 	SourceSubnetworkIPRangesToNat *string                         `json:"source_subnetwork_ip_ranges_to_nat,omitempty" cty:"source_subnetwork_ip_ranges_to_nat"`
 	Subnetworks                   []*terraformRouterNatSubnetwork `json:"subnetwork,omitempty" cty:"subnetwork"`
@@ -222,7 +222,7 @@ func (*Router) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Rout
 	trn := &terraformRouterNat{
 		Name:                          e.Name,
 		Region:                        e.Region,
-		Router:                        e.Name,
+		Router:                        e.TerraformLink(),
 		NATIPAllocateOption:           e.NATIPAllocationOption,
 		SourceSubnetworkIPRangesToNat: e.SourceSubnetworkIPRangesToNAT,
 	}
@@ -237,5 +237,5 @@ func (*Router) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *Rout
 
 // TerraformLink returns an expression for the name.
 func (r *Router) TerraformLink() *terraformWriter.Literal {
-	return terraformWriter.LiteralProperty("google_compute_router_nat", *r.Name, "name")
+	return terraformWriter.LiteralProperty("google_compute_router", *r.Name, "name")
 }


### PR DESCRIPTION
Fixes the terraform dependency graph according to the example in the [docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat#example-usage---router-nat-basic)

followup to https://github.com/kubernetes/kops/pull/12600