### PR TITLE
Automated cherry pick of #12320: pkg/apis/kops: Allow configuring dockerd --max-* upload and

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -845,6 +845,21 @@ spec:
                     items:
                       type: string
                     type: array
+                  maxConcurrentDownloads:
+                    description: MaxConcurrentDownloads sets the max concurrent downloads
+                      for each pull
+                    format: int32
+                    type: integer
+                  maxConcurrentUploads:
+                    description: MaxConcurrentUploads sets the max concurrent uploads
+                      for each push
+                    format: int32
+                    type: integer
+                  maxDownloadAttempts:
+                    description: MaxDownloadAttempts sets the max download attempts
+                      for each pull
+                    format: int32
+                    type: integer
                   metricsAddress:
                     description: Metrics address is the endpoint to serve with Prometheus
                       format metrics

--- a/pkg/apis/kops/dockerconfig.go
+++ b/pkg/apis/kops/dockerconfig.go
@@ -58,6 +58,12 @@ type DockerConfig struct {
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`
 	// Logopt is a series of options given to the log driver options for containers
 	LogOpt []string `json:"logOpt,omitempty" flag:"log-opt,repeat"`
+	// MaxConcurrentDownloads sets the max concurrent downloads for each pull
+	MaxConcurrentDownloads *int32 `json:"maxConcurrentDownloads,omitempty" flag:"max-concurrent-downloads"`
+	// MaxConcurrentUploads sets the max concurrent uploads for each push
+	MaxConcurrentUploads *int32 `json:"maxConcurrentUploads,omitempty" flag:"max-concurrent-uploads"`
+	// MaxDownloadAttempts sets the max download attempts for each pull
+	MaxDownloadAttempts *int32 `json:"maxDownloadAttempts,omitempty" flag:"max-download-attempts"`
 	// Metrics address is the endpoint to serve with Prometheus format metrics
 	MetricsAddress *string `json:"metricsAddress,omitempty" flag:"metrics-addr"`
 	// MTU is the containers network MTU

--- a/pkg/apis/kops/v1alpha2/dockerconfig.go
+++ b/pkg/apis/kops/v1alpha2/dockerconfig.go
@@ -58,6 +58,12 @@ type DockerConfig struct {
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`
 	// Logopt is a series of options given to the log driver options for containers
 	LogOpt []string `json:"logOpt,omitempty" flag:"log-opt,repeat"`
+	// MaxConcurrentDownloads sets the max concurrent downloads for each pull
+	MaxConcurrentDownloads *int32 `json:"maxConcurrentDownloads,omitempty" flag:"max-concurrent-downloads"`
+	// MaxConcurrentUploads sets the max concurrent uploads for each push
+	MaxConcurrentUploads *int32 `json:"maxConcurrentUploads,omitempty" flag:"max-concurrent-uploads"`
+	// MaxDownloadAttempts sets the max download attempts for each pull
+	MaxDownloadAttempts *int32 `json:"maxDownloadAttempts,omitempty" flag:"max-download-attempts"`
 	// Metrics address is the endpoint to serve with Prometheus format metrics
 	MetricsAddress *string `json:"metricsAddress,omitempty" flag:"metrics-addr"`
 	// MTU is the containers network MTU

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3361,6 +3361,9 @@ func autoConvert_v1alpha2_DockerConfig_To_kops_DockerConfig(in *DockerConfig, ou
 	out.LogDriver = in.LogDriver
 	out.LogLevel = in.LogLevel
 	out.LogOpt = in.LogOpt
+	out.MaxConcurrentDownloads = in.MaxConcurrentDownloads
+	out.MaxConcurrentUploads = in.MaxConcurrentUploads
+	out.MaxDownloadAttempts = in.MaxDownloadAttempts
 	out.MetricsAddress = in.MetricsAddress
 	out.MTU = in.MTU
 	if in.Packages != nil {
@@ -3409,6 +3412,9 @@ func autoConvert_kops_DockerConfig_To_v1alpha2_DockerConfig(in *kops.DockerConfi
 	out.LogDriver = in.LogDriver
 	out.LogLevel = in.LogLevel
 	out.LogOpt = in.LogOpt
+	out.MaxConcurrentDownloads = in.MaxConcurrentDownloads
+	out.MaxConcurrentUploads = in.MaxConcurrentUploads
+	out.MaxDownloadAttempts = in.MaxDownloadAttempts
 	out.MetricsAddress = in.MetricsAddress
 	out.MTU = in.MTU
 	if in.Packages != nil {

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1503,6 +1503,21 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxConcurrentDownloads != nil {
+		in, out := &in.MaxConcurrentDownloads, &out.MaxConcurrentDownloads
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MaxConcurrentUploads != nil {
+		in, out := &in.MaxConcurrentUploads, &out.MaxConcurrentUploads
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MaxDownloadAttempts != nil {
+		in, out := &in.MaxDownloadAttempts, &out.MaxDownloadAttempts
+		*out = new(int32)
+		**out = **in
+	}
 	if in.MetricsAddress != nil {
 		in, out := &in.MetricsAddress, &out.MetricsAddress
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1610,6 +1610,21 @@ func (in *DockerConfig) DeepCopyInto(out *DockerConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxConcurrentDownloads != nil {
+		in, out := &in.MaxConcurrentDownloads, &out.MaxConcurrentDownloads
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MaxConcurrentUploads != nil {
+		in, out := &in.MaxConcurrentUploads, &out.MaxConcurrentUploads
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MaxDownloadAttempts != nil {
+		in, out := &in.MaxDownloadAttempts, &out.MaxDownloadAttempts
+		*out = new(int32)
+		**out = **in
+	}
 	if in.MetricsAddress != nil {
 		in, out := &in.MetricsAddress, &out.MetricsAddress
 		*out = new(string)


### PR DESCRIPTION
Cherry pick of #12320 on release-1.22.

#12320: pkg/apis/kops: Allow configuring dockerd --max-* upload and

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.