### PR TITLE
Automated cherry pick of #12716: Add missing status fields to IAMIdentityMapping v1 CRD

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -34,6 +34,13 @@ spec:
                   type: array
                   items:
                     type: string
+            status:
+              type: object
+              properties:
+                canonicalARN:
+                  type: string
+                userID:
+                  type: string
       subresources:
         status: {}
 ---

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/authentication.aws-k8s-1.12.yaml
@@ -35,6 +35,13 @@ spec:
             - arn
             - username
             type: object
+          status:
+            properties:
+              canonicalARN:
+                type: string
+              userID:
+                type: string
+            type: object
         type: object
     served: true
     storage: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: bff1ae6a3d5e795e21aa3f417e31ba2afc047ab1410a2c918c1ea69da6e11dea
+    manifestHash: 4e708499c4b354385fbf7c05b1ab2b811f7043c92b9e33457c7591d58d29a0ee
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
Cherry pick of #12716 on release-1.22.

#12716: Add missing status fields to IAMIdentityMapping v1 CRD

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```