### PR TITLE
Automated cherry pick of #12918: Make service topology for cilium configurable

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -4698,6 +4698,10 @@ spec:
                         description: 'EnableRemoteNodeIdentity enables the remote-node-identity.
                           Default: true'
                         type: boolean
+                      enableServiceTopology:
+                        description: EnableServiceTopology determine if cilium should
+                          use topology aware hints.
+                        type: boolean
                       enableTracing:
                         description: EnableTracing is unused.
                         type: boolean

--- a/pkg/apis/kops/networking.go
+++ b/pkg/apis/kops/networking.go
@@ -411,6 +411,9 @@ type CiliumNetworkingSpec struct {
 
 	// DisableCNPStatusUpdates determines if CNP NodeStatus updates will be sent to the Kubernetes api-server.
 	DisableCNPStatusUpdates *bool `json:"disableCNPStatusUpdates,omitempty"`
+
+	// EnableServiceTopology determine if cilium should use topology aware hints.
+	EnableServiceTopology bool `json:"enableServiceTopology,omitempty"`
 }
 
 // HubbleSpec configures the Hubble service on the Cilium agent.

--- a/pkg/apis/kops/v1alpha2/networking.go
+++ b/pkg/apis/kops/v1alpha2/networking.go
@@ -575,6 +575,9 @@ type CiliumNetworkingSpec struct {
 	CniBinPath string `json:"cniBinPath,omitempty"`
 	// DisableCNPStatusUpdates determines if CNP NodeStatus updates will be sent to the Kubernetes api-server.
 	DisableCNPStatusUpdates *bool `json:"disableCNPStatusUpdates,omitempty"`
+
+	// EnableServiceTopology determine if cilium should use topology aware hints.
+	EnableServiceTopology bool `json:"enableServiceTopology,omitempty"`
 }
 
 // HubbleSpec configures the Hubble service on the Cilium agent.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1955,6 +1955,7 @@ func autoConvert_v1alpha2_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 	// INFO: in.NodeInitBootstrapFile opted out of conversion generation
 	// INFO: in.CniBinPath opted out of conversion generation
 	out.DisableCNPStatusUpdates = in.DisableCNPStatusUpdates
+	out.EnableServiceTopology = in.EnableServiceTopology
 	return nil
 }
 
@@ -2010,6 +2011,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha2_CiliumNetworkingSpec(in *
 		out.Hubble = nil
 	}
 	out.DisableCNPStatusUpdates = in.DisableCNPStatusUpdates
+	out.EnableServiceTopology = in.EnableServiceTopology
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/networking.go
+++ b/pkg/apis/kops/v1alpha3/networking.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
+
 	"k8s.io/kops/pkg/apis/kops"
 )
 
@@ -394,6 +395,9 @@ type CiliumNetworkingSpec struct {
 
 	// DisableCNPStatusUpdates determines if CNP NodeStatus updates will be sent to the Kubernetes api-server.
 	DisableCNPStatusUpdates *bool `json:"disableCNPStatusUpdates,omitempty"`
+
+	// EnableServiceTopology determine if cilium should use topology aware hints.
+	EnableServiceTopology bool `json:"enableServiceTopology,omitempty"`
 }
 
 // HubbleSpec configures the Hubble service on the Cilium agent.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1861,6 +1861,7 @@ func autoConvert_v1alpha3_CiliumNetworkingSpec_To_kops_CiliumNetworkingSpec(in *
 		out.Hubble = nil
 	}
 	out.DisableCNPStatusUpdates = in.DisableCNPStatusUpdates
+	out.EnableServiceTopology = in.EnableServiceTopology
 	return nil
 }
 
@@ -1921,6 +1922,7 @@ func autoConvert_kops_CiliumNetworkingSpec_To_v1alpha3_CiliumNetworkingSpec(in *
 		out.Hubble = nil
 	}
 	out.DisableCNPStatusUpdates = in.DisableCNPStatusUpdates
