### PR TITLE
Add option use chrony for synchronizing time in Ubuntu 20.04

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5156,6 +5156,10 @@ spec:
               ntp:
                 description: NTPConfig is the configuration for NTP.
                 properties:
+                  chrony:
+                    description: Chrony replaces timesyncd for Ubuntu 20.04 and older
+                      when set to true.
+                    type: boolean
                   managed:
                     description: Managed controls if the NTP configuration is managed
                       by kOps. The NTP configuration task is skipped if this is set

--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -99,6 +99,7 @@ go_test(
         "kube_scheduler_test.go",
         "kubectl_test.go",
         "kubelet_test.go",
+        "ntp_test.go",
         "protokube_test.go",
         "secrets_test.go",
         "update_service_test.go",

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -58,7 +58,7 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 		ntpHost = ""
 	}
 
-	if !b.RunningOnGCE() && b.Distribution.IsUbuntu() && b.Distribution.Version() <= 20.04 {
+	if !b.chrony() && !b.RunningOnGCE() && b.Distribution.IsUbuntu() && b.Distribution.Version() <= 20.04 {
 		if ntpHost != "" {
 			c.AddTask(b.buildTimesyncdConf("/etc/systemd/timesyncd.conf", ntpHost))
 		}
@@ -103,7 +103,7 @@ rtcsync
 }
 
 func (b *NTPBuilder) buildTimesyncdConf(path string, host string) *nodetasks.File {
-	conf := `# Built by Kops - do NOT edit
+	conf := `# Built by kOps - do NOT edit
 
 [Time]
 NTP=` + host + `
@@ -122,4 +122,10 @@ func (b *NTPBuilder) managed() bool {
 	// Consider the NTP is managed when the NTP configuration
 	// is not specified (for backward compatibility).
 	return n == nil || n.Managed == nil || *n.Managed
+}
+
+// chrony determines if kops should use chrony instead of timesyncd for Ubuntu 20.04 and older
+func (b *NTPBuilder) chrony() bool {
+	n := b.Cluster.Spec.NTP
+	return n != nil && n.Chrony
 }

--- a/nodeup/pkg/model/ntp_test.go
+++ b/nodeup/pkg/model/ntp_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/util/pkg/distributions"
+)
+
+func TestNTPAmazonLinux2(t *testing.T) {
+	RunGoldenTest(t, "tests/ntpbuilder/amazonlinux2", "ntp", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+		nodeupModelContext.Distribution = distributions.DistributionAmazonLinux2
+		builder := NTPBuilder{NodeupModelContext: nodeupModelContext}
+		return builder.Build(target)
+	})
+}
+
+func TestNTPDebian11(t *testing.T) {
+	RunGoldenTest(t, "tests/ntpbuilder/debian11", "ntp", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+		nodeupModelContext.Distribution = distributions.DistributionDebian11
+		builder := NTPBuilder{NodeupModelContext: nodeupModelContext}
+		return builder.Build(target)
+	})
+}
+func TestNTPUbuntu2004(t *testing.T) {
+	RunGoldenTest(t, "tests/ntpbuilder/ubuntu2004", "ntp", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+		nodeupModelContext.Distribution = distributions.DistributionUbuntu2004
+		builder := NTPBuilder{NodeupModelContext: nodeupModelContext}
+		return builder.Build(target)
+	})
+}
+
+func TestNTPUbuntu2004Chrony(t *testing.T) {
+	RunGoldenTest(t, "tests/ntpbuilder/ubuntu2004chrony", "ntp", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+		nodeupModelContext.Distribution = distributions.DistributionUbuntu2004
+		nodeupModelContext.Cluster.Spec.NTP = &kops.NTPConfig{
+			Chrony: true,
+		}
+		builder := NTPBuilder{NodeupModelContext: nodeupModelContext}
+		return builder.Build(target)
+	})
+}
+
+func TestNTPUbuntu2110(t *testing.T) {
+	RunGoldenTest(t, "tests/ntpbuilder/ubuntu2110", "ntp", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
+		nodeupModelContext.Distribution = distributions.DistributionUbuntu2110
+		builder := NTPBuilder{NodeupModelContext: nodeupModelContext}
+		return builder.Build(target)
+	})
+}

--- a/nodeup/pkg/model/tests/ntpbuilder/amazonlinux2/cluster.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/amazonlinux2/cluster.yaml
@@ -1,0 +1,64 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+    - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  containerd:
+    version: 1.3.4
+  containerRuntime: containerd
+  etcdClusters:
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: main
+      provider: Manager
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: events
+      provider: Manager
+  iam: {}
+  kubelet:
+    hostnameOverride: master.hostname.invalid
+  kubernetesVersion: v1.22.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    calico: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+    - cidr: 172.20.32.0/19
+      name: us-test-1a
+      type: Public
+      zone: us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2016-12-10T22:42:28Z"
+  name: master-1a
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  role: Master
+  subnets:
+    - us-test-1a

