### PR TITLE
Refactor nodeup script to avoid action-at-a-distance

### DIFF
--- a/pkg/model/BUILD.bazel
+++ b/pkg/model/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "master_volumes.go",
         "names.go",
         "pki.go",
-        "template_resource.go",
     ],
     importpath = "k8s.io/kops/pkg/model",
     visibility = ["//visibility:public"],

--- a/pkg/model/bootstrapscript_test.go
+++ b/pkg/model/bootstrapscript_test.go
@@ -44,8 +44,10 @@ func Test_ProxyFunc(t *testing.T) {
 		},
 	}
 
-	script := b.createProxyEnv(ps)
-
+	script, err := b.createProxyEnv(ps)
+	if err != nil {
+		t.Fatalf("createProxyEnv failed: %v", err)
+	}
 	if script == "" {
 		t.Fatalf("script cannot be empty")
 	}
@@ -56,7 +58,11 @@ func Test_ProxyFunc(t *testing.T) {
 
 	ps.ProxyExcludes = "www.google.com,www.kubernetes.io"
 
-	script = b.createProxyEnv(ps)
+	script, err = b.createProxyEnv(ps)
+	if err != nil {
+		t.Fatalf("createProxyEnv failed: %v", err)
+	}
+
 	if !strings.Contains(script, "no_proxy="+ps.ProxyExcludes) {
 		t.Fatalf("script not setting no_proxy properly")
 	}

--- a/pkg/model/resources/BUILD.bazel
+++ b/pkg/model/resources/BUILD.bazel
@@ -2,10 +2,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["nodeup.go"],
+    srcs = [
+        "nodeup.go",
+        "template_resource.go",
+    ],
     importpath = "k8s.io/kops/pkg/model/resources",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/apis/kops:go_default_library"],
+    deps = [
+        "//pkg/apis/kops:go_default_library",
+        "//upup/pkg/fi:go_default_library",
+        "//util/pkg/architectures:go_default_library",
+        "//util/pkg/mirrors:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/model/resources/nodeup_test.go
+++ b/pkg/model/resources/nodeup_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func Test_NodeUpTabs(t *testing.T) {
-	for i, line := range strings.Split(NodeUpTemplate, "\n") {
+	for i, line := range strings.Split(nodeUpTemplate, "\n") {
 		if strings.Contains(line, "\t") {
 			t.Errorf("NodeUpTemplate contains unexpected character %q on line %d: %q", "\t", i, line)
 		}

--- a/pkg/model/resources/template_resource.go
+++ b/pkg/model/resources/template_resource.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package model
+package resources
 
 import (
 	"bytes"
@@ -35,7 +35,7 @@ type templateResource struct {
 
 var _ fi.Resource = &templateResource{}
 
-func NewTemplateResource(key string, definition string, functions template.FuncMap, context interface{}) (*templateResource, error) {
+func newTemplateResource(key string, definition string, functions template.FuncMap, context interface{}) (*templateResource, error) {
 	r := &templateResource{
 		key:        key,
 		definition: definition,


### PR DESCRIPTION
We had a tight coupling with the template, so we should move the variables into the same package.

Builds on #12991 

(The resources package could also be renamed to nodeupscript or similar, but that's a follow-on PR)