+	out.EnableServiceTopology = in.EnableServiceTopology
 	return nil
 }
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -877,6 +877,12 @@ func validateNetworkingCilium(cluster *kops.Cluster, v *kops.CiliumNetworkingSpe
 		if version.Minor < 10 && v.EncryptionType == kops.CiliumEncryptionTypeWireguard {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("encryptionType"), "Cilium EncryptionType=WireGuard is not available for Cilium version < 1.10.0."))
 		}
+
+		if version.Minor < 11 {
+			if v.EnableServiceTopology {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableServiceTopology"), "Service topology requires Cilium 1.11"))
+			}
+		}
 	}
 
 	if v.EnableNodePort && c.KubeProxy != nil && (c.KubeProxy.Enabled == nil || *c.KubeProxy.Enabled) {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: c98c74504ff171fcfa552b53a87f67137a1487d31171c176a6880c0d41ebf623
+    manifestHash: 1206170b5352579dabf78db9f85cf7e4170454e18158315fe9aa7bf0d15c1b7a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -49,6 +49,7 @@ data:
   enable-l7-proxy: "true"
   enable-node-port: "false"
   enable-remote-node-identity: "true"
+  enable-service-topology: "false"
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   install-iptables-rules: "true"

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: c449432de8df143eb56fb384e16e2631d029d614172043ef42ca329fde2933b3
+    manifestHash: b6f375005c2450576148cc428680bd32b9abfe404fa43399b6f0cd60b5cd3d61
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -49,6 +49,7 @@ data:
   enable-l7-proxy: "true"
   enable-node-port: "false"
   enable-remote-node-identity: "true"
+  enable-service-topology: "false"
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   install-iptables-rules: "true"

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: abde120455236502ea9a96bfc4e884b0b73fec606df9b10ac2c61b5bcd19eb78
+    manifestHash: 316f256062e3e4560695793d66963f1efc812e38b2f746a28aa67c48007f07fc
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -49,6 +49,7 @@ data:
   enable-l7-proxy: "true"
   enable-node-port: "false"
   enable-remote-node-identity: "true"
+  enable-service-topology: "false"
   identity-allocation-mode: crd
   identity-change-grace-period: 5s
   install-iptables-rules: "true"

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 91c06f487cb2bb86db1c7dfff7dcdeb139795e0c2bc3da2b702005661a6870bd
+    manifestHash: aed3c488129f6bc6fc64a7f36e42377f38f9cc26f94bd360da82ae28f1d73906
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -53,6 +53,7 @@ data:
   enable-l7-proxy: "true"
   enable-node-port: "true"
   enable-remote-node-identity: "true"
+  enable-service-topology: "false"
   etcd-config: |-
     ---
     endpoints:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -256,6 +256,8 @@ data:
 
   disable-cnp-status-updates: "{{ .DisableCNPStatusUpdates }}"
 
+  enable-service-topology: "{{ .EnableServiceTopology }}"
+
   {{ if WithDefaultBool .Hubble.Enabled false }}
   # Enable Hubble gRPC service.
   enable-hubble: "true"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 472d1ede7b67d9a5dae1dd8b49312a238091233d56a184319e16df0027653d6f
+    manifestHash: 84627dabca6e6fe741520d1770365676b0c5b22c34d3040459e9a3ca21c4a50a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 472d1ede7b67d9a5dae1dd8b49312a238091233d56a184319e16df0027653d6f
+    manifestHash: 84627dabca6e6fe741520d1770365676b0c5b22c34d3040459e9a3ca21c4a50a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 472d1ede7b67d9a5dae1dd8b49312a238091233d56a184319e16df0027653d6f
+    manifestHash: 84627dabca6e6fe741520d1770365676b0c5b22c34d3040459e9a3ca21c4a50a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -75,7 +75,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 472d1ede7b67d9a5dae1dd8b49312a238091233d56a184319e16df0027653d6f
+    manifestHash: 84627dabca6e6fe741520d1770365676b0c5b22c34d3040459e9a3ca21c4a50a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 472d1ede7b67d9a5dae1dd8b49312a238091233d56a184319e16df0027653d6f
+    manifestHash: 84627dabca6e6fe741520d1770365676b0c5b22c34d3040459e9a3ca21c4a50a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #12918 on release-1.23.

#12918: Make service topology for cilium configurable

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```