### PR TITLE
Revert leader migration

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -522,9 +522,6 @@ spec:
                     description: ConfigureCloudRoutes enables CIDRs allocated with
                       to be configured on the cloud provider.
                     type: boolean
-                  enableLeaderMigration:
-                    description: EnableLeaderMigration enables controller leader migration.
-                    type: boolean
                   image:
                     description: Image is the OCI image of the cloud controller manager.
                     type: string
@@ -1878,9 +1875,6 @@ spec:
                     description: DisableAttachDetachReconcileSync disables the reconcile
                       sync loop in the attach-detach controller. This can cause volumes
                       to become mismatched with pods
-                    type: boolean
-                  enableLeaderMigration:
-                    description: EnableLeaderMigration enables controller leader migration.
                     type: boolean
                   enableProfiling:
                     description: EnableProfiling enables profiling via web interface

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
@@ -23,7 +23,6 @@ contents: |
       - --cluster-signing-cert-file=/srv/kubernetes/kube-controller-manager/ca.crt
       - --cluster-signing-key-file=/srv/kubernetes/kube-controller-manager/ca.key
       - --configure-cloud-routes=true
-      - --enable-leader-migration=true
       - --feature-gates=CSIMigrationAWS=true
       - --flex-volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/
       - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -650,8 +650,6 @@ type KubeControllerManagerConfig struct {
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
-	// EnableLeaderMigration enables controller leader migration.
-	EnableLeaderMigration *bool `json:"enableLeaderMigration,omitempty" flag:"enable-leader-migration"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -679,8 +677,6 @@ type CloudControllerManagerConfig struct {
 	LeaderElection *LeaderElectionConfiguration `json:"leaderElection,omitempty"`
 	// UseServiceAccountCredentials controls whether we use individual service account credentials for each controller.
 	UseServiceAccountCredentials *bool `json:"useServiceAccountCredentials,omitempty" flag:"use-service-account-credentials"`
-	// EnableLeaderMigration enables controller leader migration.
-	EnableLeaderMigration *bool `json:"enableLeaderMigration,omitempty" flag:"enable-leader-migration"`
 }
 
 // KubeSchedulerConfig is the configuration for the kube-scheduler

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -649,8 +649,6 @@ type KubeControllerManagerConfig struct {
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
-	// EnableLeaderMigration enables controller leader migration.
-	EnableLeaderMigration *bool `json:"enableLeaderMigration,omitempty" flag:"enable-leader-migration"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -678,8 +676,6 @@ type CloudControllerManagerConfig struct {
 	LeaderElection *LeaderElectionConfiguration `json:"leaderElection,omitempty"`
 	// UseServiceAccountCredentials controls whether we use individual service account credentials for each controller.
 	UseServiceAccountCredentials *bool `json:"useServiceAccountCredentials,omitempty" flag:"use-service-account-credentials"`
-	// EnableLeaderMigration enables controller leader migration.
-	EnableLeaderMigration *bool `json:"enableLeaderMigration,omitempty" flag:"enable-leader-migration"`
 }
 
 // KubeSchedulerConfig is the configuration for the kube-scheduler

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2165,7 +2165,6 @@ func autoConvert_v1alpha2_CloudControllerManagerConfig_To_kops_CloudControllerMa
 		out.LeaderElection = nil
 	}
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
-	out.EnableLeaderMigration = in.EnableLeaderMigration
 	return nil
 }
 
@@ -2194,7 +2193,6 @@ func autoConvert_kops_CloudControllerManagerConfig_To_v1alpha2_CloudControllerMa
 		out.LeaderElection = nil
 	}
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
-	out.EnableLeaderMigration = in.EnableLeaderMigration
 	return nil
 }
 
@@ -4966,7 +4964,6 @@ func autoConvert_v1alpha2_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.ExternalCloudVolumePlugin = in.ExternalCloudVolumePlugin
 	out.EnableProfiling = in.EnableProfiling
-	out.EnableLeaderMigration = in.EnableLeaderMigration
 	return nil
 }
 
@@ -5036,7 +5033,6 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha2_KubeControllerMana
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.ExternalCloudVolumePlugin = in.ExternalCloudVolumePlugin
 	out.EnableProfiling = in.EnableProfiling
-	out.EnableLeaderMigration = in.EnableLeaderMigration
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -782,11 +782,6 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 		*out = new(bool)
 		**out = **in
 	}
