### PR TITLE
If RBN, use IPv6 address instead of IPv4

### DIFF
--- a/protokube/pkg/protokube/aws_volume.go
+++ b/protokube/pkg/protokube/aws_volume.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"k8s.io/klog/v2"
+
 	"k8s.io/kops/protokube/pkg/etcd"
 	"k8s.io/kops/protokube/pkg/gossip"
 	gossipaws "k8s.io/kops/protokube/pkg/gossip/aws"
@@ -125,7 +126,11 @@ func (a *AWSVolumes) discoverTags() error {
 
 	a.clusterTag = clusterID
 
-	a.internalIP = net.ParseIP(aws.StringValue(instance.PrivateIpAddress))
+	if *instance.PrivateDnsNameOptions.HostnameType == ec2.HostnameTypeResourceName {
+		a.internalIP = net.ParseIP(aws.StringValue(instance.Ipv6Address))
+	} else {
+		a.internalIP = net.ParseIP(aws.StringValue(instance.PrivateIpAddress))
+	}
 	if a.internalIP == nil {
 		return fmt.Errorf("Internal IP not found on this instance (%q)", a.instanceId)
 	}


### PR DESCRIPTION
This code seems to only be used for gossip, but it is always run. This fixes IPv6 only networking