### PR TITLE
Use prefixes for IPv6 with Calico

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1110,10 +1110,7 @@ func validateNetworkingCalico(v *kops.CalicoNetworkingSpec, e kops.EtcdClusterSp
 	}
 
 	if v.EncapsulationMode != "" {
-		// Don't tolerate "None" for now, which would disable encapsulation in the default IPPool
-		// object. Note that with no encapsulation, we'd need to select the "bird" networking
-		// backend in order to allow use of BGP to distribute routes for pod traffic.
-		valid := []string{"ipip", "vxlan"}
+		valid := []string{"ipip", "vxlan", "none"}
 		allErrs = append(allErrs, IsValidValue(fldPath.Child("encapsulationMode"), &v.EncapsulationMode, valid)...)
 	}
 

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -451,8 +451,8 @@ func Test_Validate_AdditionalPolicies(t *testing.T) {
 }
 
 type caliInput struct {
-	Calico *kops.CalicoNetworkingSpec
-	Etcd   kops.EtcdClusterSpec
+	Cluster *kops.ClusterSpec
+	Calico  *kops.CalicoNetworkingSpec
 }
 
 func Test_Validate_Calico(t *testing.T) {
@@ -465,7 +465,6 @@ func Test_Validate_Calico(t *testing.T) {
 			Description: "empty specs",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{},
-				Etcd:   kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -474,7 +473,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					TyphaReplicas: 3,
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -483,7 +481,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					TyphaReplicas: -1,
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.typhaReplicas"},
 		},
@@ -491,9 +488,6 @@ func Test_Validate_Calico(t *testing.T) {
 			Description: "with etcd version",
 			Input: caliInput{
 				Calico: &kops.CalicoNetworkingSpec{},
-				Etcd: kops.EtcdClusterSpec{
-					Version: "3.2.18",
-				},
 			},
 		},
 		{
@@ -502,7 +496,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "first-found",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -511,7 +504,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "first-found",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -520,7 +512,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "can-reach=8.8.8.8",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -529,7 +520,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "can-reach=2001:4860:4860::8888",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -538,7 +528,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "bogus",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
@@ -548,7 +537,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "bogus",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv6AutoDetectionMethod"},
 		},
@@ -558,7 +546,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "interface=",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv6AutoDetectionMethod"},
 		},
@@ -568,7 +555,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "interface=en.*,eth0",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -577,7 +563,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv6AutoDetectionMethod: "skip-interface=en.*,eth0",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -586,7 +571,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "interface=(,en1",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
@@ -596,7 +580,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "interface=foo=bar",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
@@ -606,7 +589,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPv4AutoDetectionMethod: "=en0,eth.*",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Invalid value::calico.ipv4AutoDetectionMethod"},
 		},
@@ -616,7 +598,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					AWSSrcDstCheck: "off",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Unsupported value::calico.awsSrcDstCheck"},
 		},
@@ -626,7 +607,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					AWSSrcDstCheck: "Enable",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -635,7 +615,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					AWSSrcDstCheck: "Disable",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -644,16 +623,41 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					AWSSrcDstCheck: "DoNothing",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
 			Description: "unknown Calico encapsulation mode",
 			Input: caliInput{
-				Calico: &kops.CalicoNetworkingSpec{
-					EncapsulationMode: "None",
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "100.64.0.0/10",
 				},
-				Etcd: kops.EtcdClusterSpec{},
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "none",
+				},
+			},
+			ExpectedErrors: []string{"Unsupported value::calico.encapsulationMode"},
+		},
+		{
+			Description: "unknown Calico encapsulation mode IPIP for IPv6",
+			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "::/0",
+				},
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "ipip",
+				},
+			},
+			ExpectedErrors: []string{"Unsupported value::calico.encapsulationMode"},
+		},
+		{
+			Description: "unknown Calico encapsulation mode VXLAN for IPv6",
+			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "::/0",
+				},
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "vxlan",
+				},
 			},
 			ExpectedErrors: []string{"Unsupported value::calico.encapsulationMode"},
 		},
@@ -663,7 +667,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPIPMode: "unknown",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{"Unsupported value::calico.ipipMode"},
 		},
