### PR TITLE
gce: Add network & subnet to toolbox dump

### DIFF
--- a/pkg/resources/gce/BUILD.bazel
+++ b/pkg/resources/gce/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "dump.go",
         "gce.go",
+        "network.go",
+        "subnet.go",
     ],
     importpath = "k8s.io/kops/pkg/resources/gce",
     visibility = ["//visibility:public"],

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -740,6 +740,7 @@ func (d *clusterDiscoveryGCE) listSubnets() ([]*resources.Resource, error) {
 			Type:    typeSubnet,
 			Deleter: deleteSubnet,
 			Obj:     o,
+			Dumper:  DumpSubnetwork,
 		}
 
 		resourceTracker.Blocks = append(resourceTracker.Blocks, typeNetwork+":"+gce.LastComponent(o.Network))
@@ -868,6 +869,7 @@ func (d *clusterDiscoveryGCE) listNetworks() ([]*resources.Resource, error) {
 			Type:    typeNetwork,
 			Deleter: deleteNetwork,
 			Obj:     o,
+			Dumper:  DumpNetwork,
 		}
 
 		klog.V(4).Infof("found resource: %s", o.SelfLink)

--- a/pkg/resources/gce/network.go
+++ b/pkg/resources/gce/network.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/kops/pkg/resources"
+	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+)
+
+// DumpNetwork is responsible for dumping a resource for a Network
+func DumpNetwork(op *resources.DumpOperation, r *resources.Resource) error {
+	network := r.Obj.(*compute.Network)
+
+	vpc := &resources.VPC{
+		ID: gce.LastComponent(network.SelfLink),
+	}
+	op.Dump.VPC = vpc
+
+	return nil
+}

--- a/pkg/resources/gce/subnet.go
+++ b/pkg/resources/gce/subnet.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/kops/pkg/resources"
+	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+)
+
+// DumpSubnetwork is responsible for dumping a resource for a Subnetwork
+func DumpSubnetwork(op *resources.DumpOperation, r *resources.Resource) error {
+	obj := r.Obj.(*compute.Subnetwork)
+
+	subnet := &resources.Subnet{
+		ID: gce.LastComponent(obj.SelfLink),
+	}
+	op.Dump.Subnets = append(op.Dump.Subnets, subnet)
+
+	return nil
+}


### PR DESCRIPTION
Now that we're better managing networks & subnets on GCE, we should
include them.