--- a/nodeup/pkg/model/tests/ntpbuilder/amazonlinux2/tasks-ntp.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/amazonlinux2/tasks-ntp.yaml
@@ -1,0 +1,21 @@
+contents: |
+  # Built by kOps - do NOT edit
+
+  pool 169.254.169.123 prefer iburst
+  driftfile /var/lib/chrony/drift
+  leapsectz right/UTC
+  logdir /var/log/chrony
+  makestep 1.0 3
+  maxupdateskew 100.0
+  rtcsync
+mode: "0644"
+path: /etc/chrony.conf
+type: file
+---
+Name: chrony
+---
+Name: chronyd
+enabled: true
+manageState: true
+running: true
+smartRestart: true

--- a/nodeup/pkg/model/tests/ntpbuilder/debian11/cluster.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/debian11/cluster.yaml
@@ -1,0 +1,64 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+    - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  containerd:
+    version: 1.3.4
+  containerRuntime: containerd
+  etcdClusters:
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: main
+      provider: Manager
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: events
+      provider: Manager
+  iam: {}
+  kubelet:
+    hostnameOverride: master.hostname.invalid
+  kubernetesVersion: v1.22.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    calico: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+    - cidr: 172.20.32.0/19
+      name: us-test-1a
+      type: Public
+      zone: us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2016-12-10T22:42:28Z"
+  name: master-1a
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  role: Master
+  subnets:
+    - us-test-1a

--- a/nodeup/pkg/model/tests/ntpbuilder/debian11/tasks-ntp.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/debian11/tasks-ntp.yaml
@@ -1,0 +1,21 @@
+contents: |
+  # Built by kOps - do NOT edit
+
+  pool 169.254.169.123 prefer iburst
+  driftfile /var/lib/chrony/drift
+  leapsectz right/UTC
+  logdir /var/log/chrony
+  makestep 1.0 3
+  maxupdateskew 100.0
+  rtcsync
+mode: "0644"
+path: /etc/chrony/chrony.conf
+type: file
+---
+Name: chrony
+---
+Name: chrony
+enabled: true
+manageState: true
+running: true
+smartRestart: true

--- a/nodeup/pkg/model/tests/ntpbuilder/ubuntu2004/cluster.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/ubuntu2004/cluster.yaml
@@ -1,0 +1,64 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+    - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  containerd:
+    version: 1.3.4
+  containerRuntime: containerd
+  etcdClusters:
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: main
+      provider: Manager
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: events
+      provider: Manager
+  iam: {}
+  kubelet:
+    hostnameOverride: master.hostname.invalid
+  kubernetesVersion: v1.22.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    calico: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+    - cidr: 172.20.32.0/19
+      name: us-test-1a
+      type: Public
+      zone: us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2016-12-10T22:42:28Z"
+  name: master-1a
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  role: Master
+  subnets:
+    - us-test-1a

--- a/nodeup/pkg/model/tests/ntpbuilder/ubuntu2004/tasks-ntp.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/ubuntu2004/tasks-ntp.yaml
@@ -1,0 +1,14 @@
+contents: |
+  # Built by kOps - do NOT edit
+
+  [Time]
+  NTP=169.254.169.123
+mode: "0644"
+path: /etc/systemd/timesyncd.conf
+type: file
+---
+Name: systemd-timesyncd
+enabled: true
+manageState: true
+running: true
+smartRestart: true

--- a/nodeup/pkg/model/tests/ntpbuilder/ubuntu2004chrony/cluster.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/ubuntu2004chrony/cluster.yaml
@@ -1,0 +1,64 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+    - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  containerd:
+    version: 1.3.4
+  containerRuntime: containerd
+  etcdClusters:
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: main
+      provider: Manager
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: events
+      provider: Manager
+  iam: {}
+  kubelet:
+    hostnameOverride: master.hostname.invalid
+  kubernetesVersion: v1.22.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    calico: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+    - cidr: 172.20.32.0/19
+      name: us-test-1a
+      type: Public
+      zone: us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2016-12-10T22:42:28Z"
+  name: master-1a
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  role: Master
+  subnets:
+    - us-test-1a

--- a/nodeup/pkg/model/tests/ntpbuilder/ubuntu2004chrony/tasks-ntp.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/ubuntu2004chrony/tasks-ntp.yaml
@@ -1,0 +1,21 @@
+contents: |
+  # Built by kOps - do NOT edit
+
+  pool 169.254.169.123 prefer iburst
+  driftfile /var/lib/chrony/drift
+  leapsectz right/UTC
+  logdir /var/log/chrony
+  makestep 1.0 3
+  maxupdateskew 100.0
+  rtcsync
+mode: "0644"
+path: /etc/chrony/chrony.conf
+type: file
+---
+Name: chrony
+---
+Name: chrony
+enabled: true
+manageState: true
+running: true
+smartRestart: true

