### PR TITLE
Hubble relay should not tolerate anything

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -1087,8 +1087,6 @@ spec:
       serviceAccount: hubble-relay
       serviceAccountName: hubble-relay
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - operator: Exists
       volumes:
       - hostPath:
           path: /var/run/cilium


### PR DESCRIPTION
Upstream also have no tolerations on relay. Not sure how this got added.