### PR TITLE
e2e tests: recognize a full KOPS_BASE_URL as a KOPS_VERSION

### DIFF
--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -90,7 +90,9 @@ function kops-download-from-base() {
 }
 
 function kops-base-from-marker() {
-    if [[ "${1}" == "latest" ]]; then
+    if [[ "${1}" =~ ^https: ]]; then
+        echo "${1}"
+    elif [[ "${1}" == "latest" ]]; then
         curl -s "https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt"
     else
         curl -s "https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-${1}/latest-ci.txt"


### PR DESCRIPTION
This allows us to easily test arbitrary versions (e.g. PR builds)