--- a/nodeup/pkg/model/tests/ntpbuilder/ubuntu2110/cluster.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/ubuntu2110/cluster.yaml
@@ -1,0 +1,64 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2016-12-10T22:42:27Z"
+  name: minimal.example.com
+spec:
+  kubernetesApiAccess:
+    - 0.0.0.0/0
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://clusters.example.com/minimal.example.com
+  containerd:
+    version: 1.3.4
+  containerRuntime: containerd
+  etcdClusters:
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: main
+      provider: Manager
+    - etcdMembers:
+        - instanceGroup: master-us-test-1a
+          name: master-us-test-1a
+      name: events
+      provider: Manager
+  iam: {}
+  kubelet:
+    hostnameOverride: master.hostname.invalid
+  kubernetesVersion: v1.22.0
+  masterInternalName: api.internal.minimal.example.com
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    calico: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+    - 0.0.0.0/0
+  topology:
+    masters: public
+    nodes: public
+  subnets:
+    - cidr: 172.20.32.0/19
+      name: us-test-1a
+      type: Public
+      zone: us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2016-12-10T22:42:28Z"
+  name: master-1a
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  associatePublicIp: true
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
+  machineType: t2.medium
+  maxSize: 2
+  minSize: 2
+  role: Master
+  subnets:
+    - us-test-1a

--- a/nodeup/pkg/model/tests/ntpbuilder/ubuntu2110/tasks-ntp.yaml
+++ b/nodeup/pkg/model/tests/ntpbuilder/ubuntu2110/tasks-ntp.yaml
@@ -1,0 +1,21 @@
+contents: |
+  # Built by kOps - do NOT edit
+
+  pool 169.254.169.123 prefer iburst
+  driftfile /var/lib/chrony/drift
+  leapsectz right/UTC
+  logdir /var/log/chrony
+  makestep 1.0 3
+  maxupdateskew 100.0
+  rtcsync
+mode: "0644"
+path: /etc/chrony/chrony.conf
+type: file
+---
+Name: chrony
+---
+Name: chrony
+enabled: true
+manageState: true
+running: true
+smartRestart: true

--- a/pkg/apis/kops/ntpconfig.go
+++ b/pkg/apis/kops/ntpconfig.go
@@ -21,4 +21,7 @@ type NTPConfig struct {
 	// Managed controls if the NTP configuration is managed by kOps.
 	// The NTP configuration task is skipped if this is set to false.
 	Managed *bool `json:"managed,omitempty"`
+	// Chrony replaces timesyncd for Ubuntu 20.04 and older when set
+	// to true.
+	Chrony bool `json:"chrony,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/ntpconfig.go
+++ b/pkg/apis/kops/v1alpha2/ntpconfig.go
@@ -21,4 +21,7 @@ type NTPConfig struct {
 	// Managed controls if the NTP configuration is managed by kOps.
 	// The NTP configuration task is skipped if this is set to false.
 	Managed *bool `json:"managed,omitempty"`
+	// Chrony replaces timesyncd for Ubuntu 20.04 and older when set
+	// to true.
+	Chrony bool `json:"chrony,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -5695,6 +5695,7 @@ func Convert_kops_MixedInstancesPolicySpec_To_v1alpha2_MixedInstancesPolicySpec(
 
 func autoConvert_v1alpha2_NTPConfig_To_kops_NTPConfig(in *NTPConfig, out *kops.NTPConfig, s conversion.Scope) error {
 	out.Managed = in.Managed
+	out.Chrony = in.Chrony
 	return nil
 }
 
@@ -5705,6 +5706,7 @@ func Convert_v1alpha2_NTPConfig_To_kops_NTPConfig(in *NTPConfig, out *kops.NTPCo
 
 func autoConvert_kops_NTPConfig_To_v1alpha2_NTPConfig(in *kops.NTPConfig, out *NTPConfig, s conversion.Scope) error {
 	out.Managed = in.Managed
+	out.Chrony = in.Chrony
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/ntpconfig.go
+++ b/pkg/apis/kops/v1alpha3/ntpconfig.go
@@ -21,4 +21,7 @@ type NTPConfig struct {
 	// Managed controls if the NTP configuration is managed by kOps.
 	// The NTP configuration task is skipped if this is set to false.
 	Managed *bool `json:"managed,omitempty"`
+	// Chrony replaces timesyncd for Ubuntu 20.04 and older when set
+	// to true.
+	Chrony bool `json:"chrony,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -5533,6 +5533,7 @@ func Convert_kops_MixedInstancesPolicySpec_To_v1alpha3_MixedInstancesPolicySpec(
 
 func autoConvert_v1alpha3_NTPConfig_To_kops_NTPConfig(in *NTPConfig, out *kops.NTPConfig, s conversion.Scope) error {
 	out.Managed = in.Managed
+	out.Chrony = in.Chrony
 	return nil
 }
 
@@ -5543,6 +5544,7 @@ func Convert_v1alpha3_NTPConfig_To_kops_NTPConfig(in *NTPConfig, out *kops.NTPCo
 
 func autoConvert_kops_NTPConfig_To_v1alpha3_NTPConfig(in *kops.NTPConfig, out *NTPConfig, s conversion.Scope) error {
 	out.Managed = in.Managed
+	out.Chrony = in.Chrony
 	return nil
 }
 


### PR DESCRIPTION
Ubuntu is defaulting to `chrony` in latest versions and this was requested in the past. Will make it easier to make time synchronization more configurable in the future.