### PR TITLE
componentconfig: expose advertise-address flag for kube-apiserver

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1347,6 +1347,10 @@ spec:
                     description: AdmissionControlConfigFile is the location of the
                       admission-control-config-file
                     type: string
+                  advertiseAddress:
+                    description: AdvertiseAddress is the IP address on which to advertise
+                      the apiserver to members of the cluster.
+                    type: string
                   allowPrivileged:
                     description: AllowPrivileged indicates if we can run privileged
                       containers

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -290,6 +290,8 @@ type KubeAPIServerConfig struct {
 	InsecurePort *int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
 	// Address is the binding address for the kube api: Deprecated - use insecure-bind-address and bind-address
 	Address string `json:"address,omitempty" flag:"address"`
+	// AdvertiseAddress is the IP address on which to advertise the apiserver to members of the cluster.
+	AdvertiseAddress string `json:"advertiseAddress,omitempty" flag:"advertise-address"`
 	// BindAddress is the binding address for the secure kubernetes API
 	BindAddress string `json:"bindAddress,omitempty" flag:"bind-address"`
 	// InsecureBindAddress is the binding address for the InsecurePort for the insecure kubernetes API

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -290,6 +290,8 @@ type KubeAPIServerConfig struct {
 	InsecurePort *int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
 	// Address is the binding address for the kube api: Deprecated - use insecure-bind-address and bind-address
 	Address string `json:"address,omitempty" flag:"address"`
+	// AdvertiseAddress is the IP address on which to advertise the apiserver to members of the cluster.
+	AdvertiseAddress string `json:"advertiseAddress,omitempty" flag:"advertise-address"`
 	// BindAddress is the binding address for the secure kubernetes API
 	BindAddress string `json:"bindAddress,omitempty" flag:"bind-address"`
 	// InsecureBindAddress is the binding address for the InsecurePort for the insecure kubernetes API

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4754,6 +4754,7 @@ func autoConvert_v1alpha2_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
+	out.AdvertiseAddress = in.AdvertiseAddress
 	out.BindAddress = in.BindAddress
 	out.InsecureBindAddress = in.InsecureBindAddress
 	out.EnableBootstrapAuthToken = in.EnableBootstrapAuthToken
@@ -4865,6 +4866,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha2_KubeAPIServerConfig(in *ko
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
+	out.AdvertiseAddress = in.AdvertiseAddress
 	out.BindAddress = in.BindAddress
 	out.InsecureBindAddress = in.InsecureBindAddress
 	out.EnableBootstrapAuthToken = in.EnableBootstrapAuthToken

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -288,6 +288,8 @@ type KubeAPIServerConfig struct {
 	InsecurePort *int32 `json:"insecurePort,omitempty" flag:"insecure-port"`
 	// Address is the binding address for the kube api: Deprecated - use insecure-bind-address and bind-address
 	Address string `json:"address,omitempty" flag:"address"`
+	// AdvertiseAddress is the IP address on which to advertise the apiserver to members of the cluster.
+	AdvertiseAddress string `json:"advertiseAddress,omitempty" flag:"advertise-address"`
 	// BindAddress is the binding address for the secure kubernetes API
 	BindAddress string `json:"bindAddress,omitempty" flag:"bind-address"`
 	// InsecureBindAddress is the binding address for the InsecurePort for the insecure kubernetes API

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -4644,6 +4644,7 @@ func autoConvert_v1alpha3_KubeAPIServerConfig_To_kops_KubeAPIServerConfig(in *Ku
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
+	out.AdvertiseAddress = in.AdvertiseAddress
 	out.BindAddress = in.BindAddress
 	out.InsecureBindAddress = in.InsecureBindAddress
 	out.EnableBootstrapAuthToken = in.EnableBootstrapAuthToken
@@ -4755,6 +4756,7 @@ func autoConvert_kops_KubeAPIServerConfig_To_v1alpha3_KubeAPIServerConfig(in *ko
 	out.SecurePort = in.SecurePort
 	out.InsecurePort = in.InsecurePort
 	out.Address = in.Address
+	out.AdvertiseAddress = in.AdvertiseAddress
 	out.BindAddress = in.BindAddress
 	out.InsecureBindAddress = in.InsecureBindAddress
 	out.EnableBootstrapAuthToken = in.EnableBootstrapAuthToken


### PR DESCRIPTION
This flag determines which IPs are advertised inside the cluster, in
the "kubernetes" service in the "default" namespace.