### PR TITLE
GCE: fix for metadata-proxy on cilium

### DIFF
--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 29c78a908980393b0707da7501f2b00025cd24cc62d2605083f9d77e8f3eb40f
+    manifestHash: 836437191be1c5ee97beef4a52eeb0aaad953f217d4c727c26dc92ff5e6c28cd
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -41,7 +41,9 @@ spec:
         version: v0.12
     spec:
       containers:
-      - image: k8s.gcr.io/metadata-proxy:v0.1.12
+      - args:
+        - -addr=169.254.169.252:988
+        image: k8s.gcr.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -82,8 +84,19 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - /sbin/iptables -t nat -I PREROUTING -p tcp --dport 80 -d 169.254.169.254
-          -j DNAT --to-destination 127.0.0.1:988
+        - |
+          set -e
+          set -x
+
+          if (ip link show ens4); then
+            PRIMARY_DEV=ens4
+          else
+            PRIMARY_DEV=eth0
+          fi
+
+          ip addr add dev lo 169.254.169.252/32
+          iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
+          iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
         image: gcr.io/google_containers/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 29c78a908980393b0707da7501f2b00025cd24cc62d2605083f9d77e8f3eb40f
+    manifestHash: 836437191be1c5ee97beef4a52eeb0aaad953f217d4c727c26dc92ff5e6c28cd
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -41,7 +41,9 @@ spec:
         version: v0.12
     spec:
       containers:
-      - image: k8s.gcr.io/metadata-proxy:v0.1.12
+      - args:
+        - -addr=169.254.169.252:988
+        image: k8s.gcr.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -82,8 +84,19 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - /sbin/iptables -t nat -I PREROUTING -p tcp --dport 80 -d 169.254.169.254
-          -j DNAT --to-destination 127.0.0.1:988
+        - |
+          set -e
+          set -x
+
+          if (ip link show ens4); then
+            PRIMARY_DEV=ens4
+          else
+            PRIMARY_DEV=eth0
+          fi
+
+          ip addr add dev lo 169.254.169.252/32
+          iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
+          iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
         image: gcr.io/google_containers/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 29c78a908980393b0707da7501f2b00025cd24cc62d2605083f9d77e8f3eb40f
+    manifestHash: 836437191be1c5ee97beef4a52eeb0aaad953f217d4c727c26dc92ff5e6c28cd
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -41,7 +41,9 @@ spec:
         version: v0.12
     spec:
       containers:
-      - image: k8s.gcr.io/metadata-proxy:v0.1.12
+      - args:
+        - -addr=169.254.169.252:988
+        image: k8s.gcr.io/metadata-proxy:v0.1.12
         name: metadata-proxy
         resources:
           limits:
@@ -82,8 +84,19 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - /sbin/iptables -t nat -I PREROUTING -p tcp --dport 80 -d 169.254.169.254
-          -j DNAT --to-destination 127.0.0.1:988
+        - |
+          set -e
+          set -x
+
+          if (ip link show ens4); then
+            PRIMARY_DEV=ens4
+          else
+            PRIMARY_DEV=eth0
+          fi
+
+          ip addr add dev lo 169.254.169.252/32
+          iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
+          iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
         image: gcr.io/google_containers/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables

--- a/upup/models/cloudup/resources/addons/metadata-proxy.addons.k8s.io/v0.1.12.yaml
+++ b/upup/models/cloudup/resources/addons/metadata-proxy.addons.k8s.io/v0.1.12.yaml
@@ -50,7 +50,23 @@ spec:
           privileged: true
         image: gcr.io/google_containers/k8s-custom-iptables:1.0
         imagePullPolicy: Always
-        command: [ "/bin/sh", "-c", "/sbin/iptables -t nat -I PREROUTING -p tcp --dport 80 -d 169.254.169.254 -j DNAT --to-destination 127.0.0.1:988" ]
+        command:
+        - "/bin/sh"
+        - "-c"
+        # Based on https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure-helper.sh#L181-L184
+        - |
+          set -e
+          set -x
+
+          if (ip link show ens4); then
+            PRIMARY_DEV=ens4
+          else
+            PRIMARY_DEV=eth0
+          fi
+
+          ip addr add dev lo 169.254.169.252/32
+          iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
+          iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
         volumeMounts:
         - name: host
           mountPath: /host
@@ -64,6 +80,8 @@ spec:
         image: k8s.gcr.io/metadata-proxy:v0.1.12
         securityContext:
           privileged: true
+        args:
+        - -addr=169.254.169.252:988
         # Request and limit resources to get guaranteed QoS.
         resources:
           requests:


### PR DESCRIPTION
Cilium doesn't seem to react well to a redirect to 127.0.0.1, but if
we redirect to an IP then it works well.  This should also work
with other CNI providers.

Similar to what upstream kubernetes does, we bind to 169.254.169.252.

Upstream: https://github.com/kubernetes/kubernetes/blob/108c284a330a82ce1a1f80238e4f54bf5e8b045a/cluster/gce/gci/configure-helper.sh#L181-L184