### PR TITLE
Spotinst: Update spotinst/ocean-controller to v1.0.80

### DIFF
--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -190,7 +190,7 @@ spec:
       containers:
       - name: spotinst-kubernetes-cluster-controller
         imagePullPolicy: Always
-        image: gcr.io/spotinst-artifacts/kubernetes-cluster-controller:1.0.79
+        image: gcr.io/spotinst-artifacts/kubernetes-cluster-controller:1.0.80
         livenessProbe:
           httpGet:
             path: /healthcheck


### PR DESCRIPTION
This PR updates `spotinst/ocean-controller` to v1.0.80.