### PR TITLE
Automated cherry pick of #12729: Don't fail validation if Nvidia and containerRuntime defaults

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1404,7 +1404,7 @@ func validateNvidiaConfig(spec *kops.ClusterSpec, nvidia *kops.NvidiaGPUConfig, 
 	if kops.CloudProviderID(spec.CloudProvider) != kops.CloudProviderAWS {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "Nvidia is only supported on AWS"))
 	}
-	if spec.ContainerRuntime != "containerd" {
+	if spec.ContainerRuntime != "" && spec.ContainerRuntime != "containerd" {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "Nvidia is only supported using containerd"))
 	}
 	return allErrs


### PR DESCRIPTION
Cherry pick of #12729 on release-1.22.

#12729: Don't fail validation if Nvidia and containerRuntime defaults

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.