### PR TITLE
gce: use per InstanceGroup serviceaccounts

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -156,14 +156,6 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.ModelBuilderC
 			}
 			t.Subnet = b.LinkToSubnet(subnet)
 
-			if b.Cluster.Spec.CloudConfig.GCEServiceAccount != "" {
-				klog.Infof("VMs using Service Account: %v", b.Cluster.Spec.CloudConfig.GCEServiceAccount)
-				// b.Cluster.Spec.GCEServiceAccount = c.GCEServiceAccount
-			} else {
-				klog.Warning("VMs will be configured to use the GCE default compute Service Account! This is an anti-pattern")
-				klog.Warning("Use a pre-created Service Account with the flag: --gce-service-account=account@projectname.iam.gserviceaccount.com")
-				b.Cluster.Spec.CloudConfig.GCEServiceAccount = "default"
-			}
 			t.ServiceAccounts = append(t.ServiceAccounts, b.LinkToServiceAccount(ig))
 
 			//labels, err := b.CloudTagsForInstanceGroup(ig)

--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -132,7 +132,10 @@ func (c *GCEModelContext) LinkToServiceAccount(ig *kops.InstanceGroup) *gcetasks
 		klog.Fatalf("unknown role %q", role)
 	}
 
-	accountID := c.SafeObjectName(name)
+	accountID, err := gce.ServiceAccountName(name, c.ClusterName())
+	if err != nil {
+		klog.Fatalf("failed to construct serviceaccount name: %w", err)
+	}
 	projectID := c.ProjectID
 
 	email := accountID + "@" + projectID + ".iam.gserviceaccount.com"

--- a/pkg/model/gcemodel/storageacl.go
+++ b/pkg/model/gcemodel/storageacl.go
@@ -18,6 +18,7 @@ package gcemodel
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -40,17 +41,24 @@ type StorageAclBuilder struct {
 var _ fi.ModelBuilder = &NetworkModelBuilder{}
 
 // Build creates the tasks that set up storage acls
-func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
-	serviceAccount, err := b.Cloud.ServiceAccount()
-	if err != nil {
-		return fmt.Errorf("error fetching ServiceAccount: %v", err)
-	}
 
+func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
 	if featureflag.GoogleCloudBucketACL.Enabled() {
+		if b.Cluster.Spec.CloudConfig.GCEServiceAccount == "" {
+			return fmt.Errorf("featureflag GoogleCloudBucketACL not supported with per-instancegroup GCEServiceAccount")
+		}
+
+		klog.Warningf("featureflag GoogleCloudBucketACL is no longer recommended; use per-instancegroup GCEServiceAccounts instead")
+
+		gceDefaultServiceAccount, err := b.Cloud.ServiceAccount()
+		if err != nil {
+			return fmt.Errorf("error fetching default ServiceAccount: %w", err)
+		}
+
 		clusterPath := b.Cluster.Spec.ConfigBase
 		p, err := vfs.Context.BuildVfsPath(clusterPath)
 		if err != nil {
-			return fmt.Errorf("cannot parse cluster path %q: %v", clusterPath, err)
+			return fmt.Errorf("cannot parse cluster path %q: %w", clusterPath, err)
 		}
 
 		switch p := p.(type) {
@@ -62,7 +70,7 @@ func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
 				Name:      s("serviceaccount-statestore-list"),
 				Lifecycle: b.Lifecycle,
 				Bucket:    s(p.Bucket()),
-				Entity:    s("user-" + serviceAccount),
+				Entity:    s("user-" + gceDefaultServiceAccount),
 				Role:      s("READER"),
 			})
 		}
