### PR TITLE
Automated cherry pick of #12941: Remove support for Weave as of k8s 1.23

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -25,7 +25,7 @@ The following table provides the support status for various networking providers
 | Kubenet | 1.5 | 1.5 | - | - |
 | Lyft VPC | 1.11 | - | 1.22 | 1.23 |
 | Romana | 1.8 | - | 1.18 | 1.19 |
-| Weave | 1.5 | - | - | - |
+| Weave | 1.5 | - | 1.23 | Kubernetes 1.23 |
 
 ### Which networking provider should you use?
 

--- a/docs/networking/weave.md
+++ b/docs/networking/weave.md
@@ -1,5 +1,7 @@
 ### Weave
 
+&#9888; The Weave CNI is not supported for Kubernetes 1.23 or later.
+
 #### Installation
 
 To use the Weave, specify the following in the cluster spec.

--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -17,6 +17,8 @@ being used, then Kubernetes Node resources will be named after their AWS instanc
 
 * Support for the Lyft CNI has been removed.
 
+* The Weave CNI is not supported for Kubernetes 1.23 or later.
+
 * Support for CentOS 7 has been removed.
 
 * Support for CentOS 8 has been removed.

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -708,7 +708,9 @@ func validateNetworking(cluster *kops.Cluster, v *kops.NetworkingSpec, fldPath *
 		}
 		optionTaken = true
 
-		if cluster.Spec.IsIPv6Only() {
+		if cluster.IsKubernetesGTE("1.23") {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("weave"), "Weave is not supported for Kubernetes >= 1.23"))
+		} else if cluster.Spec.IsIPv6Only() {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("weave"), "Weave does not support IPv6"))
 		}
 	}


### PR DESCRIPTION
Cherry pick of #12941 on release-1.23.

#12941: Remove support for Weave as of k8s 1.23

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.