### PR TITLE
Automated cherry pick of #12765: Shorten filenames in the asset store

### DIFF
--- a/upup/pkg/fi/assetstore.go
+++ b/upup/pkg/fi/assetstore.go
@@ -238,9 +238,10 @@ func (a *AssetStore) addURLs(urls []string, hash *hashing.Hash) error {
 		}
 	}
 
-	// We assume the first url is the "main" url, and download to that _name_, wherever we get it from
+	// We assume the first url is the "main" url, and download to the base of that _name_, wherever we get it from
 	primaryURL := urls[0]
-	localFile := path.Join(a.cacheDir, hash.String()+"_"+utils.SanitizeString(primaryURL))
+	key := path.Base(primaryURL)
+	localFile := path.Join(a.cacheDir, hash.String()+"_"+utils.SanitizeString(key))
 
 	for _, url := range urls {
 		_, err = DownloadURL(url, localFile, hash)
@@ -255,7 +256,6 @@ func (a *AssetStore) addURLs(urls []string, hash *hashing.Hash) error {
 		return err
 	}
 
-	key := path.Base(primaryURL)
 	assetPath := primaryURL
 	r := NewFileResource(localFile)
 
@@ -282,48 +282,6 @@ func (a *AssetStore) addURLs(urls []string, hash *hashing.Hash) error {
 
 	return nil
 }
-
-//func (a *AssetStore) addFile(assetPath string, p string) error {
-//	r := NewFileResource(p)
-//	return a.addResource(assetPath, r)
-//}
-
-//func (a *AssetStore) addResource(assetPath string, r Resource) error {
-//	hash, err := HashForResource(r, HashAlgorithmSHA256)
-//	if err != nil {
-//		return err
-//	}
-//
-//	localFile := path.Join(a.assetDir, hash + "_" + utils.SanitizeString(assetPath))
-//	hasHash, err := fileHasHash(localFile, hash)
-//	if err != nil {
-//		return err
-//	}
-//
-//	if !hasHash {
-//		err = WriteFile(localFile, r, 0644, 0755)
-//		if err != nil {
-//			return err
-//		}
-//	}
-//
-//	asset := &asset{
-//		Key:       localFile,
-//		AssetPath: assetPath,
-//		resource:  r,
-//	}
-//	klog.V(2).Infof("added asset %q for %q", asset.Key, asset.resource)
-//	a.assets = append(a.assets, asset)
-//
-//	if strings.HasSuffix(assetPath, ".tar.gz") {
-//		err = a.addArchive(localFile)
-//		if err != nil {
-//			return err
-//		}
-//	}
-//
-//	return nil
-//}
 
 func (a *AssetStore) addArchive(archiveSource *Source, archiveFile string) error {
 	extracted := path.Join(a.cacheDir, "extracted/"+path.Base(archiveFile))


### PR DESCRIPTION
Cherry pick of #12765 on release-1.21.

#12765: Shorten filenames in the asset store

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.