@@ -80,27 +88,121 @@ func (b *StorageAclBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		buckets := sets.NewString()
 		for _, p := range writeablePaths {
-			if gcsPath, ok := p.(*vfs.GSPath); ok {
-				bucket := gcsPath.Bucket()
-				if buckets.Has(bucket) {
-					continue
-				}
-
-				klog.Warningf("adding bucket level write ACL to gs://%s to support etcd backup", bucket)
-
-				c.AddTask(&gcetasks.StorageBucketAcl{
-					Name:      s("serviceaccount-backup-readwrite-" + bucket),
-					Lifecycle: b.Lifecycle,
-					Bucket:    s(bucket),
-					Entity:    s("user-" + serviceAccount),
-					Role:      s("WRITER"),
-				})
-
-				buckets.Insert(bucket)
-			} else {
+			gcsPath, ok := p.(*vfs.GSPath)
+			if !ok {
 				klog.Warningf("unknown path, can't apply IAM policy: %q", p)
+				continue
 			}
+
+			bucket := gcsPath.Bucket()
+			if buckets.Has(bucket) {
+				continue
+			}
+			buckets.Insert(bucket)
+
+			klog.Warningf("adding bucket level write ACL to gs://%s to support etcd backup", bucket)
+
+			c.AddTask(&gcetasks.StorageBucketAcl{
+				Name:      s("serviceaccount-backup-readwrite-" + bucket),
+				Lifecycle: b.Lifecycle,
+				Bucket:    s(bucket),
+				Entity:    s("user-" + gceDefaultServiceAccount),
+				Role:      s("WRITER"),
+			})
+		}
+
+		return nil
+	}
+
+	type serviceAccountRole struct {
+		Email string
+		Role  kops.InstanceGroupRole
+	}
+	serviceAccountRoles := make(map[serviceAccountRole]bool)
+
+	for _, ig := range b.InstanceGroups {
+		serviceAccount := b.LinkToServiceAccount(ig)
+
+		email := *serviceAccount.Email
+		serviceAccountRoles[serviceAccountRole{Email: email, Role: ig.Spec.Role}] = true
+	}
+
+	for serviceAccountRole := range serviceAccountRoles {
+		role := serviceAccountRole.Role
+
+		nodeRole, err := iam.BuildNodeRoleSubject(role, false)
+		if err != nil {
+			return err
+		}
+
+		buckets := sets.NewString()
+
+		writeablePaths, err := iam.WriteableVFSPaths(b.Cluster, nodeRole)
+		if err != nil {
+			return err
+		}
+		for _, p := range writeablePaths {
+			gcsPath, ok := p.(*vfs.GSPath)
+			if !ok {
+				klog.Warningf("unknown path, can't apply IAM policy: %q", p)
+				continue
+			}
+
+			bucket := gcsPath.Bucket()
+			if buckets.Has(bucket) {
+				continue
+			}
+			buckets.Insert(bucket)
+
+			nameForTask := strings.ToLower(string(role))
+
+			klog.Warningf("adding bucket level write IAM for role %q to gs://%s to support etcd backup", bucket, role)
+
+			c.AddTask(&gcetasks.StorageBucketIAM{
+				Name:      s("objectadmin-" + bucket + "-serviceaccount-" + nameForTask),
+				Lifecycle: b.Lifecycle,
+				Bucket:    s(bucket),
+				Member:    s("serviceAccount:" + serviceAccountRole.Email),
+				Role:      s("roles/storage.objectAdmin"),
+			})
+		}
+
+		// Add bucket read permissions if we need to read from the bucket
+		readablePaths, err := iam.ReadableStatePaths(b.Cluster, nodeRole)
+		if err != nil {
+			return err
+		}
+		if len(readablePaths) != 0 {
+			p, err := vfs.Context.BuildVfsPath(b.Cluster.Spec.ConfigStore)
+			if err != nil {
+				return fmt.Errorf("cannot parse VFS path %q: %v", b.Cluster.Spec.ConfigStore, err)
+			}
+
+			gcsPath, ok := p.(*vfs.GSPath)
+			if !ok {
+				klog.Warningf("unknown path, can't apply IAM policy: %q", p)
+				continue
+			}
+			bucket := gcsPath.Bucket()
+			if buckets.Has(bucket) {
+				// Already marked as writeable; we can skip
+				continue
+			}
+			buckets.Insert(bucket)
+
+			nameForTask := strings.ToLower(string(role))
+
+			klog.Warningf("adding bucket level read IAM to gs://%s for role %q", bucket, role)
+
+			c.AddTask(&gcetasks.StorageBucketIAM{
+				Name:      s("objectviewer-" + bucket + "-serviceaccount-" + nameForTask),
+				Lifecycle: b.Lifecycle,
+				Bucket:    s(bucket),
+				Member:    s("serviceAccount:" + serviceAccountRole.Email),
+				Role:      s("roles/storage.objectViewer"),
+			})
 		}
 	}
+
 	return nil
 }

