### PR TITLE
Automated cherry pick of #12954: Update Go to v1.17.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.4
+          go-version: 1.17.5
 
       - uses: actions/checkout@v2
         with:
@@ -33,7 +33,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.4
+        go-version: 1.17.5
 
     - uses: actions/checkout@v2
       with:
@@ -50,7 +50,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.4
+        go-version: 1.17.5
 
     - uses: actions/checkout@v2
       with:
@@ -67,7 +67,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17.4
+          go-version: 1.17.5
 
       - uses: actions/checkout@v2
         with:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.17.4",
+    go_version = "1.17.5",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")


### PR DESCRIPTION
Cherry pick of #12954 on release-1.23.

#12954: Update Go to v1.17.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.