### PR TITLE
images: fix invalid k8s-staging-test-infra/gcb-docker-gcloud tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
   args:
   - gcs-upload-and-tag
 # Push the manifests
-- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af'
+- name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
   id: manifests
   waitFor: [images]
   entrypoint: make


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes/kops/pull/12859

I copy-pasted the wrong tag :sweat_smile:  Sorry about the churn