### PR TITLE
Fix error handling in kubetest2 dumplogs

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -106,10 +106,13 @@ func (d *deployer) dumpClusterInfo() error {
 
 	resourceTypes := []string{"csinodes", "csidrivers", "storageclasses", "persistentvolumes",
 		"mutatingwebhookconfigurations", "validatingwebhookconfigurations"}
+	if err := os.MkdirAll(path.Join(d.ArtifactsDir, "cluster-info"), 0755); err != nil {
+		return err
+	}
 	for _, resType := range resourceTypes {
 		yamlFile, err := os.Create(path.Join(d.ArtifactsDir, "cluster-info", fmt.Sprintf("%v.yaml", resType)))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		defer yamlFile.Close()
 
@@ -124,9 +127,7 @@ func (d *deployer) dumpClusterInfo() error {
 		cmd.SetEnv(d.env()...)
 		cmd.SetStdout(yamlFile)
 		if err := cmd.Run(); err != nil {
-			if err = d.dumpClusterInfoSSH(); err != nil {
-				klog.Warningf("Failed to get %v: %v", resType, err)
-			}
+			klog.Warningf("Failed to get %v: %v", resType, err)
 		}
 	}
 
@@ -141,10 +142,13 @@ func (d *deployer) dumpClusterInfo() error {
 	namespacedResourceTypes := []string{"configmaps", "endpoints", "endpointslices", "leases", "persistentvolumeclaims"}
 	for _, namespace := range namespaces {
 		namespace = strings.TrimSpace(namespace)
+		if err := os.MkdirAll(path.Join(d.ArtifactsDir, "cluster-info", namespace), 0755); err != nil {
+			return err
+		}
 		for _, resType := range namespacedResourceTypes {
 			yamlFile, err := os.Create(path.Join(d.ArtifactsDir, "cluster-info", namespace, fmt.Sprintf("%v.yaml", resType)))
 			if err != nil {
-				panic(err)
+				return err
 			}
 			defer yamlFile.Close()
 

--- a/tests/e2e/kubetest2-kops/deployer/dumplogs.go
+++ b/tests/e2e/kubetest2-kops/deployer/dumplogs.go
@@ -117,7 +117,7 @@ func (d *deployer) dumpClusterInfo() error {
 		defer yamlFile.Close()
 
 		args = []string{
-			"kubectl", "get", resType,
+			"kubectl", "--request-timeout", "5s", "get", resType,
 			"--all-namespaces",
 			"-o", "yaml",
 		}
@@ -132,7 +132,7 @@ func (d *deployer) dumpClusterInfo() error {
 	}
 
 	nsCmd := exec.Command(
-		"kubectl", "get", "namespaces", "--no-headers", "-o", "custom-columns=name:.metadata.name",
+		"kubectl", "--request-timeout", "5s", "get", "namespaces", "--no-headers", "-o", "custom-columns=name:.metadata.name",
 	)
 	namespaces, err := exec.OutputLines(nsCmd)
 	if err != nil {


### PR DESCRIPTION
Make directories prior to creating files in them. Also cleanup some error handling so that the remaining teardown steps can run even if dumplogs fails.

Add --request-timeout to some kubectl commands to shorten wait times when the cluster isnt up

