### PR TITLE
Skip SCTP test on cilium clusters in k8s 1.24 as well

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -51,7 +51,7 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|external.IP.is.not.assigned.to.a.node"
 		// https://github.com/cilium/cilium/issues/14287
 		skipRegex += "|same.port.number.but.different.protocols|same.hostPort.but.different.hostIP.and.protocol"
-		if strings.Contains(cluster.Spec.KubernetesVersion, "v1.23.0") {
+		if strings.Contains(cluster.Spec.KubernetesVersion, "v1.23.0") || strings.Contains(cluster.Spec.KubernetesVersion, "v1.24.0") {
 			// Reassess after https://github.com/kubernetes/kubernetes/pull/102643 is merged
 			// ref:
 			// https://github.com/kubernetes/kubernetes/issues/96717


### PR DESCRIPTION
With the first k8s 1.24 tag cut, prow jobs are now testing with k8s 1.24 and this test is no longer being skipped even though the PR and issues mentioned in the comments are still open. This skips the test in k8s 1.24 as well.

fixes https://testgrid.k8s.io/kops-misc#kops-grid-scenario-cilium10-arm64