### PR TITLE
Fix enabling of AWS CCM

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -36,15 +36,15 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 
 	clusterSpec := o.(*kops.ClusterSpec)
 
-	eccm := clusterSpec.ExternalCloudControllerManager
-
 	if kops.CloudProviderID(clusterSpec.CloudProvider) != kops.CloudProviderAWS {
 		return nil
 	}
 
-	if eccm == nil && b.IsKubernetesGTE("1.24") {
-		eccm = &kops.CloudControllerManagerConfig{}
+	if clusterSpec.ExternalCloudControllerManager == nil && b.IsKubernetesGTE("1.24") {
+		clusterSpec.ExternalCloudControllerManager = &kops.CloudControllerManagerConfig{}
 	}
+
+	eccm := clusterSpec.ExternalCloudControllerManager
 
 	if eccm == nil {
 		return nil

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -79,11 +79,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 	kcm.ClusterName = b.ClusterName
 	switch kops.CloudProviderID(clusterSpec.CloudProvider) {
 	case kops.CloudProviderAWS:
-		if b.IsKubernetesGTE("1.24") {
-			kcm.CloudProvider = "external"
-		} else {
-			kcm.CloudProvider = "aws"
-		}
+		kcm.CloudProvider = "aws"
 
 	case kops.CloudProviderGCE:
 		kcm.CloudProvider = "gce"
@@ -106,7 +102,7 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 	}
 
 	if clusterSpec.ExternalCloudControllerManager == nil {
-		if kcm.CloudProvider == "aws" && b.IsKubernetesGTE("1.23") && b.IsKubernetesLT("1.24") {
+		if kcm.CloudProvider == "aws" && b.IsKubernetesGTE("1.23") {
 			kcm.EnableLeaderMigration = fi.Bool(true)
 		}
 	} else {


### PR DESCRIPTION
/kind bug

The code disabled KCM in 1.24, but didn't enable CCM. This broke the kops-aws-k8s-latest periodic test, as latest now identifies as 1.24.