### PR TITLE
Automated cherry pick of #12968: Update containerd to v1.6.0-beta.4

### DIFF
--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -47,7 +47,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 		// Set version based on Kubernetes version
 		if fi.StringValue(containerd.Version) == "" {
 			if b.IsKubernetesGTE("1.23") {
-				containerd.Version = fi.String("1.6.0-beta.3")
+				containerd.Version = fi.String("1.6.0-beta.4")
 			} else if b.IsKubernetesGTE("1.19") {
 				containerd.Version = fi.String("1.4.12")
 			} else {

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -131,7 +131,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-beta.3
+  version: 1.6.0-beta.4
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -256,7 +256,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: XGw5A27FqSBqZJkyarb6t9L0kHL5Y3kJQoFr92bwBfs=
+NodeupConfigHash: Hz8bniux/XFKGAZzDGH/S7X8L4tKkECjVcxucLW3s9g=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -131,7 +131,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-beta.3
+  version: 1.6.0-beta.4
 docker:
   skipInstall: true
 kubeProxy:
@@ -165,7 +165,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 9EpL7sKUfog8xtgT1+NDNAOEijn58APNuAL/GsehetA=
+NodeupConfigHash: wsuaTXlV7xscgRfb/1IajFYMrECvSCI617mO99vaGkQ=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
   containerRuntime: containerd
   containerd:
     logLevel: info
-    version: 1.6.0-beta.3
+    version: 1.6.0-beta.4
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -55,14 +55,14 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - b7faafc73404ab95a522b7d17f273c863c3544911edb4dc2dfa5cd6e2c2bacb0@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-cni-1.6.0-beta.3-linux-amd64.tar.gz
+  - 9a33654970a73bec7ae32b1e7dffd4dd0217291ca2072f6944e241ee1b1d7fe5@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/cri-containerd-cni-1.6.0-beta.4-linux-amd64.tar.gz
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9381d0ec59d44497290752e41b9e8185f769f9225982522a3f12aab51f72481b@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-cni-1.6.0-beta.3-linux-arm64.tar.gz
+  - c84a7600a5d95306be48c85a5966011f714ee78ba990ee4526b25f042d17528d@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/cri-containerd-cni-1.6.0-beta.4-linux-arm64.tar.gz
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
 CAs:
@@ -261,7 +261,7 @@ channels:
 - memfs://tests/minimal.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-beta.3
+  version: 1.6.0-beta.4
 etcdManifests:
 - memfs://tests/minimal.example.com/manifests/etcd/main.yaml
 - memfs://tests/minimal.example.com/manifests/etcd/events.yaml

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -3,12 +3,12 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - b7faafc73404ab95a522b7d17f273c863c3544911edb4dc2dfa5cd6e2c2bacb0@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-cni-1.6.0-beta.3-linux-amd64.tar.gz
+  - 9a33654970a73bec7ae32b1e7dffd4dd0217291ca2072f6944e241ee1b1d7fe5@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/cri-containerd-cni-1.6.0-beta.4-linux-amd64.tar.gz
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9381d0ec59d44497290752e41b9e8185f769f9225982522a3f12aab51f72481b@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-cni-1.6.0-beta.3-linux-arm64.tar.gz
+  - c84a7600a5d95306be48c85a5966011f714ee78ba990ee4526b25f042d17528d@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/cri-containerd-cni-1.6.0-beta.4-linux-arm64.tar.gz
 CAs:
   kubernetes-ca: |
     -----BEGIN CERTIFICATE-----
@@ -64,4 +64,4 @@ channels:
 - memfs://tests/minimal.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-beta.3
+  version: 1.6.0-beta.4

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -22,7 +22,7 @@ spec:
   containerRuntime: containerd
   containerd:
     logLevel: info
-    version: 1.6.0-beta.3
+    version: 1.6.0-beta.4
   dnsZone: "1"
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-master-us-test1-a_content
@@ -56,7 +56,7 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - b7faafc73404ab95a522b7d17f273c863c3544911edb4dc2dfa5cd6e2c2bacb0@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-cni-1.6.0-beta.3-linux-amd64.tar.gz
+  - 9a33654970a73bec7ae32b1e7dffd4dd0217291ca2072f6944e241ee1b1d7fe5@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/cri-containerd-cni-1.6.0-beta.4-linux-amd64.tar.gz
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
   arm64:
@@ -64,7 +64,7 @@ Assets:
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9381d0ec59d44497290752e41b9e8185f769f9225982522a3f12aab51f72481b@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-cni-1.6.0-beta.3-linux-arm64.tar.gz
+  - c84a7600a5d95306be48c85a5966011f714ee78ba990ee4526b25f042d17528d@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/cri-containerd-cni-1.6.0-beta.4-linux-arm64.tar.gz
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
 CAs:
@@ -260,7 +260,7 @@ channels:
 - memfs://tests/minimal-gce.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-beta.3
+  version: 1.6.0-beta.4
 etcdManifests:
 - memfs://tests/minimal-gce.example.com/manifests/etcd/main.yaml
 - memfs://tests/minimal-gce.example.com/manifests/etcd/events.yaml

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -4,13 +4,13 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - b7faafc73404ab95a522b7d17f273c863c3544911edb4dc2dfa5cd6e2c2bacb0@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-cni-1.6.0-beta.3-linux-amd64.tar.gz
+  - 9a33654970a73bec7ae32b1e7dffd4dd0217291ca2072f6944e241ee1b1d7fe5@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/cri-containerd-cni-1.6.0-beta.4-linux-amd64.tar.gz
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9381d0ec59d44497290752e41b9e8185f769f9225982522a3f12aab51f72481b@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.3/cri-containerd-cni-1.6.0-beta.3-linux-arm64.tar.gz
+  - c84a7600a5d95306be48c85a5966011f714ee78ba990ee4526b25f042d17528d@https://github.com/containerd/containerd/releases/download/v1.6.0-beta.4/cri-containerd-cni-1.6.0-beta.4-linux-arm64.tar.gz
 CAs:
   kubernetes-ca: |
     -----BEGIN CERTIFICATE-----
@@ -63,4 +63,4 @@ channels:
 - memfs://tests/minimal-gce.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-beta.3
+  version: 1.6.0-beta.4

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -132,7 +132,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-beta.3
+  version: 1.6.0-beta.4
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -246,7 +246,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: Master
-NodeupConfigHash: 45M8SyI5mcZIVa/GNrvLCcNLpjW38FUyvxhWYhpB2U4=
+NodeupConfigHash: 8cCcPZoIIAeAXVYviPaYzn9wARCWNgrbIYGl1l4C/h0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -132,7 +132,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-beta.3
+  version: 1.6.0-beta.4
 docker:
   skipInstall: true
 kubeProxy:
@@ -164,7 +164,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 4CND72IJ99Un9iP3PVwEZaNxoPar9+uUTsY8hYTZHOQ=
+NodeupConfigHash: QTZU08f6J7D89YZ+mQ14Ugu2eA3cKtHHjIeGh4QzoZk=
 
 __EOF_KUBE_ENV
 

--- a/upup/pkg/fi/cloudup/containerd.go
+++ b/upup/pkg/fi/cloudup/containerd.go
@@ -205,7 +205,7 @@ func findAllContainerdHashesAmd64() map[string]string {
 		"1.5.6":        "afc51718ebe46cb9b985edac816e63fe86c07e37d28cdd21b2c0302dec6fa7ae",
 		"1.5.7":        "7fce75bab43a39d6f9efb3c370de2da49723f0e1dbaa9732d68fa7f620d720c8",
 		"1.5.8":        "5dbb7f43c0ac1fda79999ff63e648926e3464d7d1034402ee2117e6a93868431",
-		"1.6.0-beta.3": "b7faafc73404ab95a522b7d17f273c863c3544911edb4dc2dfa5cd6e2c2bacb0",
+		"1.6.0-beta.4": "9a33654970a73bec7ae32b1e7dffd4dd0217291ca2072f6944e241ee1b1d7fe5",
 	}
 
 	return hashes
@@ -213,7 +213,7 @@ func findAllContainerdHashesAmd64() map[string]string {
 
 func findAllContainerdHashesArm64() map[string]string {
 	hashes := map[string]string{
-		"1.6.0-beta.3": "9381d0ec59d44497290752e41b9e8185f769f9225982522a3f12aab51f72481b",
+		"1.6.0-beta.4": "c84a7600a5d95306be48c85a5966011f714ee78ba990ee4526b25f042d17528d",
 	}
 
 	return hashes


### PR DESCRIPTION
Cherry pick of #12968 on release-1.23.

#12968: Update containerd to v1.6.0-beta.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.