### PR TITLE
Route NAT64 to NAT Gateway in IPv6 private topology

### DIFF
--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -498,6 +498,17 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(r)
 
 		if b.IsIPv6Only() {
+			// Route NAT64 well-known prefix to the NAT gateway
+			c.AddTask(&awstasks.Route{
+				Name:       fi.String("private-" + zone + "-64:ff9b::/96"),
+				Lifecycle:  b.Lifecycle,
+				IPv6CIDR:   fi.String("64:ff9b::/96"),
+				RouteTable: rt,
+				// Only one of these will be not nil
+				NatGateway:       ngw,
+				TransitGatewayID: tgwID,
+			})
+
 			// Route IPv6 to the Egress-only Internet Gateway.
 			c.AddTask(&awstasks.Route{
 				Name:                      fi.String("private-" + zone + "-::/0"),

--- a/tests/integration/update_cluster/minimal-ipv6-private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-private/kubernetes.tf
@@ -596,6 +596,12 @@ resource "aws_route" "route-private-us-test-1a-0-0-0-0--0" {
   route_table_id         = aws_route_table.private-us-test-1a-minimal-ipv6-example-com.id
 }
 
+resource "aws_route" "route-private-us-test-1a-64_ff9b__--96" {
+  destination_ipv6_cidr_block = "64:ff9b::/96"
+  nat_gateway_id              = aws_nat_gateway.us-test-1a-minimal-ipv6-example-com.id
+  route_table_id              = aws_route_table.private-us-test-1a-minimal-ipv6-example-com.id
+}
+
 resource "aws_route" "route-private-us-test-1a-__--0" {
   destination_ipv6_cidr_block = "::/0"
   egress_only_gateway_id      = aws_egress_only_internet_gateway.minimal-ipv6-example-com.id
@@ -606,6 +612,12 @@ resource "aws_route" "route-private-us-test-1b-0-0-0-0--0" {
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.us-test-1b-minimal-ipv6-example-com.id
   route_table_id         = aws_route_table.private-us-test-1b-minimal-ipv6-example-com.id
+}
+
+resource "aws_route" "route-private-us-test-1b-64_ff9b__--96" {
+  destination_ipv6_cidr_block = "64:ff9b::/96"
+  nat_gateway_id              = aws_nat_gateway.us-test-1b-minimal-ipv6-example-com.id
+  route_table_id              = aws_route_table.private-us-test-1b-minimal-ipv6-example-com.id
 }
 
 resource "aws_route" "route-private-us-test-1b-__--0" {


### PR DESCRIPTION
Routes the well-known NAT64 prefix to the NAT gateway (or Transit Gateway if that's what's specified in `egress`) in IPv6 clusters with private topology.

A future PR will need to provide this option for public topology, but we will might want an option in the cluster spec in case the user doesn't need NAT64 and thus doesn't want to pay for a NAT Gateway.

We might want to later provide option to route NAT64 differently than IPv4 egress.
