### PR TITLE
wait for instances to drain from classic LB

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -578,6 +578,10 @@ func deregisterInstanceFromClassicLoadBalancer(c AWSCloud, i *cloudinstances.Clo
 		return fmt.Errorf("error describing autoScalingGroups: %v", err)
 	}
 
+	if len(asgDetails.AutoScalingGroups) == 0 {
+		return nil
+	}
+
 	// there will always be only one loadBalancer in the response.
 	loadBalancerNames := asgDetails.AutoScalingGroups[0].LoadBalancerNames
 
@@ -607,7 +611,7 @@ func deregisterInstanceFromClassicLoadBalancer(c AWSCloud, i *cloudinstances.Clo
 			break
 		}
 
-		time.Sleep(30 * time.Second)
+		time.Sleep(5 * time.Second)
 	}
 
 	return nil

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -115,6 +115,8 @@ const (
 	WellKnownAccountUbuntu       = "099720109477"
 )
 
+const instanceInServiceState = "InService"
+
 // AWSErrCodeInvalidAction is returned in AWS partitions that don't support certain actions
 const AWSErrCodeInvalidAction = "InvalidAction"
 
@@ -585,25 +587,36 @@ func deregisterInstanceFromClassicLoadBalancer(c AWSCloud, i *cloudinstances.Clo
 	// there will always be only one ASG in the DescribeAutoScalingGroups response.
 	loadBalancerNames := asgDetails.AutoScalingGroups[0].LoadBalancerNames
 
+	klog.Infof("Deregistering instance from classic loadBalancers: %v", aws.StringValueSlice(loadBalancerNames))
+
 	for {
 		instanceDraining := false
-		response, err := c.ELB().DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
-			LoadBalancerNames: loadBalancerNames,
-		})
+		for _, loadBalancerName := range loadBalancerNames {
+			response, err := c.ELB().DescribeInstanceHealth(&elb.DescribeInstanceHealthInput{
+				LoadBalancerName: loadBalancerName,
+				Instances: []*elb.Instance{{
+					InstanceId: aws.String(i.ID),
+				}},
+			})
 
-		if err != nil {
-			return fmt.Errorf("error describing load balancers %v: %v", loadBalancerNames, err)
-		}
+			if err != nil {
+				return fmt.Errorf("error describing instance health: %v", err)
+			}
 
-		for _, awsLb := range response.LoadBalancerDescriptions {
-			for _, instance := range awsLb.Instances {
-				if aws.StringValue(instance.InstanceId) == i.ID {
-					c.ELB().DeregisterInstancesFromLoadBalancer(&elb.DeregisterInstancesFromLoadBalancerInput{
-						LoadBalancerName: awsLb.LoadBalancerName,
-						Instances:        []*elb.Instance{instance},
-					})
-					instanceDraining = true
-				}
+			// describeInstanceHealth can return an empty list if the instance was already terminated.
+			if len(response.InstanceStates) == 0 {
+				continue
+			}
+
+			// there will be only one instance in the DescribeInstanceHealth response.
+			if aws.StringValue(response.InstanceStates[0].State) == instanceInServiceState {
+				c.ELB().DeregisterInstancesFromLoadBalancer(&elb.DeregisterInstancesFromLoadBalancerInput{
+					LoadBalancerName: loadBalancerName,
+					Instances: []*elb.Instance{{
+						InstanceId: aws.String(i.ID),
+					}},
+				})
+				instanceDraining = true
 			}
 		}
 

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -582,7 +582,7 @@ func deregisterInstanceFromClassicLoadBalancer(c AWSCloud, i *cloudinstances.Clo
 		return nil
 	}
 
-	// there will always be only one loadBalancer in the response.
+	// there will always be only one ASG in the DescribeAutoScalingGroups response.
 	loadBalancerNames := asgDetails.AutoScalingGroups[0].LoadBalancerNames
 
 	for {

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -120,6 +120,7 @@ const instanceInServiceState = "InService"
 // AWSErrCodeInvalidAction is returned in AWS partitions that don't support certain actions
 const AWSErrCodeInvalidAction = "InvalidAction"
 
+
 type AWSCloud interface {
 	fi.Cloud
 	CloudFormation() *cloudformation.CloudFormation

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -120,7 +120,6 @@ const instanceInServiceState = "InService"
 // AWSErrCodeInvalidAction is returned in AWS partitions that don't support certain actions
 const AWSErrCodeInvalidAction = "InvalidAction"
 
-
 type AWSCloud interface {
 	fi.Cloud
 	CloudFormation() *cloudformation.CloudFormation


### PR DESCRIPTION
Now that we've enabled connection draining by default for all classic LBs (https://github.com/kubernetes/kops/pull/12881), we need to ensure that we're waiting for connectionDraining to complete before terminating the instance.

Deleting the instance without waiting doesn't allow for connections to drain. We need to call `DeregisterInstancesFromLoadBalancer` which will ensure that there aren't any ongoing connections to the instance before we terminate.

Gathering the corresponding loadBalancers by describing the underlying ASG.

Confirmed that rolling-updates continue to behave as expected and 0% of requests are dropped from corresponding load balancers.