### PR TITLE
Fix dangling ENIs from AWS VPC CNI 

### DIFF
--- a/cloudmock/aws/mockec2/BUILD.bazel
+++ b/cloudmock/aws/mockec2/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "convenience.go",
         "dhcpoptions.go",
         "egressonlyinternetgateways.go",
+        "eni.go",
         "images.go",
         "instances.go",
         "internetgateways.go",

--- a/cloudmock/aws/mockec2/eni.go
+++ b/cloudmock/aws/mockec2/eni.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mockec2
+
+import "github.com/aws/aws-sdk-go/service/ec2"
+
+func (m *MockEC2) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	output := &ec2.DescribeNetworkInterfacesOutput{}
+	return output, nil
+}

--- a/pkg/resources/aws/BUILD.bazel
+++ b/pkg/resources/aws/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "aws.go",
         "elasticip.go",
+        "eni.go",
         "errors.go",
         "eventbridge.go",
         "filters.go",

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -71,6 +71,7 @@ func ListResourcesAWS(cloud awsup.AWSCloud, clusterName string) (map[string]*res
 		ListRouteTables,
 		ListSubnets,
 		ListVPCs,
+		ListENIs,
 		// ELBs
 		ListELBs,
 		ListELBV2s,

--- a/pkg/resources/aws/eni.go
+++ b/pkg/resources/aws/eni.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/klog/v2"
+
+	"k8s.io/kops/pkg/resources"
+	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+)
+
+func DeleteENI(cloud fi.Cloud, r *resources.Resource) error {
+	c := cloud.(awsup.AWSCloud)
+
+	id := r.ID
+
+	klog.V(2).Infof("Deleting EC2 ENI %q", id)
+	request := &ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: &id,
+	}
+	_, err := c.EC2().DeleteNetworkInterface(request)
+	if err != nil {
+		if awsup.AWSErrorCode(err) == "InvalidNetworkInterfaceID.NotFound" {
+			// Concurrently deleted
+			return nil
+		}
+
+		if IsDependencyViolation(err) {
+			return err
+		}
+		return fmt.Errorf("error deleting ENI %q: %v", id, err)
+	}
+	return nil
+}
+
+func DumpENI(op *resources.DumpOperation, r *resources.Resource) error {
+	data := make(map[string]interface{})
+	data["id"] = r.ID
+	data["type"] = ec2.ResourceTypeNetworkInterface
+	data["raw"] = r.Obj
+
+	op.Dump.Resources = append(op.Dump.Resources, data)
+
+	return nil
+}
+
+func DescribeENIs(cloud fi.Cloud, clusterName string) (map[string]*ec2.NetworkInterface, error) {
+	c := cloud.(awsup.AWSCloud)
+
+	enis := make(map[string]*ec2.NetworkInterface)
+	klog.V(2).Info("Listing ENIs")
+	for _, filters := range buildEC2FiltersForCluster(clusterName) {
+		request := &ec2.DescribeNetworkInterfacesInput{
+			Filters: filters,
+		}
+		response, err := c.EC2().DescribeNetworkInterfaces(request)
+		if err != nil {
+			return nil, fmt.Errorf("error listing ENIs: %v", err)
+		}
+
+		for _, eni := range response.NetworkInterfaces {
+			// Skip ENIs that are attached
+			if eni.Attachment != nil {
+				continue
+			}
+			enis[aws.StringValue(eni.NetworkInterfaceId)] = eni
+		}
+	}
+
+	return enis, nil
+}
+
+func ListENIs(cloud fi.Cloud, clusterName string) ([]*resources.Resource, error) {
+	enis, err := DescribeENIs(cloud, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	var resourceTrackers []*resources.Resource
+	for _, v := range enis {
+		eniID := aws.StringValue(v.NetworkInterfaceId)
+
+		resourceTracker := &resources.Resource{
+			ID:      eniID,
+			Type:    ec2.ResourceTypeNetworkInterface,
+			Deleter: DeleteENI,
+			Dumper:  DumpENI,
+			Obj:     v,
+			Shared:  !HasOwnedTag(ec2.ResourceTypeNetworkInterface+":"+eniID, v.TagSet, clusterName),
+		}
+
+		var blocks []string
+		blocks = append(blocks, ec2.ResourceTypeVpc+":"+aws.StringValue(v.VpcId))
+
+		resourceTracker.Blocks = blocks
+
+		resourceTrackers = append(resourceTrackers, resourceTracker)
+	}
+
+	return resourceTrackers, nil
+}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e45d8969bb1f6e1a6778bfe6a716d35d3fefdda09dfb3399f9a088bd09bef109
+    manifestHash: 302d76bd06cc968ba03481ada5a894aa120c7687d7d41a02dd93f83c7a6cbb9f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -157,6 +157,8 @@ spec:
                 - fargate
       containers:
       - env:
+        - name: ADDITIONAL_ENI_TAGS
+          value: '{"KubernetesCluster":"minimal.example.com","kubernetes.io/cluster/minimal.example.com":"owned"}'
         - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
           value: "false"
         - name: ENABLE_IPv4

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e45d8969bb1f6e1a6778bfe6a716d35d3fefdda09dfb3399f9a088bd09bef109
+    manifestHash: 302d76bd06cc968ba03481ada5a894aa120c7687d7d41a02dd93f83c7a6cbb9f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -157,6 +157,8 @@ spec:
                 - fargate
       containers:
       - env:
+        - name: ADDITIONAL_ENI_TAGS
+          value: '{"KubernetesCluster":"minimal.example.com","kubernetes.io/cluster/minimal.example.com":"owned"}'
         - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
           value: "false"
         - name: ENABLE_IPv4

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e45d8969bb1f6e1a6778bfe6a716d35d3fefdda09dfb3399f9a088bd09bef109
+    manifestHash: 302d76bd06cc968ba03481ada5a894aa120c7687d7d41a02dd93f83c7a6cbb9f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -157,6 +157,8 @@ spec:
                 - fargate
       containers:
       - env:
+        - name: ADDITIONAL_ENI_TAGS
+          value: '{"KubernetesCluster":"minimal.example.com","kubernetes.io/cluster/minimal.example.com":"owned"}'
         - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
           value: "false"
         - name: ENABLE_IPv4

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -187,6 +187,12 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 				envVars["ENABLE_PREFIX_DELEGATION"] = "true"
 				envVars["WARM_PREFIX_TARGET"] = "1"
 			}
