### PR TITLE
Cleanup GCE loadbalancers created by k8s

### DIFF
--- a/cloudmock/gce/mockcompute/BUILD.bazel
+++ b/cloudmock/gce/mockcompute/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "disk.go",
         "firewall.go",
         "forwarding_rule.go",
+        "http_healthcheck.go",
         "instance_group_manager.go",
         "instance_template.go",
         "network.go",

--- a/cloudmock/gce/mockcompute/api.go
+++ b/cloudmock/gce/mockcompute/api.go
@@ -27,13 +27,14 @@ type MockClient struct {
 	projectClient *projectClient
 	zoneClient    *zoneClient
 
-	networkClient        *networkClient
-	subnetworkClient     *subnetworkClient
-	routeClient          *routeClient
-	forwardingRuleClient *forwardingRuleClient
-	addressClient        *addressClient
-	firewallClient       *firewallClient
-	routerClient         *routerClient
+	networkClient          *networkClient
+	subnetworkClient       *subnetworkClient
+	routeClient            *routeClient
+	forwardingRuleClient   *forwardingRuleClient
+	httpHealthChecksClient *httpHealthChecksClient
+	addressClient          *addressClient
+	firewallClient         *firewallClient
+	routerClient           *routerClient
 
 	instanceTemplateClient     *instanceTemplateClient
 	instanceGroupManagerClient *instanceGroupManagerClient
@@ -50,13 +51,14 @@ func NewMockClient(project string) *MockClient {
 		projectClient: newProjectClient(project),
 		zoneClient:    newZoneClient(project),
 
-		networkClient:        newNetworkClient(),
-		subnetworkClient:     newSubnetworkClient(),
-		routeClient:          newRouteClient(),
-		forwardingRuleClient: newForwardingRuleClient(),
-		addressClient:        newAddressClient(),
-		firewallClient:       newFirewallClient(),
-		routerClient:         newRouterClient(),
+		networkClient:          newNetworkClient(),
+		subnetworkClient:       newSubnetworkClient(),
+		routeClient:            newRouteClient(),
+		forwardingRuleClient:   newForwardingRuleClient(),
+		httpHealthChecksClient: newHttpHealthChecksClient(),
+		addressClient:          newAddressClient(),
+		firewallClient:         newFirewallClient(),
+		routerClient:           newRouterClient(),
 
 		instanceTemplateClient:     newInstanceTemplateClient(),
 		instanceGroupManagerClient: newInstanceGroupManagerClient(),
@@ -77,6 +79,7 @@ func (c *MockClient) AllResources() map[string]interface{} {
 		c.subnetworkClient.All,
 		c.routeClient.All,
 		c.forwardingRuleClient.All,
+		c.httpHealthChecksClient.All,
 		c.addressClient.All,
 		c.firewallClient.All,
 		c.routerClient.All,
@@ -122,6 +125,10 @@ func (c *MockClient) Routes() gce.RouteClient {
 
 func (c *MockClient) ForwardingRules() gce.ForwardingRuleClient {
 	return c.forwardingRuleClient
+}
+
+func (c *MockClient) HTTPHealthChecks() gce.HttpHealthChecksClient {
+	return c.httpHealthChecksClient
 }
 
 func (c *MockClient) Addresses() gce.AddressClient {

--- a/cloudmock/gce/mockcompute/http_healthcheck.go
+++ b/cloudmock/gce/mockcompute/http_healthcheck.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockcompute
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+)
+
+type httpHealthChecksClient struct {
+	// httpHealthchecks are httpHealthchecks keyed by project, and httpHealthcheck name.
+	httpHealthchecks map[string]map[string]*compute.HttpHealthCheck
+	sync.Mutex
+}
+
+var _ gce.HttpHealthChecksClient = &httpHealthChecksClient{}
+
+func newHttpHealthChecksClient() *httpHealthChecksClient {
+	return &httpHealthChecksClient{
+		httpHealthchecks: map[string]map[string]*compute.HttpHealthCheck{},
+	}
+}
+
+func (c *httpHealthChecksClient) All() map[string]interface{} {
+	c.Lock()
+	defer c.Unlock()
+	m := map[string]interface{}{}
+	for _, hcs := range c.httpHealthchecks {
+		for n, hc := range hcs {
+			m[n] = hc
+		}
+	}
+	return m
+}
+
+func (c *httpHealthChecksClient) Insert(project string, hc *compute.HttpHealthCheck) (*compute.Operation, error) {
+	c.Lock()
+	defer c.Unlock()
+	hcs, ok := c.httpHealthchecks[project]
+	if !ok {
+		hcs = map[string]*compute.HttpHealthCheck{}
+		c.httpHealthchecks[project] = hcs
+	}
+	hc.SelfLink = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/httpHealthChecks/%s", project, hc.Name)
+	hcs[hc.Name] = hc
+	return doneOperation(), nil
+}
+
+func (c *httpHealthChecksClient) Delete(project, name string) (*compute.Operation, error) {
+	c.Lock()
+	defer c.Unlock()
+	hcs, ok := c.httpHealthchecks[project]
+	if !ok {
+		return nil, notFoundError()
+	}
+	if _, ok := hcs[name]; !ok {
+		return nil, notFoundError()
+	}
+	delete(hcs, name)
+	return doneOperation(), nil
+}
+
+func (c *httpHealthChecksClient) Get(project, name string) (*compute.HttpHealthCheck, error) {
+	c.Lock()
+	defer c.Unlock()
+	hcs, ok := c.httpHealthchecks[project]
+	if !ok {
+		return nil, notFoundError()
+	}
+	hc, ok := hcs[name]
+	if !ok {
+		return nil, notFoundError()
+	}
+	return hc, nil
+}
+
+func (c *httpHealthChecksClient) List(ctx context.Context, project string) ([]*compute.HttpHealthCheck, error) {
+	c.Lock()
+	defer c.Unlock()
+	hcs, ok := c.httpHealthchecks[project]
+	if !ok {
+		return nil, nil
+	}
+	var l []*compute.HttpHealthCheck
+	for _, hc := range hcs {
+		l = append(l, hc)
+	}
+	return l, nil
+}

--- a/upup/pkg/fi/cloudup/gce/compute.go
+++ b/upup/pkg/fi/cloudup/gce/compute.go
@@ -31,6 +31,7 @@ type ComputeClient interface {
 	Subnetworks() SubnetworkClient
 	Routes() RouteClient
 	ForwardingRules() ForwardingRuleClient
+	HTTPHealthChecks() HttpHealthChecksClient
 	Addresses() AddressClient
 	Firewalls() FirewallClient
 	Routers() RouterClient
@@ -96,6 +97,12 @@ func (c *computeClientImpl) Routes() RouteClient {
 func (c *computeClientImpl) ForwardingRules() ForwardingRuleClient {
 	return &forwardingRuleClientImpl{
 		srv: c.srv.ForwardingRules,
+	}
+}
+
+func (c *computeClientImpl) HTTPHealthChecks() HttpHealthChecksClient {
+	return &httpHealthCheckClientImpl{
+		srv: c.srv.HttpHealthChecks,
 	}
 }
 
@@ -335,6 +342,42 @@ func (c *forwardingRuleClientImpl) List(ctx context.Context, project, region str
 		return nil, err
 	}
 	return frs, nil
+}
+
+type HttpHealthChecksClient interface {
+	Insert(project string, fr *compute.HttpHealthCheck) (*compute.Operation, error)
+	Delete(project, name string) (*compute.Operation, error)
+	Get(project, name string) (*compute.HttpHealthCheck, error)
+	List(ctx context.Context, project string) ([]*compute.HttpHealthCheck, error)
+}
+
+type httpHealthCheckClientImpl struct {
+	srv *compute.HttpHealthChecksService
+}
+
+var _ HttpHealthChecksClient = &httpHealthCheckClientImpl{}
+
+func (c *httpHealthCheckClientImpl) Insert(project string, fr *compute.HttpHealthCheck) (*compute.Operation, error) {
+	return c.srv.Insert(project, fr).Do()
+}
+
+func (c *httpHealthCheckClientImpl) Delete(project, name string) (*compute.Operation, error) {
+	return c.srv.Delete(project, name).Do()
+}
+
+func (c *httpHealthCheckClientImpl) Get(project, name string) (*compute.HttpHealthCheck, error) {
+	return c.srv.Get(project, name).Do()
+}
+
+func (c *httpHealthCheckClientImpl) List(ctx context.Context, project string) ([]*compute.HttpHealthCheck, error) {
+	var hcs []*compute.HttpHealthCheck
+	if err := c.srv.List(project).Pages(ctx, func(p *compute.HttpHealthCheckList) error {
+		hcs = append(hcs, p.Items...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return hcs, nil
 }
 
 type AddressClient interface {


### PR DESCRIPTION
before

```
kops delete cluster jessegcp2.k8s.local
I1205 11:34:08.230365   66651 featureflag.go:164] FeatureFlag "AlphaAllowGCE"=true
I1205 11:34:08.251038   66651 s3context.go:89] Found S3_ENDPOINT="https://s3.eu-north-1.amazonaws.com", using as non-AWS S3 backend
I1205 11:34:08.457794   66651 gce_cloud.go:120] Will load GOOGLE_APPLICATION_CREDENTIALS from /Users/jessehaka/Downloads/sose-sre-5737-c707cbd8f8c9.json
I1205 11:34:09.046010   66651 gce.go:92] Scanning zones: [europe-north1-a europe-north1-b europe-north1-c]
TYPE			NAME							ID
Address			api-jessegcp2-k8s-local					api-jessegcp2-k8s-local
Disk			a-etcd-events-jessegcp2-k8s-local			a-etcd-events-jessegcp2-k8s-local
Disk			a-etcd-main-jessegcp2-k8s-local				a-etcd-main-jessegcp2-k8s-local
Disk			b-etcd-events-jessegcp2-k8s-local			b-etcd-events-jessegcp2-k8s-local
Disk			b-etcd-main-jessegcp2-k8s-local				b-etcd-main-jessegcp2-k8s-local
Disk			c-etcd-events-jessegcp2-k8s-local			c-etcd-events-jessegcp2-k8s-local
Disk			c-etcd-main-jessegcp2-k8s-local				c-etcd-main-jessegcp2-k8s-local
FirewallRule		https-api-ipv6-jessegcp2-k8s-local			https-api-ipv6-jessegcp2-k8s-local
FirewallRule		https-api-jessegcp2-k8s-local				https-api-jessegcp2-k8s-local
FirewallRule		master-to-master-jessegcp2-k8s-local			master-to-master-jessegcp2-k8s-local
FirewallRule		master-to-node-jessegcp2-k8s-local			master-to-node-jessegcp2-k8s-local
FirewallRule		node-to-master-jessegcp2-k8s-local			node-to-master-jessegcp2-k8s-local
FirewallRule		node-to-node-jessegcp2-k8s-local			node-to-node-jessegcp2-k8s-local
FirewallRule		nodeport-external-to-node-ipv6-jessegcp2-k8s-local	nodeport-external-to-node-ipv6-jessegcp2-k8s-local
FirewallRule		nodeport-external-to-node-jessegcp2-k8s-local		nodeport-external-to-node-jessegcp2-k8s-local
FirewallRule		ssh-external-to-master-ipv6-jessegcp2-k8s-local		ssh-external-to-master-ipv6-jessegcp2-k8s-local
FirewallRule		ssh-external-to-master-jessegcp2-k8s-local		ssh-external-to-master-jessegcp2-k8s-local
FirewallRule		ssh-external-to-node-ipv6-jessegcp2-k8s-local		ssh-external-to-node-ipv6-jessegcp2-k8s-local
FirewallRule		ssh-external-to-node-jessegcp2-k8s-local		ssh-external-to-node-jessegcp2-k8s-local
ForwardingRule		api-jessegcp2-k8s-local					api-jessegcp2-k8s-local
Instance		master-europe-north1-a-c762				europe-north1-a/master-europe-north1-a-c762
Instance		master-europe-north1-b-9dmm				europe-north1-b/master-europe-north1-b-9dmm
Instance		master-europe-north1-c-457h				europe-north1-c/master-europe-north1-c-457h
Instance		nodes-a-d6hs						europe-north1-a/nodes-a-d6hs
Instance		nodes-b-gj07						europe-north1-b/nodes-b-gj07
Instance		nodes-c-l37r						europe-north1-c/nodes-c-l37r
InstanceGroupManager	a-master-europe-north1-a-jessegcp2-k8s-local		europe-north1-a/a-master-europe-north1-a-jessegcp2-k8s-local
InstanceGroupManager	a-nodes-a-jessegcp2-k8s-local				europe-north1-a/a-nodes-a-jessegcp2-k8s-local
InstanceGroupManager	b-master-europe-north1-b-jessegcp2-k8s-local		europe-north1-b/b-master-europe-north1-b-jessegcp2-k8s-local
InstanceGroupManager	b-nodes-b-jessegcp2-k8s-local				europe-north1-b/b-nodes-b-jessegcp2-k8s-local
InstanceGroupManager	c-master-europe-north1-c-jessegcp2-k8s-local		europe-north1-c/c-master-europe-north1-c-jessegcp2-k8s-local
InstanceGroupManager	c-nodes-c-jessegcp2-k8s-local				europe-north1-c/c-nodes-c-jessegcp2-k8s-local
InstanceTemplate	master-europe-north1-a-je-3tjsue-1638692991		master-europe-north1-a-je-3tjsue-1638692991
InstanceTemplate	master-europe-north1-b-je-c8u54a-1638692992		master-europe-north1-b-je-c8u54a-1638692992
InstanceTemplate	master-europe-north1-c-je-q6rss4-1638692992		master-europe-north1-c-je-q6rss4-1638692992
InstanceTemplate	nodes-a-jessegcp2-k8s-local-1638692991			nodes-a-jessegcp2-k8s-local-1638692991
InstanceTemplate	nodes-b-jessegcp2-k8s-local-1638692992			nodes-b-jessegcp2-k8s-local-1638692992
InstanceTemplate	nodes-c-jessegcp2-k8s-local-1638692992			nodes-c-jessegcp2-k8s-local-1638692992
Network			jessegcp2-k8s-local					jessegcp2-k8s-local
Router			nat-jessegcp2-k8s-local					nat-jessegcp2-k8s-local
Subnet			europe-north1-jessegcp2-k8s-local			europe-north1-jessegcp2-k8s-local
TargetPool		api-jessegcp2-k8s-local					api-jessegcp2-k8s-local

Must specify --yes to delete cluster
```

after

```
kops delete cluster jessegcp2.k8s.local
I1205 11:32:23.368944   66388 featureflag.go:164] FeatureFlag "AlphaAllowGCE"=true
I1205 11:32:23.383057   66388 s3context.go:89] Found S3_ENDPOINT="https://s3.eu-north-1.amazonaws.com", using as non-AWS S3 backend
I1205 11:32:23.623108   66388 gce_cloud.go:120] Will load GOOGLE_APPLICATION_CREDENTIALS from /Users/jessehaka/Downloads/sose-sre-5737-c707cbd8f8c9.json
I1205 11:32:24.360972   66388 gce.go:93] Scanning zones: [europe-north1-a europe-north1-b europe-north1-c]
TYPE			NAME							ID
Address			api-jessegcp2-k8s-local					api-jessegcp2-k8s-local
Disk			a-etcd-events-jessegcp2-k8s-local			a-etcd-events-jessegcp2-k8s-local
Disk			a-etcd-main-jessegcp2-k8s-local				a-etcd-main-jessegcp2-k8s-local
Disk			b-etcd-events-jessegcp2-k8s-local			b-etcd-events-jessegcp2-k8s-local
Disk			b-etcd-main-jessegcp2-k8s-local				b-etcd-main-jessegcp2-k8s-local
Disk			c-etcd-events-jessegcp2-k8s-local			c-etcd-events-jessegcp2-k8s-local
Disk			c-etcd-main-jessegcp2-k8s-local				c-etcd-main-jessegcp2-k8s-local
FirewallRule		https-api-ipv6-jessegcp2-k8s-local			https-api-ipv6-jessegcp2-k8s-local
FirewallRule		https-api-jessegcp2-k8s-local				https-api-jessegcp2-k8s-local
FirewallRule		k8s-a141fd53708934b75b48805ef26a0c86-http-hc		k8s-a141fd53708934b75b48805ef26a0c86-http-hc
FirewallRule		k8s-fw-a141fd53708934b75b48805ef26a0c86			k8s-fw-a141fd53708934b75b48805ef26a0c86
FirewallRule		master-to-master-jessegcp2-k8s-local			master-to-master-jessegcp2-k8s-local
FirewallRule		master-to-node-jessegcp2-k8s-local			master-to-node-jessegcp2-k8s-local
FirewallRule		node-to-master-jessegcp2-k8s-local			node-to-master-jessegcp2-k8s-local
FirewallRule		node-to-node-jessegcp2-k8s-local			node-to-node-jessegcp2-k8s-local
FirewallRule		nodeport-external-to-node-ipv6-jessegcp2-k8s-local	nodeport-external-to-node-ipv6-jessegcp2-k8s-local
FirewallRule		nodeport-external-to-node-jessegcp2-k8s-local		nodeport-external-to-node-jessegcp2-k8s-local
FirewallRule		ssh-external-to-master-ipv6-jessegcp2-k8s-local		ssh-external-to-master-ipv6-jessegcp2-k8s-local
FirewallRule		ssh-external-to-master-jessegcp2-k8s-local		ssh-external-to-master-jessegcp2-k8s-local
FirewallRule		ssh-external-to-node-ipv6-jessegcp2-k8s-local		ssh-external-to-node-ipv6-jessegcp2-k8s-local
FirewallRule		ssh-external-to-node-jessegcp2-k8s-local		ssh-external-to-node-jessegcp2-k8s-local
ForwardingRule		a141fd53708934b75b48805ef26a0c86			a141fd53708934b75b48805ef26a0c86
ForwardingRule		api-jessegcp2-k8s-local					api-jessegcp2-k8s-local
HTTP HealthCheck	a141fd53708934b75b48805ef26a0c86			a141fd53708934b75b48805ef26a0c86
Instance		master-europe-north1-a-c762				europe-north1-a/master-europe-north1-a-c762
Instance		master-europe-north1-b-9dmm				europe-north1-b/master-europe-north1-b-9dmm
Instance		master-europe-north1-c-457h				europe-north1-c/master-europe-north1-c-457h
Instance		nodes-a-d6hs						europe-north1-a/nodes-a-d6hs
Instance		nodes-b-gj07						europe-north1-b/nodes-b-gj07
Instance		nodes-c-l37r						europe-north1-c/nodes-c-l37r
InstanceGroupManager	a-master-europe-north1-a-jessegcp2-k8s-local		europe-north1-a/a-master-europe-north1-a-jessegcp2-k8s-local
InstanceGroupManager	a-nodes-a-jessegcp2-k8s-local				europe-north1-a/a-nodes-a-jessegcp2-k8s-local
InstanceGroupManager	b-master-europe-north1-b-jessegcp2-k8s-local		europe-north1-b/b-master-europe-north1-b-jessegcp2-k8s-local
InstanceGroupManager	b-nodes-b-jessegcp2-k8s-local				europe-north1-b/b-nodes-b-jessegcp2-k8s-local
InstanceGroupManager	c-master-europe-north1-c-jessegcp2-k8s-local		europe-north1-c/c-master-europe-north1-c-jessegcp2-k8s-local
InstanceGroupManager	c-nodes-c-jessegcp2-k8s-local				europe-north1-c/c-nodes-c-jessegcp2-k8s-local
InstanceTemplate	master-europe-north1-a-je-3tjsue-1638692991		master-europe-north1-a-je-3tjsue-1638692991
InstanceTemplate	master-europe-north1-b-je-c8u54a-1638692992		master-europe-north1-b-je-c8u54a-1638692992
InstanceTemplate	master-europe-north1-c-je-q6rss4-1638692992		master-europe-north1-c-je-q6rss4-1638692992
InstanceTemplate	nodes-a-jessegcp2-k8s-local-1638692991			nodes-a-jessegcp2-k8s-local-1638692991
InstanceTemplate	nodes-b-jessegcp2-k8s-local-1638692992			nodes-b-jessegcp2-k8s-local-1638692992
InstanceTemplate	nodes-c-jessegcp2-k8s-local-1638692992			nodes-c-jessegcp2-k8s-local-1638692992
Network			jessegcp2-k8s-local					jessegcp2-k8s-local
Router			nat-jessegcp2-k8s-local					nat-jessegcp2-k8s-local
Subnet			europe-north1-jessegcp2-k8s-local			europe-north1-jessegcp2-k8s-local
TargetPool		a141fd53708934b75b48805ef26a0c86			a141fd53708934b75b48805ef26a0c86
TargetPool		api-jessegcp2-k8s-local					api-jessegcp2-k8s-local

Must specify --yes to delete cluster
```

as you can see this now cleanups following resources by created Kubernetes itself:
- ForwardingRule
- HTTP HealthCheck
- FirewallRule
- TargetPool


fixes #12683