### PR TITLE
Only shellcheck files

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -74,7 +74,7 @@ cd "${KOPS_ROOT}"
 all_shell_scripts=()
 while IFS=$'\n' read -r script;
   do git check-ignore -q "$script" || all_shell_scripts+=("$script");
-done < <(find . -name "*.sh" \
+done < <(find . -type f -name "*.sh" \
   -not \( \
     -path ./_\*      -o \
     -path ./.git\*   -o \


### PR DESCRIPTION
Currently shell check will fail if one has a folder called for example `karpenter.sh`. This PR ensures we are only checking files.