### PR TITLE
Add kubetest2-kops flags for overriding instance group fields

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/deployer.go
+++ b/tests/e2e/kubetest2-kops/deployer/deployer.go
@@ -56,6 +56,9 @@ type deployer struct {
 	KopsBinaryPath string   `flag:"kops-binary-path" desc:"The path to kops executable used for testing"`
 	createBucket   bool     `flag:"-"`
 
+	ControlPlaneIGOverrides []string `flag:"control-plane-instance-group-overrides" desc:"overrides for the control plane instance groups"`
+	NodeIGOverrides         []string `flag:"node-instance-group-overrides" desc:"overrides for the node instance groups"`
+
 	ValidationWait time.Duration `flag:"validation-wait" desc:"time to wait for newly created cluster to pass validation"`
 
 	TemplatePath string `flag:"template-path" desc:"The path to the manifest template used for cluster creation"`


### PR DESCRIPTION
This allows us to disable IMDSv2 on flatcar tests