@@ -675,7 +678,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPIPMode: "Always",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -684,7 +686,6 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPIPMode: "CrossSubnet",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
@@ -693,87 +694,113 @@ func Test_Validate_Calico(t *testing.T) {
 				Calico: &kops.CalicoNetworkingSpec{
 					IPIPMode: "Never",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
 			Description: "Calico IPIP encapsulation mode (explicit) with IPIP IPPool mode (always)",
 			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "100.64.0.0/10",
+				},
 				Calico: &kops.CalicoNetworkingSpec{
 					EncapsulationMode: "ipip",
 					IPIPMode:          "Always",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
 			Description: "Calico IPIP encapsulation mode (explicit) with IPIP IPPool mode (cross-subnet)",
 			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "100.64.0.0/10",
+				},
 				Calico: &kops.CalicoNetworkingSpec{
 					EncapsulationMode: "ipip",
 					IPIPMode:          "CrossSubnet",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
 			Description: "Calico IPIP encapsulation mode (explicit) with IPIP IPPool mode (never)",
 			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "100.64.0.0/10",
+				},
 				Calico: &kops.CalicoNetworkingSpec{
 					EncapsulationMode: "ipip",
 					IPIPMode:          "Never",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 		},
 		{
 			Description: "Calico VXLAN encapsulation mode with IPIP IPPool mode",
 			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "100.64.0.0/10",
+				},
 				Calico: &kops.CalicoNetworkingSpec{
 					EncapsulationMode: "vxlan",
 					IPIPMode:          "Always",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{`Forbidden::calico.ipipMode`},
 		},
 		{
 			Description: "Calico VXLAN encapsulation mode with IPIP IPPool mode (always)",
 			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "100.64.0.0/10",
+				},
 				Calico: &kops.CalicoNetworkingSpec{
 					EncapsulationMode: "vxlan",
 					IPIPMode:          "Always",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{`Forbidden::calico.ipipMode`},
 		},
 		{
 			Description: "Calico VXLAN encapsulation mode with IPIP IPPool mode (cross-subnet)",
 			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "100.64.0.0/10",
+				},
 				Calico: &kops.CalicoNetworkingSpec{
 					EncapsulationMode: "vxlan",
 					IPIPMode:          "CrossSubnet",
 				},
-				Etcd: kops.EtcdClusterSpec{},
 			},
 			ExpectedErrors: []string{`Forbidden::calico.ipipMode`},
 		},
 		{
 			Description: "Calico VXLAN encapsulation mode with IPIP IPPool mode (never)",
 			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "100.64.0.0/10",
+				},
 				Calico: &kops.CalicoNetworkingSpec{
 					EncapsulationMode: "vxlan",
 					IPIPMode:          "Never",
 				},
-				Etcd: kops.EtcdClusterSpec{},
+			},
+		},
+		{
+			Description: "Calico IPv6 without encapsulation",
+			Input: caliInput{
+				Cluster: &kops.ClusterSpec{
+					NonMasqueradeCIDR: "::/0",
+				},
+				Calico: &kops.CalicoNetworkingSpec{
+					EncapsulationMode: "none",
+					IPIPMode:          "Never",
+					VXLANMode:         "Never",
+				},
 			},
 		},
 	}
 	rootFieldPath := field.NewPath("calico")
 	for _, g := range grid {
 		t.Run(g.Description, func(t *testing.T) {
-			errs := validateNetworkingCalico(g.Input.Calico, g.Input.Etcd, rootFieldPath)
+			errs := validateNetworkingCalico(g.Input.Cluster, g.Input.Calico, rootFieldPath)
 			testErrors(t, g.Input, errs, g.ExpectedErrors)
 		})
 	}

