### PR TITLE
Revert "Migrate kube-proxy manifest to use go-runner for logging"

### DIFF
--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -210,21 +210,13 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	addHostPathMapping(pod, container, "logfile", "/var/log/kube-proxy.log").ReadOnly = false
 	// We use lighter containers that don't include shells
 	// But they have richer logging support via klog
-	if b.IsKubernetesGTE("1.23") {
-		container.Command = []string{"/go-runner"}
-		container.Args = []string{
-			"--log-file=/var/log/kube-proxy.log",
-			"/usr/local/bin/kube-proxy",
-		}
-		container.Args = append(container.Args, sortedStrings(flags)...)
-	} else {
-		container.Command = []string{"/usr/local/bin/kube-proxy"}
-		container.Args = append(
-			sortedStrings(flags),
-			"--logtostderr=false", //https://github.com/kubernetes/klog/issues/60
-			"--alsologtostderr",
-			"--log-file=/var/log/kube-proxy.log")
-	}
+	container.Command = []string{"/usr/local/bin/kube-proxy"}
+	container.Args = append(
+		sortedStrings(flags),
+		"--logtostderr=false", //https://github.com/kubernetes/klog/issues/60
+		"--alsologtostderr",
+		"--log-file=/var/log/kube-proxy.log")
+
 	{
 		addHostPathMapping(pod, container, "kubeconfig", "/var/lib/kube-proxy/kubeconfig")
 		// @note: mapping the host modules directory to fix the missing ipvs kernel module

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
@@ -11,8 +11,6 @@ contents: |
   spec:
     containers:
     - args:
-      - --log-file=/var/log/kube-proxy.log
-      - /usr/local/bin/kube-proxy
       - --cluster-cidr=100.96.0.0/11
       - --conntrack-max-per-core=131072
       - --hostname-override=@aws
@@ -20,8 +18,11 @@ contents: |
       - --master=https://127.0.0.1
       - --oom-score-adj=-998
       - --v=2
+      - --logtostderr=false
+      - --alsologtostderr
+      - --log-file=/var/log/kube-proxy.log
       command:
-      - /go-runner
+      - /usr/local/bin/kube-proxy
       image: k8s.gcr.io/kube-proxy:v1.23.0
       name: kube-proxy
       resources:


### PR DESCRIPTION
This reverts commit b0e585c751ba07d92bc25414f5403c2aa7e67d16.

The latest CI builds of the kube-proxy image don't have /go-runner. I will bring this up with the relevant team

ref: https://github.com/kubernetes/kops/pull/12664#issuecomment-957116852

ref: https://github.com/kubernetes/kops/issues/12663#issuecomment-957372273