### PR TITLE
Fix error applying AWS CCM leader migration

### DIFF
--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: leader-migration.rbac.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: 28f51292768602b07c2a63edff29a60b818e7e79e5aa05fca48fac14c5f924ef
+    manifestHash: 6211e71f8175cebcba7812f74c41d175604cbff7bab9ac788f80bac290a7b981
     name: leader-migration.rbac.addons.k8s.io
     selector:
       k8s-addon: leader-migration.rbac.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-leader-migration.rbac.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-leader-migration.rbac.addons.k8s.io-k8s-1.23_content
@@ -9,7 +9,7 @@ metadata:
   name: system::leader-locking-migration
   namespace: kube-system
 rules:
-  apiGroups:
+- apiGroups:
   - coordination.k8s.io
   resourceNames:
   - cloud-provider-extraction-migration

--- a/upup/models/cloudup/resources/addons/leader-migration.rbac.addons.k8s.io/k8s-1.23.yaml
+++ b/upup/models/cloudup/resources/addons/leader-migration.rbac.addons.k8s.io/k8s-1.23.yaml
@@ -6,7 +6,7 @@ metadata:
   name: system::leader-locking-migration
   namespace: kube-system
 rules:
-  apiGroups:
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases


### PR DESCRIPTION
/cc @johngmyers 
```
NAME					CURRENT	UPDATE									PKI
leader-migration.rbac.addons.k8s.io	-	28f51292768602b07c2a63edff29a60b818e7e79e5aa05fca48fac14c5f924ef	no
I1207 16:49:28.867828   14441 request.go:597] Waited for 198.301494ms due to client-side throttling, not priority and fairness, request: GET:https://127.0.0.1/api/v1/namespaces/kube-system
I1207 16:49:28.870601   14441 addon.go:170] Applying update from "s3://k8s-kops-prow/e2e-83f3478299-ead63.test-cncf-aws.k8s.io/addons/leader-migration.rbac.addons.k8s.io/k8s-1.23.yaml"
I1207 16:49:28.870638   14441 s3fs.go:329] Reading file "s3://k8s-kops-prow/e2e-83f3478299-ead63.test-cncf-aws.k8s.io/addons/leader-migration.rbac.addons.k8s.io/k8s-1.23.yaml"
I1207 16:49:29.033004   14441 apply.go:60] Running command: kubectl apply -f /tmp/channel2704764692/manifest.yaml --server-side --force-conflicts --field-manager=kops
I1207 16:49:29.173913   14441 apply.go:63] error running kubectl apply -f /tmp/channel2704764692/manifest.yaml --server-side --force-conflicts --field-manager=kops
I1207 16:49:29.173938   14441 apply.go:64] error: error validating "/tmp/channel2704764692/manifest.yaml": error validating data: ValidationError(Role.rules): invalid type for io.k8s.api.rbac.v1.Role.rules: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false
error updating "leader-migration.rbac.addons.k8s.io": error applying update from "s3://k8s-kops-prow/e2e-83f3478299-ead63.test-cncf-aws.k8s.io/addons/leader-migration.rbac.addons.k8s.io/k8s-1.23.yaml": error running kubectl: exit status 1
```