### PR TITLE
nodeup: store the CloudProvider in the context

### DIFF
--- a/nodeup/pkg/model/bootstrap_client.go
+++ b/nodeup/pkg/model/bootstrap_client.go
@@ -43,7 +43,7 @@ func (b BootstrapClientBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	var authenticator bootstrap.Authenticator
 	var err error
-	switch kops.CloudProviderID(b.Cluster.Spec.CloudProvider) {
+	switch b.CloudProvider {
 	case kops.CloudProviderAWS:
 		authenticator, err = awsup.NewAWSAuthenticator(b.Cloud.Region())
 	case kops.CloudProviderGCE:
@@ -52,7 +52,7 @@ func (b BootstrapClientBuilder) Build(c *fi.ModelBuilderContext) error {
 		// instead we use this as a check that protokube has now started.
 
 	default:
-		return fmt.Errorf("unsupported cloud provider for authenticator %q", b.Cluster.Spec.CloudProvider)
+		return fmt.Errorf("unsupported cloud provider for authenticator %q", b.CloudProvider)
 	}
 
 	if err != nil {

--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -86,7 +86,7 @@ func (b *CloudConfigBuilder) build(c *fi.ModelBuilderContext, inTree bool) error
 	// Add cloud config file if needed
 	var lines []string
 
-	cloudProvider := b.Cluster.Spec.CloudProvider
+	cloudProvider := b.CloudProvider
 	cloudConfig := b.Cluster.Spec.CloudConfig
 
 	if cloudConfig == nil {

--- a/nodeup/pkg/model/cloudconfig_test.go
+++ b/nodeup/pkg/model/cloudconfig_test.go
@@ -63,7 +63,8 @@ func TestBuildAzure(t *testing.T) {
 
 	b := &CloudConfigBuilder{
 		NodeupModelContext: &NodeupModelContext{
-			Cluster: cluster,
+			CloudProvider: kops.CloudProviderAzure,
+			Cluster:       cluster,
 		},
 	}
 	ctx := &fi.ModelBuilderContext{
@@ -131,7 +132,8 @@ func TestBuildAWSCustomNodeIPFamilies(t *testing.T) {
 
 	b := &CloudConfigBuilder{
 		NodeupModelContext: &NodeupModelContext{
-			Cluster: cluster,
+			CloudProvider: kops.CloudProviderAWS,
+			Cluster:       cluster,
 		},
 	}
 	ctx := &fi.ModelBuilderContext{

--- a/nodeup/pkg/model/context.go
+++ b/nodeup/pkg/model/context.go
@@ -72,6 +72,8 @@ type NodeupModelContext struct {
 	ConfigurationMode string
 	InstanceID        string
 	MachineType       string
+
+	CloudProvider kops.CloudProviderID
 }
 
 // Init completes initialization of the object, for example pre-parsing the kubernetes version
@@ -613,5 +615,5 @@ func (c *NodeupModelContext) InstallNvidiaRuntime() bool {
 
 // RunningOnGCE returns true if we are running on GCE
 func (c *NodeupModelContext) RunningOnGCE() bool {
-	return kops.CloudProviderID(c.Cluster.Spec.CloudProvider) == kops.CloudProviderGCE
+	return c.CloudProvider == kops.CloudProviderGCE
 }

--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -378,7 +378,7 @@ func (b *KubeAPIServerBuilder) writeServerCertificate(c *fi.ModelBuilderContext,
 		// We also want to be able to reference it locally via https://127.0.0.1
 		alternateNames = append(alternateNames, "127.0.0.1")
 
-		if b.Cluster.Spec.CloudProvider == "openstack" {
+		if b.CloudProvider == kops.CloudProviderOpenstack {
 			if b.Cluster.Spec.Topology != nil && b.Cluster.Spec.Topology.Masters == kops.TopologyPrivate {
 				instanceAddress, err := getInstanceAddress()
 				if err != nil {

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -599,7 +599,7 @@ func (b *KubeletBuilder) buildKubeletServingCertificate(c *fi.ModelBuilderContex
 }
 
 func (b *KubeletBuilder) kubeletNames() ([]string, error) {
-	if kops.CloudProviderID(b.Cluster.Spec.CloudProvider) != kops.CloudProviderAWS {
+	if b.CloudProvider != kops.CloudProviderAWS {
 		name, err := os.Hostname()
 		if err != nil {
 			return nil, err

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -253,8 +253,9 @@ func BuildNodeupModelContext(model *testutils.Model) (*NodeupModelContext, error
 	}
 
 	nodeupModelContext := &NodeupModelContext{
-		Architecture: "amd64",
-		BootConfig:   &nodeup.BootConfig{},
+		Architecture:  "amd64",
+		BootConfig:    &nodeup.BootConfig{},
+		CloudProvider: kops.CloudProviderID(model.Cluster.Spec.CloudProvider),
 		NodeupConfig: &nodeup.Config{
 			CAs:        map[string]string{},
 			KeypairIDs: map[string]string{},

--- a/nodeup/pkg/model/ntp.go
+++ b/nodeup/pkg/model/ntp.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"k8s.io/klog/v2"
+	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 	"k8s.io/kops/util/pkg/distributions"
@@ -49,10 +50,10 @@ func (b *NTPBuilder) Build(c *fi.ModelBuilderContext) error {
 	}
 
 	var ntpHost string
-	switch b.Cluster.Spec.CloudProvider {
-	case "aws":
+	switch b.CloudProvider {
+	case kops.CloudProviderAWS:
 		ntpHost = "169.254.169.123"
-	case "gce":
+	case kops.CloudProviderGCE:
 		ntpHost = "time.google.com"
 	default:
 		ntpHost = ""

--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -231,11 +231,11 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 		f.DNSInternalSuffix = fi.String(internalSuffix)
 	}
 
-	if t.Cluster.Spec.CloudProvider != "" {
-		f.Cloud = fi.String(t.Cluster.Spec.CloudProvider)
+	if t.CloudProvider != "" {
+		f.Cloud = fi.String(string(t.CloudProvider))
 
 		if f.DNSProvider == nil {
-			switch kops.CloudProviderID(t.Cluster.Spec.CloudProvider) {
+			switch t.CloudProvider {
 			case kops.CloudProviderAWS:
 				f.DNSProvider = fi.String("aws-route53")
 			case kops.CloudProviderDO:
@@ -243,7 +243,7 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 			case kops.CloudProviderGCE:
 				f.DNSProvider = fi.String("google-clouddns")
 			default:
-				klog.Warningf("Unknown cloudprovider %q; won't set DNS provider", t.Cluster.Spec.CloudProvider)
+				klog.Warningf("Unknown cloudprovider %q; won't set DNS provider", t.CloudProvider)
 			}
 		}
 	}
@@ -327,7 +327,7 @@ func (t *ProtokubeBuilder) buildEnvFile() (*nodetasks.File, error) {
 		}
 	}
 
-	if kops.CloudProviderID(t.Cluster.Spec.CloudProvider) == kops.CloudProviderDO && os.Getenv("DIGITALOCEAN_ACCESS_TOKEN") != "" {
+	if t.CloudProvider == kops.CloudProviderDO && os.Getenv("DIGITALOCEAN_ACCESS_TOKEN") != "" {
 		envVars["DIGITALOCEAN_ACCESS_TOKEN"] = os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
 	}
 

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -133,7 +133,7 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 	}
 
-	if b.Cluster.Spec.CloudProvider == string(kops.CloudProviderAWS) {
+	if b.CloudProvider == kops.CloudProviderAWS {
 		sysctls = append(sysctls,
 			"# AWS settings",
 			"",

--- a/nodeup/pkg/model/warm_pool.go
+++ b/nodeup/pkg/model/warm_pool.go
@@ -30,7 +30,7 @@ var _ fi.ModelBuilder = &WarmPoolBuilder{}
 
 func (b *WarmPoolBuilder) Build(c *fi.ModelBuilderContext) error {
 	// Check if the cloud provider is AWS
-	if b.Cluster == nil || b.Cluster.Spec.CloudProvider != string(kops.CloudProviderAWS) {
+	if b.CloudProvider != kops.CloudProviderAWS {
 		return nil
 	}
 


### PR DESCRIPTION
This is a bit simpler than fetching it from the cluster every time, and also can allow things like mixed-cloud clusters (in future).