--- a/pkg/model/iam/BUILD.bazel
+++ b/pkg/model/iam/BUILD.bazel
@@ -12,11 +12,11 @@ go_library(
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/model:go_default_library",
+        "//pkg/truncate:go_default_library",
         "//pkg/util/stringorslice:go_default_library",
         "//pkg/wellknownusers:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//upup/pkg/fi/cloudup/awstasks:go_default_library",
-        "//upup/pkg/fi/cloudup/awsup:go_default_library",
         "//util/pkg/vfs:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/model/iam/types.go
+++ b/pkg/model/iam/types.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/pkg/truncate"
 )
 
 // MaxLengthIAMRoleName defines the max length of an IAMRole name
@@ -54,7 +54,7 @@ func (b *IAMModelContext) IAMNameForServiceAccountRole(role Subject) (string, er
 	}
 
 	name := serviceAccount.Name + "." + strings.ReplaceAll(serviceAccount.Namespace, "*", "wildcard") + ".sa." + b.ClusterName()
-	name = awsup.TruncateString(name, awsup.TruncateStringOptions{MaxLength: MaxLengthIAMRoleName, AlwaysAddHash: false})
+	name = truncate.TruncateString(name, truncate.TruncateStringOptions{MaxLength: MaxLengthIAMRoleName, AlwaysAddHash: false})
 
 	return name, nil
 }

--- a/pkg/truncate/BUILD.bazel
+++ b/pkg/truncate/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -6,4 +6,10 @@ go_library(
     importpath = "k8s.io/kops/pkg/truncate",
     visibility = ["//visibility:public"],
     deps = ["//vendor/k8s.io/klog/v2:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["truncate_test.go"],
+    embed = [":go_default_library"],
 )

--- a/pkg/truncate/BUILD.bazel
+++ b/pkg/truncate/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["truncate.go"],
+    importpath = "k8s.io/kops/pkg/truncate",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/klog/v2:go_default_library"],
+)

