### PR TITLE
Automated cherry pick of #12672: Fix cluster name used in IAM policies

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -285,7 +285,7 @@ func NewPolicy(clusterName string) *Policy {
 
 // BuildAWSPolicy generates a custom policy for a Kubernetes master.
 func (r *NodeRoleAPIServer) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
-	p := NewPolicy(b.Cluster.GetClusterName())
+	p := NewPolicy(b.Cluster.GetName())
 
 	addNodeupPermissions(p, r.warmPool)
 
@@ -394,7 +394,7 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 
 // BuildAWSPolicy generates a custom policy for a Kubernetes node.
 func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
-	p := NewPolicy(b.Cluster.GetClusterName())
+	p := NewPolicy(b.Cluster.GetName())
 
 	addNodeupPermissions(p, r.enableLifecycleHookPermissions)
 
@@ -424,7 +424,7 @@ func (r *NodeRoleNode) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 
 // BuildAWSPolicy generates a custom policy for a bastion host.
 func (r *NodeRoleBastion) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
-	p := NewPolicy(b.Cluster.GetClusterName())
+	p := NewPolicy(b.Cluster.GetName())
 
 	// Bastion hosts currently don't require any specific permissions.
 	// A trivial permission is granted, because empty policies are not allowed.

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
@@ -41,7 +41,7 @@
       "Action": "autoscaling:CompleteLifecycleAction",
       "Condition": {
         "StringEquals": {
-          "aws:ResourceTag/KubernetesCluster": ""
+          "aws:ResourceTag/KubernetesCluster": "minimal-warmpool.example.com"
         }
       },
       "Effect": "Allow",

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
@@ -27,12 +27,23 @@
     {
       "Action": [
         "autoscaling:DescribeAutoScalingInstances",
+        "autoscaling:DescribeLifecycleHooks",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"
       ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": "autoscaling:CompleteLifecycleAction",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/KubernetesCluster": ""
+        }
+      },
       "Effect": "Allow",
       "Resource": "*"
     }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 5P+dhp0PENyR4JTHO7yhawYumM2GPmovRe36rbkZZ6s=
+NodeupConfigHash: NxV6ZykmFZSaYNya+3bE2VPGWJZ3cjV8k7y/1BQdOC8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -222,4 +222,5 @@ spec:
       type: Public
     masters: public
     nodes: public
-  warmPool: {}
+  warmPool:
+    enableLifecycleHook: true

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -32,6 +32,7 @@ CAs:
     9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
     -----END CERTIFICATE-----
 ClusterName: minimal-warmpool.example.com
+EnableLifecycleHook: true
 Hooks:
 - null
 - null

--- a/tests/integration/update_cluster/minimal-warmpool/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal-warmpool/in-v1alpha2.yaml
@@ -41,7 +41,8 @@ spec:
     name: us-test-1a
     type: Public
     zone: us-test-1a
-  warmPool: {}
+  warmPool:
+    enableLifecycleHook: true
 
 ---
 

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -198,6 +198,14 @@ resource "aws_autoscaling_group" "nodes-minimal-warmpool-example-com" {
   vpc_zone_identifier = [aws_subnet.us-test-1a-minimal-warmpool-example-com.id]
 }
 
+resource "aws_autoscaling_lifecycle_hook" "kops-warmpool-nodes" {
+  autoscaling_group_name = aws_autoscaling_group.nodes-minimal-warmpool-example-com.id
+  default_result         = "ABANDON"
+  heartbeat_timeout      = 600
+  lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"
+  name                   = "kops-warmpool"
+}
+
 resource "aws_ebs_volume" "us-test-1a-etcd-events-minimal-warmpool-example-com" {
   availability_zone = "us-test-1a"
   encrypted         = false


### PR DESCRIPTION
Cherry pick of #12672 on release-1.22.

#12672: Enable lifecycle hook in integration test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```