### PR TITLE
Update name of kubernetes-ca keypair in documentation

### DIFF
--- a/cmd/kops/create_keypair.go
+++ b/cmd/kops/create_keypair.go
@@ -63,7 +63,7 @@ var (
 
 	createKeypairExample = templates.Examples(i18n.T(`
 	# Add a CA certificate and private key to a keyset.
-	kops create keypair ca \
+	kops create keypair kubernetes-ca \
 		--cert ~/ca.pem --key ~/ca-key.pem \
 		--name k8s-cluster.example.com --state s3://my-state-store
 

--- a/cmd/kops/distrust_keypair.go
+++ b/cmd/kops/distrust_keypair.go
@@ -50,10 +50,10 @@ var (
 
 	distrustKeypairExample = templates.Examples(i18n.T(`
 	# Distrust all cluster CA keypairs older than the primary.
-	kops distrust keypair ca
+	kops distrust keypair kubernetes-ca
 
 	# Distrust a particular keypair.
-	kops distrust keypair ca 6977545226837259959403993899
+	kops distrust keypair kubernetes-ca 6977545226837259959403993899
 
 	# Distrust all rotatable keypairs older than their respective primaries.
 	kops distrust keypair all

--- a/cmd/kops/get_keypairs.go
+++ b/cmd/kops/get_keypairs.go
@@ -39,7 +39,7 @@ import (
 var (
 	getKeypairExample = templates.Examples(i18n.T(`
 	# List the cluster CA keypairs.
-	kops get keypairs ca
+	kops get keypairs kubernetes-ca
 
 	# List the service-account keypairs, including distrusted ones.
 	kops get keypairs service-account --distrusted`))

--- a/cmd/kops/promote_keypair.go
+++ b/cmd/kops/promote_keypair.go
@@ -44,8 +44,8 @@ var (
     `))
 
 	promoteKeypairExample = templates.Examples(i18n.T(`
-	# Promote the newest ca keypair to be the primary.
-	kops promote keypair ca \
+	# Promote the newest kubernetes-ca keypair to be the primary.
+	kops promote keypair kubernetes-ca \
 		--name k8s-cluster.example.com --state s3://my-state-store
 
     # Promote a specific service-account keypair to be the primary.

--- a/docs/cli/kops_create_keypair.md
+++ b/docs/cli/kops_create_keypair.md
@@ -27,7 +27,7 @@ kops create keypair {KEYSET | all} [flags]
 
 ```
   # Add a CA certificate and private key to a keyset.
-  kops create keypair ca \
+  kops create keypair kubernetes-ca \
   --cert ~/ca.pem --key ~/ca-key.pem \
   --name k8s-cluster.example.com --state s3://my-state-store
   

--- a/docs/cli/kops_distrust_keypair.md
+++ b/docs/cli/kops_distrust_keypair.md
@@ -25,10 +25,10 @@ kops distrust keypair {KEYSET [ID]... | all} [flags]
 
 ```
   # Distrust all cluster CA keypairs older than the primary.
-  kops distrust keypair ca
+  kops distrust keypair kubernetes-ca
   
   # Distrust a particular keypair.
-  kops distrust keypair ca 6977545226837259959403993899
+  kops distrust keypair kubernetes-ca 6977545226837259959403993899
   
   # Distrust all rotatable keypairs older than their respective primaries.
   kops distrust keypair all

--- a/docs/cli/kops_get_keypairs.md
+++ b/docs/cli/kops_get_keypairs.md
@@ -13,7 +13,7 @@ kops get keypairs [KEYSET]... [flags]
 
 ```
   # List the cluster CA keypairs.
-  kops get keypairs ca
+  kops get keypairs kubernetes-ca
   
   # List the service-account keypairs, including distrusted ones.
   kops get keypairs service-account --distrusted

--- a/docs/cli/kops_promote_keypair.md
+++ b/docs/cli/kops_promote_keypair.md
@@ -20,8 +20,8 @@ kops promote keypair {KEYSET [ID] | all} [flags]
 ### Examples
 
 ```
-  # Promote the newest ca keypair to be the primary.
-  kops promote keypair ca \
+  # Promote the newest kubernetes-ca keypair to be the primary.
+  kops promote keypair kubernetes-ca \
   --name k8s-cluster.example.com --state s3://my-state-store
   
   # Promote a specific service-account keypair to be the primary.

--- a/docs/custom_ca.md
+++ b/docs/custom_ca.md
@@ -2,11 +2,8 @@
 
 ## Background Info
 
-When deploying a `kops` based Kubernetes cluster, `kops` will generate a certificate authority keypair for signing
-various certificates with. In some cases, you may want to provide your own CA keypair.
-
-Another use case would be to use the CA keypair of another cluster if you are creating many
-short lived clusters and don't want to create a unique CA for each one.
+When deploying a `kops` based Kubernetes cluster, `kops` will generate a Certificate Authority keypair for signing
+various certificates. In some cases, you may want to provide your own CA keypair.
 
 ### Building a cluster with a custom CA
 
@@ -17,21 +14,10 @@ The following procedure will allow you to override the CA when creating a cluste
 
 ```bash
 kops create -f cluster.yaml
-kops create secret ca --primary --cert ca.crt --key ca.key --name cluster-name.com
+kops create keypair kubernetes-ca --primary --cert ca.crt --key ca.key --name cluster-name.com
 kops update cluster --yes
 ```
 
 1. First we create the cluster folder structure in the statestore.
-2. Second, we create a `Secret` of type `Keypair` with the name `ca` and provide our own values.
-3. Lastly, we run `kops update cluster --yes`, which will generate all the certificates needed, referencing the `Secret` called `ca` we just defined (versus generating its own).
-
-### Using a previous `kops` cluster CA
-
-In some cases you will want to create a cluster and use the CA generated in a previous `kops` cluster.
-To do so, you will need to copy the CA files from the state store, and then use them as values in the above procedure.
-
-The files are located as follows:
-
-`s3://state-store/<cluster-name>/pki/issued/ca/<id>.crt`
-
-`s3://state-store/<cluster-name>/pki/private/ca/<id>.key`
+2. Second, we create a keypair with the name `kubernetes-ca` and provide our own values.
+3. Last, we run `kops update cluster --yes`, which will generate all the certificates needed, referencing the keypair called `kubernetes-ca` we just defined (instead of generating its own).


### PR DESCRIPTION
/kind documentation

Extracting the CA of an existing cluster is not a use case we support.

Closes #12910 
