### PR TITLE
GCE: Open BGP port for calico

### DIFF
--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -102,11 +102,14 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			t.Allowed = append(t.Allowed, fmt.Sprintf("udp:%d", wellknownports.ProtokubeGossipMemberlist))
 		}
 		if b.NetworkingIsCalico() {
+			// Allow BGP and IPIP tunneling when we're using calico
 			t.Allowed = append(t.Allowed, "ipip")
+			t.Allowed = append(t.Allowed, fmt.Sprintf("tcp:%d", wellknownports.CalicoBGP))
 		}
 		if b.NetworkingIsCilium() {
 			t.Allowed = append(t.Allowed, fmt.Sprintf("udp:%d", wellknownports.VxlanUDP))
 		}
+
 		c.AddTask(t)
 	}
 

--- a/pkg/wellknownports/wellknownports.go
+++ b/pkg/wellknownports/wellknownports.go
@@ -69,6 +69,9 @@ const (
 
 	// VxlanUDP is the port used by VXLAN tunneling over UDP
 	VxlanUDP = 8472
+
+	// CalicoBGP is used for BGP route propagation by calico
+	CalicoBGP = 179
 )
 
 type PortRange struct {


### PR DESCRIPTION
Calico uses BGP for route propagation.