### PR TITLE
Use IPv6-only subnets for worker nodes in private IPv6 topology

### DIFF
--- a/docs/networking/ipv6.md
+++ b/docs/networking/ipv6.md
@@ -13,13 +13,20 @@ kOps currently supports IPv6 on AWS only.
 
 IPv6 requires the external Cloud Controller Manager.
 
-## VPC and subnets
+## VPC, subnets, and topology
 
 The VPC can be either shared or managed by kOps. If shared, it must have an IPv6 pool associated.
 
 Subnet IPv6 CIDR allocations may be specified in the cluster spec using the special syntax `/LEN#N`,
 where "LEN" is the prefix length and "N" is the hexadecimal sequence number of the CIDR within the VPC's IPv6 CIDR.
 For example, if the VPC's CIDR is `2001:db8::/56` then the syntax `/64#a` would mean `2001:db8:0:a/64`.
+
+Public and utility subnets are expected to be dual-stack. Subnets of type `Private` are expected to be IPv6-only.
+There is a new type of subnet `DualStack` which is like `Private` but is dual-stack.
+The `DualStack` subnets are used by default for the control plane and APIServer nodes.
+
+IPv6-only subnets require Kubernetes 1.23 or later. For this reason, private topology on an IPv6 cluster also
+requires Kubernetes 1.23 or later.
 
 ## Routing and NAT64
 

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -633,11 +633,17 @@ type EtcdMemberSpec struct {
 type SubnetType string
 
 const (
-	// SubnetTypePublic means the subnet is public
+	// SubnetTypePublic means the subnet has external addresses.
+	// In IPv6 clusters it is typically dual-stack.
 	SubnetTypePublic SubnetType = "Public"
-	// SubnetTypePrivate means the subnet has no public address or is natted
+	// SubnetTypePrivate means the subnet has no public addresses.
+	// In IPv6 clusters it is typically IPv6-only.
 	SubnetTypePrivate SubnetType = "Private"
-	// SubnetTypeUtility mean the subnet is used for utility services, such as the bastion
+	// SubnetTypeDualStack means the subnet has no public addresses but is dual-stack.
+	SubnetTypeDualStack SubnetType = "DualStack"
+	// SubnetTypeUtility mean the subnet has external addresses but is not used for nodes.
+	// It is used for utility services, such as the bastion or load balancers.
+	// In IPv6 clusters it is typically dual-stack.
 	SubnetTypeUtility SubnetType = "Utility"
 )
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -471,7 +471,7 @@ func validateSubnet(subnet *kops.ClusterSubnetSpec, fieldPath *field.Path) field
 			allErrs = append(allErrs, field.Invalid(fieldPath.Child("egress"), subnet.Egress,
 				"egress must be of type NAT Gateway, NAT Gateway with existing ElasticIP, NAT EC2 Instance, Transit Gateway, or External"))
 		}
-		if subnet.Egress != kops.EgressExternal && subnet.Type != "Private" && (subnet.IPv6CIDR == "" || subnet.Type != "Public") {
+		if subnet.Egress != kops.EgressExternal && subnet.Type != "DualStack" && subnet.Type != "Private" && (subnet.IPv6CIDR == "" || subnet.Type != "Public") {
 			allErrs = append(allErrs, field.Forbidden(fieldPath.Child("egress"), "egress can only be specified for private or IPv6-capable public subnets"))
 		}
 	}

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -412,7 +412,7 @@ func validateSubnets(cluster *kops.ClusterSpec, fieldPath *field.Path) field.Err
 
 	// Each subnet must be valid
 	for i := range subnets {
-		allErrs = append(allErrs, validateSubnet(&subnets[i], fieldPath.Index(i))...)
+		allErrs = append(allErrs, validateSubnet(&subnets[i], cluster, fieldPath.Index(i))...)
 	}
 
 	// cannot duplicate subnet name
@@ -448,7 +448,7 @@ func validateSubnets(cluster *kops.ClusterSpec, fieldPath *field.Path) field.Err
 	return allErrs
 }
 