--- a/pkg/truncate/truncate.go
+++ b/pkg/truncate/truncate.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package truncate
+
+import (
+	"encoding/base32"
+	"hash/fnv"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// TruncateStringOptions contains parameters for how we truncate strings
+type TruncateStringOptions struct {
+	// AlwaysAddHash will always cause the hash to be appended.
+	// Useful to stop users assuming that the name will never be truncated.
+	AlwaysAddHash bool
+
+	// MaxLength controls the maximum length of the string.
+	MaxLength int
+
+	// HashLength controls the length of the hash to be appended.
+	HashLength int
+}
+
+// TruncateString will attempt to truncate a string to a max, adding a prefix to avoid collisions.
+// Will never return a string longer than maxLength chars
+func TruncateString(s string, opt TruncateStringOptions) string {
+	if opt.MaxLength == 0 {
+		klog.Fatalf("MaxLength must be set")
+	}
+
+	if !opt.AlwaysAddHash && len(s) <= opt.MaxLength {
+		return s
+	}
+
+	if opt.HashLength == 0 {
+		opt.HashLength = 6
+	}
+
+	// We always compute the hash and add it, lest we trick users into assuming that we never do this
+	h := fnv.New32a()
+	if _, err := h.Write([]byte(s)); err != nil {
+		klog.Fatalf("error hashing values: %v", err)
+	}
+	hashString := base32.HexEncoding.EncodeToString(h.Sum(nil))
+	hashString = strings.ToLower(hashString)
+	if len(hashString) > opt.HashLength {
+		hashString = hashString[:opt.HashLength]
+	}
+
+	maxBaseLength := opt.MaxLength - len(hashString) - 1
+	if len(s) > maxBaseLength {
+		s = s[:maxBaseLength]
+	}
+	s = s + "-" + hashString
+
+	return s
+}

--- a/pkg/truncate/truncate.go
+++ b/pkg/truncate/truncate.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package truncate
 
 import (

--- a/pkg/truncate/truncate_test.go
+++ b/pkg/truncate/truncate_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package truncate
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTruncateString(t *testing.T) {
+	grid := []struct {
+		Input         string
+		Expected      string
+		MaxLength     int
+		AlwaysAddHash bool
+	}{
+		{
+			Input:     "foo",
+			Expected:  "foo",
+			MaxLength: 64,
+		},
+		{
+			Input:     "this_string_is_33_characters_long",
+			Expected:  "this_string_is_33_characters_long",
+			MaxLength: 64,
+		},
+		{
+			Input:         "this_string_is_33_characters_long",
+			Expected:      "this_string_is_33_characters_long-t4mk8d",
+			MaxLength:     64,
+			AlwaysAddHash: true,
+		},
+		{
+			Input:     "this_string_is_longer_it_is_46_characters_long",
+			Expected:  "this_string_is_longer_it_-ha2gug",
+			MaxLength: 32,
+		},
+		{
+			Input:         "this_string_is_longer_it_is_46_characters_long",
+			Expected:      "this_string_is_longer_it_-ha2gug",
+			MaxLength:     32,
+			AlwaysAddHash: true,
+		},
+		{
+			Input:     "this_string_is_even_longer_due_to_extreme_verbosity_it_is_in_fact_84_characters_long",
+			Expected:  "this_string_is_even_longer_due_to_extreme_verbosity_it_is-7mc0g6",
+			MaxLength: 64,
+		},
+	}
+
+	for _, g := range grid {
+		t.Run(fmt.Sprintf("input:%s/maxLength:%d/alwaysAddHash:%v", g.Input, g.MaxLength, g.AlwaysAddHash), func(t *testing.T) {
+			opt := TruncateStringOptions{MaxLength: g.MaxLength, AlwaysAddHash: g.AlwaysAddHash}
+			actual := TruncateString(g.Input, opt)
+			if actual != g.Expected {
+				t.Errorf("TruncateString(%q, %+v) => %q, expected %q", g.Input, opt, actual, g.Expected)
+			}
+		})
+	}
+}

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -9,8 +9,7 @@ spec:
   authorization:
     rbac: {}
   channel: stable
-  cloudConfig:
-    gceServiceAccount: default
+  cloudConfig: {}
   cloudProvider: gce
   configBase: memfs://tests/ha-gce.example.com
   etcdClusters:

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
@@ -123,7 +123,6 @@ ensure-install-dir
 
 cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
-  gceServiceAccount: default
   gcpPDCSIDriver:
     enabled: false
   manageStorageClasses: true

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
@@ -123,7 +123,6 @@ ensure-install-dir
 
 cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
-  gceServiceAccount: default
   gcpPDCSIDriver:
     enabled: false
   manageStorageClasses: true

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
@@ -123,7 +123,6 @@ ensure-install-dir
 
 cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
-  gceServiceAccount: default
   gcpPDCSIDriver:
     enabled: false
   manageStorageClasses: true

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
@@ -123,7 +123,6 @@ ensure-install-dir
 
 cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
-  gceServiceAccount: default
   gcpPDCSIDriver:
     enabled: false
   manageStorageClasses: true

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -564,7 +564,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
     preemptible         = false
   }
   service_account {
-    email  = "default"
+    email  = "control-plane-ha-gce-ex-mr702t@testproject.iam.gserviceaccount.com"
     scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
   }
   tags = ["ha-gce-example-com-k8s-io-role-master"]
@@ -610,7 +610,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
     preemptible         = false
   }
   service_account {
-    email  = "default"
+    email  = "control-plane-ha-gce-ex-mr702t@testproject.iam.gserviceaccount.com"
     scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
   }
   tags = ["ha-gce-example-com-k8s-io-role-master"]
@@ -656,7 +656,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
     preemptible         = false
   }
   service_account {
-    email  = "default"
+    email  = "control-plane-ha-gce-ex-mr702t@testproject.iam.gserviceaccount.com"
     scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
   }
   tags = ["ha-gce-example-com-k8s-io-role-master"]
@@ -702,7 +702,7 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
     preemptible         = false
   }
   service_account {
-    email  = "default"
+    email  = "node-ha-gce-example-com@testproject.iam.gserviceaccount.com"
     scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only"]
   }
   tags = ["ha-gce-example-com-k8s-io-role-node"]
