### PR TITLE
Check that there are extra fields and not fields being removed

### DIFF
--- a/pkg/edit/edit.go
+++ b/pkg/edit/edit.go
@@ -18,8 +18,10 @@ package edit
 
 import (
 	"bytes"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"k8s.io/kops/pkg/diff"
 	"k8s.io/kops/pkg/kopscodecs"
 	"k8s.io/kops/upup/pkg/fi/utils"
@@ -51,7 +53,11 @@ func HasExtraFields(yaml string, object runtime.Object) (string, error) {
 
 	if !bytes.Equal(editedYaml, newYaml) {
 		discardedChanges := diff.FormatDiff(string(newYaml), string(editedYaml))
-		return discardedChanges, nil
+		for _, line := range strings.Split(discardedChanges, "\n") {
+			if strings.HasPrefix(line, "-") {
+				return discardedChanges, nil
+			}
+		}
 	}
 
 	return "", nil

--- a/pkg/edit/edit_test.go
+++ b/pkg/edit/edit_test.go
@@ -23,19 +23,22 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"k8s.io/kops/pkg/apis/kops"
 )
 
-var testTimestamp = metav1.Time{Time: time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)}
-var testObj = kops.Cluster{
-	ObjectMeta: metav1.ObjectMeta{
-		CreationTimestamp: testTimestamp,
-		Name:              "hello",
-	},
-	Spec: kops.ClusterSpec{
-		KubernetesVersion: "1.2.3",
-	},
-}
+var (
+	testTimestamp = metav1.Time{Time: time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)}
+	testObj       = kops.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: testTimestamp,
+			Name:              "hello",
+		},
+		Spec: kops.ClusterSpec{
+			KubernetesVersion: "1.2.3",
+		},
+	}
+)
 
 func TestHasExtraFields(t *testing.T) {
 	tests := []struct {
@@ -74,6 +77,20 @@ func TestHasExtraFields(t *testing.T) {
 			- spec:
 			    kubernetesVersion: 1.2.3
 			`),
+		},
+		{
+			obj: &testObj,
+			yaml: heredoc.Doc(`
+			apiVersion: kops.k8s.io/v1alpha2
+			kind: Cluster
+			metadata:
+			  creationTimestamp: "2017-01-01T00:00:00Z"
+			  name: hello
+			spec:
+			  kubernetesVersion: 1.2.3
+			  isolateMasters: false
+			`),
+			expected: "",
 		},
 	}
 


### PR DESCRIPTION
When we check for extra fields, we check only check for byte equality. But because of omitEmpty, fields set explicitly to false are removed, which cause a diff of removed line. This change will ignore these removed lines.