### PR TITLE
Drain OpenStack loadbalancers

### DIFF
--- a/cloudmock/gce/mock_gce_cloud.go
+++ b/cloudmock/gce/mock_gce_cloud.go
@@ -181,6 +181,10 @@ func (c *MockGCECloud) DeleteInstance(i *cloudinstances.CloudInstance) error {
 	//	return recreateCloudInstance(c, i)
 }
 
+func (c *MockGCECloud) DeregisterInstance(i *cloudinstances.CloudInstance) error {
+	return nil
+}
+
 // DetachInstance is not implemented yet. It needs to cause a cloud instance to no longer be counted against the group's size limits.
 func (c *MockGCECloud) DetachInstance(i *cloudinstances.CloudInstance) error {
 	return nil

--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -646,6 +646,10 @@ func (c *RollingUpdateCluster) drainNode(u *cloudinstances.CloudInstance) error 
 		return fmt.Errorf("error excluding node from load balancer: %v", err)
 	}
 
+	if err := c.Cloud.DeregisterInstance(u); err != nil {
+		return fmt.Errorf("error deregistering instance %q, node %q: %v", u.ID, u.Node.Name, err)
+	}
+
 	if err := drain.RunNodeDrain(helper, u.Node.Name); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil

--- a/pkg/kubeconfig/create_kubecfg_test.go
+++ b/pkg/kubeconfig/create_kubecfg_test.go
@@ -74,6 +74,10 @@ func (f fakeStatusCloud) DetachInstance(instance *cloudinstances.CloudInstance) 
 	panic("not implemented")
 }
 
+func (f fakeStatusCloud) DeregisterInstance(instance *cloudinstances.CloudInstance) error {
+	panic("not implemented")
+}
+
 func (f fakeStatusCloud) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
 	panic("not implemented")
 }

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -329,6 +329,7 @@ func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 				InterfaceName: fi.String(ifName),
 				ProtocolPort:  fi.Int(443),
 				Lifecycle:     b.Lifecycle,
+				Weight:        fi.Int(1),
 			}
 
 			c.AddTask(associateTask)

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -769,6 +769,7 @@ ServerGroup:
   Name: cluster-master-a
   Policies:
   - anti-affinity
+Weight: 1
 ---
 ID: null
 InterfaceName: cluster
@@ -802,6 +803,7 @@ ServerGroup:
   Name: cluster-master-b
   Policies:
   - anti-affinity
+Weight: 1
 ---
 ID: null
 InterfaceName: cluster
@@ -835,6 +837,7 @@ ServerGroup:
   Name: cluster-master-c
   Policies:
   - anti-affinity
+Weight: 1
 ---
 AdditionalSecurityGroups: null
 ID: null

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -33,6 +33,9 @@ type Cloud interface {
 	// DeleteInstance deletes a cloud instance.
 	DeleteInstance(instance *cloudinstances.CloudInstance) error
 
+	// // DeregisterInstance drains a cloud instance and loadbalancers.
+	DeregisterInstance(instance *cloudinstances.CloudInstance) error
+
 	// DeleteGroup deletes the cloud resources that make up a CloudInstanceGroup, including the instances.
 	DeleteGroup(group *cloudinstances.CloudInstanceGroup) error
 

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -541,6 +541,12 @@ func (c *awsCloudImplementation) DeleteInstance(i *cloudinstances.CloudInstance)
 	return deleteInstance(c, i)
 }
 
