### PR TITLE
Use Cilium 1.11 as default

### DIFF
--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.10.5"
+		c.Version = "v1.11.3"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -58,6 +58,8 @@ func (t *Tester) setSkipRegexFlag() error {
 			// https://github.com/cilium/cilium/issues/5719
 			skipRegex += "|should.create.a.Pod.with.SCTP.HostPort"
 		}
+		// https://github.com/cilium/cilium/issues/18241
+		skipRegex += "|Services.should.create.endpoints.for.unready.pods"
 	} else if networking.Kuberouter != nil {
 		skipRegex += "|load-balancer|hairpin|affinity\\stimeout|service\\.kubernetes\\.io|CLOSE_WAIT"
 	} else if networking.Kubenet != nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -223,7 +223,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.10.5
+      version: v1.11.3
   nonMasqueradeCIDR: ::/0
   secretStore: memfs://clusters.example.com/minimal-ipv6.example.com/secrets
   serviceClusterIPRange: fd00:5e4f:ce::/108

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 60c771946913224e602d995e95930b404068a4143dc315e5d1e92471539c9709
+    manifestHash: fd0232e3cde7583db99cb39e7794f6b47ac9d2b602c817e91d3dffefafa51e27
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -379,7 +379,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.10.5
+        image: quay.io/cilium/cilium:v1.11.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -475,7 +475,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.10.5
+        image: quay.io/cilium/cilium:v1.11.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -601,7 +601,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.10.5
+        image: quay.io/cilium/operator:v1.11.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: hoL7NY+BBOApJhzOkhiaRIDZjFySEDFmMbCPLbf6ZNs=
+NodeupConfigHash: q1pEevxUrqqcIg+ixZGjTWhRw0i/pOuKDgndw22T0oU=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -206,7 +206,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.10.5
+      version: v1.11.3
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/minimal-warmpool.example.com/secrets

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 7338749fdf9643b1cfd121b287c8dc33406c553b4973d4d6d29d6abb4617d24d
+    manifestHash: 2a670a1670e2b0d74c7ae2b9266dd11ab0a2906301624459a559fc88687a4b2f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -379,7 +379,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.10.5
+        image: quay.io/cilium/cilium:v1.11.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -475,7 +475,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.10.5
+        image: quay.io/cilium/cilium:v1.11.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -601,7 +601,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.10.5
+        image: quay.io/cilium/operator:v1.11.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -67,8 +67,8 @@ containerdConfig:
   logLevel: info
   version: 1.4.12
 warmPoolImages:
-- quay.io/cilium/cilium:v1.10.5
-- quay.io/cilium/operator:v1.10.5
+- quay.io/cilium/cilium:v1.11.3
+- quay.io/cilium/operator:v1.11.3
 - registry.k8s.io/kube-proxy:v1.21.0
 - registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.5.0
 - registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -192,7 +192,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.10.5
+      version: v1.11.3
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/privatecilium.example.com/secrets

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 4db20d0be4b8a130c10469d1278499f5f9ed057232cef2b08af292fd548be8f6
+    manifestHash: 7fb1a684d504a68ef8bc60cca311adab1f6e14638e0846ca6efab7e2be74aeb8
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -379,7 +379,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.10.5
+        image: quay.io/cilium/cilium:v1.11.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -475,7 +475,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.10.5
+        image: quay.io/cilium/cilium:v1.11.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -601,7 +601,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.10.5
+        image: quay.io/cilium/operator:v1.11.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -202,7 +202,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.10.5
+      version: v1.11.3
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/privateciliumadvanced.example.com/secrets

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 9739b1e98948dee5b914774d8b7126c5e37c8623cb54d197048ee92331212024
+    manifestHash: ff3caf1aa959ea88ade8c5f172c830a371ea1bb32ad94b6a1545bfb870237376
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -393,7 +393,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.10.5
+        image: quay.io/cilium/cilium:v1.11.3
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -495,7 +495,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.10.5
+        image: quay.io/cilium/cilium:v1.11.3
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -632,7 +632,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.10.5
+        image: quay.io/cilium/operator:v1.11.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 760dded8cabec4049ab451a402737771777d475e6f32817ad2f470a5d107c209
+    manifestHash: 8f8cb0a7cc9ba03214f09c7fece61acc30242e4c8aa9a62eaba4e17c3ea21620
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 760dded8cabec4049ab451a402737771777d475e6f32817ad2f470a5d107c209
+    manifestHash: 8f8cb0a7cc9ba03214f09c7fece61acc30242e4c8aa9a62eaba4e17c3ea21620
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 760dded8cabec4049ab451a402737771777d475e6f32817ad2f470a5d107c209
+    manifestHash: 8f8cb0a7cc9ba03214f09c7fece61acc30242e4c8aa9a62eaba4e17c3ea21620
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cilium 1.11 released today: https://isovalent.com/blog/post/2021-12-release-111
Not sure we want this one in 1.23 or wait. Or maybe upgrade cilium based on k8s version.

Either way, this is the first version that formally supports 1.23 (although 1.10 should work fine as well).