-func validateSubnet(subnet *kops.ClusterSubnetSpec, fieldPath *field.Path) field.ErrorList {
+func validateSubnet(subnet *kops.ClusterSubnetSpec, c *kops.ClusterSpec, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// name is required
@@ -475,6 +475,18 @@ func validateSubnet(subnet *kops.ClusterSubnetSpec, fieldPath *field.Path) field
 			allErrs = append(allErrs, field.Forbidden(fieldPath.Child("egress"), "egress can only be specified for private or IPv6-capable public subnets"))
 		}
 	}
+
+	allErrs = append(allErrs, IsValidValue(fieldPath.Child("type"), fi.String(string(subnet.Type)), []string{
+		string(kops.SubnetTypePublic),
+		string(kops.SubnetTypePrivate),
+		string(kops.SubnetTypeDualStack),
+		string(kops.SubnetTypeUtility),
+	})...)
+
+	if subnet.Type == kops.SubnetTypeDualStack && !c.IsIPv6Only() {
+		allErrs = append(allErrs, field.Forbidden(fieldPath.Child("type"), "subnet type DualStack may only be used in IPv6 clusters"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -115,72 +115,72 @@ func TestValidateSubnets(t *testing.T) {
 	}{
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a"},
+				{Name: "a", Type: kops.SubnetTypePublic},
 			},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a", CIDR: "10.0.0.0/8"},
+				{Name: "a", CIDR: "10.0.0.0/8", Type: kops.SubnetTypePublic},
 			},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: ""},
+				{Name: "", Type: kops.SubnetTypePublic},
 			},
 			ExpectedErrors: []string{"Required value::subnets[0].name"},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a"},
-				{Name: "a"},
+				{Name: "a", Type: kops.SubnetTypePublic},
+				{Name: "a", Type: kops.SubnetTypePublic},
 			},
 			ExpectedErrors: []string{"Duplicate value::subnets[1].name"},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a", ProviderID: "a"},
-				{Name: "b", ProviderID: "b"},
+				{Name: "a", ProviderID: "a", Type: kops.SubnetTypePublic},
+				{Name: "b", ProviderID: "b", Type: kops.SubnetTypePublic},
 			},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a", ProviderID: "a"},
-				{Name: "b", ProviderID: ""},
+				{Name: "a", ProviderID: "a", Type: kops.SubnetTypePublic},
+				{Name: "b", ProviderID: "", Type: kops.SubnetTypePublic},
 			},
 			ExpectedErrors: []string{"Forbidden::subnets[1].id"},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a", CIDR: "10.128.0.0/8"},
+				{Name: "a", CIDR: "10.128.0.0/8", Type: kops.SubnetTypePublic},
 			},
 			ExpectedErrors: []string{"Invalid value::subnets[0].cidr"},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a", IPv6CIDR: "2001:db8::/56"},
+				{Name: "a", IPv6CIDR: "2001:db8::/56", Type: kops.SubnetTypePublic},
 			},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a", IPv6CIDR: "10.0.0.0/8"},
-			},
-			ExpectedErrors: []string{"Invalid value::subnets[0].ipv6CIDR"},
-		},
-		{
-			Input: []kops.ClusterSubnetSpec{
-				{Name: "a", IPv6CIDR: "::ffff:10.128.0.0"},
+				{Name: "a", IPv6CIDR: "10.0.0.0/8", Type: kops.SubnetTypePublic},
 			},
 			ExpectedErrors: []string{"Invalid value::subnets[0].ipv6CIDR"},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a", IPv6CIDR: "::ffff:10.128.0.0/8"},
+				{Name: "a", IPv6CIDR: "::ffff:10.128.0.0", Type: kops.SubnetTypePublic},
 			},
 			ExpectedErrors: []string{"Invalid value::subnets[0].ipv6CIDR"},
 		},
 		{
 			Input: []kops.ClusterSubnetSpec{
-				{Name: "a", CIDR: "::ffff:10.128.0.0/8"},
+				{Name: "a", IPv6CIDR: "::ffff:10.128.0.0/8", Type: kops.SubnetTypePublic},
+			},
+			ExpectedErrors: []string{"Invalid value::subnets[0].ipv6CIDR"},
+		},
+		{
+			Input: []kops.ClusterSubnetSpec{
+				{Name: "a", CIDR: "::ffff:10.128.0.0/8", Type: kops.SubnetTypePublic},
 			},
 			ExpectedErrors: []string{"Invalid value::subnets[0].cidr"},
 		},
