### PR TITLE
Update cluster_spec.md

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -415,7 +415,7 @@ spec:
       clusters:
       - name: server
         cluster:
-          server: https://my-webook-receiver
+          server: https://my-webhook-receiver
       contexts:
       - context:
           cluster: server


### PR DESCRIPTION
This is a fix for issue number Webhook is misspelt in kops/docs/cluster_spec.md #12809