@@ -718,6 +718,30 @@ resource "google_compute_subnetwork" "us-test1-ha-gce-example-com" {
   name          = "us-test1-ha-gce-example-com"
   network       = google_compute_network.ha-gce-example-com.name
   region        = "us-test1"
+}
+
+resource "google_project_iam_binding" "serviceaccount-control-plane" {
+  member  = "serviceAccount:control-plane-ha-gce-ex-mr702t@testproject.iam.gserviceaccount.com"
+  project = "testproject"
+  role    = "roles/container.serviceAgent"
+}
+
+resource "google_project_iam_binding" "serviceaccount-nodes" {
+  member  = "serviceAccount:node-ha-gce-example-com@testproject.iam.gserviceaccount.com"
+  project = "testproject"
+  role    = "roles/compute.viewer"
+}
+
+resource "google_service_account" "control-plane" {
+  account_id  = "control-plane-ha-gce-ex-mr702t"
+  description = "kubernetes control-plane instances"
+  project     = "testproject"
+}
+
+resource "google_service_account" "node" {
+  account_id  = "node-ha-gce-example-com"
+  description = "kubernetes worker nodes"
+  project     = "testproject"
 }
 
 terraform {

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -721,13 +721,13 @@ resource "google_compute_subnetwork" "us-test1-ha-gce-example-com" {
 }
 
 resource "google_project_iam_binding" "serviceaccount-control-plane" {
-  member  = "serviceAccount:control-plane-ha-gce-ex-mr702t@testproject.iam.gserviceaccount.com"
+  members = ["serviceAccount:control-plane-ha-gce-ex-mr702t@testproject.iam.gserviceaccount.com"]
   project = "testproject"
   role    = "roles/container.serviceAgent"
 }
 
 resource "google_project_iam_binding" "serviceaccount-nodes" {
-  member  = "serviceAccount:node-ha-gce-example-com@testproject.iam.gserviceaccount.com"
+  members = ["serviceAccount:node-ha-gce-example-com@testproject.iam.gserviceaccount.com"]
   project = "testproject"
   role    = "roles/compute.viewer"
 }

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -123,7 +123,6 @@ ensure-install-dir
 
 cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
-  gceServiceAccount: default
   gcpPDCSIDriver:
     enabled: true
   manageStorageClasses: true

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -123,7 +123,6 @@ ensure-install-dir
 
 cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
-  gceServiceAccount: default
   gcpPDCSIDriver:
     enabled: true
   manageStorageClasses: true

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -460,7 +460,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-examp
     preemptible         = false
   }
   service_account {
-    email  = "default"
+    email  = "control-plane-minimal-g-fu1mg6@testproject.iam.gserviceaccount.com"
     scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
   }
   tags = ["minimal-gce-example-com-k8s-io-role-master"]
@@ -506,7 +506,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
     preemptible         = false
   }
   service_account {
-    email  = "default"
+    email  = "node-minimal-gce-example-com@testproject.iam.gserviceaccount.com"
     scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only"]
   }
   tags = ["minimal-gce-example-com-k8s-io-role-node"]
@@ -522,6 +522,30 @@ resource "google_compute_subnetwork" "us-test1-minimal-gce-example-com" {
   name          = "us-test1-minimal-gce-example-com"
   network       = google_compute_network.minimal-gce-example-com.name
   region        = "us-test1"
+}
+
+resource "google_project_iam_binding" "serviceaccount-control-plane" {
+  member  = "serviceAccount:control-plane-minimal-g-fu1mg6@testproject.iam.gserviceaccount.com"
+  project = "testproject"
+  role    = "roles/container.serviceAgent"
+}
+
+resource "google_project_iam_binding" "serviceaccount-nodes" {
+  member  = "serviceAccount:node-minimal-gce-example-com@testproject.iam.gserviceaccount.com"
+  project = "testproject"
+  role    = "roles/compute.viewer"
+}
+
+resource "google_service_account" "control-plane" {
+  account_id  = "control-plane-minimal-g-fu1mg6"
+  description = "kubernetes control-plane instances"
+  project     = "testproject"
+}
+
+resource "google_service_account" "node" {
+  account_id  = "node-minimal-gce-example-com"
+  description = "kubernetes worker nodes"
+  project     = "testproject"
 }
 
 terraform {

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -525,13 +525,13 @@ resource "google_compute_subnetwork" "us-test1-minimal-gce-example-com" {
 }
 
 resource "google_project_iam_binding" "serviceaccount-control-plane" {
-  member  = "serviceAccount:control-plane-minimal-g-fu1mg6@testproject.iam.gserviceaccount.com"
+  members = ["serviceAccount:control-plane-minimal-g-fu1mg6@testproject.iam.gserviceaccount.com"]
   project = "testproject"
   role    = "roles/container.serviceAgent"
 }
 
 resource "google_project_iam_binding" "serviceaccount-nodes" {
-  member  = "serviceAccount:node-minimal-gce-example-com@testproject.iam.gserviceaccount.com"
+  members = ["serviceAccount:node-minimal-gce-example-com@testproject.iam.gserviceaccount.com"]
   project = "testproject"
   role    = "roles/compute.viewer"
 }

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_startup-script
@@ -123,7 +123,6 @@ ensure-install-dir
 
 cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
-  gceServiceAccount: default
   gcpPDCSIDriver:
     enabled: false
   manageStorageClasses: true

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_startup-script
@@ -123,7 +123,6 @@ ensure-install-dir
 
 cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
-  gceServiceAccount: default
   gcpPDCSIDriver:
     enabled: false
   manageStorageClasses: true

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -458,7 +458,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-priva
     preemptible         = false
   }
   service_account {
-    email  = "default"
+    email  = "control-plane-minimal-g-sh4okp@testproject.iam.gserviceaccount.com"
     scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_write", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
   }
   tags = ["minimal-gce-private-example-com-k8s-io-role-master"]
