### PR TITLE
Skip SCTP check for all versions of k8s 1.23/1.24

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -51,7 +51,7 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|external.IP.is.not.assigned.to.a.node"
 		// https://github.com/cilium/cilium/issues/14287
 		skipRegex += "|same.port.number.but.different.protocols|same.hostPort.but.different.hostIP.and.protocol"
-		if strings.Contains(cluster.Spec.KubernetesVersion, "v1.23.0") || strings.Contains(cluster.Spec.KubernetesVersion, "v1.24.0") {
+		if strings.Contains(cluster.Spec.KubernetesVersion, "v1.23") || strings.Contains(cluster.Spec.KubernetesVersion, "v1.24") {
 			// Reassess after https://github.com/kubernetes/kubernetes/pull/102643 is merged
 			// ref:
 			// https://github.com/kubernetes/kubernetes/issues/96717


### PR DESCRIPTION
We checked explicitly for the .0 patch version. Tests started failing once .1 was released.