### PR TITLE
Stable-sort subnets by Name

### DIFF
--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -455,7 +455,7 @@ func (e *NetworkLoadBalancer) Run(c *fi.Context) error {
 
 func (e *NetworkLoadBalancer) Normalize() {
 	// We need to sort our arrays consistently, so we don't get spurious changes
-	sort.Stable(OrderSubnetMappingsByID(e.SubnetMappings))
+	sort.Stable(OrderSubnetMappingsByName(e.SubnetMappings))
 	sort.Stable(OrderListenersByPort(e.Listeners))
 	sort.Stable(OrderTargetGroupsByName(e.TargetGroups))
 }

--- a/upup/pkg/fi/cloudup/awstasks/subnet_mapping.go
+++ b/upup/pkg/fi/cloudup/awstasks/subnet_mapping.go
@@ -49,6 +49,17 @@ func (a OrderSubnetMappingsByID) Less(i, j int) bool {
 	return v1 < v2
 }
 
+// OrderSubnetMappingsByName implements sort.Interface for []Subnet, based on Name
+type OrderSubnetMappingsByName []*SubnetMapping
+
+func (a OrderSubnetMappingsByName) Len() int      { return len(a) }
+func (a OrderSubnetMappingsByName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a OrderSubnetMappingsByName) Less(i, j int) bool {
+	v1 := fi.StringValue(a[i].Subnet.Name)
+	v2 := fi.StringValue(a[j].Subnet.Name)
+	return v1 < v2
+}
+
 func subnetMappingSlicesEqualIgnoreOrder(l, r []*SubnetMapping) bool {
 	lBySubnet := make(map[string]*SubnetMapping)
 	for _, s := range l {


### PR DESCRIPTION
This ensures a stable order, even if/when the IDs aren't set (e.g. in terraform)