### PR TITLE
Simplify Flatcar containerd exec command

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -252,9 +252,8 @@ func (b *ContainerdBuilder) buildSystemdServiceOverrideFlatcar(c *fi.ModelBuilde
 	lines := []string{
 		"[Service]",
 		"EnvironmentFile=/etc/environment",
-		"Environment=CONTAINERD_CONFIG=" + b.containerdConfigFilePath(),
 		"ExecStart=",
-		"ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}",
+		"ExecStart=/usr/bin/containerd --config " + b.containerdConfigFilePath(),
 	}
 	contents := strings.Join(lines, "\n")
 

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -47,9 +47,8 @@ afterFiles:
 contents: |-
   [Service]
   EnvironmentFile=/etc/environment
-  Environment=CONTAINERD_CONFIG=/etc/containerd/config-kops.toml
   ExecStart=
-  ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}
+  ExecStart=/usr/bin/containerd --config /etc/containerd/config-kops.toml
 onChangeExecute:
 - - systemctl
   - daemon-reload


### PR DESCRIPTION
The containerd command used in
https://github.com/kubernetes/kops/pull/12177 is a modification from
the torcx containerd unit. However, how torcx starts containerd is a
implementation detail and it's better to not hardcode torcx in case it
isn't used anymore.
Change the ExecStard command to use /usr/bin/containerd directly,
making it simpler and more future-proof.