### PR TITLE
set calico-node readiness/liveness timeout to 10s

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
@@ -751,12 +751,14 @@ spec:
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /readiness
               port: 9099
               host: localhost
             periodSeconds: 10
+            timeoutSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules


### PR DESCRIPTION
Provide calico-node with more time to come up.