### PR TITLE
Automated cherry pick of #12846: Reissue client keypairs on issuer change

### DIFF
--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -2,6 +2,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -10,6 +11,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -18,6 +20,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -26,6 +29,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -34,6 +38,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -2,6 +2,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -10,6 +11,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -18,6 +20,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -26,6 +29,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -34,6 +38,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca

--- a/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
@@ -2,6 +2,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -10,6 +11,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -18,6 +20,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -26,6 +29,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -34,6 +38,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -2,6 +2,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -10,6 +11,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -18,6 +20,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -26,6 +29,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -34,6 +38,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -79,6 +79,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -87,6 +88,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -95,6 +97,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -103,6 +106,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -111,6 +115,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -119,6 +124,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -130,10 +136,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -145,10 +153,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -157,6 +167,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -165,6 +176,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -78,6 +78,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -86,6 +87,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -94,6 +96,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -102,6 +105,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -110,6 +114,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -118,6 +123,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -129,10 +135,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -144,10 +152,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -156,6 +166,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -164,6 +175,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -78,6 +78,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -86,6 +87,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -94,6 +96,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -102,6 +105,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -110,6 +114,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -118,6 +123,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -129,10 +135,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -144,10 +152,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -156,6 +166,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -164,6 +175,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
@@ -77,6 +77,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -85,6 +86,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -93,6 +95,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -101,6 +104,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -109,6 +113,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -117,6 +122,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -128,10 +134,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -143,10 +151,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -155,6 +165,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -163,6 +174,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -545,6 +545,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -553,6 +554,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -561,6 +563,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -569,6 +572,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -577,6 +581,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -585,6 +590,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -596,10 +602,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -611,10 +619,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -623,6 +633,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -631,6 +642,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -520,6 +520,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -528,6 +529,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -536,6 +538,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -544,6 +547,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -552,6 +556,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -560,6 +565,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -571,10 +577,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -586,10 +594,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -598,6 +608,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -606,6 +617,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -557,6 +557,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -565,6 +566,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -573,6 +575,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -581,6 +584,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -589,6 +593,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -597,6 +602,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -608,10 +614,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -623,10 +631,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -635,6 +645,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -643,6 +654,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -479,6 +479,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -487,6 +488,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -495,6 +497,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -503,6 +506,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -511,6 +515,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -519,6 +524,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -530,10 +536,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -545,10 +553,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -557,6 +567,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -565,6 +576,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -235,6 +235,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -243,6 +244,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -251,6 +253,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -259,6 +262,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -267,6 +271,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -275,6 +280,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -286,10 +292,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -301,10 +309,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -313,6 +323,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -321,6 +332,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -261,6 +261,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -269,6 +270,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -277,6 +279,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -285,6 +288,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -293,6 +297,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -301,6 +306,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -312,10 +318,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -327,10 +335,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -339,6 +349,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -347,6 +358,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -161,6 +161,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -169,6 +170,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -177,6 +179,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -185,6 +188,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -193,6 +197,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -201,6 +206,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -212,10 +218,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -227,10 +235,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -239,6 +249,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -247,6 +258,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -187,6 +187,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -195,6 +196,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -203,6 +205,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -211,6 +214,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -219,6 +223,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -227,6 +232,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -238,10 +244,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -253,10 +261,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -265,6 +275,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -273,6 +284,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -79,6 +79,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -87,6 +88,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -95,6 +97,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -103,6 +106,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -111,6 +115,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -119,6 +124,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -130,10 +136,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -145,10 +153,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -157,6 +167,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -165,6 +176,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -79,6 +79,7 @@ Lifecycle: ""
 Name: apiserver-aggregator-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=apiserver-aggregator-ca
 type: ca
@@ -87,6 +88,7 @@ Lifecycle: ""
 Name: etcd-clients-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-clients-ca
 type: ca
@@ -95,6 +97,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-events
 type: ca
@@ -103,6 +106,7 @@ Lifecycle: ""
 Name: etcd-manager-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-manager-ca-main
 type: ca
@@ -111,6 +115,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-events
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-events
 type: ca
@@ -119,6 +124,7 @@ Lifecycle: ""
 Name: etcd-peers-ca-main
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=etcd-peers-ca-main
 type: ca
@@ -130,10 +136,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kube-proxy
 type: client
@@ -145,10 +153,12 @@ Signer:
   Name: kubernetes-ca
   Signer: null
   alternateNames: null
+  issuer: ""
   oldFormat: false
   subject: cn=kubernetes
   type: ca
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubelet
 type: client
@@ -157,6 +167,7 @@ Lifecycle: ""
 Name: kubernetes-ca
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=kubernetes
 type: ca
@@ -165,6 +176,7 @@ Lifecycle: ""
 Name: service-account
 Signer: null
 alternateNames: null
+issuer: ""
 oldFormat: false
 subject: cn=service-account
 type: ca


### PR DESCRIPTION
Cherry pick of #12846 on release-1.22.

#12846: Reissue client keypairs on issuer change

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.