### PR TITLE
staticcheck cleanup: fixup nodeup/pkg/model

### DIFF
--- a/nodeup/pkg/model/cloudconfig_test.go
+++ b/nodeup/pkg/model/cloudconfig_test.go
@@ -81,7 +81,7 @@ func TestBuildAzure(t *testing.T) {
 		}
 	}
 	if task == nil {
-		t.Errorf("no File task found")
+		t.Fatalf("no File task found")
 	}
 	r, err := task.Contents.Open()
 	if err != nil {
@@ -150,7 +150,7 @@ func TestBuildAWSCustomNodeIPFamilies(t *testing.T) {
 		}
 	}
 	if task == nil {
-		t.Errorf("no File task found")
+		t.Fatalf("no File task found")
 	}
 	r, err := task.Contents.Open()
 	if err != nil {

--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -169,7 +169,7 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 		for _, param := range params {
 			if !strings.ContainsRune(param, '=') {
-				return fmt.Errorf("Invalid SysctlParameter: expected %q to contain '='", param)
+				return fmt.Errorf("invalid SysctlParameter: expected %q to contain '='", param)
 			}
 			sysctls = append(sysctls, param)
 		}
@@ -181,7 +181,7 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 		for _, param := range params {
 			if !strings.ContainsRune(param, '=') {
-				return fmt.Errorf("Invalid SysctlParameter: expected %q to contain '='", param)
+				return fmt.Errorf("invalid SysctlParameter: expected %q to contain '='", param)
 			}
 			sysctls = append(sysctls, param)
 		}

--- a/nodeup/pkg/model/volumes.go
+++ b/nodeup/pkg/model/volumes.go
@@ -46,7 +46,7 @@ func (b *VolumesBuilder) Build(c *fi.ModelBuilderContext) error {
 	for _, x := range b.NodeupConfig.VolumeMounts {
 		// @check the directory exists, else create it
 		if err := b.EnsureDirectory(x.Path); err != nil {
-			return fmt.Errorf("failed to ensure the directory: %s, error: %s", x.Path, err)
+			return fmt.Errorf("failed to ensure the directory: %s, error: %w", x.Path, err)
 		}
 
 		m := &mount.SafeFormatAndMount{
@@ -56,7 +56,7 @@ func (b *VolumesBuilder) Build(c *fi.ModelBuilderContext) error {
 
 		// @check if the device is already mounted
 		if found, err := b.IsMounted(m, x.Device, x.Path); err != nil {
-			return fmt.Errorf("Failed to check if device: %s is mounted, error: %s", x.Device, err)
+			return fmt.Errorf("failed to check if device %q is mounted, error: %w", x.Device, err)
 		} else if found {
 			klog.V(3).Infof("Skipping device: %s, path: %s as already mounted", x.Device, x.Path)
 			continue


### PR DESCRIPTION
These pop up in VSCode and are pretty simple to fix:

```
nodeup/pkg/model/cloudconfig_test.go:86:17: possible nil pointer dereference (SA5011)
        nodeup/pkg/model/cloudconfig_test.go:83:5: this check suggests that the pointer can be nil
nodeup/pkg/model/cloudconfig_test.go:155:17: possible nil pointer dereference (SA5011)
        nodeup/pkg/model/cloudconfig_test.go:152:5: this check suggests that the pointer can be nil
nodeup/pkg/model/sysctls.go:172:12: error strings should not be capitalized (ST1005)
nodeup/pkg/model/sysctls.go:184:12: error strings should not be capitalized (ST1005)
nodeup/pkg/model/volumes.go:59:11: error strings should not be capitalized (ST1005)
```