### PR TITLE
Allow kops-controller to describe network interfaces

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -326,6 +326,10 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	addEtcdManagerPermissions(p)
 	b.addNodeupPermissions(p, false)
 
+	if b.Cluster.Spec.IsKopsControllerIPAM() {
+		addKopsControllerIPAMPermissions(p)
+	}
+
 	var err error
 	if p, err = b.AddS3Permissions(p); err != nil {
 		return nil, fmt.Errorf("failed to generate AWS IAM S3 access statements: %v", err)
@@ -773,6 +777,12 @@ func (b *PolicyBuilder) addNodeupPermissions(p *Policy, enableHookSupport bool) 
 			"ec2:AssignIpv6Addresses",
 		)
 	}
+}
+
+func addKopsControllerIPAMPermissions(p *Policy) {
+	p.unconditionalAction.Insert(
+		"ec2:DescribeNetworkInterfaces",
+	)
 }
 
 func addEtcdManagerPermissions(p *Policy) {

--- a/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json
@@ -1295,6 +1295,7 @@
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
                 "ec2:DescribeLaunchTemplateVersions",
+                "ec2:DescribeNetworkInterfaces",
                 "ec2:DescribeRegions",
                 "ec2:DescribeRouteTables",
                 "ec2:DescribeSecurityGroups",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -152,6 +152,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",
+        "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json
@@ -1281,6 +1281,7 @@
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
                 "ec2:DescribeLaunchTemplateVersions",
+                "ec2:DescribeNetworkInterfaces",
                 "ec2:DescribeRegions",
                 "ec2:DescribeRouteTables",
                 "ec2:DescribeSecurityGroups",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -152,6 +152,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",
+        "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",

--- a/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
@@ -1281,6 +1281,7 @@
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
                 "ec2:DescribeLaunchTemplateVersions",
+                "ec2:DescribeNetworkInterfaces",
                 "ec2:DescribeRegions",
                 "ec2:DescribeRouteTables",
                 "ec2:DescribeSecurityGroups",

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -152,6 +152,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeLaunchTemplateVersions",
+        "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",


### PR DESCRIPTION
Still needed by kops-controller for cloud IPAM:
https://testgrid.k8s.io/kops-ipv6#kops-grid-scenario-ipv6-cilium-cloudipam
https://github.com/kubernetes/kops/blob/fa29c9a6b29f21becb9453f204759f6a07a644f0/cmd/kops-controller/controllers/awsipam.go#L127

/cc @johngmyers @rifelpet @olemarkus 