### PR TITLE
Automated cherry pick of #12728: Support setting empty maps and structs

### DIFF
--- a/pkg/commands/set_cluster_test.go
+++ b/pkg/commands/set_cluster_test.go
@@ -63,6 +63,21 @@ func TestSetClusterFields(t *testing.T) {
 			},
 		},
 		{
+			Fields: []string{
+				"spec.api.dns=",
+			},
+			Input: kops.Cluster{
+				Spec: kops.ClusterSpec{},
+			},
+			Output: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					API: &kops.AccessSpec{
+						DNS: &kops.DNSAccessSpec{},
+					},
+				},
+			},
+		},
+		{
 			Fields: []string{"spec.kubelet.authorizationMode=Webhook"},
 			Output: kops.Cluster{
 				Spec: kops.ClusterSpec{

--- a/pkg/commands/unset_cluster_test.go
+++ b/pkg/commands/unset_cluster_test.go
@@ -63,6 +63,23 @@ func TestUnsetClusterFields(t *testing.T) {
 			},
 		},
 		{
+			Fields: []string{
+				"spec.api.dns",
+			},
+			Input: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					API: &kops.AccessSpec{
+						DNS: &kops.DNSAccessSpec{},
+					},
+				},
+			},
+			Output: kops.Cluster{
+				Spec: kops.ClusterSpec{
+					API: &kops.AccessSpec{},
+				},
+			},
+		},
+		{
 			Fields: []string{"spec.kubelet.authorizationMode"},
 			Input: kops.Cluster{
 				Spec: kops.ClusterSpec{

--- a/util/pkg/reflectutils/access.go
+++ b/util/pkg/reflectutils/access.go
@@ -113,6 +113,10 @@ func setPrimitive(v reflect.Value, newValue string) error {
 		return nil
 	}
 
+	if newValue == "" && (v.Type().Kind() == reflect.Map || v.Type().Kind() == reflect.Struct) {
+		return nil
+	}
+
 	if v.Type().Kind() == reflect.Ptr {
 		val := reflect.New(v.Type().Elem())
 		if err := setPrimitive(val.Elem(), newValue); err != nil {


### PR DESCRIPTION
Cherry pick of #12728 on release-1.22.

#12728: Support setting empty maps and structs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.