### PR TITLE
Automated cherry pick of #12713: set calico-node readiness/liveness timeout to 10s

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
@@ -751,12 +751,14 @@ spec:
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /readiness
               port: 9099
               host: localhost
             periodSeconds: 10
+            timeoutSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules


### PR DESCRIPTION
Cherry pick of #12713 on release-1.21.

#12713: set calico-node readiness/liveness timeout to 10s

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.