### PR TITLE
Increase upup http response header timeout

### DIFF
--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -91,7 +91,7 @@ func downloadURLAlways(url string, destPath string, dirMode os.FileMode) error {
 				KeepAlive: 30 * time.Second,
 			}).DialContext,
 			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
 			IdleConnTimeout:       30 * time.Second,
 		},
 	}


### PR DESCRIPTION
We deploy multiple clusters in different AWS regions, and since upgrading kops to `v1.21.1` we've noticed issues during the `nodeup` phase for nodes in the `ap-southeast-2` region.

After some debugging we've tracked it down to an asset that is taking > 10 seconds just to return response headers, the specific asset in question is: `https://github.com/containerd/containerd/releases/download/v1.4.9/cri-containerd-cni-1.4.9-linux-amd64.tar.gz`.

While it's highly likely this is caused by some networking issues between the AWS `ap-southeast-2` region and the above github mirror, we are seeing nodes fail to join the cluster and response headers for that asset constantly taking > 10 seconds. 

We didn't previously hit any issues with these assets when managing our clusters with older versions of kops, where the timeout for the http client was just set to:

```go
Timeout: 2 * time.Minute,
``` 

If we're happy with this change, could we please get this cherrypicked as a new `1.21` release? Currently we're hosting our own build of `nodeup` with these changes as a temporary solution. 