### PR TITLE
Automated cherry pick of #12638: Fix hardcoded ARN partitions

### DIFF
--- a/cloudmock/aws/mockelbv2/loadbalancers.go
+++ b/cloudmock/aws/mockelbv2/loadbalancers.go
@@ -113,7 +113,7 @@ func (m *MockELBV2) CreateLoadBalancer(request *elbv2.CreateLoadBalancerInput) (
 	lb.VpcId = aws.String("vpc-1")
 
 	m.lbCount++
-	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:us-test-1:000000000000:loadbalancer/net/%v/%v", aws.StringValue(request.Name), m.lbCount)
+	arn := fmt.Sprintf("arn:aws-test:elasticloadbalancing:us-test-1:000000000000:loadbalancer/net/%v/%v", aws.StringValue(request.Name), m.lbCount)
 
 	lb.LoadBalancerArn = aws.String(arn)
 

--- a/cloudmock/aws/mockelbv2/targetgroups.go
+++ b/cloudmock/aws/mockelbv2/targetgroups.go
@@ -103,7 +103,7 @@ func (m *MockELBV2) CreateTargetGroup(request *elbv2.CreateTargetGroupInput) (*e
 	}
 
 	m.tgCount++
-	arn := fmt.Sprintf("arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/%v/%v", aws.StringValue(request.Name), m.tgCount)
+	arn := fmt.Sprintf("arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/%v/%v", aws.StringValue(request.Name), m.tgCount)
 	tg.TargetGroupArn = aws.String(arn)
 
 	if m.TargetGroups == nil {

--- a/cloudmock/aws/mockeventbridge/api.go
+++ b/cloudmock/aws/mockeventbridge/api.go
@@ -39,7 +39,7 @@ func (m *MockEventBridge) PutRule(input *eventbridge.PutRuleInput) (*eventbridge
 	defer m.mutex.Unlock()
 
 	name := *input.Name
-	arn := "arn:aws:events:us-east-1:012345678901:rule/" + name
+	arn := "arn:aws-test:events:us-east-1:012345678901:rule/" + name
 
 	rule := &eventbridge.Rule{
 		Arn:          &arn,

--- a/cloudmock/aws/mockiam/oidcprovider.go
+++ b/cloudmock/aws/mockiam/oidcprovider.go
@@ -84,7 +84,7 @@ func (m *MockIAM) CreateOpenIDConnectProvider(request *iam.CreateOpenIDConnectPr
 
 	klog.Infof("CreateOpenIDConnectProvider: %v", request)
 
-	arn := fmt.Sprintf("arn:aws:iam::0000000000:oidc-provider/%s", *request.Url)
+	arn := fmt.Sprintf("arn:aws-test:iam::0000000000:oidc-provider/%s", *request.Url)
 
 	p := &iam.GetOpenIDConnectProviderOutput{
 		ClientIDList:   request.ClientIDList,

--- a/pkg/model/awsmodel/iam_test.go
+++ b/pkg/model/awsmodel/iam_test.go
@@ -44,6 +44,7 @@ func TestIAMServiceEC2(t *testing.T) {
 func Test_formatAWSIAMStatement(t *testing.T) {
 	type args struct {
 		acountId     string
+		partition    string
 		oidcProvider string
 		namespace    string
 		name         string
@@ -58,6 +59,7 @@ func Test_formatAWSIAMStatement(t *testing.T) {
 			name: "namespace and name without wildcard",
 			args: args{
 				acountId:     "0123456789",
+				partition:    "aws-test",
 				oidcProvider: "oidc-test",
 				namespace:    "test",
 				name:         "test",
@@ -66,7 +68,7 @@ func Test_formatAWSIAMStatement(t *testing.T) {
 			want: &iam.Statement{
 				Effect: "Allow",
 				Principal: iam.Principal{
-					Federated: "arn:aws:iam::0123456789:oidc-provider/oidc-test",
+					Federated: "arn:aws-test:iam::0123456789:oidc-provider/oidc-test",
 				},
 				Action: stringorslice.String("sts:AssumeRoleWithWebIdentity"),
 				Condition: map[string]interface{}{
@@ -80,6 +82,7 @@ func Test_formatAWSIAMStatement(t *testing.T) {
 			name: "name contains wildcard",
 			args: args{
 				acountId:     "0123456789",
+				partition:    "aws-test",
 				oidcProvider: "oidc-test",
 				namespace:    "test",
 				name:         "test-*",
@@ -90,6 +93,7 @@ func Test_formatAWSIAMStatement(t *testing.T) {
 			name: "namespace contains wildcard",
 			args: args{
 				acountId:     "0123456789",
+				partition:    "aws-test",
 				oidcProvider: "oidc-test",
 				namespace:    "test-*",
 				name:         "test",
@@ -98,7 +102,7 @@ func Test_formatAWSIAMStatement(t *testing.T) {
 			want: &iam.Statement{
 				Effect: "Allow",
 				Principal: iam.Principal{
-					Federated: "arn:aws:iam::0123456789:oidc-provider/oidc-test",
+					Federated: "arn:aws-test:iam::0123456789:oidc-provider/oidc-test",
 				},
 				Action: stringorslice.String("sts:AssumeRoleWithWebIdentity"),
 				Condition: map[string]interface{}{
@@ -111,7 +115,7 @@ func Test_formatAWSIAMStatement(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := formatAWSIAMStatement(tt.args.acountId, tt.args.oidcProvider, tt.args.namespace, tt.args.name)
+			got, err := formatAWSIAMStatement(tt.args.acountId, tt.args.partition, tt.args.oidcProvider, tt.args.namespace, tt.args.name)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("formatAWSIAMStatement() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/model/awsmodel/nodeterminationhandler.go
+++ b/pkg/model/awsmodel/nodeterminationhandler.go
@@ -38,7 +38,7 @@ const (
 				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
 			},
 			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws:sqs:{{ AWS_REGION }}:{{ ACCOUNT_ID }}:{{ SQS_QUEUE_NAME }}"
+			"Resource": "arn:{{ AWS_PARTITION }}:sqs:{{ AWS_REGION }}:{{ ACCOUNT_ID }}:{{ SQS_QUEUE_NAME }}"
 		}]
 	}`
 	DefaultMessageRetentionPeriod = 300
@@ -121,6 +121,7 @@ func (b *NodeTerminationHandlerBuilder) configureASG(c *fi.ModelBuilderContext, 
 func (b *NodeTerminationHandlerBuilder) buildSQSQueue(c *fi.ModelBuilderContext) error {
 	queueName := model.QueueNamePrefix(b.ClusterName()) + "-nth"
 	policy := strings.ReplaceAll(NTHTemplate, "{{ AWS_REGION }}", b.Region)
+	policy = strings.ReplaceAll(policy, "{{ AWS_PARTITION }}", b.AWSPartition)
 	policy = strings.ReplaceAll(policy, "{{ ACCOUNT_ID }}", b.AWSAccountID)
 	policy = strings.ReplaceAll(policy, "{{ SQS_QUEUE_NAME }}", queueName)
 

--- a/pkg/model/components/addonmanifests/awscloudcontrollermanager/iam.go
+++ b/pkg/model/components/addonmanifests/awscloudcontrollermanager/iam.go
@@ -32,7 +32,7 @@ var _ iam.Subject = &ServiceAccount{}
 func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
 	clusterName := b.Cluster.ObjectMeta.Name
 	p := iam.NewPolicy(clusterName)
-	iam.AddCCMPermissions(p, b.Cluster.Spec.Networking.Kubenet != nil)
+	iam.AddCCMPermissions(p, b.Partition, b.Cluster.Spec.Networking.Kubenet != nil)
 	iam.AddLegacyCCMPermissions(p)
 	return p, nil
 }

--- a/pkg/model/components/addonmanifests/awsebscsidriver/iam.go
+++ b/pkg/model/components/addonmanifests/awsebscsidriver/iam.go
@@ -36,7 +36,7 @@ func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, erro
 	p := iam.NewPolicy(clusterName)
 
 	addSnapshotControllerPermissions := b.Cluster.Spec.SnapshotController != nil && fi.BoolValue(b.Cluster.Spec.SnapshotController.Enabled)
-	iam.AddAWSEBSCSIDriverPermissions(p, addSnapshotControllerPermissions)
+	iam.AddAWSEBSCSIDriverPermissions(p, b.Partition, addSnapshotControllerPermissions)
 
 	return p, nil
 }

--- a/pkg/model/iam/BUILD.bazel
+++ b/pkg/model/iam/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
         "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//util/pkg/vfs:go_default_library",
-        "//vendor/github.com/aws/aws-sdk-go/aws/endpoints:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -33,7 +33,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
@@ -247,6 +246,7 @@ type PolicyBuilder struct {
 	HostedZoneID                          string
 	KMSKeys                               []string
 	Region                                string
+	Partition                             string
 	ResourceARN                           *string
 	Role                                  Subject
 	UseServiceAccountExternalPermisssions bool
@@ -303,7 +303,7 @@ func (r *NodeRoleAPIServer) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.AmazonVPC != nil {
-		addAmazonVPCCNIPermissions(p, b.IAMPrefix())
+		addAmazonVPCCNIPermissions(p, b.Partition)
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.LyftVPC != nil {
@@ -344,17 +344,17 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 
 	// If cluster does not use external CCM, the master IAM Role needs CCM permissions
 	if b.Cluster.Spec.ExternalCloudControllerManager == nil {
-		AddCCMPermissions(p, b.Cluster.Spec.Networking.Kubenet != nil)
+		AddCCMPermissions(p, b.Partition, b.Cluster.Spec.Networking.Kubenet != nil)
 		AddLegacyCCMPermissions(p)
 	}
 
 	if !b.UseServiceAccountExternalPermisssions {
 		esc := b.Cluster.Spec.SnapshotController != nil &&
 			fi.BoolValue(b.Cluster.Spec.SnapshotController.Enabled)
-		AddAWSEBSCSIDriverPermissions(p, esc)
+		AddAWSEBSCSIDriverPermissions(p, b.Partition, esc)
 
 		if b.Cluster.Spec.ExternalCloudControllerManager != nil {
-			AddCCMPermissions(p, b.Cluster.Spec.Networking.Kubenet != nil)
+			AddCCMPermissions(p, b.Partition, b.Cluster.Spec.Networking.Kubenet != nil)
 			AddLegacyCCMPermissions(p)
 		}
 
@@ -374,7 +374,7 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.AmazonVPC != nil {
-		addAmazonVPCCNIPermissions(p, b.IAMPrefix())
+		addAmazonVPCCNIPermissions(p, b.Partition)
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.LyftVPC != nil {
@@ -408,7 +408,7 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.AmazonVPC != nil {
-		addAmazonVPCCNIPermissions(p, b.IAMPrefix())
+		addAmazonVPCCNIPermissions(p, b.Partition)
 	}
 
 	if b.Cluster.Spec.Networking != nil && b.Cluster.Spec.Networking.LyftVPC != nil {
@@ -431,19 +431,6 @@ func (r *NodeRoleBastion) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 	p.unconditionalAction.Insert("ec2:DescribeRegions")
 
 	return p, nil
-}
-
-// IAMPrefix returns the prefix for AWS ARNs in the current region, for use with IAM
-// it is arn:aws in the default aws partition but different in other isolated or non-standard partitions
-func (b *PolicyBuilder) IAMPrefix() string {
-	partitions := endpoints.DefaultPartitions()
-	for _, p := range partitions {
-		if _, ok := p.Regions()[b.Region]; ok {
-			arn := "arn:" + p.ID()
-			return arn
-		}
-	}
-	return "arn:aws"
 }
 
 // AddS3Permissions builds an IAM Policy, with statements granting tailored
@@ -568,7 +555,7 @@ func (b *PolicyBuilder) AddS3Permissions(p *Policy) (*Policy, error) {
 				"s3:ListBucketVersions",
 			),
 			Resource: stringorslice.Slice([]string{
-				strings.Join([]string{b.IAMPrefix(), ":s3:::", s3Bucket}, ""),
+				fmt.Sprintf("arn:%v:s3:::%v", b.Partition, s3Bucket),
 			}),
 		})
 	}
@@ -586,7 +573,7 @@ func (b *PolicyBuilder) buildS3WriteStatements(p *Policy, iamS3Path string) {
 			"s3:PutObject",
 		}),
 		Resource: stringorslice.Of(
-			strings.Join([]string{b.IAMPrefix(), ":s3:::", iamS3Path, "/*"}, ""),
+			fmt.Sprintf("arn:%v:s3:::%v/*", b.Partition, iamS3Path),
 		),
 	})
 
@@ -604,7 +591,7 @@ func (b *PolicyBuilder) buildS3GetStatements(p *Policy, iamS3Path string) error 
 
 		// Add the prefix for IAM
 		for i, r := range resources {
-			resources[i] = b.IAMPrefix() + ":s3:::" + iamS3Path + r
+			resources[i] = fmt.Sprintf("arn:%v:s3:::%v%v", b.Partition, iamS3Path, r)
 		}
 
 		p.Statement = append(p.Statement, &Statement{
@@ -815,7 +802,7 @@ func AddLegacyCCMPermissions(p *Policy) {
 	)
 }
 
-func AddCCMPermissions(p *Policy, cloudRoutes bool) {
+func AddCCMPermissions(p *Policy, partition string, cloudRoutes bool) {
 	p.unconditionalAction.Insert(
 		"autoscaling:DescribeAutoScalingGroups",
 		"autoscaling:DescribeTags",
@@ -884,8 +871,8 @@ func AddCCMPermissions(p *Policy, cloudRoutes bool) {
 			),
 			Resource: stringorslice.Slice(
 				[]string{
-					"arn:aws:ec2:*:*:volume/*",
-					"arn:aws:ec2:*:*:snapshot/*",
+					fmt.Sprintf("arn:%v:ec2:*:*:volume/*", partition),
+					fmt.Sprintf("arn:%v:ec2:*:*:snapshot/*", partition),
 				},
 			),
 			Condition: Condition{
@@ -949,7 +936,7 @@ func AddClusterAutoscalerPermissions(p *Policy) {
 }
 
 // AddAWSEBSCSIDriverPermissions appens policy statements that the AWS EBS CSI Driver needs to operate.
-func AddAWSEBSCSIDriverPermissions(p *Policy, appendSnapshotPermissions bool) {
+func AddAWSEBSCSIDriverPermissions(p *Policy, partition string, appendSnapshotPermissions bool) {
 
 	if appendSnapshotPermissions {
 		addSnapshotPersmissions(p)
@@ -981,8 +968,8 @@ func AddAWSEBSCSIDriverPermissions(p *Policy, appendSnapshotPermissions bool) {
 			),
 			Resource: stringorslice.Slice(
 				[]string{
-					"arn:aws:ec2:*:*:volume/*",
-					"arn:aws:ec2:*:*:snapshot/*",
+					fmt.Sprintf("arn:%v:ec2:*:*:volume/*", partition),
+					fmt.Sprintf("arn:%v:ec2:*:*:snapshot/*", partition),
 				},
 			),
 			Condition: Condition{
@@ -1002,8 +989,8 @@ func AddAWSEBSCSIDriverPermissions(p *Policy, appendSnapshotPermissions bool) {
 			),
 			Resource: stringorslice.Slice(
 				[]string{
-					"arn:aws:ec2:*:*:volume/*",
-					"arn:aws:ec2:*:*:snapshot/*",
+					fmt.Sprintf("arn:%v:ec2:*:*:volume/*", partition),
+					fmt.Sprintf("arn:%v:ec2:*:*:snapshot/*", partition),
 				},
 			),
 			Condition: Condition{
@@ -1044,13 +1031,13 @@ func AddDNSControllerPermissions(b *PolicyBuilder, p *Policy) {
 		Action: stringorslice.Of("route53:ChangeResourceRecordSets",
 			"route53:ListResourceRecordSets",
 			"route53:GetHostedZone"),
-		Resource: stringorslice.Slice([]string{b.IAMPrefix() + ":route53:::hostedzone/" + hostedZoneID}),
+		Resource: stringorslice.Slice([]string{fmt.Sprintf("arn:%v:route53:::hostedzone/%v", b.Partition, hostedZoneID)}),
 	})
 
 	p.Statement = append(p.Statement, &Statement{
 		Effect:   StatementEffectAllow,
 		Action:   stringorslice.Slice([]string{"route53:GetChange"}),
-		Resource: stringorslice.Slice([]string{b.IAMPrefix() + ":route53:::change/*"}),
+		Resource: stringorslice.Slice([]string{fmt.Sprintf("arn:%v:route53:::change/*", b.Partition)}),
 	})
 
 	wildcard := stringorslice.Slice([]string{"*"})
@@ -1137,7 +1124,7 @@ func addCiliumEniPermissions(p *Policy) {
 	)
 }
 
-func addAmazonVPCCNIPermissions(p *Policy, iamPrefix string) {
+func addAmazonVPCCNIPermissions(p *Policy, partition string) {
 	p.unconditionalAction.Insert(
 		"ec2:AssignPrivateIpAddresses",
 		"ec2:AttachNetworkInterface",
@@ -1158,7 +1145,7 @@ func addAmazonVPCCNIPermissions(p *Policy, iamPrefix string) {
 				"ec2:CreateTags",
 			}),
 			Resource: stringorslice.Slice([]string{
-				strings.Join([]string{iamPrefix, ":ec2:*:*:network-interface/*"}, ""),
+				strings.Join([]string{"arn:", partition, ":ec2:*:*:network-interface/*"}, ""),
 			})},
 	)
 }

--- a/pkg/model/iam/iam_builder_test.go
+++ b/pkg/model/iam/iam_builder_test.go
@@ -30,25 +30,6 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 )
 
-func TestIAMPrefix(t *testing.T) {
-	var expectations = map[string]string{
-		"us-east-1":      "arn:aws",
-		"us-iso-east-1":  "arn:aws-iso",
-		"us-isob-east-1": "arn:aws-iso-b",
-		"us-gov-east-1":  "arn:aws-us-gov",
-		"randomunknown":  "arn:aws",
-		"cn-north-1":     "arn:aws-cn",
-		"cn-northwest-1": "arn:aws-cn",
-	}
-
-	for region, expect := range expectations {
-		arn := (&PolicyBuilder{Region: region}).IAMPrefix()
-		if arn != expect {
-			t.Errorf("expected %s for %s, received %s", expect, region, arn)
-		}
-	}
-}
-
 func TestRoundTrip(t *testing.T) {
 	grid := []struct {
 		IAM  *Statement
@@ -192,7 +173,8 @@ func TestPolicyGeneration(t *testing.T) {
 					},
 				},
 			},
-			Role: x.Role,
+			Role:      x.Role,
+			Partition: "aws-test",
 		}
 		b.Cluster.SetName("iam-builder-test.k8s.local")
 

--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
+      "Resource": "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
       "Action": [
@@ -29,7 +29,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::kops-tests"
+        "arn:aws-test:s3:::kops-tests"
       ]
     },
     {
@@ -44,8 +44,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -60,8 +60,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -73,8 +73,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/*"
+      "Resource": "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/*"
     },
     {
       "Action": [
@@ -29,7 +29,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::kops-tests"
+        "arn:aws-test:s3:::kops-tests"
       ]
     },
     {
@@ -44,8 +44,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -60,8 +60,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -73,8 +73,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -6,12 +6,12 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/addons/*",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/cluster-completed.spec",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/igconfig/node/*",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kube-proxy/*",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/addons/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/cluster-completed.spec",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/igconfig/node/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kube-proxy/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
       ]
     },
     {
@@ -23,7 +23,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::kops-tests"
+        "arn:aws-test:s3:::kops-tests"
       ]
     },
     {

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -6,12 +6,12 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/addons/*",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/cluster-completed.spec",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/igconfig/node/*",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kube-proxy/*",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
-        "arn:aws:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/addons/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/cluster-completed.spec",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/igconfig/node/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kube-proxy/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/pki/private/kubelet/*",
+        "arn:aws-test:s3:::kops-tests/iam-builder-test.k8s.local/secrets/dockerconfig"
       ]
     },
     {
@@ -23,7 +23,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::kops-tests"
+        "arn:aws-test:s3:::kops-tests"
       ]
     },
     {

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json
@@ -1175,7 +1175,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
             },
             {
               "Action": [
@@ -1186,7 +1186,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1235,7 +1235,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
             },
             {
               "Action": [
@@ -1245,7 +1245,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1255,7 +1255,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1266,7 +1266,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1278,7 +1278,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1289,7 +1289,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1298,7 +1298,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1323,8 +1323,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1339,8 +1339,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1352,8 +1352,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1474,10 +1474,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1489,7 +1489,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -8,7 +8,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -17,7 +17,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/bastionuserdata.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/bastionuserdata.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/bastionuserdata.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/bastionuserdata.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/bastionuserdata.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -274,7 +274,7 @@
                 "Throughput": 125,
                 "DeleteOnTermination": true,
                 "Encrypted": true,
-                "KmsKeyId": "arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+                "KmsKeyId": "arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
               }
             },
             {
@@ -447,7 +447,7 @@
                 "VolumeSize": 20,
                 "DeleteOnTermination": true,
                 "Encrypted": true,
-                "KmsKeyId": "arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+                "KmsKeyId": "arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
               }
             }
           ],
@@ -1386,7 +1386,7 @@
       "Properties": {
         "Certificates": [
           {
-            "CertificateArn": "arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
+            "CertificateArn": "arn:aws-test:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
           }
         ],
         "DefaultActions": [
@@ -1888,7 +1888,7 @@
           ],
           "Version": "2012-10-17"
         },
-        "PermissionsBoundary": "arn:aws:iam::000000000000:policy/boundaries",
+        "PermissionsBoundary": "arn:aws-test:iam::000000000000:policy/boundaries",
         "Tags": [
           {
             "Key": "KubernetesCluster",
@@ -1929,7 +1929,7 @@
           ],
           "Version": "2012-10-17"
         },
-        "PermissionsBoundary": "arn:aws:iam::000000000000:policy/boundaries",
+        "PermissionsBoundary": "arn:aws-test:iam::000000000000:policy/boundaries",
         "Tags": [
           {
             "Key": "KubernetesCluster",

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -1598,7 +1598,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/*"
             },
             {
               "Action": [
@@ -1608,7 +1608,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/complex.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/complex.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1618,7 +1618,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/complex.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/complex.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1629,7 +1629,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1641,7 +1641,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1652,7 +1652,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1661,7 +1661,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1686,8 +1686,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1702,8 +1702,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1715,8 +1715,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1837,10 +1837,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1852,7 +1852,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/complex/cluster.overrides.txt
+++ b/tests/integration/update_cluster/complex/cluster.overrides.txt
@@ -1,3 +1,3 @@
-spec.api.loadBalancer.sslCertificate=arn:aws:acm:us-east-1:123456789012:certificate/123456789012-1234-1234-1234-12345678
+spec.api.loadBalancer.sslCertificate=arn:aws-test:acm:us-east-1:123456789012:certificate/123456789012-1234-1234-1234-12345678
 ---
 spec.api.loadBalancer.additionalSecurityGroups=sg-123456

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/complex.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/complex.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/complex.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/complex.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/complex.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
       - sg-exampleid6
       class: Network
       crossZoneLoadBalancing: true
-      sslCertificate: arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
+      sslCertificate: arn:aws-test:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
       sslPolicy: ELBSecurityPolicy-2016-08
       subnets:
       - allocationId: eipalloc-012345a678b9cdefa
@@ -68,7 +68,7 @@ spec:
     provider: dns-controller
   iam:
     legacy: false
-    permissionsBoundary: arn:aws:iam::000000000000:policy/boundaries
+    permissionsBoundary: arn:aws-test:iam::000000000000:policy/boundaries
   keyStore: memfs://clusters.example.com/complex.example.com/pki
   kubeAPIServer:
     allowPrivileged: true

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -12,7 +12,7 @@ spec:
       - sg-exampleid6
       crossZoneLoadBalancing: true
       class: Network
-      sslCertificate: arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
+      sslCertificate: arn:aws-test:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
       sslPolicy: ELBSecurityPolicy-2016-08
       subnets:
         - name: us-test-1a
@@ -37,7 +37,7 @@ spec:
       name: a
     name: events
   iam:
-    permissionsBoundary: arn:aws:iam::000000000000:policy/boundaries
+    permissionsBoundary: arn:aws-test:iam::000000000000:policy/boundaries
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
     auditWebhookBatchThrottleQps: 3.14
@@ -125,7 +125,7 @@ spec:
     size: 20
     type: gp2
     encrypted: true
-    key: arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
+    key: arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
   additionalUserData:
   - name: myscript.sh
     type: text/x-shellscript
@@ -152,7 +152,7 @@ spec:
   minSize: 1
   role: Master
   rootVolumeEncryption: true
-  rootVolumeEncryptionKey: arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
+  rootVolumeEncryptionKey: arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
   subnets:
   - us-test-1a
   instanceMetadata:

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -12,7 +12,7 @@ spec:
       - sg-exampleid6
       crossZoneLoadBalancing: true
       class: Network
-      sslCertificate: arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
+      sslCertificate: arn:aws-test:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678
       sslPolicy: ELBSecurityPolicy-2016-08
       subnets:
         - name: us-test-1a
@@ -37,7 +37,7 @@ spec:
       name: a
     name: events
   iam:
-    permissionsBoundary: arn:aws:iam::000000000000:policy/boundaries
+    permissionsBoundary: arn:aws-test:iam::000000000000:policy/boundaries
   kubeAPIServer:
     serviceNodePortRange: 28000-32767
     auditWebhookBatchThrottleQps: 3.14
@@ -125,7 +125,7 @@ spec:
     size: 20
     type: gp2
     encrypted: true
-    key: arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
+    key: arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
   additionalUserData:
   - name: myscript.sh
     type: text/x-shellscript
@@ -152,7 +152,7 @@ spec:
   minSize: 1
   role: Master
   rootVolumeEncryption: true
-  rootVolumeEncryptionKey: arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
+  rootVolumeEncryptionKey: arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab
   subnets:
   - us-test-1a
   instanceMetadata:

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -302,7 +302,7 @@ resource "aws_iam_instance_profile" "nodes-complex-example-com" {
 resource "aws_iam_role" "masters-complex-example-com" {
   assume_role_policy   = file("${path.module}/data/aws_iam_role_masters.complex.example.com_policy")
   name                 = "masters.complex.example.com"
-  permissions_boundary = "arn:aws:iam::000000000000:policy/boundaries"
+  permissions_boundary = "arn:aws-test:iam::000000000000:policy/boundaries"
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "masters.complex.example.com"
@@ -315,7 +315,7 @@ resource "aws_iam_role" "masters-complex-example-com" {
 resource "aws_iam_role" "nodes-complex-example-com" {
   assume_role_policy   = file("${path.module}/data/aws_iam_role_nodes.complex.example.com_policy")
   name                 = "nodes.complex.example.com"
-  permissions_boundary = "arn:aws:iam::000000000000:policy/boundaries"
+  permissions_boundary = "arn:aws-test:iam::000000000000:policy/boundaries"
   tags = {
     "KubernetesCluster"                         = "complex.example.com"
     "Name"                                      = "nodes.complex.example.com"
@@ -355,7 +355,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-complex-example-com" {
       delete_on_termination = true
       encrypted             = true
       iops                  = 3000
-      kms_key_id            = "arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+      kms_key_id            = "arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
       throughput            = 125
       volume_size           = 64
       volume_type           = "gp3"
@@ -457,7 +457,7 @@ resource "aws_launch_template" "nodes-complex-example-com" {
     ebs {
       delete_on_termination = true
       encrypted             = true
-      kms_key_id            = "arn:aws:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+      kms_key_id            = "arn:aws-test:kms:us-test-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
       volume_size           = 20
       volume_type           = "gp2"
     }
@@ -555,7 +555,7 @@ resource "aws_lb" "api-complex-example-com" {
 }
 
 resource "aws_lb_listener" "api-complex-example-com-443" {
-  certificate_arn = "arn:aws:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
+  certificate_arn = "arn:aws-test:acm:us-test-1:000000000000:certificate/123456789012-1234-1234-1234-12345678"
   default_action {
     target_group_arn = aws_lb_target_group.tls-complex-example-com-5nursn.id
     type             = "forward"

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/compress.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/compress.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/compress.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/compress.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/compress.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json
@@ -970,7 +970,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/*"
             },
             {
               "Action": [
@@ -980,7 +980,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/containerd.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/containerd.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -990,7 +990,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/containerd.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/containerd.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1001,7 +1001,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1013,7 +1013,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1024,7 +1024,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1033,7 +1033,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1058,8 +1058,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1074,8 +1074,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1087,8 +1087,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1209,10 +1209,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1224,7 +1224,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/containerd/cloudformation.json
+++ b/tests/integration/update_cluster/containerd/cloudformation.json
@@ -970,7 +970,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/*"
             },
             {
               "Action": [
@@ -980,7 +980,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/containerd.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/containerd.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -990,7 +990,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/containerd.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/containerd.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1001,7 +1001,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1013,7 +1013,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1024,7 +1024,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1033,7 +1033,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1058,8 +1058,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1074,8 +1074,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1087,8 +1087,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1209,10 +1209,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/containerd.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1224,7 +1224,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_myotherserviceaccount.myapp.sa.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_myotherserviceaccount.myapp.sa.123.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/123.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/123.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_myserviceaccount.default.sa.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_myserviceaccount.default.sa.123.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/123.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/123.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/123.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/123.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/123.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/123.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/123.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -52,7 +52,7 @@ spec:
     serviceAccountExternalPermissions:
     - aws:
         policyARNs:
-        - arn:aws:iam::123456789012:policy/UsersManageOwnCredentials
+        - arn:aws-test:iam::123456789012:policy/UsersManageOwnCredentials
       name: myserviceaccount
       namespace: default
     - aws:

--- a/tests/integration/update_cluster/digit/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/digit/in-v1alpha2.yaml
@@ -24,7 +24,7 @@ spec:
         namespace: default
         aws:
           policyARNs:
-          - arn:aws:iam::123456789012:policy/UsersManageOwnCredentials
+          - arn:aws-test:iam::123456789012:policy/UsersManageOwnCredentials
       - name: myotherserviceaccount
         namespace: myapp
         aws:

--- a/tests/integration/update_cluster/digit/kubernetes.tf
+++ b/tests/integration/update_cluster/digit/kubernetes.tf
@@ -349,8 +349,8 @@ resource "aws_iam_role_policy" "nodes-123-example-com" {
   role   = aws_iam_role.nodes-123-example-com.name
 }
 
-resource "aws_iam_role_policy_attachment" "external-myserviceaccount-default-sa-123-example-com-3186075376" {
-  policy_arn = "arn:aws:iam::123456789012:policy/UsersManageOwnCredentials"
+resource "aws_iam_role_policy_attachment" "external-myserviceaccount-default-sa-123-example-com-3197825879" {
+  policy_arn = "arn:aws-test:iam::123456789012:policy/UsersManageOwnCredentials"
   role       = aws_iam_role.myserviceaccount-default-sa-123-example-com.name
 }
 

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json
@@ -970,7 +970,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/*"
             },
             {
               "Action": [
@@ -980,7 +980,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/docker.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/docker.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -990,7 +990,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/docker.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/docker.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1001,7 +1001,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1013,7 +1013,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1024,7 +1024,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1033,7 +1033,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1058,8 +1058,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1074,8 +1074,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1087,8 +1087,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1209,10 +1209,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/docker.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1224,7 +1224,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam/in-v1alpha2.yaml
@@ -69,7 +69,7 @@ metadata:
   name: master-us-test-1a
 spec:
   iam:
-    profile: arn:aws:iam::4222917490108:instance-profile/kops-custom-master-role
+    profile: arn:aws-test:iam::4222917490108:instance-profile/kops-custom-master-role
   image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
@@ -89,7 +89,7 @@ metadata:
   name: master-us-test-1b
 spec:
   iam:
-    profile: arn:aws:iam::4222917490108:instance-profile/kops-custom-master-role
+    profile: arn:aws-test:iam::4222917490108:instance-profile/kops-custom-master-role
   image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
@@ -109,7 +109,7 @@ metadata:
   name: master-us-test-1c
 spec:
   iam:
-    profile: arn:aws:iam::4222917490108:instance-profile/kops-custom-master-role
+    profile: arn:aws-test:iam::4222917490108:instance-profile/kops-custom-master-role
   image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: m3.medium
   maxSize: 1
@@ -129,7 +129,7 @@ metadata:
   name: nodes
 spec:
   iam:
-    profile: arn:aws:iam::422917490108:instance-profile/kops-custom-node-role
+    profile: arn:aws-test:iam::422917490108:instance-profile/kops-custom-node-role
   image: kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-08-16
   machineType: t2.medium
   maxSize: 2

--- a/tests/integration/update_cluster/existing_iam_cloudformation/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/in-v1alpha2.yaml
@@ -51,7 +51,7 @@ metadata:
 spec:
   associatePublicIp: true
   iam:
-    profile: arn:aws:iam::422917490108:instance-profile/kops-custom-node-role
+    profile: arn:aws-test:iam::422917490108:instance-profile/kops-custom-node-role
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: t2.medium
   maxSize: 2
@@ -72,7 +72,7 @@ metadata:
 spec:
   associatePublicIp: true
   iam:
-    profile: arn:aws:iam::422917490108:instance-profile/kops-custom-master-role
+    profile: arn:aws-test:iam::422917490108:instance-profile/kops-custom-master-role
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: m3.medium
   maxSize: 1

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/existingsg.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/existingsg.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/existingsg.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/existingsg.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/existingsg.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_external-dns.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_external-dns.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_external-dns.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_external-dns.kube-system.sa.minimal.example.com_policy
@@ -8,7 +8,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -17,7 +17,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -95,9 +95,9 @@
           "my-external-elb-3"
         ],
         "TargetGroupARNs": [
-          "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1",
-          "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2",
-          "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3"
+          "arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1",
+          "arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2",
+          "arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3"
         ]
       }
     },
@@ -179,7 +179,7 @@
           "my-external-elb-1"
         ],
         "TargetGroupARNs": [
-          "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1"
+          "arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1"
         ]
       }
     },

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -986,7 +986,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/*"
             },
             {
               "Action": [
@@ -996,7 +996,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/externallb.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/externallb.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1006,7 +1006,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/externallb.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/externallb.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1017,7 +1017,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1029,7 +1029,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1040,7 +1040,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1049,7 +1049,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1074,8 +1074,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1090,8 +1090,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1103,8 +1103,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1225,10 +1225,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1240,7 +1240,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/externallb.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/externallb.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/externallb.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/externallb.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externallb.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/externallb/in-v1alpha2.yaml
@@ -58,7 +58,7 @@ spec:
   subnets:
   - us-test-1a
   externalLoadBalancers:
-  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1
+  - targetGroupArn: arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1
   - loadBalancerName: my-external-elb-1
 
 ---
@@ -80,9 +80,9 @@ spec:
   subnets:
   - us-test-1a
   externalLoadBalancers:
-  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2
-  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1
-  - targetGroupArn: arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3
+  - targetGroupArn: arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2
+  - targetGroupArn: arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1
+  - targetGroupArn: arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3
   - loadBalancerName: my-external-elb-2
   - loadBalancerName: my-external-elb-1
   - loadBalancerName: my-external-elb-3

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -147,7 +147,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-externallb-example-c
     propagate_at_launch = true
     value               = "owned"
   }
-  target_group_arns   = ["arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1", "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2", "arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3"]
+  target_group_arns   = ["arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1", "arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-2/2", "arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-3/3"]
   vpc_zone_identifier = [aws_subnet.us-test-1a-externallb-example-com.id]
 }
 
@@ -198,7 +198,7 @@ resource "aws_autoscaling_group" "nodes-externallb-example-com" {
     propagate_at_launch = true
     value               = "owned"
   }
-  target_group_arns   = ["arn:aws:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1"]
+  target_group_arns   = ["arn:aws-test:elasticloadbalancing:us-test-1:000000000000:targetgroup/my-external-tg-1/1"]
   vpc_zone_identifier = [aws_subnet.us-test-1a-externallb-example-com.id]
 }
 

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/externalpolicies.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/externalpolicies.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/externalpolicies.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/externalpolicies.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/externalpolicies.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -57,11 +57,11 @@ spec:
     provider: dns-controller
   externalPolicies:
     bastion:
-    - arn:aws:iam::123456789000:policy/test-policy
+    - arn:aws-test:iam::123456789000:policy/test-policy
     master:
-    - arn:aws:iam::123456789000:policy/test-policy
+    - arn:aws-test:iam::123456789000:policy/test-policy
     node:
-    - arn:aws:iam::123456789000:policy/test-policy
+    - arn:aws-test:iam::123456789000:policy/test-policy
   iam:
     legacy: false
   keyStore: memfs://clusters.example.com/externalpolicies.example.com/pki

--- a/tests/integration/update_cluster/externalpolicies/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/externalpolicies/in-v1alpha2.yaml
@@ -50,11 +50,11 @@ spec:
     nodes: public
   externalPolicies:
     node:
-      - arn:aws:iam::123456789000:policy/test-policy
+      - arn:aws-test:iam::123456789000:policy/test-policy
     master:
-      - arn:aws:iam::123456789000:policy/test-policy
+      - arn:aws-test:iam::123456789000:policy/test-policy
     bastion:
-      - arn:aws:iam::123456789000:policy/test-policy
+      - arn:aws-test:iam::123456789000:policy/test-policy
   subnets:
   - cidr: 172.20.32.0/19
     name: us-test-1a

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -344,13 +344,13 @@ resource "aws_iam_role_policy" "nodes-externalpolicies-example-com" {
   role   = aws_iam_role.nodes-externalpolicies-example-com.name
 }
 
-resource "aws_iam_role_policy_attachment" "master-policyoverride-1242070525" {
-  policy_arn = "arn:aws:iam::123456789000:policy/test-policy"
+resource "aws_iam_role_policy_attachment" "master-policyoverride-1544513530" {
+  policy_arn = "arn:aws-test:iam::123456789000:policy/test-policy"
   role       = aws_iam_role.masters-externalpolicies-example-com.name
 }
 
-resource "aws_iam_role_policy_attachment" "node-policyoverride-1242070525" {
-  policy_arn = "arn:aws:iam::123456789000:policy/test-policy"
+resource "aws_iam_role_policy_attachment" "node-policyoverride-1544513530" {
+  policy_arn = "arn:aws-test:iam::123456789000:policy/test-policy"
   role       = aws_iam_role.nodes-externalpolicies-example-com.name
 }
 

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/tests/ha.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/tests/ha.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/tests/ha.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/tests/ha.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/tests/ha.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/tests/ha.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/tests/ha.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/tests/ha.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/tests/ha.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/tests/ha.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/tests/ha.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/tests/ha.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/tests/ha.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/tests/ha.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_myotherserviceaccount.myapp.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_myotherserviceaccount.myapp.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_myserviceaccount.default.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_myserviceaccount.default.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_myserviceaccount.test-wildcard.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_myserviceaccount.test-wildcard.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -52,12 +52,12 @@ spec:
     serviceAccountExternalPermissions:
     - aws:
         policyARNs:
-        - arn:aws:iam::123456789012:policy/UsersManageOwnCredentials
+        - arn:aws-test:iam::123456789012:policy/UsersManageOwnCredentials
       name: myserviceaccount
       namespace: default
     - aws:
         policyARNs:
-        - arn:aws:iam::123456789012:policy/UsersManageOwnCredentials
+        - arn:aws-test:iam::123456789012:policy/UsersManageOwnCredentials
       name: myserviceaccount
       namespace: test-*
     - aws:

--- a/tests/integration/update_cluster/irsa/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/irsa/in-v1alpha2.yaml
@@ -24,12 +24,12 @@ spec:
         namespace: default
         aws:
           policyARNs:
-          - arn:aws:iam::123456789012:policy/UsersManageOwnCredentials
+          - arn:aws-test:iam::123456789012:policy/UsersManageOwnCredentials
       - name: myserviceaccount
         namespace: test-*
         aws:
           policyARNs:
-          - arn:aws:iam::123456789012:policy/UsersManageOwnCredentials
+          - arn:aws-test:iam::123456789012:policy/UsersManageOwnCredentials
       - name: myotherserviceaccount
         namespace: myapp
         aws:

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -369,13 +369,13 @@ resource "aws_iam_role_policy" "nodes-minimal-example-com" {
   role   = aws_iam_role.nodes-minimal-example-com.name
 }
 
-resource "aws_iam_role_policy_attachment" "external-myserviceaccount-default-sa-minimal-example-com-3186075376" {
-  policy_arn = "arn:aws:iam::123456789012:policy/UsersManageOwnCredentials"
+resource "aws_iam_role_policy_attachment" "external-myserviceaccount-default-sa-minimal-example-com-3197825879" {
+  policy_arn = "arn:aws-test:iam::123456789012:policy/UsersManageOwnCredentials"
   role       = aws_iam_role.myserviceaccount-default-sa-minimal-example-com.name
 }
 
-resource "aws_iam_role_policy_attachment" "external-myserviceaccount-test-wildcard-sa-minimal-example-com-3186075376" {
-  policy_arn = "arn:aws:iam::123456789012:policy/UsersManageOwnCredentials"
+resource "aws_iam_role_policy_attachment" "external-myserviceaccount-test-wildcard-sa-minimal-example-com-3197825879" {
+  policy_arn = "arn:aws-test:iam::123456789012:policy/UsersManageOwnCredentials"
   role       = aws_iam_role.myserviceaccount-test-wildcard-sa-minimal-example-com.name
 }
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_aws-load-balancer-controller.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_aws-node-termination-handler.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_aws-node-termination-handler.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_cluster-autoscaler.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_cluster-autoscaler.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_aws-cloud-controller-manager.kube-system.sa.minimal.example.com_policy
@@ -12,8 +12,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -8,7 +8,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -17,7 +17,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -12,8 +12,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -25,8 +25,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -100,7 +100,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*"
+        "arn:aws-test:ec2:*:*:network-interface/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -30,7 +30,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*"
+        "arn:aws-test:ec2:*:*:network-interface/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -119,8 +119,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -145,7 +145,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*"
+        "arn:aws-test:ec2:*:*:network-interface/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -30,7 +30,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*"
+        "arn:aws-test:ec2:*:*:network-interface/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -145,7 +145,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*"
+        "arn:aws-test:ec2:*:*:network-interface/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -30,7 +30,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*"
+        "arn:aws-test:ec2:*:*:network-interface/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-etcd/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-etcd/cloudformation.json
@@ -970,7 +970,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/*"
             },
             {
               "Action": [
@@ -980,7 +980,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal-etcd.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal-etcd.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -990,7 +990,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal-etcd.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal-etcd.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1001,7 +1001,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1013,7 +1013,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1024,7 +1024,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1033,7 +1033,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1058,8 +1058,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1074,8 +1074,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1087,8 +1087,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1209,10 +1209,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-etcd.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1224,7 +1224,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json
@@ -966,7 +966,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
             },
             {
               "Action": [
@@ -976,7 +976,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -986,7 +986,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -997,7 +997,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1009,7 +1009,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1020,7 +1020,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1029,7 +1029,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1054,8 +1054,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1070,8 +1070,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1083,8 +1083,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1205,10 +1205,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1220,7 +1220,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
@@ -1147,7 +1147,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/*"
             },
             {
               "Action": [
@@ -1157,7 +1157,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal-ipv6.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal-ipv6.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1167,7 +1167,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal-ipv6.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal-ipv6.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1178,7 +1178,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1190,7 +1190,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1201,7 +1201,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1210,7 +1210,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1235,8 +1235,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1251,8 +1251,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1264,8 +1264,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1386,10 +1386,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1401,7 +1401,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal-ipv6.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal-ipv6.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal-ipv6.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal-ipv6.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-ipv6.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal-warmpool.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal-warmpool.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal-warmpool.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal-warmpool.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal-warmpool.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal/cloudformation.json
+++ b/tests/integration/update_cluster/minimal/cloudformation.json
@@ -970,7 +970,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
             },
             {
               "Action": [
@@ -980,7 +980,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -990,7 +990,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1001,7 +1001,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1013,7 +1013,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1024,7 +1024,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1033,7 +1033,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1058,8 +1058,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1074,8 +1074,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1087,8 +1087,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1209,10 +1209,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1224,7 +1224,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.k8s.local/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.k8s.local/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.k8s.local/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.k8s.local/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -76,8 +76,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -92,8 +92,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -105,8 +105,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.k8s.local/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -1689,7 +1689,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/*"
             },
             {
               "Action": [
@@ -1699,7 +1699,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1709,7 +1709,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1720,7 +1720,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1732,7 +1732,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1743,7 +1743,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1752,7 +1752,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1777,8 +1777,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1793,8 +1793,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1806,8 +1806,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1928,10 +1928,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1943,7 +1943,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -1690,7 +1690,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/*"
             },
             {
               "Action": [
@@ -1700,7 +1700,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1710,7 +1710,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1721,7 +1721,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1733,7 +1733,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1744,7 +1744,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1753,7 +1753,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1778,8 +1778,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1794,8 +1794,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1807,8 +1807,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1929,10 +1929,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1944,7 +1944,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/mixedinstances.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/mixedinstances.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
@@ -1100,7 +1100,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/*"
             },
             {
               "Action": [
@@ -1110,7 +1110,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1120,7 +1120,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1131,7 +1131,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1143,7 +1143,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1154,7 +1154,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1163,7 +1163,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1188,8 +1188,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1204,8 +1204,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1217,8 +1217,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1342,10 +1342,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1357,7 +1357,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
@@ -1460,7 +1460,7 @@
                   "sqs.amazonaws.com"
                 ]
               },
-              "Resource": "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+              "Resource": "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
             }
           ],
           "Version": "2012-10-17"

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_masters.nthsqsresources.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_masters.nthsqsresources.longclustername.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_nodes.nthsqsresources.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_nodes.nthsqsresources.longclustername.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/nthsqsresources.longclustername.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_sqs_queue_nthsqsresources-longclustername-example-com-nth_policy
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_sqs_queue_nthsqsresources-longclustername-example-com-nth_policy
@@ -6,6 +6,6 @@
 				"Service": ["events.amazonaws.com", "sqs.amazonaws.com"]
 			},
 			"Action": "sqs:SendMessage",
-			"Resource": "arn:aws:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
+			"Resource": "arn:aws-test:sqs:us-test-1:123456789012:nthsqsresources-longclustername-example-com-nth"
 		}]
 	}

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -1486,7 +1486,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/*"
             },
             {
               "Action": [
@@ -1496,7 +1496,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/private-shared-ip.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/private-shared-ip.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1506,7 +1506,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/private-shared-ip.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/private-shared-ip.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1517,7 +1517,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1529,7 +1529,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1540,7 +1540,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1549,7 +1549,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1574,8 +1574,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1590,8 +1590,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1603,8 +1603,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1725,10 +1725,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1740,7 +1740,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/private-shared-ip.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/private-shared-ip.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/private-shared-ip.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/private-shared-ip.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-ip.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/private-shared-subnet.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/private-shared-subnet.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/private-shared-subnet.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/private-shared-subnet.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/private-shared-subnet.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -1642,7 +1642,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/*"
             },
             {
               "Action": [
@@ -1652,7 +1652,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecalico.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecalico.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1662,7 +1662,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecalico.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecalico.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1673,7 +1673,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1685,7 +1685,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1696,7 +1696,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1705,7 +1705,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1730,8 +1730,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1746,8 +1746,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1759,8 +1759,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1882,10 +1882,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1897,7 +1897,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecalico.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecalico.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecalico.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecalico.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecalico.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecanal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecanal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecanal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecanal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_nodes.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_nodes.privatecanal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecanal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -1628,7 +1628,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/*"
             },
             {
               "Action": [
@@ -1638,7 +1638,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1648,7 +1648,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1659,7 +1659,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1671,7 +1671,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1682,7 +1682,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1691,7 +1691,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1716,8 +1716,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1732,8 +1732,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1745,8 +1745,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1867,10 +1867,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1882,7 +1882,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -1628,7 +1628,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/*"
             },
             {
               "Action": [
@@ -1638,7 +1638,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1648,7 +1648,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1659,7 +1659,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1671,7 +1671,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1682,7 +1682,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1691,7 +1691,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1716,8 +1716,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1732,8 +1732,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1745,8 +1745,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1867,12 +1867,12 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/pki/private/kube-proxy/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/pki/private/kubelet/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/pki/private/kube-proxy/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/pki/private/kubelet/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1884,7 +1884,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatecilium.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -6,12 +6,12 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/pki/private/kube-proxy/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/pki/private/kubelet/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/pki/private/kube-proxy/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/pki/private/kubelet/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatecilium.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -23,7 +23,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -1661,7 +1661,7 @@
                 "s3:Get*"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/*"
+              "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/*"
             },
             {
               "Action": [
@@ -1671,7 +1671,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/main/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/main/*"
             },
             {
               "Action": [
@@ -1681,7 +1681,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events/*"
             },
             {
               "Action": [
@@ -1691,7 +1691,7 @@
                 "s3:PutObject"
               ],
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium/*"
+              "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium/*"
             },
             {
               "Action": [
@@ -1702,7 +1702,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {
@@ -1714,7 +1714,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-write-bucket"
+                "arn:aws-test:s3:::placeholder-write-bucket"
               ]
             },
             {
@@ -1725,7 +1725,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+                "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
               ]
             },
             {
@@ -1734,7 +1734,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:route53:::change/*"
+                "arn:aws-test:route53:::change/*"
               ]
             },
             {
@@ -1759,8 +1759,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1775,8 +1775,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1788,8 +1788,8 @@
               },
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:ec2:*:*:volume/*",
-                "arn:aws:ec2:*:*:snapshot/*"
+                "arn:aws-test:ec2:*:*:volume/*",
+                "arn:aws-test:ec2:*:*:snapshot/*"
               ]
             },
             {
@@ -1919,10 +1919,10 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/addons/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/cluster-completed.spec",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/igconfig/node/*",
-                "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/secrets/dockerconfig"
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/addons/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/cluster-completed.spec",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/igconfig/node/*",
+                "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/secrets/dockerconfig"
               ]
             },
             {
@@ -1934,7 +1934,7 @@
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:s3:::placeholder-read-bucket"
+                "arn:aws-test:s3:::placeholder-read-bucket"
               ]
             },
             {

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -48,7 +48,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateciliumadvanced.example.com/backups/etcd/cilium/*"
     },
     {
       "Action": [
@@ -59,7 +59,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -71,7 +71,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -82,7 +82,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -91,7 +91,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -116,8 +116,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -132,8 +132,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -145,8 +145,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateciliumadvanced.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatedns1.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatedns1.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatedns1.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatedns1.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z2AFAKE1ZON3NO"
+        "arn:aws-test:route53:::hostedzone/Z2AFAKE1ZON3NO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns1.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatedns2.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatedns2.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatedns2.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatedns2.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z3AFAKE1ZOMORE"
+        "arn:aws-test:route53:::hostedzone/Z3AFAKE1ZOMORE"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatedns2.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateflannel.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateflannel.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateflannel.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateflannel.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateflannel.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatekopeio.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatekopeio.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privatekopeio.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privatekopeio.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privatekopeio.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateweave.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateweave.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/privateweave.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/privateweave.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_nodes.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_nodes.privateweave.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/privateweave.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -9,7 +9,7 @@
       },
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
+        "Federated": "arn:aws-test:iam::123456789012:oidc-provider/discovery.example.com/minimal.example.com"
       }
     }
   ],

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_dns-controller.kube-system.sa.minimal.example.com_policy
@@ -8,7 +8,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -17,7 +17,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/sharedsubnet.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/sharedsubnet.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/sharedsubnet.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/sharedsubnet.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedsubnet.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/sharedvpc.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/sharedvpc.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/sharedvpc.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/sharedvpc.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/sharedvpc.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/unmanaged.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/unmanaged.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/unmanaged.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/unmanaged.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/unmanaged.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -18,7 +18,7 @@
         "s3:Get*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
+      "Resource": "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/*"
     },
     {
       "Action": [
@@ -28,7 +28,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/main/*"
     },
     {
       "Action": [
@@ -38,7 +38,7 @@
         "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
+      "Resource": "arn:aws-test:s3:::placeholder-write-bucket/clusters.example.com/minimal.example.com/backups/etcd/events/*"
     },
     {
       "Action": [
@@ -49,7 +49,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {
@@ -61,7 +61,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-write-bucket"
+        "arn:aws-test:s3:::placeholder-write-bucket"
       ]
     },
     {
@@ -72,7 +72,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::hostedzone/Z1AFAKE1ZON3YO"
+        "arn:aws-test:route53:::hostedzone/Z1AFAKE1ZON3YO"
       ]
     },
     {
@@ -81,7 +81,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:route53:::change/*"
+        "arn:aws-test:route53:::change/*"
       ]
     },
     {
@@ -106,8 +106,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -122,8 +122,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -135,8 +135,8 @@
       },
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws-test:ec2:*:*:volume/*",
+        "arn:aws-test:ec2:*:*:snapshot/*"
       ]
     },
     {

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -6,10 +6,10 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
-        "arn:aws:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/addons/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/cluster-completed.spec",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/igconfig/node/*",
+        "arn:aws-test:s3:::placeholder-read-bucket/clusters.example.com/minimal.example.com/secrets/dockerconfig"
       ]
     },
     {
@@ -21,7 +21,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:aws:s3:::placeholder-read-bucket"
+        "arn:aws-test:s3:::placeholder-read-bucket"
       ]
     },
     {


### PR DESCRIPTION
Cherry pick of #12638 on release-1.22.

#12638: Update cloudmock and integration test inputs to use

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```