### PR TITLE
Enable DNS64 on ipv6 subnets

### DIFF
--- a/cloudmock/aws/mockec2/subnets.go
+++ b/cloudmock/aws/mockec2/subnets.go
@@ -72,6 +72,7 @@ func (m *MockEC2) CreateSubnetWithId(request *ec2.CreateSubnetInput, id string) 
 		VpcId:            request.VpcId,
 		CidrBlock:        request.CidrBlock,
 		AvailabilityZone: request.AvailabilityZone,
+		EnableDns64:      aws.Bool(false),
 	}
 
 	if request.Ipv6CidrBlock != nil {
@@ -217,9 +218,11 @@ func (m *MockEC2) AssociateRouteTable(request *ec2.AssociateRouteTableInput) (*e
 	}
 	return response, nil
 }
+
 func (m *MockEC2) AssociateRouteTableWithContext(aws.Context, *ec2.AssociateRouteTableInput, ...request.Option) (*ec2.AssociateRouteTableOutput, error) {
 	panic("Not implemented")
 }
+
 func (m *MockEC2) AssociateRouteTableRequest(*ec2.AssociateRouteTableInput) (*request.Request, *ec2.AssociateRouteTableOutput) {
 	panic("Not implemented")
 }
@@ -243,6 +246,14 @@ func (m *MockEC2) DeleteSubnet(request *ec2.DeleteSubnetInput) (*ec2.DeleteSubne
 func (m *MockEC2) DeleteSubnetWithContext(aws.Context, *ec2.DeleteSubnetInput, ...request.Option) (*ec2.DeleteSubnetOutput, error) {
 	panic("Not implemented")
 }
+
 func (m *MockEC2) DeleteSubnetRequest(*ec2.DeleteSubnetInput) (*request.Request, *ec2.DeleteSubnetOutput) {
 	panic("Not implemented")
+}
+
+func (m *MockEC2) ModifySubnetAttribute(request *ec2.ModifySubnetAttributeInput) (*ec2.ModifySubnetAttributeOutput, error) {
+	id := *request.SubnetId
+	subnet := m.subnets[id]
+	subnet.main.EnableDns64 = request.EnableDns64.Value
+	return nil, nil
 }

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -264,6 +264,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			subnet.IPv6CIDR = fi.String(subnetSpec.IPv6CIDR)
 			// TODO: set this to true once NAT64 is in place
 			subnet.DNS64 = fi.Bool(false)
+			subnet.ResourceBasedNaming = fi.Bool(true)
 		}
 		if subnetSpec.ProviderID != "" {
 			subnet.ID = fi.String(subnetSpec.ProviderID)

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 
 	"k8s.io/klog/v2"
+	"k8s.io/legacy-cloud-providers/aws"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
-	"k8s.io/legacy-cloud-providers/aws"
 )
 
 // NetworkModelBuilder configures network objects
@@ -253,6 +254,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			CIDR:             fi.String(subnetSpec.CIDR),
 			Shared:           fi.Bool(sharedSubnet),
 			Tags:             tags,
+			DNS64:            fi.Bool(false),
 		}
 
 		if subnetSpec.IPv6CIDR != "" {
@@ -260,6 +262,8 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				subnet.AmazonIPv6CIDR = b.LinkToAmazonVPCIPv6CIDR()
 			}
 			subnet.IPv6CIDR = fi.String(subnetSpec.IPv6CIDR)
+			// TODO: set this to true once NAT64 is in place
+			subnet.DNS64 = fi.Bool(false)
 		}
 		if subnetSpec.ProviderID != "" {
 			subnet.ID = fi.String(subnetSpec.ProviderID)
@@ -411,7 +415,6 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			} else {
 				return fmt.Errorf("kops currently only supports re-use of either NAT EC2 Instances or NAT Gateways. We will support more eventually! Please see https://github.com/kubernetes/kops/issues/1530")
 			}
