### PR TITLE
Use AWS metadata to retrieve local-hostname in nodeup

### DIFF
--- a/nodeup/pkg/model/BUILD.bazel
+++ b/nodeup/pkg/model/BUILD.bazel
@@ -67,7 +67,6 @@ go_library(
         "//util/pkg/distributions:go_default_library",
         "//util/pkg/proxy:go_default_library",
         "//util/pkg/vfs:go_default_library",
-        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/ec2metadata:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",

--- a/upup/pkg/fi/nodeup/BUILD.bazel
+++ b/upup/pkg/fi/nodeup/BUILD.bazel
@@ -33,7 +33,6 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/aws/ec2metadata:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/autoscaling:go_default_library",
-        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/kms:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],


### PR DESCRIPTION
Cloud Provider: AWS

This PR changes nodeups method of looking up an instance private DNS name from a DescribeInstances call to an instance metadata lookup. DescribeInstances is prone to throttling with large clusters and can cause significant delays when a node is trying to join a cluster.