### PR TITLE
Support NodeLocalDNS on IPv6 clusters

### DIFF
--- a/pkg/model/components/kubedns.go
+++ b/pkg/model/components/kubedns.go
@@ -91,7 +91,11 @@ func (b *KubeDnsOptionsBuilder) BuildOptions(o interface{}) error {
 		nodeLocalDNS.Enabled = fi.Bool(false)
 	}
 	if fi.BoolValue(nodeLocalDNS.Enabled) && nodeLocalDNS.LocalIP == "" {
-		nodeLocalDNS.LocalIP = "169.254.20.10"
+		if clusterSpec.IsIPv6Only() {
+			nodeLocalDNS.LocalIP = "fd00:90de:d95::1"
+		} else {
+			nodeLocalDNS.LocalIP = "169.254.20.10"
+		}
 	}
 	if fi.BoolValue(nodeLocalDNS.Enabled) && nodeLocalDNS.ForwardToKubeDNS == nil {
 		nodeLocalDNS.ForwardToKubeDNS = fi.Bool(false)

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -54,7 +54,7 @@ data:
           force_tcp
         }
         prometheus :9253
-        health {{ KubeDNS.NodeLocalDNS.LocalIP }}:{{ NodeLocalDNSHealthCheck }}
+        health {{ joinHostPort KubeDNS.NodeLocalDNS.LocalIP NodeLocalDNSHealthCheck }}
     }
     {{- if WithDefaultBool KubeDNS.NodeLocalDNS.ForwardToKubeDNS false }}
     .:53 {
@@ -99,9 +99,6 @@ data:
         bind {{ KubeDNS.NodeLocalDNS.LocalIP }}
         forward . __PILLAR__UPSTREAM__SERVERS__
         prometheus :9253
-        {{- if IsIPv6Only }}
-        dns64
-        {{- end }}
     }
     {{- end }}
 ---

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -31,6 +31,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path"
 	"sort"
@@ -87,6 +88,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["join"] = func(a []string, sep string) string {
 		return strings.Join(a, sep)
 	}
+	dest["joinHostPort"] = net.JoinHostPort
 
 	sprigTxtFuncMap := sprig.TxtFuncMap()
 	dest["nindent"] = sprigTxtFuncMap["nindent"]


### PR DESCRIPTION
The `dns64` plugin is not supported by node-cache, so I had to temporarily remove that from our template. I filed kubernetes/dns#489 to add the plugin.

IPv6 doesn't have unscoped link-local addresses, so I had to invent an ULA.
