### PR TITLE
Ignore white space when validating IAM policy size limits

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
+++ b/upup/pkg/fi/cloudup/awstasks/iamrolepolicy.go
@@ -22,6 +22,7 @@ import (
 	"hash/fnv"
 	"net/url"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -296,9 +297,9 @@ func (e *IAMRolePolicy) policyDocumentString() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	policySize := len(policy)
+	policySize := len(strings.Join(strings.Fields(policy), ""))
 	if policySize > 10240 {
-		return "", fmt.Errorf("policy size was %d. Policy cannot exceed 10240 bytes.", policySize)
+		return "", fmt.Errorf("policy size was %d. Policy cannot exceed 10240 bytes", policySize)
 	}
 	return policy, err
 }


### PR DESCRIPTION
The [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length) mentions:

> IAM does not count white space when calculating the size of a policy against these quotas.

Therefore we should be excluding white space when performing this validation client-side.

fixes https://github.com/kubernetes/kops/issues/12606