-	if in.EnableLeaderMigration != nil {
-		in, out := &in.EnableLeaderMigration, &out.EnableLeaderMigration
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 
@@ -3111,11 +3106,6 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 	}
 	if in.EnableProfiling != nil {
 		in, out := &in.EnableProfiling, &out.EnableProfiling
-		*out = new(bool)
-		**out = **in
-	}
-	if in.EnableLeaderMigration != nil {
-		in, out := &in.EnableLeaderMigration, &out.EnableLeaderMigration
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -647,8 +647,6 @@ type KubeControllerManagerConfig struct {
 
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling *bool `json:"enableProfiling,omitempty" flag:"profiling"`
-	// EnableLeaderMigration enables controller leader migration.
-	EnableLeaderMigration *bool `json:"enableLeaderMigration,omitempty" flag:"enable-leader-migration"`
 }
 
 // CloudControllerManagerConfig is the configuration of the cloud controller
@@ -676,8 +674,6 @@ type CloudControllerManagerConfig struct {
 	LeaderElection *LeaderElectionConfiguration `json:"leaderElection,omitempty"`
 	// UseServiceAccountCredentials controls whether we use individual service account credentials for each controller.
 	UseServiceAccountCredentials *bool `json:"useServiceAccountCredentials,omitempty" flag:"use-service-account-credentials"`
-	// EnableLeaderMigration enables controller leader migration.
-	EnableLeaderMigration *bool `json:"enableLeaderMigration,omitempty" flag:"enable-leader-migration"`
 }
 
 // KubeSchedulerConfig is the configuration for the kube-scheduler

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2043,7 +2043,6 @@ func autoConvert_v1alpha3_CloudControllerManagerConfig_To_kops_CloudControllerMa
 		out.LeaderElection = nil
 	}
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
-	out.EnableLeaderMigration = in.EnableLeaderMigration
 	return nil
 }
 
@@ -2072,7 +2071,6 @@ func autoConvert_kops_CloudControllerManagerConfig_To_v1alpha3_CloudControllerMa
 		out.LeaderElection = nil
 	}
 	out.UseServiceAccountCredentials = in.UseServiceAccountCredentials
-	out.EnableLeaderMigration = in.EnableLeaderMigration
 	return nil
 }
 
@@ -4824,7 +4822,6 @@ func autoConvert_v1alpha3_KubeControllerManagerConfig_To_kops_KubeControllerMana
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.ExternalCloudVolumePlugin = in.ExternalCloudVolumePlugin
 	out.EnableProfiling = in.EnableProfiling
-	out.EnableLeaderMigration = in.EnableLeaderMigration
 	return nil
 }
 
@@ -4894,7 +4891,6 @@ func autoConvert_kops_KubeControllerManagerConfig_To_v1alpha3_KubeControllerMana
 	out.AuthorizationAlwaysAllowPaths = in.AuthorizationAlwaysAllowPaths
 	out.ExternalCloudVolumePlugin = in.ExternalCloudVolumePlugin
 	out.EnableProfiling = in.EnableProfiling
-	out.EnableLeaderMigration = in.EnableLeaderMigration
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -728,11 +728,6 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 		*out = new(bool)
 		**out = **in
 	}
-	if in.EnableLeaderMigration != nil {
-		in, out := &in.EnableLeaderMigration, &out.EnableLeaderMigration
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 
@@ -3052,11 +3047,6 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 	}
 	if in.EnableProfiling != nil {
 		in, out := &in.EnableProfiling, &out.EnableProfiling
-		*out = new(bool)
-		**out = **in
-	}
-	if in.EnableLeaderMigration != nil {
-		in, out := &in.EnableLeaderMigration, &out.EnableLeaderMigration
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -820,11 +820,6 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 		*out = new(bool)
 		**out = **in
 	}
-	if in.EnableLeaderMigration != nil {
-		in, out := &in.EnableLeaderMigration, &out.EnableLeaderMigration
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 
@@ -3226,11 +3221,6 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 	}
 	if in.EnableProfiling != nil {
 		in, out := &in.EnableProfiling, &out.EnableProfiling
-		*out = new(bool)
-		**out = **in
-	}
-	if in.EnableLeaderMigration != nil {
-		in, out := &in.EnableLeaderMigration, &out.EnableLeaderMigration
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -38,14 +38,6 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 
 	eccm := clusterSpec.ExternalCloudControllerManager
 
-	if kops.CloudProviderID(clusterSpec.CloudProvider) != kops.CloudProviderAWS {
-		return nil
-	}
-
-	if eccm == nil && b.IsKubernetesGTE("1.24") {
-		eccm = &kops.CloudControllerManagerConfig{}
-	}
-
 	if eccm == nil || kops.CloudProviderID(clusterSpec.CloudProvider) != kops.CloudProviderAWS {
 		return nil
 	}
@@ -97,10 +89,6 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		default:
 			eccm.Image = "gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest"
 		}
-	}
-
-	if b.IsKubernetesGTE("1.24") && b.IsKubernetesLT("1.25") {
-		eccm.EnableLeaderMigration = fi.Bool(true)
 	}
 
 	return nil

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -79,11 +79,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 	kcm.ClusterName = b.ClusterName
 	switch kops.CloudProviderID(clusterSpec.CloudProvider) {
 	case kops.CloudProviderAWS:
-		if b.IsKubernetesGTE("1.24") {
-			kcm.CloudProvider = "external"
-		} else {
-			kcm.CloudProvider = "aws"
-		}
+		kcm.CloudProvider = "aws"
 
 	case kops.CloudProviderGCE:
 		kcm.CloudProvider = "gce"
@@ -105,11 +101,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)
 	}
 
-	if clusterSpec.ExternalCloudControllerManager == nil {
-		if kcm.CloudProvider == "aws" && b.IsKubernetesGTE("1.23") {
-			kcm.EnableLeaderMigration = fi.Bool(true)
-		}
-	} else {
+	if clusterSpec.ExternalCloudControllerManager != nil {
 		kcm.CloudProvider = "external"
 	}
 


### PR DESCRIPTION
It appears we need to also patch the `system::leader-locking-kube-controller-manager` Role. Revert until we can figure out how best to do this.
