### PR TITLE
Fix use of deprecated method

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1434,7 +1434,7 @@ func validateRollingUpdate(rollingUpdate *kops.RollingUpdate, fldpath *field.Pat
 	var err error
 	unavailable := 1
 	if rollingUpdate.MaxUnavailable != nil {
-		unavailable, err = intstr.GetValueFromIntOrPercent(rollingUpdate.MaxUnavailable, 1, false)
+		unavailable, err = intstr.GetScaledValueFromIntOrPercent(rollingUpdate.MaxUnavailable, 1, false)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(fldpath.Child("maxUnavailable"), rollingUpdate.MaxUnavailable,
 				fmt.Sprintf("Unable to parse: %v", err)))
@@ -1444,7 +1444,7 @@ func validateRollingUpdate(rollingUpdate *kops.RollingUpdate, fldpath *field.Pat
 		}
 	}
 	if rollingUpdate.MaxSurge != nil {
-		surge, err := intstr.GetValueFromIntOrPercent(rollingUpdate.MaxSurge, 1000, true)
+		surge, err := intstr.GetScaledValueFromIntOrPercent(rollingUpdate.MaxSurge, 1000, true)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(fldpath.Child("maxSurge"), rollingUpdate.MaxSurge,
 				fmt.Sprintf("Unable to parse: %v", err)))

--- a/pkg/instancegroups/settings.go
+++ b/pkg/instancegroups/settings.go
@@ -54,7 +54,7 @@ func resolveSettings(cluster *kops.Cluster, group *kops.InstanceGroup, numInstan
 	}
 
 	if rollingUpdate.MaxSurge.Type == intstr.String {
-		surge, _ := intstr.GetValueFromIntOrPercent(rollingUpdate.MaxSurge, numInstances, true)
+		surge, _ := intstr.GetScaledValueFromIntOrPercent(rollingUpdate.MaxSurge, numInstances, true)
 		surgeInt := intstr.FromInt(surge)
 		rollingUpdate.MaxSurge = &surgeInt
 	}
@@ -68,7 +68,7 @@ func resolveSettings(cluster *kops.Cluster, group *kops.InstanceGroup, numInstan
 	}
 
 	if rollingUpdate.MaxUnavailable.Type == intstr.String {
-		unavailable, _ := intstr.GetValueFromIntOrPercent(rollingUpdate.MaxUnavailable, numInstances, false)
+		unavailable, _ := intstr.GetScaledValueFromIntOrPercent(rollingUpdate.MaxUnavailable, numInstances, false)
 		if unavailable <= 0 {
 			// While we round down, percentages should resolve to a minimum of 1
 			unavailable = 1


### PR DESCRIPTION
`GetValueFromIntOrPercent()` treated all string values as percentages, even if they didn't have a trailing percent sign. `GetScaledValueFromIntOrPercent()` treats string values not followed by a percent sign as errors.