@@ -430,7 +430,7 @@ func Test_Validate_AdditionalPolicies(t *testing.T) {
 			KubernetesVersion:  "1.17.0",
 			AdditionalPolicies: &g.Input,
 			Subnets: []kops.ClusterSubnetSpec{
-				{Name: "subnet1"},
+				{Name: "subnet1", Type: kops.SubnetTypePublic},
 			},
 			EtcdClusters: []kops.EtcdClusterSpec{
 				{

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -211,14 +211,14 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 			return nil, err
 		}
 
-		// @step: check if we can add an public ip to this subnet
+		// @step: check if we can add a public ip to this subnet
 		switch subnets[0].Type {
 		case kops.SubnetTypePublic, kops.SubnetTypeUtility:
 			lt.AssociatePublicIP = fi.Bool(true)
 			if ig.Spec.AssociatePublicIP != nil {
 				lt.AssociatePublicIP = ig.Spec.AssociatePublicIP
 			}
-		case kops.SubnetTypePrivate:
+		case kops.SubnetTypeDualStack, kops.SubnetTypePrivate:
 			lt.AssociatePublicIP = fi.Bool(false)
 		}
 

--- a/pkg/model/awsmodel/bastion.go
+++ b/pkg/model/awsmodel/bastion.go
@@ -240,7 +240,7 @@ func (b *BastionModelBuilder) Build(c *fi.ModelBuilderContext) error {
 					continue
 				}
 
-			case kops.SubnetTypePrivate:
+			case kops.SubnetTypeDualStack, kops.SubnetTypePrivate:
 				if bastionLoadBalancerType != kops.LoadBalancerTypeInternal {
 					continue
 				}

--- a/pkg/model/awsmodel/spotinst.go
+++ b/pkg/model/awsmodel/spotinst.go
@@ -687,7 +687,7 @@ func (b *SpotInstanceGroupModelBuilder) buildPublicIpOpts(ig *kops.InstanceGroup
 		if ig.Spec.AssociatePublicIP != nil {
 			associatePublicIP = *ig.Spec.AssociatePublicIP
 		}
-	case kops.SubnetTypePrivate:
+	case kops.SubnetTypeDualStack, kops.SubnetTypePrivate:
 		associatePublicIP = false
 		if ig.Spec.AssociatePublicIP != nil {
 			if *ig.Spec.AssociatePublicIP {

--- a/pkg/model/azuremodel/api_loadbalancer.go
+++ b/pkg/model/azuremodel/api_loadbalancer.go
@@ -99,7 +99,7 @@ func (c *AzureModelContext) subnetForLoadBalancer() (*kops.ClusterSubnetSpec, er
 		if len(subnets) != 1 {
 			return nil, fmt.Errorf("expected exactly one subnet for InstanceGroup %q; subnets was %s", ig.Name, ig.Spec.Subnets)
 		}
-		if subnets[0].Type != kops.SubnetTypePrivate {
+		if subnets[0].Type != kops.SubnetTypeDualStack && subnets[0].Type != kops.SubnetTypePrivate {
 			continue
 		}
 		return subnets[0], nil

--- a/pkg/model/azuremodel/vmscaleset.go
+++ b/pkg/model/azuremodel/vmscaleset.go
@@ -130,7 +130,7 @@ func (b *VMScaleSetModelBuilder) buildVMScaleSetTask(
 		if ig.Spec.AssociatePublicIP != nil {
 			t.RequirePublicIP = ig.Spec.AssociatePublicIP
 		}
-	case kops.SubnetTypePrivate:
+	case kops.SubnetTypeDualStack, kops.SubnetTypePrivate:
 		t.RequirePublicIP = fi.Bool(false)
 	default:
 		return nil, fmt.Errorf("unexpected subnet type: for InstanceGroup %q; type was %s", ig.Name, subnet.Type)

--- a/pkg/model/gcemodel/network.go
+++ b/pkg/model/gcemodel/network.go
@@ -94,7 +94,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		for i := range b.Cluster.Spec.Subnets {
 			subnet := &b.Cluster.Spec.Subnets[i]
 			// Only need to deal with private subnets
-			if subnet.Type != kops.SubnetTypePrivate {
+			if subnet.Type != kops.SubnetTypeDualStack && subnet.Type != kops.SubnetTypePrivate {
 				continue
 			}
 

--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -263,7 +263,7 @@ func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		var lbSubnetName string
 		var err error
 		for _, sp := range b.Cluster.Spec.Subnets {
-			if sp.Type == kops.SubnetTypePrivate {
+			if sp.Type == kops.SubnetTypeDualStack || sp.Type == kops.SubnetTypePrivate {
 				lbSubnetName, err = b.findSubnetNameByID(sp.ProviderID, sp.Name)
 				if err != nil {
 					return err

--- a/pkg/testutils/cluster.go
+++ b/pkg/testutils/cluster.go
@@ -51,9 +51,9 @@ func BuildMinimalCluster(clusterName string) *kops.Cluster {
 
 	c.Spec.NetworkCIDR = "172.20.0.0/16"
 	c.Spec.Subnets = []kops.ClusterSubnetSpec{
-		{Name: "subnet-us-mock-1a", Zone: "us-mock-1a", CIDR: "172.20.1.0/24"},
-		{Name: "subnet-us-mock-1b", Zone: "us-mock-1b", CIDR: "172.20.2.0/24"},
-		{Name: "subnet-us-mock-1c", Zone: "us-mock-1c", CIDR: "172.20.3.0/24"},
+		{Name: "subnet-us-mock-1a", Zone: "us-mock-1a", CIDR: "172.20.1.0/24", Type: kops.SubnetTypePublic},
+		{Name: "subnet-us-mock-1b", Zone: "us-mock-1b", CIDR: "172.20.2.0/24", Type: kops.SubnetTypePublic},
+		{Name: "subnet-us-mock-1c", Zone: "us-mock-1c", CIDR: "172.20.3.0/24", Type: kops.SubnetTypePublic},
 	}
 
 	c.Spec.NonMasqueradeCIDR = "100.64.0.0/10"

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -190,23 +190,31 @@ spec:
   - 0.0.0.0/0
   - ::/0
   subnets:
-  - cidr: 172.20.32.0/19
-    ipv6CIDR: 2001:db8:0:111::/64
+  - ipv6CIDR: 2001:db8:0:111::/64
     name: us-test-1a
     type: Private
     zone: us-test-1a
-  - cidr: 172.20.64.0/19
-    ipv6CIDR: 2001:db8:0:112::/64
+  - ipv6CIDR: 2001:db8:0:112::/64
     name: us-test-1b
     type: Private
     zone: us-test-1b
-  - cidr: 172.20.0.0/22
+  - cidr: 172.20.32.0/19
     ipv6CIDR: 2001:db8:0:113::/64
+    name: dualstack-us-test-1a
+    type: DualStack
+    zone: us-test-1a
+  - cidr: 172.20.64.0/19
+    ipv6CIDR: 2001:db8:0:114::/64
+    name: dualstack-us-test-1b
+    type: DualStack
+    zone: us-test-1b
+  - cidr: 172.20.0.0/22
+    ipv6CIDR: 2001:db8:0:115::/64
     name: utility-us-test-1a
     type: Utility
     zone: us-test-1a
   - cidr: 172.20.4.0/22
-    ipv6CIDR: 2001:db8:0:114::/64
+    ipv6CIDR: 2001:db8:0:116::/64
     name: utility-us-test-1b
     type: Utility
     zone: us-test-1b

--- a/tests/integration/update_cluster/minimal-ipv6-private/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal-ipv6-private/in-v1alpha2.yaml
@@ -44,23 +44,31 @@ spec:
     masters: private
     nodes: private
   subnets:
-  - cidr: 172.20.32.0/19
-    ipv6CIDR: 2001:db8:0:111::/64
+  - ipv6CIDR: 2001:db8:0:111::/64
     name: us-test-1a
     type: Private
     zone: us-test-1a
-  - cidr: 172.20.64.0/19
-    ipv6CIDR: 2001:db8:0:112::/64
+  - ipv6CIDR: 2001:db8:0:112::/64
     name: us-test-1b
     type: Private
     zone: us-test-1b
-  - cidr: 172.20.0.0/22
+  - cidr: 172.20.32.0/19
     ipv6CIDR: 2001:db8:0:113::/64
+    name: dualstack-us-test-1a
+    type: DualStack
+    zone: us-test-1a
+  - cidr: 172.20.64.0/19
+    ipv6CIDR: 2001:db8:0:114::/64
+    name: dualstack-us-test-1b
+    type: DualStack
+    zone: us-test-1b
+  - cidr: 172.20.0.0/22
+    ipv6CIDR: 2001:db8:0:115::/64
     name: utility-us-test-1a
     type: Utility
     zone: us-test-1a
   - cidr: 172.20.4.0/22
-    ipv6CIDR: 2001:db8:0:114::/64
+    ipv6CIDR: 2001:db8:0:116::/64
     name: utility-us-test-1b
     type: Utility
     zone: us-test-1b
@@ -102,4 +110,4 @@ spec:
   minSize: 1
   role: Master
   subnets:
-  - us-test-1a
+  - dualstack-us-test-1a

--- a/tests/integration/update_cluster/minimal-ipv6-private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-ipv6-private/kubernetes.tf
@@ -13,6 +13,8 @@ locals {
   route_table_private-us-test-1a_id = aws_route_table.private-us-test-1a-minimal-ipv6-example-com.id
   route_table_private-us-test-1b_id = aws_route_table.private-us-test-1b-minimal-ipv6-example-com.id
   route_table_public_id             = aws_route_table.minimal-ipv6-example-com.id
+  subnet_dualstack-us-test-1a_id    = aws_subnet.dualstack-us-test-1a-minimal-ipv6-example-com.id
+  subnet_dualstack-us-test-1b_id    = aws_subnet.dualstack-us-test-1b-minimal-ipv6-example-com.id
   subnet_us-test-1a_id              = aws_subnet.us-test-1a-minimal-ipv6-example-com.id
   subnet_us-test-1b_id              = aws_subnet.us-test-1b-minimal-ipv6-example-com.id
   subnet_utility-us-test-1a_id      = aws_subnet.utility-us-test-1a-minimal-ipv6-example-com.id
@@ -75,6 +77,14 @@ output "route_table_private-us-test-1b_id" {
 
 output "route_table_public_id" {
   value = aws_route_table.minimal-ipv6-example-com.id
+}
+
+output "subnet_dualstack-us-test-1a_id" {
+  value = aws_subnet.dualstack-us-test-1a-minimal-ipv6-example-com.id
+}
+
+output "subnet_dualstack-us-test-1b_id" {
+  value = aws_subnet.dualstack-us-test-1b-minimal-ipv6-example-com.id
 }
 
 output "subnet_us-test-1a_id" {
@@ -172,7 +182,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-ipv6-example
     value               = "owned"
   }
   target_group_arns   = [aws_lb_target_group.tcp-minimal-ipv6-example--bne5ih.id]
-  vpc_zone_identifier = [aws_subnet.us-test-1a-minimal-ipv6-example-com.id]
+  vpc_zone_identifier = [aws_subnet.dualstack-us-test-1a-minimal-ipv6-example-com.id]
 }
 
 resource "aws_autoscaling_group" "nodes-minimal-ipv6-example-com" {
@@ -678,6 +688,16 @@ resource "aws_route_table" "private-us-test-1b-minimal-ipv6-example-com" {
   vpc_id = aws_vpc.minimal-ipv6-example-com.id
 }
 
+resource "aws_route_table_association" "private-dualstack-us-test-1a-minimal-ipv6-example-com" {
+  route_table_id = aws_route_table.private-us-test-1a-minimal-ipv6-example-com.id
+  subnet_id      = aws_subnet.dualstack-us-test-1a-minimal-ipv6-example-com.id
+}
+
+resource "aws_route_table_association" "private-dualstack-us-test-1b-minimal-ipv6-example-com" {
+  route_table_id = aws_route_table.private-us-test-1b-minimal-ipv6-example-com.id
+  subnet_id      = aws_subnet.dualstack-us-test-1b-minimal-ipv6-example-com.id
+}
+
 resource "aws_route_table_association" "private-us-test-1a-minimal-ipv6-example-com" {
   route_table_id = aws_route_table.private-us-test-1a-minimal-ipv6-example-com.id
   subnet_id      = aws_subnet.us-test-1a-minimal-ipv6-example-com.id
@@ -1071,36 +1091,68 @@ resource "aws_security_group_rule" "icmpv6-pmtu-api-elb-__--0" {
   type              = "ingress"
 }
 
-resource "aws_subnet" "us-test-1a-minimal-ipv6-example-com" {
+resource "aws_subnet" "dualstack-us-test-1a-minimal-ipv6-example-com" {
   availability_zone                              = "us-test-1a"
   cidr_block                                     = "172.20.32.0/19"
   enable_resource_name_dns_a_record_on_launch    = true
   enable_resource_name_dns_aaaa_record_on_launch = true
-  ipv6_cidr_block                                = "2001:db8:0:111::/64"
+  ipv6_cidr_block                                = "2001:db8:0:113::/64"
   private_dns_hostname_type_on_launch            = "resource-name"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
-    "Name"                                           = "us-test-1a.minimal-ipv6.example.com"
-    "SubnetType"                                     = "Private"
+    "Name"                                           = "dualstack-us-test-1a.minimal-ipv6.example.com"
+    "SubnetType"                                     = "DualStack"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
     "kubernetes.io/role/internal-elb"                = "1"
   }
   vpc_id = aws_vpc.minimal-ipv6-example-com.id
 }
 
-resource "aws_subnet" "us-test-1b-minimal-ipv6-example-com" {
+resource "aws_subnet" "dualstack-us-test-1b-minimal-ipv6-example-com" {
   availability_zone                              = "us-test-1b"
   cidr_block                                     = "172.20.64.0/19"
   enable_resource_name_dns_a_record_on_launch    = true
   enable_resource_name_dns_aaaa_record_on_launch = true
+  ipv6_cidr_block                                = "2001:db8:0:114::/64"
+  private_dns_hostname_type_on_launch            = "resource-name"
+  tags = {
+    "KubernetesCluster"                              = "minimal-ipv6.example.com"
+    "Name"                                           = "dualstack-us-test-1b.minimal-ipv6.example.com"
+    "SubnetType"                                     = "DualStack"
+    "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
+    "kubernetes.io/role/internal-elb"                = "1"
+  }
+  vpc_id = aws_vpc.minimal-ipv6-example-com.id
+}
+
+resource "aws_subnet" "us-test-1a-minimal-ipv6-example-com" {
+  availability_zone                              = "us-test-1a"
+  enable_dns64                                   = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  ipv6_cidr_block                                = "2001:db8:0:111::/64"
+  ipv6_native                                    = true
+  private_dns_hostname_type_on_launch            = "resource-name"
+  tags = {
+    "KubernetesCluster"                              = "minimal-ipv6.example.com"
+    "Name"                                           = "us-test-1a.minimal-ipv6.example.com"
+    "SubnetType"                                     = "Private"
+    "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
+  }
+  vpc_id = aws_vpc.minimal-ipv6-example-com.id
+}
+
+resource "aws_subnet" "us-test-1b-minimal-ipv6-example-com" {
+  availability_zone                              = "us-test-1b"
+  enable_dns64                                   = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
   ipv6_cidr_block                                = "2001:db8:0:112::/64"
+  ipv6_native                                    = true
   private_dns_hostname_type_on_launch            = "resource-name"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
     "Name"                                           = "us-test-1b.minimal-ipv6.example.com"
     "SubnetType"                                     = "Private"
     "kubernetes.io/cluster/minimal-ipv6.example.com" = "owned"
-    "kubernetes.io/role/internal-elb"                = "1"
   }
   vpc_id = aws_vpc.minimal-ipv6-example-com.id
 }
@@ -1110,7 +1162,7 @@ resource "aws_subnet" "utility-us-test-1a-minimal-ipv6-example-com" {
   cidr_block                                     = "172.20.0.0/22"
   enable_resource_name_dns_a_record_on_launch    = true
   enable_resource_name_dns_aaaa_record_on_launch = true
-  ipv6_cidr_block                                = "2001:db8:0:113::/64"
+  ipv6_cidr_block                                = "2001:db8:0:115::/64"
   private_dns_hostname_type_on_launch            = "resource-name"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"
@@ -1127,7 +1179,7 @@ resource "aws_subnet" "utility-us-test-1b-minimal-ipv6-example-com" {
   cidr_block                                     = "172.20.4.0/22"
   enable_resource_name_dns_a_record_on_launch    = true
   enable_resource_name_dns_aaaa_record_on_launch = true
-  ipv6_cidr_block                                = "2001:db8:0:114::/64"
+  ipv6_cidr_block                                = "2001:db8:0:116::/64"
   private_dns_hostname_type_on_launch            = "resource-name"
   tags = {
     "KubernetesCluster"                              = "minimal-ipv6.example.com"

--- a/upup/pkg/fi/cloudup/deepvalidate_test.go
+++ b/upup/pkg/fi/cloudup/deepvalidate_test.go
@@ -116,8 +116,8 @@ func TestDeepValidate_DuplicateZones(t *testing.T) {
 func TestDeepValidate_ExtraMasterZone(t *testing.T) {
 	c := buildDefaultCluster(t)
 	c.Spec.Subnets = []kopsapi.ClusterSubnetSpec{
-		{Name: "mock1a", Zone: "us-mock-1a", CIDR: "172.20.1.0/24"},
-		{Name: "mock1b", Zone: "us-mock-1b", CIDR: "172.20.2.0/24"},
+		{Name: "mock1a", Zone: "us-mock-1a", CIDR: "172.20.1.0/24", Type: kopsapi.SubnetTypePublic},
+		{Name: "mock1b", Zone: "us-mock-1b", CIDR: "172.20.2.0/24", Type: kopsapi.SubnetTypePublic},
 	}
 	var groups []*kopsapi.InstanceGroup
 	groups = append(groups, buildMinimalMasterInstanceGroup("subnet-us-mock-1a"))

--- a/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
@@ -244,9 +244,9 @@ func TestPopulateCluster_Custom_CIDR(t *testing.T) {
 	cloud, c := buildMinimalCluster()
 	c.Spec.NetworkCIDR = "172.20.2.0/24"
 	c.Spec.Subnets = []kopsapi.ClusterSubnetSpec{
-		{Name: "subnet-us-mock-1a", Zone: "us-mock-1a", CIDR: "172.20.2.0/27"},
-		{Name: "subnet-us-mock-1b", Zone: "us-mock-1b", CIDR: "172.20.2.32/27"},
-		{Name: "subnet-us-mock-1c", Zone: "us-mock-1c", CIDR: "172.20.2.64/27"},
+		{Name: "subnet-us-mock-1a", Zone: "us-mock-1a", CIDR: "172.20.2.0/27", Type: kopsapi.SubnetTypePublic},
+		{Name: "subnet-us-mock-1b", Zone: "us-mock-1b", CIDR: "172.20.2.32/27", Type: kopsapi.SubnetTypePublic},
+		{Name: "subnet-us-mock-1c", Zone: "us-mock-1c", CIDR: "172.20.2.64/27", Type: kopsapi.SubnetTypePublic},
 	}
 
 	err := PerformAssignments(c, cloud)

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -144,7 +144,23 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 		if len(ig.Spec.Subnets) == 0 {
 			return nil, fmt.Errorf("master InstanceGroup %s did not specify any Subnets", ig.ObjectMeta.Name)
 		}
+	} else if ig.IsAPIServerOnly() && cluster.Spec.IsIPv6Only() {
+		if len(ig.Spec.Subnets) == 0 {
+			for _, subnet := range cluster.Spec.Subnets {
+				if subnet.Type != kops.SubnetTypePrivate && subnet.Type != kops.SubnetTypeUtility {
+					ig.Spec.Subnets = append(ig.Spec.Subnets, subnet.Name)
+				}
+			}
+		}
 	} else {
+		if len(ig.Spec.Subnets) == 0 {
+			for _, subnet := range cluster.Spec.Subnets {
+				if subnet.Type != kops.SubnetTypeDualStack && subnet.Type != kops.SubnetTypeUtility {
+					ig.Spec.Subnets = append(ig.Spec.Subnets, subnet.Name)
+				}
+			}
+		}
+
 		if len(ig.Spec.Subnets) == 0 {
 			for _, subnet := range cluster.Spec.Subnets {
 				if subnet.Type != kops.SubnetTypeUtility {

--- a/upup/pkg/fi/cloudup/subnets.go
+++ b/upup/pkg/fi/cloudup/subnets.go
@@ -119,7 +119,7 @@ func assignCIDRsToSubnets(c *kops.Cluster, cloud fi.Cloud) error {
 	for i := range c.Spec.Subnets {
 		subnet := &c.Spec.Subnets[i]
 		switch subnet.Type {
-		case kops.SubnetTypePublic, kops.SubnetTypePrivate:
+		case kops.SubnetTypeDualStack, kops.SubnetTypePublic, kops.SubnetTypePrivate:
 			bigSubnets = append(bigSubnets, subnet)
 
 		case kops.SubnetTypeUtility:
@@ -174,8 +174,7 @@ func assignCIDRsToSubnets(c *kops.Cluster, cloud fi.Cloud) error {
 		if subnet.CIDR != "" {
 			continue
 		}
-		// TODO: Replace this with a check against type "dualstack" if has IPv6CIDR
-		if subnet.IPv6CIDR != "" && subnet.Name != subnet.Zone {
+		if subnet.IPv6CIDR != "" && subnet.Type == kops.SubnetTypePrivate {
 			continue
 		}
 

--- a/upup/pkg/fi/cloudup/subnets_test.go
+++ b/upup/pkg/fi/cloudup/subnets_test.go
@@ -78,6 +78,37 @@ func Test_AssignSubnets(t *testing.T) {
 		},
 		{
 			subnets: []kops.ClusterSubnetSpec{
+				{Name: "a", Zone: "a", CIDR: "", IPv6CIDR: "/64#0", Type: kops.SubnetTypePublic},
+				{Name: "a", Zone: "a", CIDR: "", IPv6CIDR: "/64#1", Type: kops.SubnetTypeUtility},
+			},
+			expected: []string{"10.32.0.0/11", "10.0.0.0/14"},
+		},
+		{
+			subnets: []kops.ClusterSubnetSpec{
+				{Name: "a", Zone: "a", CIDR: "10.1.0.0/16", Type: kops.SubnetTypePrivate},
+			},
+			expected: []string{"10.1.0.0/16"},
+		},
+		{
+			subnets: []kops.ClusterSubnetSpec{
+				{Name: "a", Zone: "a", CIDR: "", Type: kops.SubnetTypePrivate},
+			},
+			expected: []string{"10.32.0.0/11"},
+		},
+		{
+			subnets: []kops.ClusterSubnetSpec{
+				{Name: "a", Zone: "a", CIDR: "", IPv6CIDR: "/64#0", Type: kops.SubnetTypePrivate},
+			},
+			expected: []string{""},
+		},
+		{
+			subnets: []kops.ClusterSubnetSpec{
+				{Name: "a", Zone: "a", CIDR: "", IPv6CIDR: "/64#0", Type: kops.SubnetTypeDualStack},
+			},
+			expected: []string{"10.32.0.0/11"},
+		},
+		{
+			subnets: []kops.ClusterSubnetSpec{
 				{Name: "a", Zone: "a", CIDR: "", Type: kops.SubnetTypePublic},
 				{Name: "a", Zone: "a", CIDR: "", Type: kops.SubnetTypeUtility},
 				{Name: "b", Zone: "b", CIDR: "", Type: kops.SubnetTypePublic},


### PR DESCRIPTION
One alternative would be to omit creating dualstack subnets in zones that don't have control plane nodes when there are no apiserver nodes.

/cc @olemarkus @hakman 
Closes #12886