### PR TITLE
Use InternalIP as preferred kubelet address only in ivp6 mode

### DIFF
--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -132,7 +132,7 @@ spec:
           - --secure-port=443
           - --kubelet-use-node-status-port
           - --metric-resolution=15s
-          - --kubelet-preferred-address-types=InternalIP
+          - --kubelet-preferred-address-types={{ if IsIPv6Only }}InternalIP{{ else }}Hostname{{ end }}
 {{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
           - --tls-cert-file=/srv/tls.crt
           - --tls-private-key-file=/srv/tls.key

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 4dff6f6241cb58b551453522219441ea26a49878bec473702d2812aae4331c86
+    manifestHash: edda11094163a5cf06f13412aac22c289182a25004abb2e3f7e17fc3d881b720
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -168,7 +168,7 @@ spec:
         - --secure-port=443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 4dff6f6241cb58b551453522219441ea26a49878bec473702d2812aae4331c86
+    manifestHash: edda11094163a5cf06f13412aac22c289182a25004abb2e3f7e17fc3d881b720
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -168,7 +168,7 @@ spec:
         - --secure-port=443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-preferred-address-types=Hostname
         - --cert-dir=/tmp
         - --kubelet-insecure-tls
         image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 9731b5082d21212b47d01fef745c867bb7ae07ba5e67d313ff052c1f2ab41c64
+    manifestHash: 650aae104655b86ec6ccefc4f2d7c723703f4a39e5ffd1223a1cfe45c11e4dbe
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -168,7 +168,7 @@ spec:
         - --secure-port=443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-preferred-address-types=Hostname
         - --tls-cert-file=/srv/tls.crt
         - --tls-private-key-file=/srv/tls.key
         - --kubelet-insecure-tls

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: ee0475eb7db9ad2892bb0a41ee55c94c312c528af4205326b93df84180e63034
+    manifestHash: 4404a283ef24baedfdb7bd5a739fc0f0ca82a46800ceb8fd303f94e523a08861
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -168,7 +168,7 @@ spec:
         - --secure-port=443
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-preferred-address-types=Hostname
         - --tls-cert-file=/srv/tls.crt
         - --tls-private-key-file=/srv/tls.key
         image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0


### PR DESCRIPTION
As metrics-server rolls before the worker nodes, and worker nodes do not yet have IP SANs, upgrade breaks if InternalIP is used.
IPv6 never worked with hostnames, so there is no BC break there.