### PR TITLE
[DigitalOcean] Show load balancer id in logs

### DIFF
--- a/pkg/model/domodel/BUILD.bazel
+++ b/pkg/model/domodel/BUILD.bazel
@@ -16,5 +16,6 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/do:go_default_library",
         "//upup/pkg/fi/cloudup/dotasks:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/pkg/model/domodel/api_loadbalancer.go
+++ b/pkg/model/domodel/api_loadbalancer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/upup/pkg/fi"
@@ -62,10 +63,11 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	// Create LoadBalancer for API LB
 	loadbalancer := &dotasks.LoadBalancer{
-		Name:       fi.String(loadbalancerName),
-		Region:     fi.String(b.Cluster.Spec.Subnets[0].Region),
-		DropletTag: fi.String(clusterMasterTag),
-		Lifecycle:  b.Lifecycle,
+		Name:         fi.String(loadbalancerName),
+		Region:       fi.String(b.Cluster.Spec.Subnets[0].Region),
+		DropletTag:   fi.String(clusterMasterTag),
+		Lifecycle:    b.Lifecycle,
+		ForAPIServer: true,
 	}
 	c.AddTask(loadbalancer)
 
@@ -75,6 +77,8 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		// if we're not going to use an alias for it
 		loadbalancer.ForAPIServer = true
 	}
+
+	klog.Infof("In Building loadbalancer = %v", loadbalancer)
 
 	return nil
 

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -114,6 +114,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		"--kubernetes-version", d.KubernetesVersion,
 		"--ssh-public-key", d.SSHPublicKeyPath,
 		"--override", "cluster.spec.nodePortAccess=0.0.0.0/0",
