### PR TITLE
Revert "Make dns-controller delete placeholder addresses for IPv6 cluster"

### DIFF
--- a/dns-controller/pkg/dns/dnscontroller.go
+++ b/dns-controller/pkg/dns/dnscontroller.go
@@ -299,31 +299,6 @@ func (c *DNSController) runOnce() error {
 		}
 	}
 
-	// Look for records of wrong record type.
-	for k := range newValueMap {
-		switch k.RecordType {
-		case RecordTypeA:
-			k.RecordType = RecordTypeAAAA
-		case RecordTypeAAAA:
-			k.RecordType = RecordTypeA
-		default:
-			continue
-		}
-
-		if c.StopRequested() {
-			return fmt.Errorf("stop requested")
-		}
-
-		newValues := newValueMap[k]
-		if newValues == nil {
-			err := op.deleteRecords(k)
-			if err != nil {
-				klog.Infof("error deleting records for %s: %v", k, err)
-				errors = append(errors, err)
-			}
-		}
-	}
-
 	// Look for deleted hostnames
 	for k := range oldValueMap {
 		if c.StopRequested() {


### PR DESCRIPTION
This reverts commit c58f104e4de205ccd49effb4126f052114c31dd9.

From the logs, it appears that the node's IPv4 addresses appear in the node resource some time after the node's IPv6 internal address does. This causes dns-controller to delete the placeholder address upon new cluster creation.

Since #12616 fixed the generation of placeholder addresses to just the appropriate address families, revert #12605.
