### PR TITLE
Revert "Recognize debian bullseye as having "broken" resolv.conf"

### DIFF
--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -95,11 +95,6 @@ func (d *Distribution) HasLoopbackEtcResolvConf() bool {
 		// Ubuntu > 16.04 has it
 		return d.version > 16.04
 	}
-	// TODO: Should we read /etc/resolv.conf??
-	if d.IsDebianFamily() {
-		// Bullseye has it
-		return d.version >= 11.0
-	}
 	return false
 }
 


### PR DESCRIPTION
Reverts kubernetes/kops#12937