### PR TITLE
Automated cherry pick of #12789: Add support for --dns flag in Docker config

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -732,6 +732,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  dns:
+                    description: DNS is the IP address of the DNS server
+                    items:
+                      type: string
+                    type: array
                   execOpt:
                     description: ExecOpt is a series of options passed to the runtime
                     items:

--- a/nodeup/pkg/model/docker_test.go
+++ b/nodeup/pkg/model/docker_test.go
@@ -105,6 +105,18 @@ func TestDockerBuilder_BuildFlags(t *testing.T) {
 			kops.DockerConfig{InsecureRegistries: []string{"registry1", "registry2"}},
 			"--insecure-registry=registry1 --insecure-registry=registry2",
 		},
+		{
+			kops.DockerConfig{DNS: []string{}},
+			"",
+		},
+		{
+			kops.DockerConfig{DNS: []string{"8.8.4.4"}},
+			"--dns=8.8.4.4",
+		},
+		{
+			kops.DockerConfig{DNS: []string{"8.8.4.4", "8.8.8.8"}},
+			"--dns=8.8.4.4 --dns=8.8.8.8",
+		},
 	}
 
 	for _, g := range grid {

--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -30,6 +30,8 @@ type DockerConfig struct {
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
 	// DefaultRuntime is the default OCI runtime for containers (default "runc")
 	DefaultRuntime *string `json:"defaultRuntime,omitempty" flag:"default-runtime"`
+	// DNS is the IP address of the DNS server
+	DNS []string `json:"dns,omitempty" flag:"dns,repeat"`
 	// ExecOpt is a series of options passed to the runtime
 	ExecOpt []string `json:"execOpt,omitempty" flag:"exec-opt,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -30,6 +30,8 @@ type DockerConfig struct {
 	DefaultUlimit []string `json:"defaultUlimit,omitempty" flag:"default-ulimit,repeat"`
 	// DefaultRuntime is the default OCI runtime for containers (default "runc")
 	DefaultRuntime *string `json:"defaultRuntime,omitempty" flag:"default-runtime"`
+	// DNS is the IP address of the DNS server
+	DNS []string `json:"dns,omitempty" flag:"dns,repeat"`
 	// ExecOpt is a series of options passed to the runtime
 	ExecOpt []string `json:"execOpt,omitempty" flag:"exec-opt,repeat"`
 	// ExecRoot is the root directory for execution state files (default "/var/run/docker")

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3211,6 +3211,7 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
 	out.DefaultRuntime = in.DefaultRuntime
+	out.DNS = in.DNS
 	out.ExecOpt = in.ExecOpt
 	out.ExecRoot = in.ExecRoot
 	out.Experimental = in.Experimental
@@ -3258,6 +3259,7 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.DataRoot = in.DataRoot
 	out.DefaultUlimit = in.DefaultUlimit
 	out.DefaultRuntime = in.DefaultRuntime
+	out.DNS = in.DNS
 	out.ExecOpt = in.ExecOpt
 	out.ExecRoot = in.ExecRoot
 	out.Experimental = in.Experimental

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1376,6 +1376,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DNS != nil {
+		in, out := &in.DNS, &out.DNS
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExecOpt != nil {
 		in, out := &in.ExecOpt, &out.ExecOpt
 		*out = make([]string, len(*in))

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1499,6 +1499,11 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DNS != nil {
+		in, out := &in.DNS, &out.DNS
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ExecOpt != nil {
 		in, out := &in.ExecOpt, &out.ExecOpt
 		*out = make([]string, len(*in))


### PR DESCRIPTION
Cherry pick of #12789 on release-1.21.

#12789: Add support for --dns flag in Docker config

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.