### PR TITLE
enable connection-draining for aws classic lb

### DIFF
--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -213,6 +213,11 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 				IdleTimeout: fi.Int64(int64(idleTimeout.Seconds())),
 			},
 
+			ConnectionDraining: &awstasks.ClassicLoadBalancerConnectionDraining{
+				Enabled: fi.Bool(true),
+				Timeout: fi.Int64(300),
+			},
+
 			Tags: tags,
 		}
 

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -321,7 +321,9 @@ resource "aws_eip" "us-test-1a-bastionuserdata-example-com" {
 }
 
 resource "aws_elb" "api-bastionuserdata-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -436,7 +436,9 @@ resource "aws_ebs_volume" "c-etcd-main-existingsg-example-com" {
 }
 
 resource "aws_elb" "api-existingsg-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -257,7 +257,9 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-externalpolicies-example-com" {
 }
 
 resource "aws_elb" "api-externalpolicies-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -1335,6 +1335,10 @@
           "Interval": "10",
           "Timeout": "5"
         },
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 300
+        },
         "ConnectionSettings": {
           "IdleTimeout": 300
         },

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -307,7 +307,9 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-private-shared-ip-example-com" {
 }
 
 resource "aws_elb" "api-private-shared-ip-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -302,7 +302,9 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-private-shared-subnet-example-co
 }
 
 resource "aws_elb" "api-private-shared-subnet-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -1491,6 +1491,10 @@
           "Interval": "10",
           "Timeout": "5"
         },
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 300
+        },
         "ConnectionSettings": {
           "IdleTimeout": 300
         },

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -321,7 +321,9 @@ resource "aws_eip" "us-test-1a-privatecalico-example-com" {
 }
 
 resource "aws_elb" "api-privatecalico-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -321,7 +321,9 @@ resource "aws_eip" "us-test-1a-privatecanal-example-com" {
 }
 
 resource "aws_elb" "api-privatecanal-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -1477,6 +1477,10 @@
           "Interval": "10",
           "Timeout": "5"
         },
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 300
+        },
         "ConnectionSettings": {
           "IdleTimeout": 300
         },

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -321,7 +321,9 @@ resource "aws_eip" "us-test-1a-privatecilium-example-com" {
 }
 
 resource "aws_elb" "api-privatecilium-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -1477,6 +1477,10 @@
           "Interval": "10",
           "Timeout": "5"
         },
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 300
+        },
         "ConnectionSettings": {
           "IdleTimeout": 300
         },

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -321,7 +321,9 @@ resource "aws_eip" "us-test-1a-privatecilium-example-com" {
 }
 
 resource "aws_elb" "api-privatecilium-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -1510,6 +1510,10 @@
           "Interval": "10",
           "Timeout": "5"
         },
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 300
+        },
         "ConnectionSettings": {
           "IdleTimeout": 300
         },

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -337,7 +337,9 @@ resource "aws_eip" "us-test-1a-privateciliumadvanced-example-com" {
 }
 
 resource "aws_elb" "api-privateciliumadvanced-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -357,7 +357,9 @@ resource "aws_eip" "us-test-1a-privatedns1-example-com" {
 }
 
 resource "aws_elb" "api-privatedns1-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -316,7 +316,9 @@ resource "aws_eip" "us-test-1a-privatedns2-example-com" {
 }
 
 resource "aws_elb" "api-privatedns2-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -321,7 +321,9 @@ resource "aws_eip" "us-test-1a-privateflannel-example-com" {
 }
 
 resource "aws_elb" "api-privateflannel-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -327,7 +327,9 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-privatekopeio-example-com" {
 }
 
 resource "aws_elb" "api-privatekopeio-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -321,7 +321,9 @@ resource "aws_eip" "us-test-1a-privateweave-example-com" {
 }
 
 resource "aws_elb" "api-privateweave-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -307,7 +307,9 @@ resource "aws_ebs_volume" "us-test-1a-etcd-main-unmanaged-example-com" {
 }
 
 resource "aws_elb" "api-unmanaged-example-com" {
-  cross_zone_load_balancing = false
+  connection_draining         = true
+  connection_draining_timeout = 300
+  cross_zone_load_balancing   = false
   health_check {
     healthy_threshold   = 2
     interval            = 10

--- a/upup/pkg/fi/cloudup/awstasks/classic_loadbalancer_attributes.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_loadbalancer_attributes.go
@@ -165,6 +165,9 @@ func (_ *ClassicLoadBalancer) modifyLoadBalancerAttributes(t *awsup.AWSAPITarget
 	if e.AccessLog != nil && e.AccessLog.S3BucketPrefix != nil {
 		request.LoadBalancerAttributes.AccessLog.S3BucketPrefix = e.AccessLog.S3BucketPrefix
 	}
+	if e.ConnectionDraining != nil && e.ConnectionDraining.Enabled != nil {
+		request.LoadBalancerAttributes.ConnectionDraining.Enabled = e.ConnectionDraining.Enabled
+	}
 	if e.ConnectionDraining != nil && e.ConnectionDraining.Timeout != nil {
 		request.LoadBalancerAttributes.ConnectionDraining.Timeout = e.ConnectionDraining.Timeout
 	}


### PR DESCRIPTION
This PR enables connection draining for aws classic LBs by default. 

Currently, kops doesn't enable connection draining and dropped connections can happen while cycling instanceGroups (master instanceGroups in particular).