### PR TITLE
Migrate kube-proxy manifest to use go-runner for logging

### DIFF
--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -210,13 +210,21 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	addHostPathMapping(pod, container, "logfile", "/var/log/kube-proxy.log").ReadOnly = false
 	// We use lighter containers that don't include shells
 	// But they have richer logging support via klog
-	container.Command = []string{"/usr/local/bin/kube-proxy"}
-	container.Args = append(
-		sortedStrings(flags),
-		"--logtostderr=false", //https://github.com/kubernetes/klog/issues/60
-		"--alsologtostderr",
-		"--log-file=/var/log/kube-proxy.log")
-
+	if b.IsKubernetesGTE("1.23") {
+		container.Command = []string{"/go-runner"}
+		container.Args = []string{
+			"--log-file=/var/log/kube-proxy.log",
+			"/usr/local/bin/kube-proxy",
+		}
+		container.Args = append(container.Args, sortedStrings(flags)...)
+	} else {
+		container.Command = []string{"/usr/local/bin/kube-proxy"}
+		container.Args = append(
+			sortedStrings(flags),
+			"--logtostderr=false", //https://github.com/kubernetes/klog/issues/60
+			"--alsologtostderr",
+			"--log-file=/var/log/kube-proxy.log")
+	}
 	{
 		addHostPathMapping(pod, container, "kubeconfig", "/var/lib/kube-proxy/kubeconfig")
 		// @note: mapping the host modules directory to fix the missing ipvs kernel module

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
@@ -11,6 +11,8 @@ contents: |
   spec:
     containers:
     - args:
+      - --log-file=/var/log/kube-proxy.log
+      - /usr/local/bin/kube-proxy
       - --cluster-cidr=100.96.0.0/11
       - --conntrack-max-per-core=131072
       - --hostname-override=@aws
@@ -18,11 +20,8 @@ contents: |
       - --master=https://127.0.0.1
       - --oom-score-adj=-998
       - --v=2
-      - --logtostderr=false
-      - --alsologtostderr
-      - --log-file=/var/log/kube-proxy.log
       command:
-      - /usr/local/bin/kube-proxy
+      - /go-runner
       image: k8s.gcr.io/kube-proxy:v1.23.0
       name: kube-proxy
       resources:


### PR DESCRIPTION
Second attempt followup to https://github.com/kubernetes/kops/pull/12664

/hold for k8s 1.23.0-beta.0 next week to include https://github.com/kubernetes/kubernetes/issues/106086

Fixes #12663