### PR TITLE
Remove featureflag for creating IPv6 clusters

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -314,9 +314,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	// TODO: Can we deprecate this flag - it is awkward?
 	cmd.Flags().BoolVar(&associatePublicIP, "associate-public-ip", false, "Specify --associate-public-ip=[true|false] to enable/disable association of public IP for master ASG and nodes. Default is 'true'.")
 
-	if featureflag.AWSIPv6.Enabled() {
-		cmd.Flags().BoolVar(&options.IPv6, "ipv6", false, "Allocate IPv6 CIDRs to subnets for clusters with public topology (AWS only)")
-	}
+	cmd.Flags().BoolVar(&options.IPv6, "ipv6", false, "Use IPv6 for the pod network (AWS only)")
 
 	cmd.Flags().StringSliceVar(&options.NodeSecurityGroups, "node-security-groups", options.NodeSecurityGroups, "Additional precreated security groups to add to worker nodes.")
 	cmd.RegisterFlagCompletionFunc("node-security-groups", completeSecurityGroup)

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -277,11 +277,6 @@ func TestMinimalIPv6Private(t *testing.T) {
 
 // TestMinimalIPv6Calico runs the test on a minimum IPv6 configuration with Calico
 func TestMinimalIPv6Calico(t *testing.T) {
-	featureflag.ParseFlags("+AWSIPv6")
-	unsetFeatureFlags := func() {
-		featureflag.ParseFlags("-AWSIPv6")
-	}
-	defer unsetFeatureFlags()
 	newIntegrationTest("minimal-ipv6.example.com", "minimal-ipv6-calico").
 		withAddons(awsCCMAddon, awsEBSCSIAddon, calicoAddon, dnsControllerAddon).
 		runTestTerraformAWS(t)
@@ -290,11 +285,6 @@ func TestMinimalIPv6Calico(t *testing.T) {
 
 // TestMinimalIPv6Calico runs the test on a minimum IPv6 configuration with Cilium
 func TestMinimalIPv6Cilium(t *testing.T) {
-	featureflag.ParseFlags("+AWSIPv6")
-	unsetFeatureFlags := func() {
-		featureflag.ParseFlags("-AWSIPv6")
-	}
-	defer unsetFeatureFlags()
 	newIntegrationTest("minimal-ipv6.example.com", "minimal-ipv6-cilium").
 		withAddons(awsCCMAddon, awsEBSCSIAddon, ciliumAddon, dnsControllerAddon).
 		runTestTerraformAWS(t)

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -86,6 +86,7 @@ kops create cluster [CLUSTER] [flags]
       --gce-service-account string       Service account with which the GCE VM runs. Warning: if not set, VMs will run as default compute service account.
   -h, --help                             help for cluster
       --image string                     Machine image for all instances
+      --ipv6                             Use IPv6 for the pod network (AWS only)
       --kubernetes-version string        Version of kubernetes to run (defaults to version in channel)
       --master-count int32               Number of masters. Defaults to one master per master-zone
       --master-image string              Machine image for masters. Takes precedence over --image

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -86,8 +86,6 @@ var (
 	APIServerNodes = new("APIServerNodes", Bool(false))
 	// UseAddonOperators activates experimental addon operator support
 	UseAddonOperators = new("UseAddonOperators", Bool(false))
-	// AWSIPv6 activates experimental AWS IPv6 support.
-	AWSIPv6 = new("AWSIPv6", Bool(false))
 	// TerraformManagedFiles enables rendering managed files into the Terraform configuration.
 	TerraformManagedFiles = new("TerraformManagedFiles", Bool(true))
 	// AlphaAllowGCE is a feature flag that gates GCE support while it is alpha.


### PR DESCRIPTION
Makes it easier for operators to create IPv6 clusters, which and should be pretty good already in 1.23.