### PR TITLE
Watch Ingress by default when using the external-dns provider

### DIFF
--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -44,6 +44,8 @@ This is a document to gather the release notes prior to the release.
 
 # Other changes of note
 
+* If `externalDns.provider` is `external-dns`, then `externalDns.watchIngress` will now default to `true`.
+
 # Full change list since 1.22.0 release
 
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1109,8 +1109,9 @@ spec:
                       will use kubernetes-sigs/external-dns.
                     type: string
                   watchIngress:
-                    description: WatchIngress indicates you want the dns-controller
-                      to watch and create dns entries for ingress resources
+                    description: 'WatchIngress indicates you want the dns-controller
+                      to watch and create dns entries for ingress resources. Default:
+                      true if provider is ''external-dns'', false otherwise.'
                     type: boolean
                   watchNamespace:
                     description: WatchNamespace is namespace to watch, defaults to

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -542,7 +542,8 @@ const (
 type ExternalDNSConfig struct {
 	// Disable indicates we do not wish to run the dns-controller addon
 	Disable bool `json:"disable,omitempty"`
-	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources
+	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources.
+	// Default: true if provider is 'external-dns', false otherwise.
 	WatchIngress *bool `json:"watchIngress,omitempty"`
 	// WatchNamespace is namespace to watch, defaults to all (use to control whom can creates dns entries)
 	WatchNamespace string `json:"watchNamespace,omitempty"`

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -544,7 +544,8 @@ const (
 type ExternalDNSConfig struct {
 	// Disable indicates we do not wish to run the dns-controller addon
 	Disable bool `json:"disable,omitempty"`
-	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources
+	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources.
+	// Default: true if provider is 'external-dns', false otherwise.
 	WatchIngress *bool `json:"watchIngress,omitempty"`
 	// WatchNamespace is namespace to watch, defaults to all (use to control whom can creates dns entries)
 	WatchNamespace string `json:"watchNamespace,omitempty"`

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -518,7 +518,8 @@ const (
 type ExternalDNSConfig struct {
 	// Disable indicates we do not wish to run the dns-controller addon
 	Disable bool `json:"disable,omitempty"`
-	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources
+	// WatchIngress indicates you want the dns-controller to watch and create dns entries for ingress resources.
+	// Default: true if provider is 'external-dns', false otherwise.
 	WatchIngress *bool `json:"watchIngress,omitempty"`
 	// WatchNamespace is namespace to watch, defaults to all (use to control whom can creates dns entries)
 	WatchNamespace string `json:"watchNamespace,omitempty"`

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: external-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 28d9eae60d92399c9316208d6cca6d96920446de60872395f1743d8908439129
+    manifestHash: c56e7a43d0d3e268d8d5d47fb014fd71309e933729ce186ded43624bb4270037
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,7 @@ spec:
       - args:
         - --provider=aws
         - --events
+        - --source=ingress
         - --source=pod
         - --source=service
         - --compatibility=kops-dns-controller

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: external-dns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 28d9eae60d92399c9316208d6cca6d96920446de60872395f1743d8908439129
+    manifestHash: c56e7a43d0d3e268d8d5d47fb014fd71309e933729ce186ded43624bb4270037
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,7 @@ spec:
       - args:
         - --provider=aws
         - --events
+        - --source=ingress
         - --source=pod
         - --source=service
         - --compatibility=kops-dns-controller

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -623,7 +623,7 @@ func (tf *TemplateFunctions) ExternalDNSArgv() ([]string, error) {
 	}
 
 	argv = append(argv, "--events")
-	if fi.BoolValue(externalDNS.WatchIngress) {
+	if externalDNS.WatchIngress == nil || *externalDNS.WatchIngress {
 		argv = append(argv, "--source=ingress")
 	}
 	argv = append(argv, "--source=pod")


### PR DESCRIPTION
When using dns-controller, it's likely that there would be an externally installed external-dns creating DNS records for ingresses, so in order to avoid two controllers fighting over the same domains the default of `false` for `watchIngress` makes sense.

With a kops-managed external-dns, it makes more sense to enable `watchIngress` by default.