-
 		} else {
 
 			// Every NGW needs a public (Elastic) IP address, every private
@@ -439,7 +442,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			// using a network address translation (NAT) gateway that resides
 			// in the public subnet.
 
-			//var ngw = &awstasks.NatGateway{}
+			// var ngw = &awstasks.NatGateway{}
 			ngw = &awstasks.NatGateway{
 				Name:                 fi.String(zone + "." + b.ClusterName()),
 				Lifecycle:            b.Lifecycle,
@@ -474,7 +477,6 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		// Will route IPv4 to the NAT Gateway
 		var r *awstasks.Route
 		if in != nil {
-
 			r = &awstasks.Route{
 				Name:       fi.String("private-" + zone + "-0.0.0.0/0"),
 				Lifecycle:  b.Lifecycle,
@@ -482,9 +484,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				RouteTable: rt,
 				Instance:   in,
 			}
-
 		} else {
-
 			r = &awstasks.Route{
 				Name:       fi.String("private-" + zone + "-0.0.0.0/0"),
 				Lifecycle:  b.Lifecycle,

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
+
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/cloudformation"
@@ -50,6 +51,7 @@ type Subnet struct {
 	CIDR             *string
 	IPv6CIDR         *string
 	Shared           *bool
+	DNS64            *bool
 
 	Tags map[string]string
 }
@@ -87,6 +89,7 @@ func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
 		Name:             findNameTag(subnet.Tags),
 		Shared:           e.Shared,
 		Tags:             intersectTags(subnet.Tags, e.Tags),
+		DNS64:            subnet.EnableDns64,
 	}
 
 	for _, association := range subnet.Ipv6CidrBlockAssociationSet {
@@ -258,6 +261,16 @@ func (_ *Subnet) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Subnet) error {
 			if err != nil {
 				return fmt.Errorf("error associating subnet cidr block: %v", err)
 			}
+		}
+	}
+	if changes.DNS64 != nil {
+		request := &ec2.ModifySubnetAttributeInput{
+			EnableDns64: &ec2.AttributeBooleanValue{Value: e.DNS64},
+			SubnetId:    e.ID,
+		}
+		_, err := t.Cloud.EC2().ModifySubnetAttribute(request)
+		if err != nil {
+			return fmt.Errorf("error enabling DNS64: %v", err)
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/subnet.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet.go
@@ -44,14 +44,15 @@ type Subnet struct {
 
 	Lifecycle fi.Lifecycle
 
-	ID               *string
-	VPC              *VPC
-	AmazonIPv6CIDR   *VPCAmazonIPv6CIDRBlock
-	AvailabilityZone *string
-	CIDR             *string
-	IPv6CIDR         *string
-	Shared           *bool
-	DNS64            *bool
+	ID                  *string
+	VPC                 *VPC
+	AmazonIPv6CIDR      *VPCAmazonIPv6CIDRBlock
+	AvailabilityZone    *string
+	CIDR                *string
+	IPv6CIDR            *string
+	Shared              *bool
+	DNS64               *bool
+	ResourceBasedNaming *bool
 
 	Tags map[string]string
 }
@@ -82,14 +83,15 @@ func (e *Subnet) Find(c *fi.Context) (*Subnet, error) {
 	}
 
 	actual := &Subnet{
-		ID:               subnet.SubnetId,
-		AvailabilityZone: subnet.AvailabilityZone,
-		VPC:              &VPC{ID: subnet.VpcId},
-		CIDR:             subnet.CidrBlock,
-		Name:             findNameTag(subnet.Tags),
-		Shared:           e.Shared,
-		Tags:             intersectTags(subnet.Tags, e.Tags),
-		DNS64:            subnet.EnableDns64,
+		ID:                  subnet.SubnetId,
+		AvailabilityZone:    subnet.AvailabilityZone,
+		VPC:                 &VPC{ID: subnet.VpcId},
+		CIDR:                subnet.CidrBlock,
+		Name:                findNameTag(subnet.Tags),
+		Shared:              e.Shared,
+		Tags:                intersectTags(subnet.Tags, e.Tags),
+		DNS64:               subnet.EnableDns64,
+		ResourceBasedNaming: subnet.PrivateDnsNameOptionsOnLaunch.EnableResourceNameDnsAAAARecord,
 	}
 
 	for _, association := range subnet.Ipv6CidrBlockAssociationSet {
@@ -263,14 +265,34 @@ func (_ *Subnet) RenderAWS(t *awsup.AWSAPITarget, a, e, changes *Subnet) error {
 			}
 		}
 	}
+
 	if changes.DNS64 != nil {
 		request := &ec2.ModifySubnetAttributeInput{
-			EnableDns64: &ec2.AttributeBooleanValue{Value: e.DNS64},
 			SubnetId:    e.ID,
+			EnableDns64: &ec2.AttributeBooleanValue{Value: e.DNS64},
 		}
 		_, err := t.Cloud.EC2().ModifySubnetAttribute(request)
 		if err != nil {
-			return fmt.Errorf("error enabling DNS64: %v", err)
+			return fmt.Errorf("error enabling DNS64 on subnet: %v", err)
+		}
+	}
+
+	if changes.ResourceBasedNaming != nil {
+		request := &ec2.ModifySubnetAttributeInput{
+			SubnetId:                                e.ID,
+			EnableResourceNameDnsAAAARecordOnLaunch: &ec2.AttributeBooleanValue{Value: e.ResourceBasedNaming},
+		}
+		_, err := t.Cloud.EC2().ModifySubnetAttribute(request)
+		if err != nil {
+			return fmt.Errorf("error enabling resource based dns on subnet: %v", err)
+		}
+		request = &ec2.ModifySubnetAttributeInput{
+			SubnetId:                             e.ID,
+			EnableResourceNameDnsARecordOnLaunch: &ec2.AttributeBooleanValue{Value: e.ResourceBasedNaming},
+		}
+		_, err = t.Cloud.EC2().ModifySubnetAttribute(request)
+		if err != nil {
+			return fmt.Errorf("error enabling resource based dns on subnet: %v", err)
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/awstasks/subnet_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+
 	"k8s.io/kops/cloudmock/aws/mockec2"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
@@ -123,6 +124,7 @@ func TestSubnetCreate(t *testing.T) {
 			Tags: buildTags(map[string]string{
 				"Name": "subnet1",
 			}),
+			EnableDns64: aws.Bool(false),
 		}
 		actual := c.FindSubnet(*subnet1.ID)
 		if actual == nil {
@@ -216,6 +218,7 @@ func TestSubnetCreateIPv6(t *testing.T) {
 			Tags: buildTags(map[string]string{
 				"Name": "subnet1",
 			}),
+			EnableDns64: aws.Bool(false),
 		}
 		actual := c.FindSubnet(*subnet1.ID)
 		if actual == nil {
@@ -309,6 +312,7 @@ func TestSubnetCreateIPv6NetNum(t *testing.T) {
 			Tags: buildTags(map[string]string{
 				"Name": "subnet1",
 			}),
+			EnableDns64: aws.Bool(false),
 		}
 		actual := c.FindSubnet(*subnet1.ID)
 		if actual == nil {
@@ -432,6 +436,7 @@ func TestSharedSubnetCreateDoesNotCreateNew(t *testing.T) {
 				"Name": "ExistingSubnet",
 				"kubernetes.io/cluster/cluster.example.com": "shared",
 			}),
+			EnableDns64: aws.Bool(false),
 		}
 
 		mockec2.SortTags(expected.Tags)


### PR DESCRIPTION
There is nothing NATing these synthetic IPs so for now, this is more just to get kOps to provision instances where one can test the behavior of DNS64 itself.