### PR TITLE
kubetest2: force printing of the plan on cluster creation

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -178,6 +178,7 @@ func (d *deployer) updateCluster(yes bool) error {
 	args := []string{
 		d.KopsBinaryPath, "update", "cluster",
 		"--name", d.ClusterName,
+		"--admin",
 	}
 	if yes {
 		args = append(args, "--yes")


### PR DESCRIPTION
When we run create with --yes, we skip printing the plan.  Instead, we
run a "normal" create, and then run an update.

We don't touch the terraform case, as there may be issues here and we
want to tackle those separately.