### PR TITLE
[calico] Add support for allow_ip_forwarding field

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -4209,6 +4209,10 @@ spec:
                     description: CalicoNetworkingSpec declares that we want Calico
                       networking
                     properties:
+                      allowIPForwarding:
+                        description: 'AllowIPForwarding enable ip_forwarding setting
+                          within the container namespace. (default: false)'
+                        type: boolean
                       awsSrcDstCheck:
                         description: 'AWSSrcDstCheck enables/disables ENI source/destination
                           checks (AWS only) Options: Disable (default), Enable, or

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -106,6 +106,9 @@ type CalicoNetworkingSpec struct {
 	// Version overrides the Calico container image tag.
 	Version string `json:"version,omitempty"`
 
+	// AllowIPForwarding enable ip_forwarding setting within the container namespace.
+	// (default: false)
+	AllowIPForwarding bool `json:"allowIPForwarding,omitempty"`
 	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS only)
 	// Options: Disable (default), Enable, or DoNothing
 	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -109,6 +109,9 @@ type CalicoNetworkingSpec struct {
 	// Version overrides the Calico container image tag.
 	Version string `json:"version,omitempty"`
 
+	// AllowIPForwarding enable ip_forwarding setting within the container namespace.
+	// (default: false)
+	AllowIPForwarding bool `json:"allowIPForwarding,omitempty"`
 	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS only)
 	// Options: Disable (default), Enable, or DoNothing
 	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1708,6 +1708,7 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha2_CNINetworkingSpec(in *kops.CNINe
 func autoConvert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
 	out.Registry = in.Registry
 	out.Version = in.Version
+	out.AllowIPForwarding = in.AllowIPForwarding
 	out.AWSSrcDstCheck = in.AWSSrcDstCheck
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
@@ -1744,6 +1745,7 @@ func Convert_v1alpha2_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha2_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
 	out.Registry = in.Registry
 	out.Version = in.Version
+	out.AllowIPForwarding = in.AllowIPForwarding
 	out.AWSSrcDstCheck = in.AWSSrcDstCheck
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -104,6 +104,9 @@ type CalicoNetworkingSpec struct {
 	// Version overrides the Calico container image tag.
 	Version string `json:"version,omitempty"`
 
+	// AllowIPForwarding enable ip_forwarding setting within the container namespace.
+	// (default: false)
+	AllowIPForwarding bool `json:"allowIPForwarding,omitempty"`
 	// AWSSrcDstCheck enables/disables ENI source/destination checks (AWS only)
 	// Options: Disable (default), Enable, or DoNothing
 	AWSSrcDstCheck string `json:"awsSrcDstCheck,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1658,6 +1658,7 @@ func Convert_kops_CNINetworkingSpec_To_v1alpha3_CNINetworkingSpec(in *kops.CNINe
 func autoConvert_v1alpha3_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *CalicoNetworkingSpec, out *kops.CalicoNetworkingSpec, s conversion.Scope) error {
 	out.Registry = in.Registry
 	out.Version = in.Version
+	out.AllowIPForwarding = in.AllowIPForwarding
 	out.AWSSrcDstCheck = in.AWSSrcDstCheck
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode
@@ -1693,6 +1694,7 @@ func Convert_v1alpha3_CalicoNetworkingSpec_To_kops_CalicoNetworkingSpec(in *Cali
 func autoConvert_kops_CalicoNetworkingSpec_To_v1alpha3_CalicoNetworkingSpec(in *kops.CalicoNetworkingSpec, out *CalicoNetworkingSpec, s conversion.Scope) error {
 	out.Registry = in.Registry
 	out.Version = in.Version
+	out.AllowIPForwarding = in.AllowIPForwarding
 	out.AWSSrcDstCheck = in.AWSSrcDstCheck
 	out.BPFEnabled = in.BPFEnabled
 	out.BPFExternalServiceMode = in.BPFExternalServiceMode

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -61,6 +61,11 @@ data:
               "type": "calico-ipam"
               {{- end }}
           },
+          {{- if .Networking.Calico.AllowIPForwarding }}
+          "container_settings": {
+              "allow_ip_forwarding": true
+          },
+          {{- end }}
           "policy": {
               "type": "k8s"
           },


### PR DESCRIPTION
This is a needed configuration option for calico users that want to set **allow_ip_forwarding** within the container namespace. 

Ref issue: #12678