@@ -502,7 +502,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-private-example-c
     preemptible         = false
   }
   service_account {
-    email  = "default"
+    email  = "node-minimal-gce-privat-sh4okp@testproject.iam.gserviceaccount.com"
     scopes = ["https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/logging.write", "https://www.googleapis.com/auth/devstorage.read_only"]
   }
   tags = ["minimal-gce-private-example-com-k8s-io-role-node"]
@@ -535,6 +535,30 @@ resource "google_compute_subnetwork" "us-test1-minimal-gce-private-example-com" 
   name          = "us-test1-minimal-gce-private-example-com"
   network       = google_compute_network.minimal-gce-private-example-com.name
   region        = "us-test1"
+}
+
+resource "google_project_iam_binding" "serviceaccount-control-plane" {
+  member  = "serviceAccount:control-plane-minimal-g-sh4okp@testproject.iam.gserviceaccount.com"
+  project = "testproject"
+  role    = "roles/container.serviceAgent"
+}
+
+resource "google_project_iam_binding" "serviceaccount-nodes" {
+  member  = "serviceAccount:node-minimal-gce-privat-sh4okp@testproject.iam.gserviceaccount.com"
+  project = "testproject"
+  role    = "roles/compute.viewer"
+}
+
+resource "google_service_account" "control-plane" {
+  account_id  = "control-plane-minimal-g-sh4okp"
+  description = "kubernetes control-plane instances"
+  project     = "testproject"
+}
+
+resource "google_service_account" "node" {
+  account_id  = "node-minimal-gce-privat-sh4okp"
+  description = "kubernetes worker nodes"
+  project     = "testproject"
 }
 
 terraform {

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -538,13 +538,13 @@ resource "google_compute_subnetwork" "us-test1-minimal-gce-private-example-com" 
 }
 
 resource "google_project_iam_binding" "serviceaccount-control-plane" {
-  member  = "serviceAccount:control-plane-minimal-g-sh4okp@testproject.iam.gserviceaccount.com"
+  members = ["serviceAccount:control-plane-minimal-g-sh4okp@testproject.iam.gserviceaccount.com"]
   project = "testproject"
   role    = "roles/container.serviceAgent"
 }
 
 resource "google_project_iam_binding" "serviceaccount-nodes" {
-  member  = "serviceAccount:node-minimal-gce-privat-sh4okp@testproject.iam.gserviceaccount.com"
+  members = ["serviceAccount:node-minimal-gce-privat-sh4okp@testproject.iam.gserviceaccount.com"]
   project = "testproject"
   role    = "roles/compute.viewer"
 }

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -589,6 +589,7 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 			)
 		case kops.CloudProviderGCE:
 			gceModelContext := &gcemodel.GCEModelContext{
+				ProjectID:        project,
 				KopsModelContext: modelContext,
 			}
 

