### PR TITLE
kops auth-plugin: need to clear any existing password / key

### DIFF
--- a/pkg/kubeconfig/create_kubecfg.go
+++ b/pkg/kubeconfig/create_kubecfg.go
@@ -164,6 +164,10 @@ func BuildKubecfg(cluster *kops.Cluster, keyStore fi.Keystore, secretStore fi.Se
 			"--cluster=" + clusterName,
 			"--state=" + kopsStateStore,
 		}
+
+		// If there's an existing client-cert / client-key, we need to clear it so it won't be used
+		b.ClientCert = nil
+		b.ClientKey = nil
 	}
 
 	b.Server = server

--- a/pkg/kubeconfig/kubecfg_builder.go
+++ b/pkg/kubeconfig/kubecfg_builder.go
@@ -127,14 +127,18 @@ func (b *KubeconfigBuilder) WriteKubecfg(configAccess clientcmd.ConfigAccess) er
 			authInfo = clientcmdapi.NewAuthInfo()
 		}
 
-		if b.KubeUser != "" && b.KubePassword != "" {
+		// If we are using the auth plugin, we want to clear the password & client-key,
+		// otherwise the auth plugin won't be used
+
+		usingAuthPlugin := len(b.AuthenticationExec) != 0
+		if (b.KubeUser != "" && b.KubePassword != "") || usingAuthPlugin {
 			authInfo.Username = b.KubeUser
 			authInfo.Password = b.KubePassword
 
 			haveUserInfo = true
 		}
 
-		if b.ClientCert != nil && b.ClientKey != nil {
+		if (b.ClientCert != nil && b.ClientKey != nil) || usingAuthPlugin {
 			authInfo.ClientCertificate = ""
 			authInfo.ClientCertificateData = b.ClientCert
 			authInfo.ClientKey = ""
@@ -143,7 +147,7 @@ func (b *KubeconfigBuilder) WriteKubecfg(configAccess clientcmd.ConfigAccess) er
 			haveUserInfo = true
 		}
 
-		if len(b.AuthenticationExec) != 0 {
+		if usingAuthPlugin {
 			authInfo.Exec = &clientcmdapi.ExecConfig{
 				APIVersion: "client.authentication.k8s.io/v1beta1",
 				Command:    b.AuthenticationExec[0],


### PR DESCRIPTION
Otherwise the password / key is used in preference to the auth plugin,
so these are used even if they have expired.
