### PR TITLE
[Digital Ocean] Fix load balancer retry logic while retrieving ip

### DIFF
--- a/upup/pkg/fi/cloudup/do/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/do/BUILD.bazel
@@ -17,9 +17,11 @@ go_library(
         "//pkg/cloudinstances:go_default_library",
         "//protokube/pkg/etcd:go_default_library",
         "//upup/pkg/fi:go_default_library",
+        "//util/pkg/vfs:go_default_library",
         "//vendor/github.com/digitalocean/godo:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -28,6 +28,7 @@ import (
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
 	dns "k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/do"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/kops/pkg/cloudinstances"
 	"k8s.io/kops/protokube/pkg/etcd"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/util/pkg/vfs"
 )
 
 const TagKubernetesClusterIndex = "k8s-index"
@@ -70,6 +72,13 @@ type DOCloud interface {
 	GetAllLoadBalancers() ([]godo.LoadBalancer, error)
 	GetAllDropletsByTag(tag string) ([]godo.Droplet, error)
 	GetAllVolumesByRegion() ([]godo.Volume, error)
+}
+
+var readBackoff = wait.Backoff{
+	Duration: time.Second,
+	Factor:   2,
+	Jitter:   0.1,
+	Steps:    10,
 }
 
 // static compile time check to validate DOCloud's fi.Cloud Interface.
@@ -228,34 +237,41 @@ func (c *doCloudImplementation) FindVPCInfo(id string) (*fi.VPCInfo, error) {
 
 func (c *doCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]fi.ApiIngressStatus, error) {
 	var ingresses []fi.ApiIngressStatus
-	if cluster.Spec.MasterPublicName != "" {
-		// Note that this must match Digital Ocean's lb name
-		klog.V(2).Infof("Querying DO to find Loadbalancers for API (%q)", cluster.Name)
+	done, err := vfs.RetryWithBackoff(readBackoff, func() (bool, error) {
+		if cluster.Spec.MasterPublicName != "" {
+			// Note that this must match Digital Ocean's lb name
+			klog.V(2).Infof("Querying DO to find Loadbalancers for API (%q)", cluster.Name)
 
-		loadBalancers, err := c.GetAllLoadBalancers()
-		if err != nil {
-			return nil, fmt.Errorf("LoadBalancers.List returned error: %v", err)
-		}
+			loadBalancers, err := c.GetAllLoadBalancers()
+			if err != nil {
+				return false, fmt.Errorf("LoadBalancers.List returned error: %v", err)
+			}
 
-		lbName := "api-" + strings.Replace(cluster.Name, ".", "-", -1)
+			lbName := "api-" + strings.Replace(cluster.Name, ".", "-", -1)
 
-		for _, lb := range loadBalancers {
-			if lb.Name == lbName {
-				klog.V(10).Infof("Matching LB name found for API (%q)", cluster.Name)
+			for _, lb := range loadBalancers {
+				if lb.Name == lbName {
+					klog.V(10).Infof("Matching LB name found for API (%q)", cluster.Name)
 
-				if lb.Status != "active" {
-					return nil, fmt.Errorf("load-balancer is not yet active (current status: %s)", lb.Status)
+					if lb.Status != "active" {
+						return false, fmt.Errorf("load-balancer is not yet active (current status: %s)", lb.Status)
+					}
+
+					address := lb.IP
+					ingresses = append(ingresses, fi.ApiIngressStatus{IP: address})
 				}
-
-				address := lb.IP
-				ingresses = append(ingresses, fi.ApiIngressStatus{IP: address})
-
-				return ingresses, nil
 			}
 		}
+		return true, nil
+	})
+	if done {
+		return ingresses, nil
+	} else {
+		if err == nil {
+			err = wait.ErrWaitTimeout
+		}
+		return ingresses, err
 	}
-
-	return nil, nil
 }
 
 // FindClusterStatus discovers the status of the cluster, by looking for the tagged etcd volumes

--- a/upup/pkg/fi/cloudup/dotasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/dotasks/BUILD.bazel
@@ -16,7 +16,9 @@ go_library(
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/do:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
+        "//util/pkg/vfs:go_default_library",
         "//vendor/github.com/digitalocean/godo:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],
 )


### PR DESCRIPTION
The [e2e tests for Digital Ocean cloud provider](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#e2e-kops-do-calico) was failing after this PR got merged - https://github.com/kubernetes/kops/pull/12624/files

With the above changes, kubetest2 was modified to do a create and then followed by an update with `--yes`. But the DO's load balancer logic didn't handle the create logic previously. It assumed that creation happens with `--yes`. So when the args wasn't passed, it kept waiting until the IP address is created, and eventually timesout.

The fix now only checks if loadbalancer IP is created during ingress status check which includes an exponential backoff retry logic. This gets triggered only when cluster creation is triggered.

FYI - @rifelpet @timoreimann 