+		"--v=10",
 	}
 	if yes {
 		args = append(args, "--yes")

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -114,7 +114,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 		"--kubernetes-version", d.KubernetesVersion,
 		"--ssh-public-key", d.SSHPublicKeyPath,
 		"--override", "cluster.spec.nodePortAccess=0.0.0.0/0",
-		"--v=10",
+		"--v=6",
 	}
 	if yes {
 		args = append(args, "--yes")

--- a/tests/e2e/scenarios/digital-ocean/run-test
+++ b/tests/e2e/scenarios/digital-ocean/run-test
@@ -23,7 +23,7 @@ export KOPS_FEATURE_FLAGS="SpecOverrideFlag,${KOPS_FEATURE_FLAGS:-}"
 REPO_ROOT=$(git rev-parse --show-toplevel);
 PATH=$REPO_ROOT/.bazel-bin/cmd/kops/$(go env GOOS)-$(go env GOARCH):$PATH
 
-KUBETEST2_COMMON_ARGS="-v=2 --cloud-provider=digitalocean --cluster-name=e2e-test-do.k8s.local --kops-binary-path=${REPO_ROOT}/.bazel-bin/cmd/kops/linux-amd64/kops"
+KUBETEST2_COMMON_ARGS="-v=10 --cloud-provider=digitalocean --cluster-name=e2e-test-do.k8s.local --kops-binary-path=${REPO_ROOT}/.bazel-bin/cmd/kops/linux-amd64/kops"
 KUBETEST2_COMMON_ARGS="${KUBETEST2_COMMON_ARGS} --admin-access=${ADMIN_ACCESS:-}"
 
 export GO111MODULE=on
@@ -36,7 +36,6 @@ go install ./kubetest2-tester-kops
 kubetest2 kops ${KUBETEST2_COMMON_ARGS} --build --kops-root=${REPO_ROOT} --stage-location=${STAGE_LOCATION:-}
 
 kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
-		-v 6 \
 		--up --down \
 		--env S3_ENDPOINT=sfo3.digitaloceanspaces.com \
 		--env JOB_NAME=pull-kops-e2e-kubernetes-do-kubetest2 \
@@ -45,7 +44,6 @@ kubetest2 kops ${KUBETEST2_COMMON_ARGS} \
 		--kubernetes-version=https://storage.googleapis.com/kubernetes-release/release/stable-1.20.txt \
 		--test=kops \
 		-- \
-		--ginkgo-args="--debug" \
 		--test-package-marker=stable-1.20.txt \
 		--parallel 25 \
 		--skip-regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|RuntimeClass|RuntimeHandler|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*NodePort.*listening.*same.*port|TCP.CLOSE_WAIT|should.*run.*through.*the.*lifecycle.*of.*Pods.*and.*PodStatus"

--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -121,6 +121,9 @@ func (d *Droplet) Run(c *fi.Context) error {
 }
 
 func (_ *Droplet) RenderDO(t *do.DOAPITarget, a, e, changes *Droplet) error {
+	if a == nil {
+		klog.V(2).Infof("In Droplet Render DO..")
+	}
 	userData, err := fi.ResourceAsString(e.UserData)
 	if err != nil {
 		return err

--- a/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
@@ -129,6 +129,8 @@ func (_ *LoadBalancer) RenderDO(t *do.DOAPITarget, a, e, changes *LoadBalancer) 
 		HealthyThreshold:       5,
 	}
 
+	klog.Infof("In RenderDO: loadbalancer")
+
 	// check if load balancer exist.
 	loadBalancers, err := t.Cloud.GetAllLoadBalancers()
 
@@ -147,7 +149,7 @@ func (_ *LoadBalancer) RenderDO(t *do.DOAPITarget, a, e, changes *LoadBalancer) 
 	}
 
 	// load balancer doesn't exist. Create one.
-	klog.V(10).Infof("Creating load balancer for DO now..")
+	klog.Infof("Creating load balancer for DO")
 
 	loadBalancerService := t.Cloud.LoadBalancersService()
 	loadbalancer, _, err := loadBalancerService.Create(context.TODO(), &godo.LoadBalancerRequest{

--- a/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
@@ -163,6 +163,8 @@ func (_ *LoadBalancer) RenderDO(t *do.DOAPITarget, a, e, changes *LoadBalancer) 
 		return err
 	}
 
+	klog.Infof("Load balancer created with ID=%s", loadbalancer.ID)
+
 	e.ID = fi.String(loadbalancer.ID)
 	e.IPAddress = fi.String(loadbalancer.IP) // This will be empty on create, but will be filled later on FindIPAddress invokation.
 

--- a/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
@@ -137,7 +137,7 @@ func (_ *LoadBalancer) RenderDO(t *do.DOAPITarget, a, e, changes *LoadBalancer) 
 	}
 
 	for _, loadbalancer := range loadBalancers {
-		klog.V(10).Infof("load balancer retrieved=%s, e.Name=%s", loadbalancer.Name, fi.StringValue(e.Name))
+		klog.Infof("load balancer retrieved=%s, e.Name=%s", loadbalancer.Name, fi.StringValue(e.Name))
 		if strings.Contains(loadbalancer.Name, fi.StringValue(e.Name)) {
 			// load balancer already exists.
 			e.ID = fi.String(loadbalancer.ID)
@@ -147,7 +147,7 @@ func (_ *LoadBalancer) RenderDO(t *do.DOAPITarget, a, e, changes *LoadBalancer) 
 	}
 
 	// load balancer doesn't exist. Create one.
-	klog.V(10).Infof("Creating load balancer for DO")
+	klog.V(10).Infof("Creating load balancer for DO now..")
 
 	loadBalancerService := t.Cloud.LoadBalancersService()
 	loadbalancer, _, err := loadBalancerService.Create(context.TODO(), &godo.LoadBalancerRequest{
@@ -216,7 +216,7 @@ func (lb *LoadBalancer) FindIPAddress(c *fi.Context) (*string, error) {
 	}
 
 	const lbWaitTime = 10 * time.Second
-	klog.Warningf("IP address for LB %s not yet available -- sleeping %s", fi.StringValue(lb.Name), lbWaitTime)
+	klog.Warningf("IP address for Loadbalancer id(name) %s(%s) not yet available -- sleeping %s", fi.StringValue(lb.ID), fi.StringValue(lb.Name), lbWaitTime)
 	time.Sleep(lbWaitTime)
 
 	return nil, errors.New("IP Address is still empty.")

--- a/upup/pkg/fi/executor.go
+++ b/upup/pkg/fi/executor.go
@@ -183,7 +183,7 @@ func (e *executor) forkJoin(tasks []*taskState) []error {
 		go func(ts *taskState, index int) {
 			results[index] = fmt.Errorf("function panic")
 			defer wg.Done()
-			klog.V(2).Infof("Executing task %q: %v\n", ts.key, ts.task)
+			klog.Infof("Sri testing..Executing task %q: %v\n", ts.key, ts.task)
 			results[index] = ts.task.Run(e.context)
 		}(tasks[i], i)
 	}


### PR DESCRIPTION
The [e2e tests](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#e2e-kops-do-calico) for DO are failing to create a load balancer. I haven't been able to reproduce it locally, so adding the load balancer ID in logs for further troubleshooting.

FYI - @timoreimann 

