### PR TITLE
Automated cherry pick of #12694: Increase upup http response header timeout

### DIFF
--- a/upup/pkg/fi/http.go
+++ b/upup/pkg/fi/http.go
@@ -89,7 +89,7 @@ func downloadURLAlways(url string, destPath string, dirMode os.FileMode) error {
 				KeepAlive: 30 * time.Second,
 			}).DialContext,
 			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
 			IdleConnTimeout:       30 * time.Second,
 		},
 	}


### PR DESCRIPTION
Cherry pick of #12694 on release-1.21.

#12694: Increase upup http response header timeout

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.