### PR TITLE
Fix volume ratio comparisons

### DIFF
--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -65,7 +65,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["bootstrapscript_test.go"],
+    srcs = [
+        "bootstrapscript_test.go",
+        "master_volumes_test.go",
+    ],
     data = glob(["tests/**"]),  #keep
     embed = [":go_default_library"],
     deps = [

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -197,18 +197,18 @@ func validateAWSVolume(name, volumeType string, volumeSize, volumeIops, volumeTh
 	volumeThroughputIopsRatio := float64(volumeThroughput) / float64(volumeIops)
 	switch volumeType {
 	case ec2.VolumeTypeIo1:
-		if volumeIopsSizeRatio >= 50.0 {
+		if volumeIopsSizeRatio > 50.0 {
 			return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 50. For %s ratio is %.02f", name, volumeIopsSizeRatio)
 		}
 	case ec2.VolumeTypeIo2:
-		if volumeIopsSizeRatio >= 500.0 {
+		if volumeIopsSizeRatio > 500.0 {
 			return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 500. For %s ratio is %.02f", name, volumeIopsSizeRatio)
 		}
 	case ec2.VolumeTypeGp3:
-		if volumeIops > 3000 && volumeIopsSizeRatio >= 500.0 {
+		if volumeIops > 3000 && volumeIopsSizeRatio > 500.0 {
 			return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 500. For %s ratio is %.02f", name, volumeIopsSizeRatio)
 		}
-		if volumeThroughputIopsRatio >= 0.25 {
+		if volumeThroughputIopsRatio > 0.25 {
 			return fmt.Errorf("volumeThroughput to volumeIops ratio must be lower than 0.25. For %s ratio is %.02f", name, volumeThroughputIopsRatio)
 		}
 	}

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/upup/pkg/fi"
@@ -143,24 +144,9 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 			volumeThroughput = DefaultAWSEtcdVolumeGp3Throughput
 		}
 	}
-	volumeIopsSizeRatio := float64(volumeIops) / float64(volumeSize)
-	volumeThroughputIopsRatio := float64(volumeThroughput) / float64(volumeIops)
-	switch volumeType {
-	case ec2.VolumeTypeIo1:
-		if volumeIopsSizeRatio >= 50.0 {
-			return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 50. For %s ratio is %.02f", name, volumeIopsSizeRatio)
-		}
-	case ec2.VolumeTypeIo2:
-		if volumeIopsSizeRatio >= 500.0 {
-			return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 500. For %s ratio is %.02f", name, volumeIopsSizeRatio)
-		}
-	case ec2.VolumeTypeGp3:
-		if volumeIops > 3000 && volumeIopsSizeRatio >= 500.0 {
-			return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 500. For %s ratio is %.02f", name, volumeIopsSizeRatio)
-		}
-		if volumeThroughputIopsRatio >= 0.25 {
-			return fmt.Errorf("volumeThroughput to volumeIops ratio must be lower than 0.25. For %s ratio is %.02f", name, volumeThroughputIopsRatio)
-		}
+
+	if err := validateAWSVolume(name, volumeType, volumeSize, volumeIops, volumeThroughput); err != nil {
+		return err
 	}
 
 	// The tags are how protokube knows to mount the volume and use it for etcd
@@ -171,7 +157,7 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 		tags[k] = v
 	}
 
-	//tags[awsup.TagClusterName] = b.C.cluster.Name
+	// tags[awsup.TagClusterName] = b.C.cluster.Name
 	// This is the configuration of the etcd cluster
 	tags[awsup.TagNameEtcdClusterPrefix+etcd.Name] = m.Name + "/" + strings.Join(allMembers, ",")
 	// This says "only mount on a master"
@@ -203,6 +189,29 @@ func (b *MasterVolumeBuilder) addAWSVolume(c *fi.ModelBuilderContext, name strin
 
 	c.AddTask(t)
 
+	return nil
+}
+
+func validateAWSVolume(name, volumeType string, volumeSize, volumeIops, volumeThroughput int32) error {
+	volumeIopsSizeRatio := float64(volumeIops) / float64(volumeSize)
+	volumeThroughputIopsRatio := float64(volumeThroughput) / float64(volumeIops)
+	switch volumeType {
+	case ec2.VolumeTypeIo1:
+		if volumeIopsSizeRatio >= 50.0 {
+			return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 50. For %s ratio is %.02f", name, volumeIopsSizeRatio)
+		}
+	case ec2.VolumeTypeIo2:
+		if volumeIopsSizeRatio >= 500.0 {
+			return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 500. For %s ratio is %.02f", name, volumeIopsSizeRatio)
+		}
+	case ec2.VolumeTypeGp3:
+		if volumeIops > 3000 && volumeIopsSizeRatio >= 500.0 {
+			return fmt.Errorf("volumeIops to volumeSize ratio must be lower than 500. For %s ratio is %.02f", name, volumeIopsSizeRatio)
+		}
+		if volumeThroughputIopsRatio >= 0.25 {
+			return fmt.Errorf("volumeThroughput to volumeIops ratio must be lower than 0.25. For %s ratio is %.02f", name, volumeThroughputIopsRatio)
+		}
+	}
 	return nil
 }
 
@@ -312,7 +321,7 @@ func (b *MasterVolumeBuilder) addOpenstackVolume(c *fi.ModelBuilderContext, name
 }
 
 func (b *MasterVolumeBuilder) addALIVolume(c *fi.ModelBuilderContext, name string, volumeSize int32, zone string, etcd kops.EtcdClusterSpec, m kops.EtcdMemberSpec, allMembers []string) {
-	//Alicloud does not support volumeName starts with number
+	// Alicloud does not support volumeName starts with number
 	name = "v" + name
 	volumeType := fi.StringValue(m.VolumeType)
 	if volumeType == "" {

--- a/pkg/model/master_volumes_test.go
+++ b/pkg/model/master_volumes_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"testing"
+)
+
+func TestValidateAWSVolumeAllow50ratio(t *testing.T) {
+	volumeName := "a"
+	volumeType := "io1"
+	volumeIops := 1000
+	volumeThroughput := 0
+	volumeSize := 20
+
+	err := validateAWSVolume(volumeName, volumeType, int32(volumeSize), int32(volumeIops), int32(volumeThroughput))
+	if err != nil {
+		t.Errorf("Failed to validate valid etcd member spec: %v", err)
+	}
+}


### PR DESCRIPTION
Our ratio checks check for e.g == 50, which is actually allowed by AWS.
Fixes #12038