### PR TITLE
Automated cherry pick of #12721: Fix render template cilium AgentPrometheusPort into a UNICODE

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
@@ -421,7 +421,7 @@ spec:
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ printf "%q" .Networking.Cilium.AgentPrometheusPort }}
+        prometheus.io/port: "{{ .Networking.Cilium.AgentPrometheusPort }}"
         {{ end }}
       labels:
         k8s-app: cilium

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -549,7 +549,7 @@ spec:
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
+        prometheus.io/port: "{{ .AgentPrometheusPort }}"
         {{ end }}
       labels:
         k8s-app: cilium

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -578,7 +578,7 @@ spec:
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
         prometheus.io/scrape: "true"
-        prometheus.io/port: {{ printf "%q" .AgentPrometheusPort }}
+        prometheus.io/port: "{{ .AgentPrometheusPort }}"
         {{ end }}
       labels:
         k8s-app: cilium


### PR DESCRIPTION
Cherry pick of #12721 on release-1.22.

#12721: Fix render template cilium AgentPrometheusPort into a UNICODE

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.