### PR TITLE
Use dualstack endpoint for s3

### DIFF
--- a/pkg/model/components/discovery.go
+++ b/pkg/model/components/discovery.go
@@ -68,7 +68,7 @@ func (b *DiscoveryOptionsBuilder) BuildOptions(o interface{}) error {
 			}
 			switch base := base.(type) {
 			case *vfs.S3Path:
-				serviceAccountIssuer, err = base.GetHTTPsUrl()
+				serviceAccountIssuer, err = base.GetHTTPsUrl(clusterSpec.IsIPv6Only())
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
If we are launching kops in an environment with only ipv6, we need to use dualstack endpoints for fetching things from S3.

There is a challenge in that for existing clusters, this will change the issuer urls, and we have run into problems with this in the past.