### PR TITLE
Use NAT64 instead of dual-stack for AWS EBS CSI driver

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -627,8 +627,6 @@ spec:
         - --extra-tags=KubernetesCluster=minimal-ipv6.example.com
         - --v=5
         env:
-        - name: AWS_EC2_ENDPOINT
-          value: https://api.ec2.us-test-1.aws
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5e4856fdee88cd2aa86d4ffe5bf8d33d365991d861a5a25d6d217d2262f776b9
+    manifestHash: 859d2efbcb97d06440eeb782ebbd761fa2cd1b350a830585a8e24a0e1e9a3088
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -627,8 +627,6 @@ spec:
         - --extra-tags=KubernetesCluster=minimal-ipv6.example.com
         - --v=5
         env:
-        - name: AWS_EC2_ENDPOINT
-          value: https://api.ec2.us-test-1.aws
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5e4856fdee88cd2aa86d4ffe5bf8d33d365991d861a5a25d6d217d2262f776b9
+    manifestHash: 859d2efbcb97d06440eeb782ebbd761fa2cd1b350a830585a8e24a0e1e9a3088
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -627,8 +627,6 @@ spec:
         - --extra-tags=KubernetesCluster=minimal-ipv6.example.com
         - --v=5
         env:
-        - name: AWS_EC2_ENDPOINT
-          value: https://api.ec2.us-test-1.aws
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5e4856fdee88cd2aa86d4ffe5bf8d33d365991d861a5a25d6d217d2262f776b9
+    manifestHash: 859d2efbcb97d06440eeb782ebbd761fa2cd1b350a830585a8e24a0e1e9a3088
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -627,8 +627,6 @@ spec:
         - --extra-tags=KubernetesCluster=minimal-ipv6.example.com
         - --v=5
         env:
-        - name: AWS_EC2_ENDPOINT
-          value: https://api.ec2.us-test-1.aws
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
         - name: CSI_NODE_NAME

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 5e4856fdee88cd2aa86d4ffe5bf8d33d365991d861a5a25d6d217d2262f776b9
+    manifestHash: 859d2efbcb97d06440eeb782ebbd761fa2cd1b350a830585a8e24a0e1e9a3088
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -440,10 +440,6 @@ spec:
             - --v=5
           env:
             {{- if IsIPv6Only }}
-            # TODO: Replace with "AWS_USE_DUALSTACK_ENDPOINT=true" when the relevant PR is merged:
-            # https://github.com/aws/aws-sdk-go/pull/3938
-            - name: AWS_EC2_ENDPOINT
-              value: https://api.ec2.{{ Region }}.aws
             - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
               value: IPv6
             {{- end }}


### PR DESCRIPTION
`AWS_EC2_ENDPOINT=https://api.ec2.us-east-1.aws` is broken as it overrides both EC2 and STS endpoint:
https://github.com/kubernetes/kops/pull/12843#issuecomment-980827347

The above is not needed with NAT64 and using `AWS_USE_DUALSTACK_ENDPOINT=true` needs more testing.

/cc @johngmyers @olemarkus @rifelpet 