### PR TITLE
Automated cherry pick of #12741: Add create cluster flag for enabling IRSA

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -217,6 +217,11 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		})
 	}
+	cmd.Flags().StringVar(&options.DiscoveryStore, "discovery-store", options.DiscoveryStore, "A public location where we publish OIDC-compatible discovery information under a cluster-specific directory. Enables IRSA in AWS.")
+	cmd.RegisterFlagCompletionFunc("discovery-store", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// TODO complete vfs paths
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	cmd.Flags().StringVar(&options.CloudProvider, "cloud", options.CloudProvider, fmt.Sprintf("Cloud provider to use - %s", strings.Join(cloudup.SupportedClouds(), ", ")))
 	cmd.RegisterFlagCompletionFunc("cloud", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -77,6 +77,7 @@ kops create cluster [CLUSTER] [flags]
       --cloud-labels string              A list of key/value pairs used to tag all instance groups (for example "Owner=John Doe,Team=Some Team").
       --container-runtime string         Container runtime to use: containerd, docker
       --disable-subnet-tags              Disable automatic subnet tagging
+      --discovery-store string           A public location where we publish OIDC-compatible discovery information under a cluster-specific directory. Enables IRSA in AWS.
       --dns string                       DNS type to use: public or private (default "Public")
       --dns-zone string                  DNS hosted zone (defaults to longest matching zone)
       --dry-run                          If true, only print the object that would be sent, without sending it. This flag can be used to create a cluster YAML or JSON manifest.

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 const (
@@ -57,6 +58,8 @@ type NewClusterOptions struct {
 	Channel string
 	// ConfigBase is the location where we will store the configuration. It defaults to the state store.
 	ConfigBase string
+	// DiscoveryStore is the location where we will store public OIDC-compatible discovery documents, under a cluster-specific directory. It defaults to not publishing discovery documents.
+	DiscoveryStore string
 	// KubernetesVersion is the version of Kubernetes to deploy. It defaults to the version recommended by the channel.
 	KubernetesVersion string
 	// AdminAccess is the set of CIDR blocks permitted to connect to the Kubernetes API. It defaults to "0.0.0.0/0" and "::/0".
@@ -249,6 +252,20 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 				return nil, fmt.Errorf("must specify --zones or --cloud")
 			}
 			return nil, fmt.Errorf("unable to infer cloud provider from zones. pass in the cloud provider explicitly using --cloud")
+		}
+	}
+
+	if opt.DiscoveryStore != "" {
+		discoveryPath, err := vfs.Context.BuildVfsPath(opt.DiscoveryStore)
+		if err != nil {
+			return nil, fmt.Errorf("error building DiscoveryStore for cluster: %v", err)
+		}
+		cluster.Spec.ServiceAccountIssuerDiscovery = &api.ServiceAccountIssuerDiscoveryConfig{
+			DiscoveryStore: discoveryPath.Join(cluster.Name).Path(),
+		}
+		if cluster.Spec.CloudProvider == string(api.CloudProviderAWS) {
+			cluster.Spec.ServiceAccountIssuerDiscovery.EnableAWSOIDCProvider = true
+			cluster.Spec.IAM.UseServiceAccountExternalPermissions = fi.Bool(true)
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #12741 on release-1.22.

#12741: Add create cluster flag for enabling IRSA

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.