### PR TITLE
tests gce: fix project arg on gsutil rm

### DIFF
--- a/tests/e2e/kubetest2-kops/gce/gcs.go
+++ b/tests/e2e/kubetest2-kops/gce/gcs.go
@@ -80,10 +80,9 @@ func EnsureGCSBucket(bucketPath, projectID string) error {
 
 func DeleteGCSBucket(bucketPath, projectID string) error {
 	rmArgs := []string{
-		"gsutil", "rm", "-r", bucketPath,
-	}
-	if projectID != "" {
-		rmArgs = append(rmArgs, "-p", projectID)
+		"gsutil",
+		"-u", projectID,
+		"rm", "-r", bucketPath,
 	}
 
 	klog.Info(strings.Join(rmArgs, " "))


### PR DESCRIPTION
Because we don't actually need to pass the project when deleting
objects (as it can be inferred from the bucket), the syntax for
passing it is a little different.