--- a/pkg/model/components/calico.go
+++ b/pkg/model/components/calico.go
@@ -36,6 +36,9 @@ func (b *CalicoOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	c.EncapsulationMode = "ipip"
+	if clusterSpec.IsIPv6Only() {
+		c.EncapsulationMode = "none"
+	}
 
 	return nil
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -172,7 +172,7 @@ spec:
   networkCIDR: 172.20.0.0/16
   networking:
     calico:
-      encapsulationMode: ipip
+      encapsulationMode: none
   nonMasqueradeCIDR: ::/0
   secretStore: memfs://clusters.example.com/minimal-ipv6.example.com/secrets
   serviceClusterIPRange: fd00:5e4f:ce::/108

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.projectcalico.org/k8s-1.16.yaml
-    manifestHash: 6a817374cc82d7d9c09560427f963f589fc63a81e08c1770636aeb65022cb4ac
+    manifestHash: ac010a4bac0ae69a9e7693ebaf06e6a2a82010c0c97b01a58b19c89ff7db1803
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.16_content
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  calico_backend: bird
+  calico_backend: none
   cni_network_config: |-
     {
       "name": "k8s-pod-network",
@@ -16,7 +16,8 @@ data:
           "ipam": {
               "assign_ipv4": "false",
               "assign_ipv6": "true",
-              "type": "calico-ipam"
+              "type": "host-local",
+              "ranges": [[{ "subnet": "usePodCidr" }]]
           },
           "policy": {
               "type": "k8s"
@@ -3807,6 +3808,8 @@ spec:
       - env:
         - name: DATASTORE_TYPE
           value: kubernetes
+        - name: USE_POD_CIDR
+          value: "true"
         - name: WAIT_FOR_DATASTORE
           value: "true"
         - name: NODENAME
@@ -3825,11 +3828,11 @@ spec:
         - name: IP6
           value: autodetect
         - name: IP_AUTODETECTION_METHOD
-          value: first-found
+          value: none
         - name: IP6_AUTODETECTION_METHOD
           value: first-found
         - name: CALICO_IPV4POOL_IPIP
-          value: CrossSubnet
+          value: Never
         - name: CALICO_IPV4POOL_VXLAN
           value: Never
         - name: FELIX_IPINIPMTU
@@ -3847,12 +3850,10 @@ spec:
             configMapKeyRef:
               key: veth_mtu
               name: calico-config
-        - name: CALICO_IPV6POOL_CIDR
-          value: ""
-        - name: CALICO_IPV6POOL_NAT_OUTGOING
-          value: "true"
         - name: CALICO_ROUTER_ID
           value: hash
+        - name: NO_DEFAULT_POOLS
+          value: "true"
         - name: CALICO_DISABLE_FILE_LOGGING
           value: "true"
         - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
@@ -3897,8 +3898,6 @@ spec:
             command:
             - /bin/calico-node
             - -felix-live
-            - -bird-live
-            - -bird6-live
           failureThreshold: 6
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -3909,8 +3908,6 @@ spec:
             command:
             - /bin/calico-node
             - -felix-ready
-            - -bird-ready
-            - -bird6-ready
           periodSeconds: 10
           timeoutSeconds: 10
         resources:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.projectcalico.org/k8s-1.16.yaml
-    manifestHash: 428732ac1fb6297372b249afb3e4039f759ea5ba7c94dd4d73759a37eadc4972
+    manifestHash: f9fc744ae00cc5fe205bfd59f562399640761293460628da11e56c0f42b51757
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.16_content
@@ -3827,7 +3827,7 @@ spec:
         - name: IP_AUTODETECTION_METHOD
           value: first-found
         - name: IP6_AUTODETECTION_METHOD
-          value: first-found
+          value: none
         - name: CALICO_IPV4POOL_IPIP
           value: CrossSubnet
         - name: CALICO_IPV4POOL_VXLAN

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -26,7 +26,7 @@ data:
   # You must set a non-zero value for Typha replicas below.
   typha_service_name: "{{- if .Networking.Calico.TyphaReplicas -}}calico-typha{{- else -}}none{{- end -}}"
   # Configure the backend to use.
-  calico_backend: "{{- if eq .Networking.Calico.EncapsulationMode "vxlan" -}}vxlan{{- else -}}bird{{- end -}}"
+  calico_backend: "{{- if eq .Networking.Calico.EncapsulationMode "ipip" -}}bird{{- else -}}{{ .Networking.Calico.EncapsulationMode }}{{- end -}}"
 
   # Configure the MTU to use for workload interfaces and tunnels.
   # By default, MTU is auto-detected, and explicitly setting this field should not be required.
@@ -54,7 +54,12 @@ data:
           "ipam": {
               "assign_ipv4": "{{ not IsIPv6Only }}",
               "assign_ipv6": "{{ IsIPv6Only }}",
+              {{- if not IsIPv6Only }}
               "type": "calico-ipam"
+              {{- else }}
+              "type": "host-local",
+              "ranges": [[{ "subnet": "usePodCidr" }]]
+              {{- end }}
           },
           "policy": {
               "type": "k8s"
@@ -3997,6 +4002,11 @@ spec:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
               value: "kubernetes"
+            {{- if IsIPv6Only }}
+            # Configure route aggregation based on pod CIDR.
+            - name: USE_POD_CIDR
+              value: "true"
+            {{- end }}
             {{- if .Networking.Calico.TyphaReplicas }}
             # Typha support: controlled by the ConfigMap.
             - name: FELIX_TYPHAK8SSERVICENAME
@@ -4027,10 +4037,17 @@ spec:
               value: "{{- if not IsIPv6Only -}}autodetect{{- else -}}none{{- end -}}"
             - name: IP6
               value: "{{- if IsIPv6Only -}}autodetect{{- else -}}none{{- end -}}"
+            {{- if not IsIPv6Only }}
             - name: IP_AUTODETECTION_METHOD
               value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "first-found" }}"
             - name: IP6_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "none" }}"
