### PR TITLE
Document CoreDNS configuration settings

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -830,7 +830,7 @@ spec:
 
 **Note:** If you are upgrading to CoreDNS, kube-dns will be left in place and must be removed manually (you can scale the kube-dns and kube-dns-autoscaler deployments in the `kube-system` namespace to 0 as a starting point). The `kube-dns` Service itself should be left in place, as this retains the ClusterIP and eliminates the possibility of DNS outages in your cluster. If you would like to continue autoscaling, update the `kube-dns-autoscaler` Deployment container command for `--target=Deployment/kube-dns` to be `--target=Deployment/coredns`.
 
-For larger clusters you may need to set custom resource requests and limits. For the CoreDNS provicer you can set
+For larger clusters you may need to set custom resource requests and limits. For the CoreDNS provider you can set
 
 - memoryLimit
 - cpuRequest

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -830,6 +830,22 @@ spec:
 
 **Note:** If you are upgrading to CoreDNS, kube-dns will be left in place and must be removed manually (you can scale the kube-dns and kube-dns-autoscaler deployments in the `kube-system` namespace to 0 as a starting point). The `kube-dns` Service itself should be left in place, as this retains the ClusterIP and eliminates the possibility of DNS outages in your cluster. If you would like to continue autoscaling, update the `kube-dns-autoscaler` Deployment container command for `--target=Deployment/kube-dns` to be `--target=Deployment/coredns`.
 
+For larger clusters you may need to set custom resource requests and limits. For the CoreDNS provicer you can set
+
+- memoryLimit
+- cpuRequest
+- memoryRequest
+
+This will override the default limit value for memory of 170Mi and default request values for memory and cpu of 70Mi and 100m.
+
+Example:
+```
+  kubeDNS:
+    memoryLimit: 2Gi
+    cpuRequest: 300m
+    memoryRequest: 700Mi
+```
+
 ## kubeControllerManager
 This block contains configurations for the `controller-manager`.
 


### PR DESCRIPTION
Cluster spec settings to override the default resource request and limit values of CoreDNS . Currently not documented.

Reference:
- [coredns k8s-1.12.yaml.template](https://github.com/kubernetes/kops/blob/1c78abb288a06b5719e4750b63b7ef06c967de84/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template#L156-L161)
- [cluster.go](https://github.com/kubernetes/kops/blob/1c78abb288a06b5719e4750b63b7ef06c967de84/pkg/apis/kops/v1alpha2/cluster.go#L476-L515)