### PR TITLE
kubetest2 - Use the same binary path and env when fetching IGs

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -177,7 +177,7 @@ func (d *deployer) createCluster(zones []string, adminAccess string, yes bool) e
 }
 
 func (d *deployer) setInstanceGroupOverrides() error {
-	igs, err := kops.GetInstanceGroups(d.ClusterName)
+	igs, err := kops.GetInstanceGroups(d.KopsBinaryPath, d.ClusterName, d.env())
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/pkg/kops/state.go
+++ b/tests/e2e/pkg/kops/state.go
@@ -20,23 +20,24 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"k8s.io/klog/v2"
 	api "k8s.io/kops/pkg/apis/kops/v1alpha2"
+	"sigs.k8s.io/kubetest2/pkg/exec"
 )
 
 // GetCluster will retrieve the specified Cluster from the state store.
-func GetCluster(clusterName string) (*api.Cluster, error) {
+func GetCluster(kopsBinary, clusterName string, env []string) (*api.Cluster, error) {
 	args := []string{
-		"kops", "get", "cluster", clusterName, "-ojson",
+		kopsBinary, "get", "cluster", clusterName, "-ojson",
 	}
 	c := exec.Command(args[0], args[1:]...)
+	c.SetEnv(env...)
 	var stdout bytes.Buffer
-	c.Stdout = &stdout
+	c.SetStdout(&stdout)
 	var stderr bytes.Buffer
-	c.Stderr = &stderr
+	c.SetStderr(&stderr)
 	if err := c.Run(); err != nil {
 		klog.Warningf("failed to run %s; stderr=%s", strings.Join(args, " "), stderr.String())
 		return nil, fmt.Errorf("error querying cluster from %s: %w", strings.Join(args, " "), err)
@@ -50,15 +51,16 @@ func GetCluster(clusterName string) (*api.Cluster, error) {
 }
 
 // GetInstanceGroups will retrieve the instance groups for the specified Cluster from the state store.
-func GetInstanceGroups(clusterName string) ([]*api.InstanceGroup, error) {
+func GetInstanceGroups(kopsBinary, clusterName string, env []string) ([]*api.InstanceGroup, error) {
 	args := []string{
-		"kops", "get", "instancegroups", "--name", clusterName, "-ojson",
+		kopsBinary, "get", "instancegroups", "--name", clusterName, "-ojson",
 	}
 	c := exec.Command(args[0], args[1:]...)
+	c.SetEnv(env...)
 	var stdout bytes.Buffer
-	c.Stdout = &stdout
+	c.SetStdout(&stdout)
 	var stderr bytes.Buffer
-	c.Stderr = &stderr
+	c.SetStderr(&stderr)
 	if err := c.Run(); err != nil {
 		klog.Warningf("failed to run %s; stderr=%s", strings.Join(args, " "), stderr.String())
 		return nil, fmt.Errorf("error querying instance groups from %s: %w", strings.Join(args, " "), err)

--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -114,7 +114,7 @@ func (t *Tester) getKopsCluster() (*api.Cluster, error) {
 
 	kopsClusterName := currentContext
 
-	cluster, err := kops.GetCluster(kopsClusterName)
+	cluster, err := kops.GetCluster("kops", kopsClusterName, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (t *Tester) getKopsInstanceGroups() ([]*api.InstanceGroup, error) {
 		return nil, err
 	}
 
-	igs, err := kops.GetInstanceGroups(cluster.Name)
+	igs, err := kops.GetInstanceGroups("kops", cluster.Name, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

The GetInstanceGroup function was used in kubetest2-tester-kops which has the desired `kops` set in PATH and KOPS_STATE_STORE already set.
Now that we're using GetInstanceGroups in kubetest2-kops (the deployer) we need to override these to the values that the deployer determines.

This should this empty error in the flatcar jobs now that we override their instance groups to disable IMDSv2: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-distro-imageflatcar/1472938989487919104#1:build-log.txt%3A666

`W1220 14:38:09.103159    4731 state.go:63] failed to run kops get instancegroups --name e2e-b5f84bd12b-91d99.test-cncf-aws.k8s.io -ojson; stderr=`