### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/channels/pkg/channels/apply.go
+++ b/channels/pkg/channels/apply.go
@@ -18,7 +18,6 @@ package channels
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -31,7 +30,7 @@ import (
 // We will likely in future change this to create things directly (or more likely embed this logic into kubectl itself)
 func Apply(data []byte) error {
 	// We copy the manifest to a temp file because it is likely e.g. an s3 URL, which kubectl can't read
-	tmpDir, err := ioutil.TempDir("", "channel")
+	tmpDir, err := os.MkdirTemp("", "channel")
 	if err != nil {
 		return fmt.Errorf("error creating temp dir: %v", err)
 	}
@@ -43,7 +42,7 @@ func Apply(data []byte) error {
 	}()
 
 	localManifestFile := path.Join(tmpDir, "manifest.yaml")
-	if err := ioutil.WriteFile(localManifestFile, data, 0600); err != nil {
+	if err := os.WriteFile(localManifestFile, data, 0600); err != nil {
 		return fmt.Errorf("error writing temp file: %v", err)
 	}
 

--- a/cmd/kops-controller/main.go
+++ b/cmd/kops-controller/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -76,7 +75,7 @@ func main() {
 	opt.PopulateDefaults()
 
 	{
-		b, err := ioutil.ReadFile(configPath)
+		b, err := os.ReadFile(configPath)
 		if err != nil {
 			klog.Fatalf("failed to read configuration file %q: %v", configPath, err)
 		}

--- a/cmd/kops-controller/pkg/server/keystore.go
+++ b/cmd/kops-controller/pkg/server/keystore.go
@@ -18,7 +18,7 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"k8s.io/kops/pkg/pki"
@@ -49,7 +49,7 @@ func newKeystore(basePath string, cas []string) (pki.Keystore, map[string]string
 		keys: map[string]keystoreEntry{},
 	}
 	for _, name := range cas {
-		certBytes, err := ioutil.ReadFile(path.Join(basePath, name+".crt"))
+		certBytes, err := os.ReadFile(path.Join(basePath, name+".crt"))
 		if err != nil {
 			return nil, nil, fmt.Errorf("reading %q certificate: %v", name, err)
 		}
@@ -58,7 +58,7 @@ func newKeystore(basePath string, cas []string) (pki.Keystore, map[string]string
 			return nil, nil, fmt.Errorf("parsing %q certificate: %v", name, err)
 		}
 
-		keyBytes, err := ioutil.ReadFile(path.Join(basePath, name+".key"))
+		keyBytes, err := os.ReadFile(path.Join(basePath, name+".key"))
 		if err != nil {
 			return nil, nil, fmt.Errorf("reading %q key: %v", name, err)
 		}
@@ -74,7 +74,7 @@ func newKeystore(basePath string, cas []string) (pki.Keystore, map[string]string
 	}
 
 	var keypairIDs map[string]string
-	keypairIDsBytes, err := ioutil.ReadFile(path.Join(basePath, "keypair-ids.yaml"))
+	keypairIDsBytes, err := os.ReadFile(path.Join(basePath, "keypair-ids.yaml"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading keypair-ids.yaml")
 	}

--- a/cmd/kops-controller/pkg/server/server.go
+++ b/cmd/kops-controller/pkg/server/server.go
@@ -24,7 +24,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime/debug"
 	"time"
@@ -98,7 +98,7 @@ func (s *Server) bootstrap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		klog.Infof("bootstrap %s read err: %v", r.RemoteAddr, err)
 		w.WriteHeader(http.StatusBadRequest)

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -22,7 +22,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -830,7 +829,7 @@ func loadSSHPublicKeys(sshPublicKey string) (map[string][]byte, error) {
 	sshPublicKeys := make(map[string][]byte)
 	if sshPublicKey != "" {
 		sshPublicKey = utils.ExpandPath(sshPublicKey)
-		authorized, err := ioutil.ReadFile(sshPublicKey)
+		authorized, err := os.ReadFile(sshPublicKey)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -19,7 +19,7 @@ package main
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -179,7 +179,7 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 	factory := util.NewFactory(factoryOptions)
 
 	{
-		optionsBytes, err := ioutil.ReadFile(path.Join(srcDir, optionsYAML))
+		optionsBytes, err := os.ReadFile(path.Join(srcDir, optionsYAML))
 		if err != nil {
 			t.Fatalf("error reading options file: %v", err)
 		}
@@ -197,7 +197,7 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 
 		// Use the public key we produced
 		{
-			publicKey, err := ioutil.ReadFile(publicKeyPath)
+			publicKey, err := os.ReadFile(publicKeyPath)
 			if err != nil {
 				t.Fatalf("error reading public key %q: %v", publicKeyPath, err)
 			}

--- a/cmd/kops/create_keypair.go
+++ b/cmd/kops/create_keypair.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -189,7 +188,7 @@ func createKeypair(out io.Writer, options *CreateKeypairOptions, name string, ke
 	var privateKey *pki.PrivateKey
 	if options.PrivateKeyPath != "" {
 		options.PrivateKeyPath = utils.ExpandPath(options.PrivateKeyPath)
-		privateKeyBytes, err := ioutil.ReadFile(options.PrivateKeyPath)
+		privateKeyBytes, err := os.ReadFile(options.PrivateKeyPath)
 		if err != nil {
 			return fmt.Errorf("error reading user provided private key %q: %v", options.PrivateKeyPath, err)
 		}
@@ -222,7 +221,7 @@ func createKeypair(out io.Writer, options *CreateKeypairOptions, name string, ke
 		}
 	} else {
 		options.CertPath = utils.ExpandPath(options.CertPath)
-		certBytes, err := ioutil.ReadFile(options.CertPath)
+		certBytes, err := os.ReadFile(options.CertPath)
 		if err != nil {
 			return fmt.Errorf("error reading user provided cert %q: %v", options.CertPath, err)
 		}

--- a/cmd/kops/create_secret_ciliumpassword.go
+++ b/cmd/kops/create_secret_ciliumpassword.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/kops/cmd/kops/util"
@@ -108,7 +108,7 @@ func RunCreateSecretCiliumEncryptionConfig(ctx context.Context, f *util.Factory,
 			return fmt.Errorf("reading Cilium IPSec config from stdin: %v", err)
 		}
 	} else {
-		data, err = ioutil.ReadFile(options.CiliumPasswordFilePath)
+		data, err = os.ReadFile(options.CiliumPasswordFilePath)
 		if err != nil {
 			return fmt.Errorf("reading Cilium IPSec config %v: %v", options.CiliumPasswordFilePath, err)
 		}

--- a/cmd/kops/create_secret_dockerconfig.go
+++ b/cmd/kops/create_secret_dockerconfig.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/kops/cmd/kops/util"
@@ -113,7 +113,7 @@ func RunCreateSecretDockerConfig(ctx context.Context, f *util.Factory, out io.Wr
 			return fmt.Errorf("reading Docker config from stdin: %v", err)
 		}
 	} else {
-		data, err = ioutil.ReadFile(options.DockerConfigPath)
+		data, err = os.ReadFile(options.DockerConfigPath)
 		if err != nil {
 			return fmt.Errorf("reading Docker config %v: %v", options.DockerConfigPath, err)
 		}

--- a/cmd/kops/create_secret_encryptionconfig.go
+++ b/cmd/kops/create_secret_encryptionconfig.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/kops/cmd/kops/util"
@@ -106,7 +106,7 @@ func RunCreateSecretEncryptionConfig(ctx context.Context, f *util.Factory, out i
 			return fmt.Errorf("reading encryption config from stdin: %v", err)
 		}
 	} else {
-		data, err = ioutil.ReadFile(options.EncryptionConfigPath)
+		data, err = os.ReadFile(options.EncryptionConfigPath)
 		if err != nil {
 			return fmt.Errorf("reading encryption config %v: %v", options.EncryptionConfigPath, err)
 		}

--- a/cmd/kops/create_secret_weavepassword.go
+++ b/cmd/kops/create_secret_weavepassword.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"k8s.io/kops/pkg/commands/commandutils"
@@ -117,7 +117,7 @@ func RunCreateSecretWeavePassword(ctx context.Context, f *util.Factory, out io.W
 				return fmt.Errorf("reading Weave password file from stdin: %v", err)
 			}
 		} else {
-			data, err = ioutil.ReadFile(options.WeavePasswordFilePath)
+			data, err = os.ReadFile(options.WeavePasswordFilePath)
 			if err != nil {
 				return fmt.Errorf("reading Weave password file %v: %v", options.WeavePasswordFilePath, err)
 			}

--- a/cmd/kops/create_sshpublickey.go
+++ b/cmd/kops/create_sshpublickey.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -96,7 +96,7 @@ func RunCreateSSHPublicKey(ctx context.Context, f *util.Factory, out io.Writer, 
 		return err
 	}
 
-	data, err := ioutil.ReadFile(options.PublicKeyPath)
+	data, err := os.ReadFile(options.PublicKeyPath)
 	if err != nil {
 		return fmt.Errorf("error reading SSH public key %v: %v", options.PublicKeyPath, err)
 	}

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -27,7 +27,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -732,7 +731,7 @@ func (i *integrationTest) runTest(t *testing.T, h *testutils.IntegrationTestHarn
 
 	// Compare main files
 	{
-		files, err := ioutil.ReadDir(path.Join(h.TempDir, "out"))
+		files, err := os.ReadDir(path.Join(h.TempDir, "out"))
 		if err != nil {
 			t.Fatalf("failed to read dir: %v", err)
 		}
@@ -754,7 +753,7 @@ func (i *integrationTest) runTest(t *testing.T, h *testutils.IntegrationTestHarn
 			t.Fatalf("unexpected files.  actual=%q, expected=%q, test=%q", actualFilenames, expectedFilenames, testDataTFPath)
 		}
 
-		actualTF, err := ioutil.ReadFile(path.Join(h.TempDir, "out", actualTFPath))
+		actualTF, err := os.ReadFile(path.Join(h.TempDir, "out", actualTFPath))
 		if err != nil {
 			t.Fatalf("unexpected error reading actual terraform output: %v", err)
 		}
@@ -765,7 +764,7 @@ func (i *integrationTest) runTest(t *testing.T, h *testutils.IntegrationTestHarn
 	// Compare data files if they are provided
 	if len(expectedDataFilenames) > 0 {
 		actualDataPath := path.Join(h.TempDir, "out", "data")
-		files, err := ioutil.ReadDir(actualDataPath)
+		files, err := os.ReadDir(actualDataPath)
 		if err != nil {
 			t.Fatalf("failed to read data dir: %v", err)
 		}
@@ -797,7 +796,7 @@ func (i *integrationTest) runTest(t *testing.T, h *testutils.IntegrationTestHarn
 		{
 			for _, dataFileName := range expectedDataFilenames {
 				actualDataContent, err :=
-					ioutil.ReadFile(path.Join(actualDataPath, dataFileName))
+					os.ReadFile(path.Join(actualDataPath, dataFileName))
 				if err != nil {
 					t.Fatalf("failed to read actual data file: %v", err)
 				}
@@ -805,7 +804,7 @@ func (i *integrationTest) runTest(t *testing.T, h *testutils.IntegrationTestHarn
 			}
 		}
 
-		existingExpectedFiles, err := ioutil.ReadDir(expectedDataPath)
+		existingExpectedFiles, err := os.ReadDir(expectedDataPath)
 		if err != nil {
 			t.Fatalf("failed to read data dir: %v", err)
 		}
@@ -1202,7 +1201,7 @@ func (i *integrationTest) runTestCloudformation(t *testing.T) {
 
 	// Compare main files
 	{
-		files, err := ioutil.ReadDir(path.Join(h.TempDir, "out"))
+		files, err := os.ReadDir(path.Join(h.TempDir, "out"))
 		if err != nil {
 			t.Fatalf("failed to read dir: %v", err)
 		}
@@ -1220,7 +1219,7 @@ func (i *integrationTest) runTestCloudformation(t *testing.T) {
 		}
 
 		actualPath := path.Join(h.TempDir, "out", "kubernetes.json")
-		actualCF, err := ioutil.ReadFile(actualPath)
+		actualCF, err := os.ReadFile(actualPath)
 		if err != nil {
 			t.Fatalf("unexpected error reading actual cloudformation output: %v", err)
 		}
@@ -1295,7 +1294,7 @@ func MakeSSHKeyPair(publicKeyPath string, privateKeyPath string) error {
 	if err := pem.Encode(&privateKeyBytes, privateKeyPEM); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(privateKeyPath, privateKeyBytes.Bytes(), os.FileMode(0700)); err != nil {
+	if err := os.WriteFile(privateKeyPath, privateKeyBytes.Bytes(), os.FileMode(0700)); err != nil {
 		return err
 	}
 
@@ -1304,7 +1303,7 @@ func MakeSSHKeyPair(publicKeyPath string, privateKeyPath string) error {
 		return err
 	}
 	publicKeyBytes := ssh.MarshalAuthorizedKey(publicKey)
-	if err := ioutil.WriteFile(publicKeyPath, publicKeyBytes, os.FileMode(0744)); err != nil {
+	if err := os.WriteFile(publicKeyPath, publicKeyBytes, os.FileMode(0744)); err != nil {
 		return err
 	}
 

--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,7 +137,7 @@ func RunToolboxDump(ctx context.Context, f *util.Factory, out io.Writer, options
 		if strings.HasPrefix(privateKeyPath, "~/") {
 			privateKeyPath = filepath.Join(os.Getenv("HOME"), privateKeyPath[2:])
 		}
-		key, err := ioutil.ReadFile(privateKeyPath)
+		key, err := os.ReadFile(privateKeyPath)
 		if err != nil {
 			return fmt.Errorf("error reading private key %q: %v", privateKeyPath, err)
 		}

--- a/cmd/kops/toolbox_template.go
+++ b/cmd/kops/toolbox_template.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -167,7 +166,7 @@ func RunToolBoxTemplate(f *util.Factory, out io.Writer, options *ToolboxTemplate
 		}
 
 		for _, j := range list {
-			content, err := ioutil.ReadFile(j)
+			content, err := os.ReadFile(j)
 			if err != nil {
 				return fmt.Errorf("unable to read snippet: %s, error: %s", j, err)
 			}
@@ -184,7 +183,7 @@ func RunToolBoxTemplate(f *util.Factory, out io.Writer, options *ToolboxTemplate
 	r := templater.NewTemplater(channel)
 	var documents []string
 	for _, x := range templates {
-		content, err := ioutil.ReadFile(x)
+		content, err := os.ReadFile(x)
 		if err != nil {
 			return fmt.Errorf("unable to read template: %s, error: %s", x, err)
 		}
@@ -249,7 +248,7 @@ func newTemplateContext(files []string, values []string, stringValues []string) 
 			return nil, err
 		}
 		for _, j := range list {
-			content, err := ioutil.ReadFile(j)
+			content, err := os.ReadFile(j)
 			if err != nil {
 				return nil, fmt.Errorf("unable to configuration file: %s, error: %s", j, err)
 			}

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -229,7 +229,7 @@ func RunUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Up
 		fmt.Fprintf(out, "--ssh-public-key on update is deprecated - please use `kops create secret --name %s sshpublickey admin -i ~/.ssh/id_rsa.pub` instead\n", cluster.ObjectMeta.Name)
 
 		c.SSHPublicKey = utils.ExpandPath(c.SSHPublicKey)
-		authorized, err := ioutil.ReadFile(c.SSHPublicKey)
+		authorized, err := os.ReadFile(c.SSHPublicKey)
 		if err != nil {
 			return results, fmt.Errorf("error reading SSH key file %q: %v", c.SSHPublicKey, err)
 		}

--- a/cmd/kube-apiserver-healthcheck/main.go
+++ b/cmd/kube-apiserver-healthcheck/main.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -147,7 +146,7 @@ func run() error {
 	tlsConfig := &tls.Config{}
 
 	if caCert != "" {
-		b, err := ioutil.ReadFile(caCert)
+		b, err := os.ReadFile(caCert)
 		if err != nil {
 			return fmt.Errorf("error reading certificate %q: %v", caCert, err)
 		}

--- a/dnsprovider/pkg/dnsprovider/providers/do/dns_test.go
+++ b/dnsprovider/pkg/dnsprovider/providers/do/dns_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -280,7 +280,7 @@ func TestRemove(t *testing.T) {
 			Response: &http.Response{},
 		}
 		resp.StatusCode = http.StatusOK
-		resp.Body = ioutil.NopCloser(bytes.NewBufferString("error!"))
+		resp.Body = io.NopCloser(bytes.NewBufferString("error!"))
 		return resp, errors.New("error!")
 	}
 	client.Domains = fake

--- a/examples/kops-api-example/up.go
+++ b/examples/kops-api-example/up.go
@@ -19,7 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	api "k8s.io/kops/pkg/apis/kops"
@@ -116,7 +116,7 @@ func up(ctx context.Context) error {
 	// Add a public key
 	{
 		f := utils.ExpandPath(sshPublicKey)
-		pubKey, err := ioutil.ReadFile(f)
+		pubKey, err := os.ReadFile(f)
 		if err != nil {
 			return fmt.Errorf("error reading SSH key file %q: %v", f, err)
 		}

--- a/nodeup/pkg/model/cloudconfig_test.go
+++ b/nodeup/pkg/model/cloudconfig_test.go
@@ -18,7 +18,7 @@ package model
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -86,7 +86,7 @@ func TestBuildAzure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -154,7 +154,7 @@ func TestBuildAWSCustomNodeIPFamilies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	awsCloudConfig, err := ioutil.ReadAll(r)
+	awsCloudConfig, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/nodeup/pkg/model/docker.go
+++ b/nodeup/pkg/model/docker.go
@@ -19,7 +19,6 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -352,7 +351,7 @@ func (b *DockerBuilder) buildSysconfig(c *fi.ModelBuilderContext) error {
 	// ContainerOS now sets the storage flag in /etc/docker/daemon.json, and it is an error to set it twice
 	if b.Distribution == distributions.DistributionContainerOS {
 		// So that we can support older COS images though, we do check for /etc/docker/daemon.json
-		if b, err := ioutil.ReadFile("/etc/docker/daemon.json"); err != nil {
+		if b, err := os.ReadFile("/etc/docker/daemon.json"); err != nil {
 			if os.IsNotExist(err) {
 				klog.V(2).Infof("/etc/docker/daemon.json not found")
 			} else {

--- a/pkg/assets/builder_test.go
+++ b/pkg/assets/builder_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package assets
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -169,7 +169,7 @@ func TestRemapEmptySection(t *testing.T) {
 	inputPath := filepath.Join(testdir, key+".input.yaml")
 	expectedPath := filepath.Join(testdir, key+".expected.yaml")
 
-	input, err := ioutil.ReadFile(inputPath)
+	input, err := os.ReadFile(inputPath)
 	if err != nil {
 		t.Errorf("error reading file %q: %v", inputPath, err)
 	}

--- a/pkg/commands/helpers/kubectl_auth.go
+++ b/pkg/commands/helpers/kubectl_auth.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -148,7 +147,7 @@ func RunKubectlAuthHelper(ctx context.Context, f *util.Factory, out io.Writer, o
 		if err := os.MkdirAll(filepath.Dir(cacheFilePath), 0755); err != nil {
 			klog.Warningf("failed to make cache directory for %q: %v", cacheFilePath, err)
 		}
-		if err := ioutil.WriteFile(cacheFilePath, b, 0600); err != nil {
+		if err := os.WriteFile(cacheFilePath, b, 0600); err != nil {
 			klog.Warningf("failed to write cache file %q: %v", cacheFilePath, err)
 		}
 	}
@@ -194,7 +193,7 @@ func cacheFilePath(kopsStateStore string, clusterName string) string {
 }
 
 func loadCachedExecCredential(cacheFilePath string) (*ExecCredential, error) {
-	b, err := ioutil.ReadFile(cacheFilePath)
+	b, err := os.ReadFile(cacheFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// expected - a cache miss

--- a/pkg/nodeidentity/azure/client.go
+++ b/pkg/nodeidentity/azure/client.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
@@ -95,7 +95,7 @@ func queryInstanceMetadata() (*instanceMetadata, error) {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading a response from the metadata server: %s", err)
 	}

--- a/pkg/nodeidentity/azure/client_test.go
+++ b/pkg/nodeidentity/azure/client_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package azure
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
 
 func TestUnmarshalMetadata(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/metadata.json")
+	data, err := os.ReadFile("testdata/metadata.json")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/pkg/nodeidentity/do/identify.go
+++ b/pkg/nodeidentity/do/identify.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -107,7 +107,7 @@ func getMetadata(url string) (string, error) {
 		return "", fmt.Errorf("droplet metadata returned non-200 status code: %d", resp.StatusCode)
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read metadata information %s: %v", url, err)
 	}

--- a/pkg/testutils/golden/compare.go
+++ b/pkg/testutils/golden/compare.go
@@ -17,7 +17,6 @@ limitations under the License.
 package golden
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -40,7 +39,7 @@ func AssertMatchesFile(t *testing.T, actual string, p string) {
 		p = abs
 	}
 
-	expectedBytes, err := ioutil.ReadFile(p)
+	expectedBytes, err := os.ReadFile(p)
 	if err != nil {
 		if !os.IsNotExist(err) || os.Getenv("HACK_UPDATE_EXPECTED_IN_PLACE") == "" {
 			t.Fatalf("error reading file %q: %v", p, err)
@@ -64,7 +63,7 @@ func AssertMatchesFile(t *testing.T, actual string, p string) {
 		if err := os.MkdirAll(path.Dir(p), 0755); err != nil {
 			t.Errorf("error creating directory %s: %v", path.Dir(p), err)
 		}
-		if err := ioutil.WriteFile(p, []byte(actual), 0644); err != nil {
+		if err := os.WriteFile(p, []byte(actual), 0644); err != nil {
 			t.Errorf("error writing expected output %s: %v", p, err)
 		}
 

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testutils
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -77,7 +76,7 @@ type IntegrationTestHarness struct {
 
 func NewIntegrationTestHarness(t *testing.T) *IntegrationTestHarness {
 	h := &IntegrationTestHarness{}
-	tempDir, err := ioutil.TempDir("", "test")
+	tempDir, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}

--- a/pkg/testutils/modelharness.go
+++ b/pkg/testutils/modelharness.go
@@ -18,7 +18,7 @@ package testutils
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"sort"
 	"strings"
@@ -41,7 +41,7 @@ type Model struct {
 // LoadModel loads a cluster and instancegroups from a cluster.yaml file found in basedir
 func LoadModel(basedir string) (*Model, error) {
 	clusterYamlPath := path.Join(basedir, "cluster.yaml")
-	clusterYaml, err := ioutil.ReadFile(clusterYamlPath)
+	clusterYaml, err := os.ReadFile(clusterYamlPath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading file %q: %v", clusterYamlPath, err)
 	}

--- a/pkg/util/templater/templater_test.go
+++ b/pkg/util/templater/templater_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package templater
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -189,7 +188,7 @@ func TestAllowForMissingVars(t *testing.T) {
 
 func TestRenderIntegration(t *testing.T) {
 	var cases []renderTest
-	content, err := ioutil.ReadFile("integration_tests.yml")
+	content, err := os.ReadFile("integration_tests.yml")
 	if err != nil {
 		t.Fatalf("unable to load the integration tests, error: %s", err)
 	}

--- a/protokube/pkg/gossip/azure/client.go
+++ b/protokube/pkg/gossip/azure/client.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -187,7 +187,7 @@ func queryInstanceMetadata() (*instanceMetadata, error) {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading a response from the metadata server: %s", err)
 	}

--- a/protokube/pkg/gossip/azure/client_test.go
+++ b/protokube/pkg/gossip/azure/client_test.go
@@ -17,14 +17,14 @@ limitations under the License.
 package azure
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 	"reflect"
 	"testing"
 )
 
 func TestUnmarshalMetadata(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/metadata.json")
+	data, err := os.ReadFile("testdata/metadata.json")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -68,7 +68,7 @@ func TestUnmarshalMetadata(t *testing.T) {
 }
 
 func TestGetInternalIP(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/metadata.json")
+	data, err := os.ReadFile("testdata/metadata.json")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/protokube/pkg/gossip/dns/hosts/hosts.go
+++ b/protokube/pkg/gossip/dns/hosts/hosts.go
@@ -19,7 +19,6 @@ package hosts
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	math_rand "math/rand"
 	"os"
 	"sort"
@@ -117,7 +116,7 @@ func UpdateHostsFileWithRecords(p string, mutator func(guarded []string) (*HostM
 		return fmt.Errorf("error getting file status of %q: %v", p, err)
 	}
 
-	data, err := ioutil.ReadFile(p)
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return fmt.Errorf("error reading file %q: %v", p, err)
 	}
@@ -218,7 +217,7 @@ func pseudoAtomicWrite(p string, b []byte, mode os.FileMode) error {
 			return fmt.Errorf("failed to consistently write file %q - too many retries", p)
 		}
 
-		if err := ioutil.WriteFile(p, b, mode); err != nil {
+		if err := os.WriteFile(p, b, mode); err != nil {
 			klog.Warningf("error writing file %q: %v", p, err)
 			continue
 		}
@@ -226,7 +225,7 @@ func pseudoAtomicWrite(p string, b []byte, mode os.FileMode) error {
 		n := 1 + math_rand.Intn(20)
 		time.Sleep(time.Duration(n) * time.Millisecond)
 
-		contents, err := ioutil.ReadFile(p)
+		contents, err := os.ReadFile(p)
 		if err != nil {
 			klog.Warningf("error re-reading file %q: %v", p, err)
 			continue

--- a/protokube/pkg/gossip/dns/hosts/hosts_test.go
+++ b/protokube/pkg/gossip/dns/hosts/hosts_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package hosts
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -113,7 +112,7 @@ func TestRecoversFromBadNesting(t *testing.T) {
 }
 
 func runTest(t *testing.T, in string, expected string) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
 	}
@@ -131,7 +130,7 @@ func runTest(t *testing.T, in string, expected string) {
 		"c": {},
 	}
 
-	if err := ioutil.WriteFile(p, []byte(in), 0755); err != nil {
+	if err := os.WriteFile(p, []byte(in), 0755); err != nil {
 		t.Fatalf("error writing hosts file: %v", err)
 	}
 
@@ -154,7 +153,7 @@ func runTest(t *testing.T, in string, expected string) {
 			t.Fatalf("error updating hosts file: %v", err)
 		}
 
-		b, err := ioutil.ReadFile(p)
+		b, err := os.ReadFile(p)
 		if err != nil {
 			t.Fatalf("error reading output file: %v", err)
 		}

--- a/protokube/pkg/protokube/do_volume.go
+++ b/protokube/pkg/protokube/do_volume.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -362,7 +362,7 @@ func getMetadata(url string) (string, error) {
 		return "", fmt.Errorf("droplet metadata returned non-200 status code: %d", resp.StatusCode)
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/protokube/pkg/protokube/openstack_volume.go
+++ b/protokube/pkg/protokube/openstack_volume.go
@@ -19,7 +19,7 @@ package protokube
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -75,7 +75,7 @@ func getLocalMetadata() (*InstanceMetadata, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/e2e/kubetest2-kops/builder/build.go
+++ b/tests/e2e/kubetest2-kops/builder/build.go
@@ -18,7 +18,6 @@ package builder
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +53,7 @@ func (b *BuildOptions) Build() error {
 	}
 	p := filepath.Join(metaDir, "kops-base-url")
 	kopsBaseURL := strings.Replace(b.StageLocation, "gs://", "https://storage.googleapis.com/", 1)
-	if err := ioutil.WriteFile(p, []byte(kopsBaseURL), 0644); err != nil {
+	if err := os.WriteFile(p, []byte(kopsBaseURL), 0644); err != nil {
 		return fmt.Errorf("failed to WriteFile(%q): %w", p, err)
 	}
 

--- a/tests/integration/channel/integration_test.go
+++ b/tests/integration/channel/integration_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -116,7 +116,7 @@ func TestKopsUpgrades(t *testing.T) {
 func TestKubernetesUpgrades(t *testing.T) {
 	srcDir := "simple"
 	sourcePath := path.Join(srcDir, "channel.yaml")
-	sourceBytes, err := ioutil.ReadFile(sourcePath)
+	sourceBytes, err := os.ReadFile(sourcePath)
 	if err != nil {
 		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 	}
@@ -210,7 +210,7 @@ func TestKubernetesUpgrades(t *testing.T) {
 func TestFindImage(t *testing.T) {
 	srcDir := "simple"
 	sourcePath := path.Join(srcDir, "channel.yaml")
-	sourceBytes, err := ioutil.ReadFile(sourcePath)
+	sourceBytes, err := os.ReadFile(sourcePath)
 	if err != nil {
 		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 	}
@@ -265,7 +265,7 @@ func TestFindImage(t *testing.T) {
 func TestRecommendedKubernetesVersion(t *testing.T) {
 	srcDir := "simple"
 	sourcePath := path.Join(srcDir, "channel.yaml")
-	sourceBytes, err := ioutil.ReadFile(sourcePath)
+	sourceBytes, err := os.ReadFile(sourcePath)
 	if err != nil {
 		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 	}
@@ -360,7 +360,7 @@ func TestChannelsSelfConsistent(t *testing.T) {
 	for _, g := range grid {
 		srcDir := "../../../channels/"
 		sourcePath := path.Join(srcDir, g.Channel)
-		sourceBytes, err := ioutil.ReadFile(sourcePath)
+		sourceBytes, err := os.ReadFile(sourcePath)
 		if err != nil {
 			t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 		}
@@ -408,7 +408,7 @@ func TestChannelImages(t *testing.T) {
 	for _, channel := range []string{"stable", "alpha"} {
 		t.Run(channel+"-channel", func(t *testing.T) {
 			sourcePath := "../../../channels/" + channel
-			sourceBytes, err := ioutil.ReadFile(sourcePath)
+			sourceBytes, err := os.ReadFile(sourcePath)
 			if err != nil {
 				t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 			}

--- a/tests/integration/channel/simple/mock_channel.go
+++ b/tests/integration/channel/simple/mock_channel.go
@@ -18,13 +18,13 @@ package simple
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"k8s.io/kops/pkg/apis/kops"
 )
 
 func NewMockChannel(sourcePath string) (*kops.Channel, error) {
-	sourceBytes, err := ioutil.ReadFile(sourcePath)
+	sourceBytes, err := os.ReadFile(sourcePath)
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 	}

--- a/tests/integration/conversion/integration_test.go
+++ b/tests/integration/conversion/integration_test.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -41,13 +41,13 @@ func TestConversionMinimal(t *testing.T) {
 func runTest(t *testing.T, srcDir string, fromVersion string, toVersion string) {
 	t.Run(fromVersion+"-"+toVersion, func(t *testing.T) {
 		sourcePath := path.Join(srcDir, fromVersion+".yaml")
-		sourceBytes, err := ioutil.ReadFile(sourcePath)
+		sourceBytes, err := os.ReadFile(sourcePath)
 		if err != nil {
 			t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 		}
 
 		expectedPath := path.Join(srcDir, toVersion+".yaml")
-		expectedBytes, err := ioutil.ReadFile(expectedPath)
+		expectedBytes, err := os.ReadFile(expectedPath)
 		if err != nil {
 			t.Fatalf("unexpected error reading expectedPath %q: %v", expectedPath, err)
 		}

--- a/upup/pkg/fi/cloudup/awstasks/render_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/render_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package awstasks
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -36,7 +35,7 @@ type renderTest struct {
 }
 
 func doRenderTests(t *testing.T, method string, cases []*renderTest) {
-	outdir, err := ioutil.TempDir("", "kops-render-")
+	outdir, err := os.MkdirTemp("", "kops-render-")
 	if err != nil {
 		t.Errorf("failed to create local render directory: %s", err)
 		t.FailNow()
@@ -88,7 +87,7 @@ func doRenderTests(t *testing.T, method string, cases []*renderTest) {
 
 			// @step: check the render is as expected
 			if c.Expected != "" {
-				content, err := ioutil.ReadFile(path.Join(outdir, filename))
+				content, err := os.ReadFile(path.Join(outdir, filename))
 				if err != nil {
 					return err
 				}

--- a/upup/pkg/fi/cloudup/awsup/aws_verifier.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_verifier.go
@@ -25,7 +25,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strconv"
@@ -150,7 +149,7 @@ func (a awsVerifier) VerifyToken(ctx context.Context, token string, body []byte)
 		return nil, fmt.Errorf("incorrect SHA")
 	}
 
-	requestBytes, _ := ioutil.ReadAll(stsRequest.Body)
+	requestBytes, _ := io.ReadAll(stsRequest.Body)
 	_, _ = stsRequest.Body.Seek(0, io.SeekStart)
 	if stsRequest.HTTPRequest.Header.Get("Content-Length") != strconv.Itoa(len(requestBytes)) {
 		return nil, fmt.Errorf("incorrect content-length")
@@ -164,7 +163,7 @@ func (a awsVerifier) VerifyToken(ctx context.Context, token string, body []byte)
 		defer response.Body.Close()
 	}
 
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading STS response: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cloudup
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -86,7 +86,7 @@ func runChannelBuilderTest(t *testing.T, key string, addonManifests []string) {
 	basedir := path.Join("tests/bootstrapchannelbuilder/", key)
 
 	clusterYamlPath := path.Join(basedir, "cluster.yaml")
-	clusterYaml, err := ioutil.ReadFile(clusterYamlPath)
+	clusterYaml, err := os.ReadFile(clusterYamlPath)
 	if err != nil {
 		t.Fatalf("error reading cluster yaml file %q: %v", clusterYamlPath, err)
 	}

--- a/upup/pkg/fi/cloudup/cloudformation/target.go
+++ b/upup/pkg/fi/cloudup/cloudformation/target.go
@@ -19,7 +19,6 @@ package cloudformation
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -160,7 +159,7 @@ func (t *CloudformationTarget) Finish(taskMap map[string]fi.Task) error {
 			return fmt.Errorf("error creating output directory %q: %v", path.Dir(p), err)
 		}
 
-		err = ioutil.WriteFile(p, contents, os.FileMode(0644))
+		err = os.WriteFile(p, contents, os.FileMode(0644))
 		if err != nil {
 			return fmt.Errorf("error writing cloudformation data to output file %q: %v", p, err)
 		}

--- a/upup/pkg/fi/cloudup/terraform/target.go
+++ b/upup/pkg/fi/cloudup/terraform/target.go
@@ -19,7 +19,6 @@ package terraform
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -117,7 +116,7 @@ func (t *TerraformTarget) Finish(taskMap map[string]fi.Task) error {
 			return fmt.Errorf("error creating output directory %q: %v", path.Dir(p), err)
 		}
 
-		err = ioutil.WriteFile(p, contents, os.FileMode(0644))
+		err = os.WriteFile(p, contents, os.FileMode(0644))
 		if err != nil {
 			return fmt.Errorf("error writing terraform data to output file %q: %v", p, err)
 		}

--- a/upup/pkg/fi/context.go
+++ b/upup/pkg/fi/context.go
@@ -19,7 +19,6 @@ package fi
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -66,7 +65,7 @@ func NewContext(target Target, cluster *kops.Cluster, cloud Cloud, keystore Keys
 		tasks:             tasks,
 	}
 
-	t, err := ioutil.TempDir("", "deploy")
+	t, err := os.MkdirTemp("", "deploy")
 	if err != nil {
 		return nil, fmt.Errorf("error creating temporary directory: %v", err)
 	}
@@ -102,7 +101,7 @@ func (c *Context) Close() {
 //}
 
 func (c *Context) NewTempDir(prefix string) (string, error) {
-	t, err := ioutil.TempDir(c.Tmpdir, prefix)
+	t, err := os.MkdirTemp(c.Tmpdir, prefix)
 	if err != nil {
 		return "", fmt.Errorf("error creating temporary directory: %v", err)
 	}

--- a/upup/pkg/fi/files.go
+++ b/upup/pkg/fi/files.go
@@ -19,7 +19,6 @@ package fi
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -65,7 +64,7 @@ func writeFileContents(destPath string, src Resource, fileMode os.FileMode) erro
 
 	dir := filepath.Dir(destPath)
 
-	tempFile, err := ioutil.TempFile(dir, ".writefile")
+	tempFile, err := os.CreateTemp(dir, ".writefile")
 	if err != nil {
 		return fmt.Errorf("error creating temp file in %q: %w", dir, err)
 	}

--- a/upup/pkg/fi/files_test.go
+++ b/upup/pkg/fi/files_test.go
@@ -21,7 +21,6 @@ package fi
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"syscall"
@@ -32,7 +31,7 @@ func TestWriteFile(t *testing.T) {
 	// Clear the umask so an unusual umask doesn't break our test (for directory mode)
 	syscall.Umask(0)
 
-	tempDir, err := ioutil.TempDir("", "fitest")
+	tempDir, err := os.MkdirTemp("", "fitest")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
 	}
@@ -64,7 +63,7 @@ func TestWriteFile(t *testing.T) {
 		}
 
 		// Check file content
-		data, err := ioutil.ReadFile(test.path)
+		data, err := os.ReadFile(test.path)
 		if err != nil {
 			t.Errorf("Error reading file {%s}, error: {%v}", test.path, err)
 			continue

--- a/upup/pkg/fi/nodeup/command.go
+++ b/upup/pkg/fi/nodeup/command.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -666,7 +665,7 @@ func evaluateDockerSpecStorage(spec *api.DockerConfig) error {
 
 // kernelHasFilesystem checks if /proc/filesystems contains the specified filesystem
 func kernelHasFilesystem(fs string) (bool, error) {
-	contents, err := ioutil.ReadFile("/proc/filesystems")
+	contents, err := os.ReadFile("/proc/filesystems")
 	if err != nil {
 		return false, fmt.Errorf("error reading /proc/filesystems: %v", err)
 	}

--- a/upup/pkg/fi/nodeup/nodetasks/aptsource.go
+++ b/upup/pkg/fi/nodeup/nodetasks/aptsource.go
@@ -18,7 +18,6 @@ package nodetasks
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -58,7 +57,7 @@ func (*AptSource) CheckChanges(a, e, changes *AptSource) error {
 
 func (f *AptSource) RenderLocal(t *local.LocalTarget, a, e, changes *AptSource) error {
 
-	tmpDir, err := ioutil.TempDir("", "aptsource")
+	tmpDir, err := os.MkdirTemp("", "aptsource")
 	if err != nil {
 		return fmt.Errorf("error creating temp dir: %v", err)
 	}

--- a/upup/pkg/fi/nodeup/nodetasks/archive.go
+++ b/upup/pkg/fi/nodeup/nodetasks/archive.go
@@ -19,7 +19,6 @@ package nodetasks
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -93,7 +92,7 @@ func (e *Archive) Dir() string {
 func (e *Archive) Find(c *fi.Context) (*Archive, error) {
 	// We write a marker file to prevent re-execution
 	localStateFile := path.Join(localArchiveStateDir, e.Name)
-	stateBytes, err := ioutil.ReadFile(localStateFile)
+	stateBytes, err := os.ReadFile(localStateFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			stateBytes = nil
@@ -201,7 +200,7 @@ func (_ *Archive) RenderLocal(t *local.LocalTarget, a, e, changes *Archive) erro
 			return fmt.Errorf("error marshaling archive state: %v", err)
 		}
 
-		if err := ioutil.WriteFile(localStateFile, state, 0644); err != nil {
+		if err := os.WriteFile(localStateFile, state, 0644); err != nil {
 			return fmt.Errorf("error writing archive state: %v", err)
 		}
 	} else {

--- a/upup/pkg/fi/nodeup/nodetasks/bindmount.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bindmount.go
@@ -18,7 +18,7 @@ package nodetasks
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -94,7 +94,7 @@ func findTaskInSlice(tasks []fi.Task, task fi.Task) int {
 }
 
 func (e *BindMount) Find(c *fi.Context) (*BindMount, error) {
-	mounts, err := ioutil.ReadFile("/proc/self/mountinfo")
+	mounts, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {
 		return nil, fmt.Errorf("error reading /proc/self/mountinfo: %v", err)
 	}

--- a/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
+++ b/upup/pkg/fi/nodeup/nodetasks/bootstrap_client.go
@@ -25,7 +25,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -210,7 +210,7 @@ func (b *KopsBootstrapClient) QueryBootstrap(ctx context.Context, req *nodeup.Bo
 	}
 
 	var bootstrapResp nodeup.BootstrapResponse
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/upup/pkg/fi/nodeup/nodetasks/load_image.go
+++ b/upup/pkg/fi/nodeup/nodetasks/load_image.go
@@ -18,7 +18,6 @@ package nodetasks
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -125,7 +124,7 @@ func (_ *LoadImageTask) RenderLocal(t *local.LocalTarget, a, e, changes *LoadIma
 	// TODO: Improve the naive gzip format detection by checking the content type bytes "\x1F\x8B\x08"
 	var tarFile string
 	if strings.HasSuffix(localFile, "gz") {
-		tmpDir, err := ioutil.TempDir("", "loadimage")
+		tmpDir, err := os.MkdirTemp("", "loadimage")
 		if err != nil {
 			return fmt.Errorf("error creating temp dir: %v", err)
 		}

--- a/upup/pkg/fi/nodeup/nodetasks/service.go
+++ b/upup/pkg/fi/nodeup/nodetasks/service.go
@@ -18,7 +18,6 @@ package nodetasks
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -169,7 +168,7 @@ func (e *Service) Find(c *fi.Context) (*Service, error) {
 
 	servicePath := path.Join(systemdSystemPath, e.Name)
 
-	d, err := ioutil.ReadFile(servicePath)
+	d, err := os.ReadFile(servicePath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("Error reading systemd file %q: %v", servicePath, err)

--- a/upup/pkg/fi/users.go
+++ b/upup/pkg/fi/users.go
@@ -18,7 +18,7 @@ package fi
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -42,7 +42,7 @@ func parseUsers() (map[string]*User, error) {
 	users := make(map[string]*User)
 
 	path := "/etc/passwd"
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading user file %q", path)
 	}
@@ -114,7 +114,7 @@ func parseGroups() (map[string]*Group, error) {
 	groups := make(map[string]*Group)
 
 	path := "/etc/group"
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading group file %q", path)
 	}

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -18,7 +18,7 @@ package distributions
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -28,7 +28,7 @@ import (
 // FindDistribution identifies the distribution on which we are running
 func FindDistribution(rootfs string) (Distribution, error) {
 	// All supported distros have an /etc/os-release file
-	osReleaseBytes, err := ioutil.ReadFile(path.Join(rootfs, "etc/os-release"))
+	osReleaseBytes, err := os.ReadFile(path.Join(rootfs, "etc/os-release"))
 	osRelease := make(map[string]string)
 	if err == nil {
 		for _, line := range strings.Split(string(osReleaseBytes), "\n") {

--- a/util/pkg/vfs/azureclient.go
+++ b/util/pkg/vfs/azureclient.go
@@ -19,7 +19,7 @@ package vfs
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -107,7 +107,7 @@ func getAccessTokenFromInstanceMetadataService() (string, error) {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading a response from the metadata server: %s", err)
 	}

--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -19,7 +19,7 @@ package vfs
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -228,7 +228,7 @@ func (c *VFSContext) readHTTPLocation(httpURL string, httpHeaders map[string]str
 		if err != nil {
 			return false, fmt.Errorf("error fetching %q: %v", httpURL, err)
 		}
-		body, err = ioutil.ReadAll(response.Body)
+		body, err = io.ReadAll(response.Body)
 		if err != nil {
 			return false, fmt.Errorf("error reading response for %q: %v", httpURL, err)
 		}

--- a/util/pkg/vfs/fs.go
+++ b/util/pkg/vfs/fs.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -56,7 +55,7 @@ func (p *FSPath) WriteFile(data io.ReadSeeker, acl ACL) error {
 		return fmt.Errorf("error creating directories %q: %v", dir, err)
 	}
 
-	f, err := ioutil.TempFile(dir, "tmp")
+	f, err := os.CreateTemp(dir, "tmp")
 	if err != nil {
 		return fmt.Errorf("error creating temp file in %q: %v", dir, err)
 	}
@@ -114,7 +113,7 @@ func (p *FSPath) CreateFile(data io.ReadSeeker, acl ACL) error {
 
 // ReadFile implements Path::ReadFile
 func (p *FSPath) ReadFile() ([]byte, error) {
-	file, err := ioutil.ReadFile(p.location)
+	file, err := os.ReadFile(p.location)
 	if errors.Is(err, syscall.ENOENT) {
 		err = os.ErrNotExist
 	}
@@ -133,7 +132,7 @@ func (p *FSPath) WriteTo(out io.Writer) (int64, error) {
 }
 
 func (p *FSPath) ReadDir() ([]Path, error) {
-	files, err := ioutil.ReadDir(p.location)
+	files, err := os.ReadDir(p.location)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, err
@@ -159,7 +158,7 @@ func (p *FSPath) ReadTree() ([]Path, error) {
 // readTree recursively finds files and adds them to dest
 // It excludes directories.
 func readTree(base string, dest *[]Path) error {
-	files, err := ioutil.ReadDir(base)
+	files, err := os.ReadDir(base)
 	if err != nil {
 		return err
 	}

--- a/util/pkg/vfs/fs_test.go
+++ b/util/pkg/vfs/fs_test.go
@@ -18,14 +18,13 @@ package vfs
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 )
 
 func TestCreateFile(t *testing.T) {
-	TempDir, err := ioutil.TempDir("", "test")
+	TempDir, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
 	}
@@ -71,7 +70,7 @@ func TestCreateFile(t *testing.T) {
 }
 
 func TestWriteTo(t *testing.T) {
-	TempDir, err := ioutil.TempDir("", "test")
+	TempDir, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
 	}

--- a/util/pkg/vfs/memfs.go
+++ b/util/pkg/vfs/memfs.go
@@ -19,7 +19,6 @@ package vfs
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -103,7 +102,7 @@ func (p *MemFSPath) Join(relativePath ...string) Path {
 }
 
 func (p *MemFSPath) WriteFile(r io.ReadSeeker, acl ACL) error {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("error reading data: %v", err)
 	}
@@ -213,7 +212,7 @@ type terraformMemFSFile struct {
 }
 
 func (p *MemFSPath) RenderTerraform(w *terraformWriter.TerraformWriter, name string, data io.Reader, acl ACL) error {
-	bytes, err := ioutil.ReadAll(data)
+	bytes, err := io.ReadAll(data)
 	if err != nil {
 		return fmt.Errorf("reading data: %v", err)
 	}

--- a/util/pkg/vfs/ossfs.go
+++ b/util/pkg/vfs/ossfs.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -150,7 +149,7 @@ func (p *OSSPath) WriteFile(data io.ReadSeeker, acl ACL) error {
 			return false, fmt.Errorf("error seeking to start of data stream for write to %s: %v", p, err)
 		}
 
-		bytes, err := ioutil.ReadAll(data)
+		bytes, err := io.ReadAll(data)
 		if err != nil {
 			return false, fmt.Errorf("error reading from data stream: %v", err)
 		}

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -18,7 +18,6 @@ package vfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -329,7 +328,7 @@ func bruteforceBucketLocation(region *string, request *s3.GetBucketLocationInput
 func isRunningOnEC2() (bool, error) {
 	if runtime.GOOS == "linux" {
 		// Approach based on https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html
-		productUUID, err := ioutil.ReadFile("/sys/devices/virtual/dmi/id/product_uuid")
+		productUUID, err := os.ReadFile("/sys/devices/virtual/dmi/id/product_uuid")
 		if err != nil {
 			klog.V(2).Infof("unable to read /sys/devices/virtual/dmi/id/product_uuid, assuming not running on EC2: %v", err)
 			return false, err

--- a/util/pkg/vfs/s3fs.go
+++ b/util/pkg/vfs/s3fs.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -527,7 +526,7 @@ type terraformS3File struct {
 }
 
 func (p *S3Path) RenderTerraform(w *terraformWriter.TerraformWriter, name string, data io.Reader, acl ACL) error {
-	bytes, err := ioutil.ReadAll(data)
+	bytes, err := io.ReadAll(data)
 	if err != nil {
 		return fmt.Errorf("reading data: %v", err)
 	}

--- a/util/pkg/vfs/vaultcontext.go
+++ b/util/pkg/vfs/vaultcontext.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -74,7 +74,7 @@ func awsAuth(client *vault.Client, host string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	requestBody, err := ioutil.ReadAll(stsRequest.HTTPRequest.Body)
+	requestBody, err := io.ReadAll(stsRequest.HTTPRequest.Body)
 	if err != nil {
 		return "", err
 	}

--- a/util/pkg/vfs/vaultfs.go
+++ b/util/pkg/vfs/vaultfs.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -210,7 +209,7 @@ func encodeData(data io.ReadSeeker) (string, error) {
 		}
 	}()
 
-	out, err := ioutil.ReadAll(pr)
+	out, err := io.ReadAll(pr)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since kops has been upgraded to Go 1.17 in #12505, this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.