+// DeregisterInstance drains a cloud instance and loadbalancers.
+func (c *awsCloudImplementation) DeregisterInstance(i *cloudinstances.CloudInstance) error {
+	klog.V(8).Info("AWS DeregisterInstance not implemented")
+	return nil
+}
+
 func deleteInstance(c AWSCloud, i *cloudinstances.CloudInstance) error {
 	id := i.ID
 	if id == "" {

--- a/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/mock_aws_cloud.go
@@ -96,6 +96,10 @@ func (c *MockAWSCloud) DeleteInstance(i *cloudinstances.CloudInstance) error {
 	return deleteInstance(c, i)
 }
 
+func (c *MockAWSCloud) DeregisterInstance(i *cloudinstances.CloudInstance) error {
+	return nil
+}
+
 func (c *MockAWSCloud) DetachInstance(i *cloudinstances.CloudInstance) error {
 	return detachInstance(c, i)
 }

--- a/upup/pkg/fi/cloudup/azure/azure_cloud.go
+++ b/upup/pkg/fi/cloudup/azure/azure_cloud.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"k8s.io/klog/v2"
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/cloudinstances"
@@ -142,6 +143,12 @@ func (c *azureCloudImplementation) FindVNetInfo(id, resourceGroup string) (*fi.V
 
 func (c *azureCloudImplementation) DeleteInstance(i *cloudinstances.CloudInstance) error {
 	return errors.New("DeleteInstance not implemented on azureCloud")
+}
+
+// DeregisterInstance drains a cloud instance and loadbalancers.
+func (c *azureCloudImplementation) DeregisterInstance(i *cloudinstances.CloudInstance) error {
+	klog.V(8).Info("Azure DeregisterInstance not implemented")
+	return nil
 }
 
 func (c *azureCloudImplementation) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error {

--- a/upup/pkg/fi/cloudup/azuretasks/testing.go
+++ b/upup/pkg/fi/cloudup/azuretasks/testing.go
@@ -131,6 +131,10 @@ func (c *MockAzureCloud) DeleteInstance(i *cloudinstances.CloudInstance) error {
 	return errors.New("DeleteInstance not implemented on azureCloud")
 }
 
+func (c *MockAzureCloud) DeregisterInstance(i *cloudinstances.CloudInstance) error {
+	return nil
+}
+
 // DeleteGroup deletes the group.
 func (c *MockAzureCloud) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error {
 	return errors.New("DeleteGroup not implemented on azureCloud")

--- a/upup/pkg/fi/cloudup/do/cloud.go
+++ b/upup/pkg/fi/cloudup/do/cloud.go
@@ -136,6 +136,12 @@ func (c *doCloudImplementation) DeleteGroup(g *cloudinstances.CloudInstanceGroup
 	return fmt.Errorf("digital ocean cloud provider does not support deleting cloud groups at this time")
 }
 
+// DeregisterInstance drains a cloud instance and loadbalancers.
+func (c *doCloudImplementation) DeregisterInstance(i *cloudinstances.CloudInstance) error {
+	klog.V(8).Info("DO DeregisterInstance not implemented")
+	return nil
+}
+
 func (c *doCloudImplementation) DeleteInstance(i *cloudinstances.CloudInstance) error {
 	dropletID, err := strconv.Atoi(i.ID)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/do/mock_do_cloud.go
+++ b/upup/pkg/fi/cloudup/do/mock_do_cloud.go
@@ -69,6 +69,10 @@ func (c *doCloudMockImplementation) DeleteInstance(instance *cloudinstances.Clou
 	return errors.New("not tested")
 }
 
+func (c *doCloudMockImplementation) DeregisterInstance(i *cloudinstances.CloudInstance) error {
+	return nil
+}
+
 // DetachInstance is not implemented yet. It needs to cause a cloud instance to no longer be counted against the group's size limits.
 func (c *doCloudMockImplementation) DetachInstance(i *cloudinstances.CloudInstance) error {
 	return fmt.Errorf("digital ocean cloud provider does not support surging")

--- a/upup/pkg/fi/cloudup/gce/instancegroups.go
+++ b/upup/pkg/fi/cloudup/gce/instancegroups.go
@@ -51,6 +51,11 @@ func (c *gceCloudImplementation) DeleteInstance(i *cloudinstances.CloudInstance)
 	return recreateCloudInstance(c, i)
 }
 
+func (c *gceCloudImplementation) DeregisterInstance(i *cloudinstances.CloudInstance) error {
+	klog.V(8).Info("GCE DeregisterInstance not implemented")
+	return nil
+}
+
 // DetachInstance is not implemented yet. It needs to cause a cloud instance to no longer be counted against the group's size limits.
 func (c *gceCloudImplementation) DetachInstance(i *cloudinstances.CloudInstance) error {
 	klog.V(8).Info("gce cloud provider DetachInstance not implemented yet")

--- a/upup/pkg/fi/cloudup/openstack/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/openstack/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/pagination:go_default_library",
         "//vendor/github.com/mitchellh/mapstructure:go_default_library",
+        "//vendor/golang.org/x/sync/errgroup:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -252,8 +252,11 @@ type OpenstackCloud interface {
 	// ListDNSRecordsets will list the DNS recordsets for the given zone id
 	ListDNSRecordsets(zoneID string, opt recordsets.ListOptsBuilder) ([]recordsets.RecordSet, error)
 	GetLB(loadbalancerID string) (*loadbalancers.LoadBalancer, error)
+	GetLBStats(loadbalancerID string) (*loadbalancers.Stats, error)
 	CreateLB(opt loadbalancers.CreateOptsBuilder) (*loadbalancers.LoadBalancer, error)
 	ListLBs(opt loadbalancers.ListOptsBuilder) ([]loadbalancers.LoadBalancer, error)
+	UpdateMemberInPool(poolID string, memberID string, opts v2pools.UpdateMemberOptsBuilder) (*v2pools.Member, error)
+	ListPoolMembers(poolID string, opts v2pools.ListMembersOpts) ([]v2pools.Member, error)
 
 	// DeleteLB will delete loadbalancer
 	DeleteLB(lbID string, opt loadbalancers.DeleteOpts) error

--- a/upup/pkg/fi/cloudup/openstack/mock_cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/mock_cloud.go
@@ -130,6 +130,10 @@ func (c *MockCloud) DeleteInstance(i *cloudinstances.CloudInstance) error {
 	return deleteInstance(c, i)
 }
 
+func (c *MockCloud) DeregisterInstance(i *cloudinstances.CloudInstance) error {
+	return deregisterInstance(c, i.ID)
+}
+
 func (c *MockCloud) DetachInstance(i *cloudinstances.CloudInstance) error {
 	return detachInstance(c, i)
 }
@@ -403,6 +407,18 @@ func (c *MockCloud) ListKeypairs() ([]keypairs.KeyPair, error) {
 
 func (c *MockCloud) ListL3FloatingIPs(opts l3floatingip.ListOpts) (fips []l3floatingip.FloatingIP, err error) {
 	return listL3FloatingIPs(c, opts)
+}
+
+func (c *MockCloud) UpdateMemberInPool(poolID string, memberID string, opts v2pools.UpdateMemberOptsBuilder) (*v2pools.Member, error) {
+	return updateMemberInPool(c, poolID, memberID, opts)
+}
+
+func (c *MockCloud) GetLBStats(loadbalancerID string) (*loadbalancers.Stats, error) {
+	return getLBStats(c, loadbalancerID)
+}
+
+func (c *MockCloud) ListPoolMembers(poolID string, opts v2pools.ListMembersOpts) ([]v2pools.Member, error) {
+	return listPoolMembers(c, poolID, opts)
 }
 
 func (c *MockCloud) ListLBs(opt loadbalancers.ListOptsBuilder) (lbs []loadbalancers.LoadBalancer, err error) {


### PR DESCRIPTION
Why OpenStack cannot use current structure at all if we want drain connections? Delete kubernetes node is executed before delete instance https://github.com/kubernetes/kops/blob/master/pkg/instancegroups/instancegroups.go#L418 in OpenStack cloudprovider this means that when node is deleted, it will automatically remove all loadbalancer members -> we cannot drain anything anymore.

Now when we add `DeregisterInstance` function to clouds, we have way to execute things BEFORE node is deleted from Kubernetes. By using this we should be able to do real draining in all clouds including for instance google cloud. AWS works in little bit different way than others (it keeps terminated instances in API lists for sometime).

I also was thinking could we use https://github.com/kubernetes/kops/blob/9ed4ec13f0dbe29e2e9066c554ce968f99ffdc1d/pkg/instancegroups/instancegroups.go#L641 but in fact, we cannot use that for drain Kubernetes API (created by kOps) loadbalancer. That is why I decided to make new function. 

as you are currently making similar thing in https://github.com/kubernetes/kops/pull/12966
cc @heybronson @rifelpet