--- a/upup/pkg/fi/cloudup/awsup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/awsup/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/featureflag:go_default_library",
         "//pkg/nodeidentity/aws:go_default_library",
         "//pkg/resources/spotinst:go_default_library",
+        "//pkg/truncate:go_default_library",
         "//protokube/pkg/etcd:go_default_library",
         "//upup/pkg/fi:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",

--- a/upup/pkg/fi/cloudup/awsup/aws_utils.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils.go
@@ -17,9 +17,7 @@ limitations under the License.
 package awsup
 
 import (
-	"encoding/base32"
 	"fmt"
-	"hash/fnv"
 	"os"
 	"strings"
 	"sync"
@@ -35,6 +33,7 @@ import (
 	elbv2 "github.com/aws/aws-sdk-go/service/elbv2"
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/truncate"
 )
 
 // allRegions is the list of all regions; tests will set the values
@@ -223,7 +222,7 @@ func ELBv2Tags(tags map[string]string) []*elbv2.Tag {
 
 // GetClusterName40 will attempt to calculate a meaningful cluster name with a max length of 40
 func GetClusterName40(cluster string) string {
-	return TruncateString(cluster, TruncateStringOptions{
+	return truncate.TruncateString(cluster, truncate.TruncateStringOptions{
 		MaxLength: 40,
 	})
 }
@@ -234,60 +233,12 @@ func GetResourceName32(cluster string, prefix string) string {
 	s := prefix + "-" + strings.Replace(cluster, ".", "-", -1)
 
 	// We always compute the hash and add it, lest we trick users into assuming that we never do this
-	opt := TruncateStringOptions{
+	opt := truncate.TruncateStringOptions{
 		MaxLength:     32,
 		AlwaysAddHash: true,
 		HashLength:    6,
 	}
-	return TruncateString(s, opt)
-}
-
-// TruncateStringOptions contains parameters for how we truncate strings
-type TruncateStringOptions struct {
-	// AlwaysAddHash will always cause the hash to be appended.
-	// Useful to stop users assuming that the name will never be truncated.
-	AlwaysAddHash bool
-
-	// MaxLength controls the maximum length of the string.
-	MaxLength int
-
-	// HashLength controls the length of the hash to be appended.
-	HashLength int
-}
-
-// TruncateString will attempt to truncate a string to a max, adding a prefix to avoid collisions.
-// Will never return a string longer than maxLength chars
-func TruncateString(s string, opt TruncateStringOptions) string {
-	if opt.MaxLength == 0 {
-		klog.Fatalf("MaxLength must be set")
-	}
-
-	if !opt.AlwaysAddHash && len(s) <= opt.MaxLength {
-		return s
-	}
-
-	if opt.HashLength == 0 {
-		opt.HashLength = 6
-	}
-
-	// We always compute the hash and add it, lest we trick users into assuming that we never do this
-	h := fnv.New32a()
-	if _, err := h.Write([]byte(s)); err != nil {
-		klog.Fatalf("error hashing values: %v", err)
-	}
-	hashString := base32.HexEncoding.EncodeToString(h.Sum(nil))
-	hashString = strings.ToLower(hashString)
-	if len(hashString) > opt.HashLength {
-		hashString = hashString[:opt.HashLength]
-	}
-
-	maxBaseLength := opt.MaxLength - len(hashString) - 1
-	if len(s) > maxBaseLength {
-		s = s[:maxBaseLength]
-	}
-	s = s + "-" + hashString
-
-	return s
+	return truncate.TruncateString(s, opt)
 }
 
 // GetTargetGroupNameFromARN will attempt to parse a target group ARN and return its name

--- a/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_utils_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package awsup
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -138,57 +137,5 @@ func Test_GetResourceName32(t *testing.T) {
 		if actual != g.Expected {
 			t.Errorf("unexpected result from %q+%q.  expected %q, got %q", g.Prefix, g.ClusterName, g.Expected, actual)
 		}
-	}
-}
-
-func TestTruncateString(t *testing.T) {
-	grid := []struct {
-		Input         string
-		Expected      string
-		MaxLength     int
-		AlwaysAddHash bool
-	}{
-		{
-			Input:     "foo",
-			Expected:  "foo",
-			MaxLength: 64,
-		},
-		{
-			Input:     "this_string_is_33_characters_long",
-			Expected:  "this_string_is_33_characters_long",
-			MaxLength: 64,
-		},
-		{
-			Input:         "this_string_is_33_characters_long",
-			Expected:      "this_string_is_33_characters_long-t4mk8d",
-			MaxLength:     64,
-			AlwaysAddHash: true,
-		},
-		{
-			Input:     "this_string_is_longer_it_is_46_characters_long",
-			Expected:  "this_string_is_longer_it_-ha2gug",
-			MaxLength: 32,
-		},
-		{
-			Input:         "this_string_is_longer_it_is_46_characters_long",
-			Expected:      "this_string_is_longer_it_-ha2gug",
-			MaxLength:     32,
-			AlwaysAddHash: true,
-		},
-		{
-			Input:     "this_string_is_even_longer_due_to_extreme_verbosity_it_is_in_fact_84_characters_long",
-			Expected:  "this_string_is_even_longer_due_to_extreme_verbosity_it_is-7mc0g6",
-			MaxLength: 64,
-		},
-	}
-
-	for _, g := range grid {
-		t.Run(fmt.Sprintf("input:%s/maxLength:%d/alwaysAddHash:%v", g.Input, g.MaxLength, g.AlwaysAddHash), func(t *testing.T) {
-			opt := TruncateStringOptions{MaxLength: g.MaxLength, AlwaysAddHash: g.AlwaysAddHash}
-			actual := TruncateString(g.Input, opt)
-			if actual != g.Expected {
-				t.Errorf("TruncateString(%q, %+v) => %q, expected %q", g.Input, opt, actual, g.Expected)
-			}
-		})
 	}
 }

--- a/upup/pkg/fi/cloudup/gce/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/gce/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//dnsprovider/pkg/dnsprovider/providers/google/clouddns:go_default_library",
         "//pkg/apis/kops:go_default_library",
         "//pkg/cloudinstances:go_default_library",
+        "//pkg/truncate:go_default_library",
         "//pkg/util/subnet:go_default_library",
         "//protokube/pkg/etcd:go_default_library",
         "//upup/pkg/fi:go_default_library",

--- a/upup/pkg/fi/cloudup/gcetasks/projectiambinding.go
+++ b/upup/pkg/fi/cloudup/gcetasks/projectiambinding.go
@@ -127,16 +127,16 @@ func (_ *ProjectIAMBinding) RenderGCE(t *gce.GCEAPITarget, a, e, changes *Projec
 
 // terraformProjectIAMBinding is the model for a terraform google_project_iam_binding rule
 type terraformProjectIAMBinding struct {
-	Project string `json:"project,omitempty" cty:"project"`
-	Role    string `json:"role,omitempty" cty:"role"`
-	Member  string `json:"member,omitempty" cty:"member"`
+	Project string   `json:"project,omitempty" cty:"project"`
+	Role    string   `json:"role,omitempty" cty:"role"`
+	Members []string `json:"members,omitempty" cty:"members"`
 }
 
 func (_ *ProjectIAMBinding) RenderTerraform(t *terraform.TerraformTarget, a, e, changes *ProjectIAMBinding) error {
 	tf := &terraformProjectIAMBinding{
 		Project: fi.StringValue(e.Project),
 		Role:    fi.StringValue(e.Role),
-		Member:  fi.StringValue(e.Member),
+		Members: []string{fi.StringValue(e.Member)},
 	}
 
 	return t.RenderResource("google_project_iam_binding", *e.Name, tf)

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -367,10 +367,6 @@ func setupVPC(opt *NewClusterOptions, cluster *api.Cluster) error {
 			// TODO remove this logging?
 			klog.Infof("VMs will be configured to use specified Service Account: %v", opt.GCEServiceAccount)
 			cluster.Spec.CloudConfig.GCEServiceAccount = opt.GCEServiceAccount
-		} else {
-			klog.Warning("VMs will be configured to use the GCE default compute Service Account! This is an anti-pattern")
-			klog.Warning("Use a pre-created Service Account with the flag: --gce-service-account=account@projectname.iam.gserviceaccount.com")
-			cluster.Spec.CloudConfig.GCEServiceAccount = "default"
 		}
 
 	case api.CloudProviderOpenstack:


### PR DESCRIPTION
We no longer set the cloudconfig serviceaccount on new clusters, and instead use a per-IG setting if this is not set.
