### PR TITLE
Use fi.Keyset instead of passing tasks around

### DIFF
--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -72,7 +72,7 @@ type nodeupConfigBuilder struct {
 	cluster *kops.Cluster
 }
 
-func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, caTasks map[string]*fitasks.Keypair) (*nodeup.Config, *nodeup.BootConfig, error) {
+func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, keysets map[string]*fi.Keyset) (*nodeup.Config, *nodeup.BootConfig, error) {
 	config, bootConfig := nodeup.NewConfig(n.cluster, ig)
 	return config, bootConfig, nil
 }

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -1060,7 +1060,7 @@ func createBuilderForCluster(cluster *kops.Cluster, instanceGroups []*kops.Insta
 
 type nodeupConfigBuilder struct{}
 
-func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, caTasks map[string]*fitasks.Keypair) (*nodeup.Config, *nodeup.BootConfig, error) {
+func (n *nodeupConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAdditionalIPs []string, keysets map[string]*fi.Keyset) (*nodeup.Config, *nodeup.BootConfig, error) {
 	return &nodeup.Config{}, &nodeup.BootConfig{}, nil
 }
 

--- a/upup/pkg/fi/ca.go
+++ b/upup/pkg/fi/ca.go
@@ -47,7 +47,10 @@ type Keyset struct {
 	// LegacyFormat instructs a keypair task to convert a Legacy Keyset to the new Keyset API format.
 	LegacyFormat bool
 	Items        map[string]*KeysetItem
-	Primary      *KeysetItem
+
+	// Primary is the KeysetItem that is considered the "active" key.
+	// It is guaranteed to be non-nil, if there are any keypairs.
+	Primary *KeysetItem
 }
 
 // KeysetItem is a certificate/key pair in a Keyset.

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -69,7 +69,6 @@ go_library(
         "//upup/pkg/fi/cloudup/openstack:go_default_library",
         "//upup/pkg/fi/cloudup/terraform:go_default_library",
         "//upup/pkg/fi/cloudup/terraformWriter:go_default_library",
-        "//upup/pkg/fi/fitasks:go_default_library",
         "//upup/pkg/fi/loader:go_default_library",
         "//util/pkg/architectures:go_default_library",
         "//util/pkg/env:go_default_library",


### PR DESCRIPTION
Using a task leads to layering complexity.  We could introduce a new type, but fi.Keyset is the type we seem to want.
    
(We could move Keyset out of fi, but we don't need to yet)