### PR TITLE
Add missing status fields to IAMIdentityMapping v1 CRD

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -34,6 +34,13 @@ spec:
                   type: array
                   items:
                     type: string
+            status:
+              type: object
+              properties:
+                canonicalARN:
+                  type: string
+                userID:
+                  type: string
       subresources:
         status: {}
 ---

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
@@ -35,6 +35,13 @@ spec:
             - arn
             - username
             type: object
+          status:
+            properties:
+              canonicalARN:
+                type: string
+              userID:
+                type: string
+            type: object
         type: object
     served: true
     storage: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: bff1ae6a3d5e795e21aa3f417e31ba2afc047ab1410a2c918c1ea69da6e11dea
+    manifestHash: 4e708499c4b354385fbf7c05b1ab2b811f7043c92b9e33457c7591d58d29a0ee
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
@@ -35,6 +35,13 @@ spec:
             - arn
             - username
             type: object
+          status:
+            properties:
+              canonicalARN:
+                type: string
+              userID:
+                type: string
+            type: object
         type: object
     served: true
     storage: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 0cfdcbd7be8aa8a99c0e23b9417bf1c0e23bdbb5a5702168ff26f9248284ce8d
+    manifestHash: 4a9be77f6d2ad82454ef7bff16fbe02b07f86a3e8f72d06e865bc4885e2779e5
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/411

regression from https://github.com/kubernetes/kops/pull/12425 and will need cherrypicking to 1.22