### PR TITLE
Extend terraform support for IPv6

### DIFF
--- a/tests/integration/update_cluster/apiservernodes/kubernetes.tf
+++ b/tests/integration/update_cluster/apiservernodes/kubernetes.tf
@@ -1010,7 +1010,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -923,7 +923,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
+++ b/tests/integration/update_cluster/bastionadditional_user-data/kubernetes.tf
@@ -1245,7 +1245,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -1158,7 +1158,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/compress/kubernetes.tf
+++ b/tests/integration/update_cluster/compress/kubernetes.tf
@@ -806,7 +806,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/digit/kubernetes.tf
+++ b/tests/integration/update_cluster/digit/kubernetes.tf
@@ -906,7 +906,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_iam/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_iam/kubernetes.tf
@@ -1174,7 +1174,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/existing_sg/kubernetes.tf
+++ b/tests/integration/update_cluster/existing_sg/kubernetes.tf
@@ -1547,7 +1547,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/external_dns/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns/kubernetes.tf
@@ -818,7 +818,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
@@ -881,7 +881,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externallb/kubernetes.tf
+++ b/tests/integration/update_cluster/externallb/kubernetes.tf
@@ -822,7 +822,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/externalpolicies/kubernetes.tf
+++ b/tests/integration/update_cluster/externalpolicies/kubernetes.tf
@@ -1016,7 +1016,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/ha/kubernetes.tf
+++ b/tests/integration/update_cluster/ha/kubernetes.tf
@@ -1246,7 +1246,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -931,7 +931,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/karpenter/kubernetes.tf
+++ b/tests/integration/update_cluster/karpenter/kubernetes.tf
@@ -999,7 +999,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
+++ b/tests/integration/update_cluster/lifecycle_phases/network-kubernetes.tf
@@ -185,7 +185,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
@@ -1084,7 +1084,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm/kubernetes.tf
@@ -891,7 +891,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/many-addons/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons/kubernetes.tf
@@ -883,7 +883,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-1.23/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.23/kubernetes.tf
@@ -877,7 +877,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-1.24/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.24/kubernetes.tf
@@ -885,7 +885,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-1.24/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.24/kubernetes.tf
@@ -839,8 +839,10 @@ resource "aws_security_group_rule" "from-nodes-minimal-example-com-ingress-udp-1
 }
 
 resource "aws_subnet" "us-test-1a-minimal-example-com" {
-  availability_zone = "us-test-1a"
-  cidr_block        = "172.20.32.0/19"
+  availability_zone                           = "us-test-1a"
+  cidr_block                                  = "172.20.32.0/19"
+  enable_resource_name_dns_a_record_on_launch = true
+  private_dns_hostname_type_on_launch         = "resource-name"
   tags = {
     "KubernetesCluster"                         = "minimal.example.com"
     "Name"                                      = "us-test-1a.minimal.example.com"

--- a/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-gp3/kubernetes.tf
@@ -814,7 +814,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/kubernetes.tf
@@ -1034,7 +1034,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/kubernetes.tf
@@ -1025,7 +1025,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6-private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-private/kubernetes.tf
@@ -1160,7 +1160,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-ipv6-private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-private/kubernetes.tf
@@ -1072,9 +1072,12 @@ resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
 }
 
 resource "aws_subnet" "us-test-1a-minimal-ipv6-example-com" {
-  availability_zone = "us-test-1a"
-  cidr_block        = "172.20.32.0/19"
-  ipv6_cidr_block   = "2001:db8:0:111::/64"
+  availability_zone                              = "us-test-1a"
+  cidr_block                                     = "172.20.32.0/19"
+  enable_resource_name_dns_a_record_on_launch    = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  ipv6_cidr_block                                = "2001:db8:0:111::/64"
+  private_dns_hostname_type_on_launch            = "resource-name"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1a.minimal-ipv6.example.com"
@@ -1086,9 +1089,12 @@ resource "aws_subnet" "us-test-1a-minimal-ipv6-example-com" {
 }
 
 resource "aws_subnet" "us-test-1b-minimal-ipv6-example-com" {
-  availability_zone = "us-test-1b"
-  cidr_block        = "172.20.64.0/19"
-  ipv6_cidr_block   = "2001:db8:0:112::/64"
+  availability_zone                              = "us-test-1b"
+  cidr_block                                     = "172.20.64.0/19"
+  enable_resource_name_dns_a_record_on_launch    = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  ipv6_cidr_block                                = "2001:db8:0:112::/64"
+  private_dns_hostname_type_on_launch            = "resource-name"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1b.minimal-ipv6.example.com"
@@ -1100,9 +1106,12 @@ resource "aws_subnet" "us-test-1b-minimal-ipv6-example-com" {
 }
 
 resource "aws_subnet" "utility-us-test-1a-minimal-ipv6-example-com" {
-  availability_zone = "us-test-1a"
-  cidr_block        = "172.20.0.0/22"
-  ipv6_cidr_block   = "2001:db8:0:113::/64"
+  availability_zone                              = "us-test-1a"
+  cidr_block                                     = "172.20.0.0/22"
+  enable_resource_name_dns_a_record_on_launch    = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  ipv6_cidr_block                                = "2001:db8:0:113::/64"
+  private_dns_hostname_type_on_launch            = "resource-name"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "utility-us-test-1a.minimal-ipv6.example.com"
@@ -1114,9 +1123,12 @@ resource "aws_subnet" "utility-us-test-1a-minimal-ipv6-example-com" {
 }
 
 resource "aws_subnet" "utility-us-test-1b-minimal-ipv6-example-com" {
-  availability_zone = "us-test-1b"
-  cidr_block        = "172.20.4.0/22"
-  ipv6_cidr_block   = "2001:db8:0:114::/64"
+  availability_zone                              = "us-test-1b"
+  cidr_block                                     = "172.20.4.0/22"
+  enable_resource_name_dns_a_record_on_launch    = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  ipv6_cidr_block                                = "2001:db8:0:114::/64"
+  private_dns_hostname_type_on_launch            = "resource-name"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "utility-us-test-1b.minimal-ipv6.example.com"

--- a/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6/kubernetes.tf
@@ -1017,7 +1017,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-warmpool/kubernetes.tf
@@ -842,7 +842,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal/kubernetes.tf
@@ -818,7 +818,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gossip/kubernetes.tf
@@ -818,7 +818,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -1263,7 +1263,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances_spot/kubernetes.tf
@@ -1264,7 +1264,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
+++ b/tests/integration/update_cluster/nth_sqs_resources/kubernetes.tf
@@ -929,7 +929,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/nvidia/kubernetes.tf
+++ b/tests/integration/update_cluster/nvidia/kubernetes.tf
@@ -834,7 +834,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-ip/kubernetes.tf
@@ -1186,7 +1186,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/private-shared-subnet/kubernetes.tf
@@ -1097,7 +1097,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecalico/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecalico/kubernetes.tf
@@ -1253,7 +1253,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecanal/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecanal/kubernetes.tf
@@ -1252,7 +1252,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium/kubernetes.tf
@@ -1244,7 +1244,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatecilium2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatecilium2/kubernetes.tf
@@ -1244,7 +1244,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
+++ b/tests/integration/update_cluster/privateciliumadvanced/kubernetes.tf
@@ -1276,7 +1276,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns1/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns1/kubernetes.tf
@@ -1347,7 +1347,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatedns2/kubernetes.tf
+++ b/tests/integration/update_cluster/privatedns2/kubernetes.tf
@@ -1195,7 +1195,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateflannel/kubernetes.tf
+++ b/tests/integration/update_cluster/privateflannel/kubernetes.tf
@@ -1244,7 +1244,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privatekopeio/kubernetes.tf
+++ b/tests/integration/update_cluster/privatekopeio/kubernetes.tf
@@ -1292,7 +1292,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/privateweave/kubernetes.tf
+++ b/tests/integration/update_cluster/privateweave/kubernetes.tf
@@ -1244,7 +1244,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -881,7 +881,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_subnet/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_subnet/kubernetes.tf
@@ -736,7 +736,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/shared_vpc/kubernetes.tf
+++ b/tests/integration/update_cluster/shared_vpc/kubernetes.tf
@@ -777,7 +777,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/unmanaged/kubernetes.tf
+++ b/tests/integration/update_cluster/unmanaged/kubernetes.tf
@@ -1154,7 +1154,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -855,7 +855,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup_test.go
@@ -251,7 +251,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }
@@ -326,7 +326,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_terraform_test.go
@@ -99,7 +99,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }
@@ -186,7 +186,7 @@ terraform {
     aws = {
       "configuration_aliases" = [aws.files]
       "source"                = "hashicorp/aws"
-      "version"               = ">= 3.59.0"
+      "version"               = ">= 3.71.0"
     }
   }
 }

--- a/upup/pkg/fi/cloudup/terraform/target_hcl2.go
+++ b/upup/pkg/fi/cloudup/terraform/target_hcl2.go
@@ -122,7 +122,7 @@ func (t *TerraformTarget) finishHCL2() error {
 		}
 		writeMap(requiredProvidersBody, "aws", map[string]cty.Value{
 			"source":                cty.StringVal("hashicorp/aws"),
-			"version":               cty.StringVal(">= 3.59.0"),
+			"version":               cty.StringVal(">= 3.71.0"),
 			"configuration_aliases": aliasesVal,
 		})
 		if featureflag.Spotinst.Enabled() {


### PR DESCRIPTION
With https://github.com/hashicorp/terraform-provider-aws/pull/22339 merged we can add terraform support for the recently added IPv6 functionality.

WIP until the next terraform provider release that includes that PR