+            {{- else }}
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "none" }}"
+            - name: IP6_AUTODETECTION_METHOD
               value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "first-found" }}"
+            {{- end }}
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{ CalicoIPv4PoolIPIPMode }}"
@@ -4059,12 +4076,10 @@ spec:
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
             {{- if IsIPv6Only }}
-            - name: CALICO_IPV6POOL_CIDR
-              value: "{{ .KubeControllerManager.ClusterCIDR }}"
-            - name: CALICO_IPV6POOL_NAT_OUTGOING
-              value: "true"
             - name: CALICO_ROUTER_ID
               value: "hash"
+            - name: NO_DEFAULT_POOLS
+              value: "true"
             {{- else }}
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .KubeControllerManager.ClusterCIDR }}"
@@ -4136,10 +4151,11 @@ spec:
               - /bin/calico-node
               - -felix-live
               {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
+              {{- if not IsIPv6Only }}
               - -bird-live
-              {{- end }}
-              {{- if IsIPv6Only }}
+              {{- else }}
               - -bird6-live
+              {{- end }}
               {{- end }}
             periodSeconds: 10
             initialDelaySeconds: 10
@@ -4151,10 +4167,11 @@ spec:
               - /bin/calico-node
               - -felix-ready
               {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
+              {{- if not IsIPv6Only }}
               - -bird-ready
-              {{- end }}
-              {{- if IsIPv6Only }}
+              {{- else }}
               - -bird6-ready
+              {{- end }}
               {{- end }}
             periodSeconds: 10
             timeoutSeconds: 10

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -54,11 +54,11 @@ data:
           "ipam": {
               "assign_ipv4": "{{ not IsIPv6Only }}",
               "assign_ipv6": "{{ IsIPv6Only }}",
-              {{- if not IsIPv6Only }}
-              "type": "calico-ipam"
-              {{- else }}
+              {{- if IsIPv6Only }}
               "type": "host-local",
               "ranges": [[{ "subnet": "usePodCidr" }]]
+              {{- else }}
+              "type": "calico-ipam"
               {{- end }}
           },
           "policy": {
@@ -4037,16 +4037,16 @@ spec:
               value: "{{- if not IsIPv6Only -}}autodetect{{- else -}}none{{- end -}}"
             - name: IP6
               value: "{{- if IsIPv6Only -}}autodetect{{- else -}}none{{- end -}}"
-            {{- if not IsIPv6Only }}
-            - name: IP_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "first-found" }}"
-            - name: IP6_AUTODETECTION_METHOD
-              value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "none" }}"
-            {{- else }}
+            {{- if IsIPv6Only }}
             - name: IP_AUTODETECTION_METHOD
               value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "none" }}"
             - name: IP6_AUTODETECTION_METHOD
               value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "first-found" }}"
+            {{- else }}
+            - name: IP_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "first-found" }}"
+            - name: IP6_AUTODETECTION_METHOD
+              value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "none" }}"
             {{- end }}
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
@@ -4151,10 +4151,10 @@ spec:
               - /bin/calico-node
               - -felix-live
               {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
-              {{- if not IsIPv6Only }}
-              - -bird-live
-              {{- else }}
+              {{- if IsIPv6Only }}
               - -bird6-live
+              {{- else }}
+              - -bird-live
               {{- end }}
               {{- end }}
             periodSeconds: 10
@@ -4167,10 +4167,10 @@ spec:
               - /bin/calico-node
               - -felix-ready
               {{- if eq .Networking.Calico.EncapsulationMode "ipip" }}
-              {{- if not IsIPv6Only }}
-              - -bird-ready
-              {{- else }}
+              {{- if IsIPv6Only }}
               - -bird6-ready
+              {{- else }}
+              - -bird-ready
               {{- end }}
               {{- end }}
             periodSeconds: 10


### PR DESCRIPTION
Time for Calico to join the party. Seems to work pretty well with the Debian 11 image and the return of `net.ipv6.conf.ens5.accept_ra=2`.

/cc @johngmyers @olemarkus @rifelpet 