### PR TITLE
Don't create placeholder A record on IPv6 clusters without API LB

### DIFF
--- a/upup/pkg/fi/cloudup/dns.go
+++ b/upup/pkg/fi/cloudup/dns.go
@@ -262,14 +262,8 @@ func buildPrecreateDNSHostnames(cluster *kops.Cluster) []recordKey {
 	if cluster.Spec.MasterPublicName != "" && !hasAPILoadbalancer {
 		recordKeys = append(recordKeys, recordKey{
 			hostname: cluster.Spec.MasterPublicName,
-			rrsType:  rrstype.A,
+			rrsType:  internalType,
 		})
-		if internalType != rrstype.A {
-			recordKeys = append(recordKeys, recordKey{
-				hostname: cluster.Spec.MasterPublicName,
-				rrsType:  internalType,
-			})
-		}
 	}
 
 	if cluster.Spec.MasterInternalName != "" && !useLBForInternalAPI {

--- a/upup/pkg/fi/cloudup/dns_test.go
+++ b/upup/pkg/fi/cloudup/dns_test.go
@@ -45,7 +45,6 @@ func TestPrecreateDNSNames(t *testing.T) {
 				},
 			},
 			expected: []recordKey{
-				{"api.cluster1.example.com", rrstype.A},
 				{"api.cluster1.example.com", rrstype.AAAA},
 				{"api.internal.cluster1.example.com", rrstype.AAAA},
 			},
@@ -109,8 +108,23 @@ func TestPrecreateDNSNames(t *testing.T) {
 				},
 			},
 			expected: []recordKey{
-				{"api.cluster1.example.com", rrstype.A},
 				{"api.cluster1.example.com", rrstype.AAAA},
+				{"api.internal.cluster1.example.com", rrstype.AAAA},
+				{"kops-controller.internal.cluster1.example.com", rrstype.AAAA},
+			},
+		},
+		{
+			cluster: &kops.Cluster{
+				Spec: kops.ClusterSpec{
+					API: &kops.AccessSpec{
+						LoadBalancer: &kops.LoadBalancerAccessSpec{},
+					},
+					CloudProvider:     "aws",
+					KubernetesVersion: "1.22.0",
+					NonMasqueradeCIDR: "::/0",
+				},
+			},
+			expected: []recordKey{
 				{"api.internal.cluster1.example.com", rrstype.AAAA},
 				{"kops-controller.internal.cluster1.example.com", rrstype.AAAA},
 			},


### PR DESCRIPTION
dns-controller updates this record to the node IPs, but in this case nodes wont have any IPv4 addresses so dns-controller never updates the record from the placeholder value, causing `validate cluster` to fail (even if the AAAA placeholder is updated)

I noticed this in [this job](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/12657/pull-kops-e2e-ipv6-amazonvpc/1455030868530696192) (ref: https://github.com/kubernetes/kops/pull/12657#issuecomment-956195781)

`kops validate cluster` fails with the error message containing the IPv4 placeholder IP which shouldn't be relevant to an IPv6 cluster:

`The dns-controller Kubernetes deployment has not updated the Kubernetes cluster's API DNS entry to the correct IP address.  The API DNS IP address is the placeholder address that kops creates: 203.0.113.123.  Please wait about 5-10 minutes for a master to start, dns-controller to launch, and DNS to propagate.  The protokube container and dns-controller deployment logs may contain more diagnostic information.  Etcd and the API DNS entries must be updated for a kops Kubernetes cluster to start.`


`kops delete cluster` reports cleaning up these records, notice the A record for the API name:

```
route53-record		api.e2e-09c66f4ca2-5e791.test-cncf-aws.k8s.io.								ZEMLNXIIWQ0RV/A/api.e2e-09c66f4ca2-5e791.test-cncf-aws.k8s.io.
route53-record		api.e2e-09c66f4ca2-5e791.test-cncf-aws.k8s.io.								ZEMLNXIIWQ0RV/AAAA/api.e2e-09c66f4ca2-5e791.test-cncf-aws.k8s.io.
route53-record		api.internal.e2e-09c66f4ca2-5e791.test-cncf-aws.k8s.io.							ZEMLNXIIWQ0RV/AAAA/api.internal.e2e-09c66f4ca2-5e791.test-cncf-aws.k8s.io.
route53-record		kops-controller.internal.e2e-09c66f4ca2-5e791.test-cncf-aws.k8s.io.					ZEMLNXIIWQ0RV/AAAA/kops-controller.internal.e2e-09c66f4ca2-5e791.test-cncf-aws.k8s.io. 
```

[dns-controller logs](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/12657/pull-kops-e2e-ipv6-amazonvpc/1455030868530696192/artifacts/cluster-info/kube-system/dns-controller-58dc6bc8b9-vrb2c/logs.txt) report adding AAAA record but not any A record.

Neither the [apiserver pod](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/12657/pull-kops-e2e-ipv6-amazonvpc/1455030868530696192/artifacts/cluster-info/kube-system/pods.yaml) nor the [nodes](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/12657/pull-kops-e2e-ipv6-amazonvpc/1455030868530696192/artifacts/cluster-info/nodes.yaml) have any IPv4 addresses.