### PR TITLE
GCE: Fix race around route deletion

### DIFF
--- a/pkg/resources/gce/BUILD.bazel
+++ b/pkg/resources/gce/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//upup/pkg/fi/cloudup/gce:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/dns/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )


### PR DESCRIPTION
Because the control-plane can recreate routes, there's a race between
deleting instances and deleting routes.  Add a dependency so we don't
try to delete routes until after we've deleted all the instances.