### PR TITLE
Automated cherry pick of #12956: Update Go to v1.16.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.11
+          go-version: 1.16.12
 
       - uses: actions/checkout@v2
         with:
@@ -33,7 +33,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.11
+        go-version: 1.16.12
 
     - uses: actions/checkout@v2
       with:
@@ -50,7 +50,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.11
+        go-version: 1.16.12
 
     - uses: actions/checkout@v2
       with:
@@ -67,7 +67,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.11
+          go-version: 1.16.12
 
       - uses: actions/checkout@v2
         with:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.16.11",
+    go_version = "1.16.12",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")


### PR DESCRIPTION
Cherry pick of #12956 on release-1.21.

#12956: Update Go to v1.16.12

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.