### PR TITLE
Automated cherry pick of #12893: Fix external-dns service name

### DIFF
--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: external-dns.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: becbb20d8a89e33c89132134fe9c61d8893e4e8aad035832ae5974bf8200dcdc
+    manifestHash: 2da83fc2af2aa81afe4ff384ee46d17f072f4ae857f2c2fc898e5db5b5b47a32
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
@@ -96,7 +96,7 @@ metadata:
     addon.kops.k8s.io/name: external-dns.addons.k8s.io
     app.kubernetes.io/managed-by: kops
     k8s-addon: external-dns.addons.k8s.io
-  name: kops:external-dns
+  name: external-dns
 spec:
   ports:
   - name: http

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: external-dns.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 2c8bfcfc61c90359c01f2b4c683e6b8c60a9cde6972ccdaa9a36f606e3f6958b
+    manifestHash: 46f4f6b8465092df66cbecfb6400f085d2e6637dd15eeaec95c596e1a7640af7
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
@@ -113,7 +113,7 @@ metadata:
     addon.kops.k8s.io/name: external-dns.addons.k8s.io
     app.kubernetes.io/managed-by: kops
     k8s-addon: external-dns.addons.k8s.io
-  name: kops:external-dns
+  name: external-dns
 spec:
   ports:
   - name: http

--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
@@ -83,7 +83,7 @@ kind: Service
 metadata:
   labels:
     k8s-addon: external-dns.addons.k8s.io
-  name: kops:external-dns
+  name: external-dns
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
Cherry pick of #12893 on release-1.22.

#12893: Fix external-dns service name

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.