### PR TITLE
Ignore InvalidAction errors when tagging IAM Instance Profiles

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -115,6 +115,9 @@ const (
 	WellKnownAccountUbuntu       = "099720109477"
 )
 
+// AWSErrCodeInvalidAction is returned in AWS partitions that don't support certain actions
+const AWSErrCodeInvalidAction = "InvalidAction"
+
 type AWSCloud interface {
 	fi.Cloud
 	CloudFormation() *cloudformation.CloudFormation


### PR DESCRIPTION
Ref #12184

This has the unfortunate side-effect of constantly reporting tag additions to instance profiles in dryrun outputs of `kops update cluster` but they can be ignored.

/hold for manual testing