### PR TITLE
Automated cherry pick of #12587: GCE: use chrony on Ubuntu + GCE
#12681: Use chrony for synchronizing time in Ubuntu

### DIFF
--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -708,3 +708,8 @@ func (c *NodeupModelContext) InstallNvidiaRuntime() bool {
 		fi.BoolValue(c.NodeupConfig.NvidiaGPU.Enabled) &&
 		c.GPUVendor == architectures.GPUVendorNvidia
 }
+
+// RunningOnGCE returns true if we are running on GCE
+func (c *NodeupModelContext) RunningOnGCE() bool {
+	return kops.CloudProviderID(c.Cluster.Spec.CloudProvider) == kops.CloudProviderGCE
+}

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -59,7 +59,8 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	if b.Distribution.IsDebianFamily() {
-		if b.Distribution.IsUbuntu() {
+		// Ubuntu recommends systemd-timesyncd, but on ubuntu on GCE systemd-timesyncd is blocked (in favor of chrony)
+		if b.Distribution.IsUbuntu() && !b.RunningOnGCE() {
 			if ntpHost != "" {
 				c.AddTask(b.buildTimesyncdConf("/etc/systemd/timesyncd.conf", ntpHost))
 			}


### PR DESCRIPTION
Cherry pick of #12587 #12681 on release-1.22.

#12587: GCE: use chrony on Ubuntu + GCE
#12681: Use chrony for synchronizing time in Ubuntu

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.