### PR TITLE
Skip RuntimeClass tests for older Kubernetes versions

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -80,6 +80,14 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|should.be.mountable.when.non-attachable"
 		// The in-tree driver and its E2E tests use `topology.kubernetes.io/zone` but the CSI driver uses `topology.gke.io/zone`
 		skipRegex += "|In-tree.Volumes.\\[Driver:.gcepd\\].*topology.should.provision.a.volume.and.schedule.a.pod.with.AllowedTopologies"
+	} else if strings.Contains(cluster.Spec.KubernetesVersion, "v1.1") ||
+		strings.Contains(cluster.Spec.KubernetesVersion, "v1.20.") ||
+		strings.Contains(cluster.Spec.KubernetesVersion, "v1.21.") ||
+		strings.Contains(cluster.Spec.KubernetesVersion, "v1.22.") {
+		// this tests assumes a custom config for containerd:
+		// https://github.com/kubernetes/test-infra/blob/578d86a7be187214be6ccd60e6ea7317b51aeb15/jobs/e2e_node/containerd/config.toml#L19-L21
+		// ref: https://github.com/kubernetes/kubernetes/pull/104803
+		skipRegex += "|RuntimeClass.should.run"
 	}
 
 	if strings.Contains(cluster.Spec.KubernetesVersion, "v1.23.") && cluster.Spec.CloudProvider == "aws" && utils.IsIPv6CIDR(cluster.Spec.NonMasqueradeCIDR) {


### PR DESCRIPTION
This should fix the failing tests: https://testgrid.k8s.io/kops-versions#Summary.

Ref: https://github.com/kubernetes/kops/pull/12974

/cc @rifelpet @olemarkus 