### PR TITLE
Automated cherry pick of #12677: Fix that states AWS IAM Instance Profile blocks IAM Role

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -2041,6 +2041,7 @@ func ListIAMInstanceProfiles(cloud fi.Cloud, clusterName string) ([]*resources.R
 			Deleter: DeleteIAMInstanceProfile,
 			Obj:     profile,
 		}
+		resourceTracker.Blocks = append(resourceTracker.Blocks, "iam-role:"+name)
 
 		resourceTrackers = append(resourceTrackers, resourceTracker)
 	}


### PR DESCRIPTION
Cherry pick of #12677 on release-1.22.

#12677: Fix that states AWS IAM Instance Profile blocks IAM Role

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```