+			envVars["ADDITIONAL_ENI_TAGS"] = fmt.Sprintf(
+				"{\\\"KubernetesCluster\\\":\\\"%s\\\",\\\"kubernetes.io/cluster/%s\\\":\\\"owned\\\"}",
+				tf.ClusterName(),
+				tf.ClusterName(),
+			)
+
 			return envVars
 		}
 	}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 76438b822817f225ab6fef37503012029f06c3fbee07f1c982ef068cc34388e2
+    manifestHash: e1481a4e469c4be8ef19de5bdf81e5bc852dfc2376bdf6b8b1ecc7c5dccd8e64
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -157,6 +157,8 @@ spec:
                 - fargate
       containers:
       - env:
+        - name: ADDITIONAL_ENI_TAGS
+          value: '{"KubernetesCluster":"minimal.example.com","kubernetes.io/cluster/minimal.example.com":"owned"}'
         - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
           value: "false"
         - name: AWS_VPC_K8S_CNI_LOGLEVEL

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 76438b822817f225ab6fef37503012029f06c3fbee07f1c982ef068cc34388e2
+    manifestHash: e1481a4e469c4be8ef19de5bdf81e5bc852dfc2376bdf6b8b1ecc7c5dccd8e64
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -157,6 +157,8 @@ spec:
                 - fargate
       containers:
       - env:
+        - name: ADDITIONAL_ENI_TAGS
+          value: '{"KubernetesCluster":"minimal.example.com","kubernetes.io/cluster/minimal.example.com":"owned"}'
         - name: AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER
           value: "false"
         - name: AWS_VPC_K8S_CNI_LOGLEVEL


### PR DESCRIPTION
This should fix future dangling ENIs from AWS VPC CNI should it occur in the future.
Cilium already tags its ENIs so should the same problem happen there, this should fix that as well.