### PR TITLE
Fix render template cilium AgentPrometheusPort into a UNICODE char error

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -420,7 +420,7 @@ spec:
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ printf "%q" .Networking.Cilium.AgentPrometheusPort }}
+        prometheus.io/port: "{{ .Networking.Cilium.AgentPrometheusPort }}"
         {{ end }}
       labels:
         k8s-app: cilium

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -552,7 +552,7 @@ spec:
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
+        prometheus.io/port: "{{ .AgentPrometheusPort }}"
         {{ end }}
 {{- with .AgentPodAnnotations }}
         {{- . | nindent 8 }}

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -591,7 +591,7 @@ spec:
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
+        prometheus.io/port: "{{ .AgentPrometheusPort }}"
         {{ end }}
 {{- with .AgentPodAnnotations }}
         {{- . | nindent 8 }}


### PR DESCRIPTION
**What this PR does / why we need it:**

The type of `Cilium.AgentPrometheusPort` is Int, golang template function `printf` with format `%q` is used for unicode character.

**Which issue(s) this PR fixes:**

Fixes #12717
 


