### PR TITLE
Use instance requirements with Karpenter

### DIFF
--- a/cloudmock/aws/mockec2/instances.go
+++ b/cloudmock/aws/mockec2/instances.go
@@ -56,3 +56,13 @@ func (m *MockEC2) DescribeInstanceTypes(*ec2.DescribeInstanceTypesInput) (*ec2.D
 	klog.Warningf("MockEc2::DescribeInstanceTypes is stub-implemented")
 	return &ec2.DescribeInstanceTypesOutput{}, nil
 }
+
+func (m *MockEC2) GetInstanceTypesFromInstanceRequirements(input *ec2.GetInstanceTypesFromInstanceRequirementsInput) (*ec2.GetInstanceTypesFromInstanceRequirementsOutput, error) {
+	return &ec2.GetInstanceTypesFromInstanceRequirementsOutput{
+		InstanceTypes: []*ec2.InstanceTypeInfoFromInstanceRequirements{
+			{
+				InstanceType: aws.String("c5.large"),
+			},
+		},
+	}, nil
+}

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -608,8 +608,10 @@ func TestKarpenter(t *testing.T) {
 		withAddons("karpenter.sh-k8s-1.19").
 		withServiceAccountRole("karpenter.kube-system", true)
 	test.expectTerraformFilenames = append(test.expectTerraformFilenames,
-		"aws_launch_template_karpenter-nodes.minimal.example.com_user_data",
-		"aws_s3_bucket_object_nodeupconfig-karpenter-nodes_content",
+		"aws_launch_template_karpenter-nodes-single-machinetype.minimal.example.com_user_data",
+		"aws_launch_template_karpenter-nodes-default.minimal.example.com_user_data",
+		"aws_s3_bucket_object_nodeupconfig-karpenter-nodes-single-machinetype_content",
+		"aws_s3_bucket_object_nodeupconfig-karpenter-nodes-default_content",
 	)
 	test.runTestTerraformAWS(t)
 }

--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -188,7 +188,6 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 		ImageID:                      fi.String(ig.Spec.Image),
 		InstanceInterruptionBehavior: ig.Spec.InstanceInterruptionBehavior,
 		InstanceMonitoring:           fi.Bool(false),
-		InstanceType:                 fi.String(strings.Split(ig.Spec.MachineType, ",")[0]),
 		IPv6AddressCount:             fi.Int64(0),
 		RootVolumeIops:               fi.Int64(int64(fi.Int32Value(ig.Spec.RootVolumeIOPS))),
 		RootVolumeOptimization:       ig.Spec.RootVolumeOptimization,
@@ -199,6 +198,10 @@ func (b *AutoscalingGroupModelBuilder) buildLaunchTemplateTask(c *fi.ModelBuilde
 		SecurityGroups:               securityGroups,
 		Tags:                         tags,
 		UserData:                     userData,
+	}
+
+	if ig.Spec.Manager == kops.InstanceManagerCloudGroup {
+		lt.InstanceType = fi.String(strings.Split(ig.Spec.MachineType, ",")[0])
 	}
 
 	{
@@ -493,7 +496,7 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 	sort.Stable(awstasks.OrderTargetGroupsByName(t.TargetGroups))
 
 	// @step: are we using a mixed instance policy
-	if ig.Spec.MixedInstancesPolicy != nil {
+	if ig.Spec.MixedInstancesPolicy != nil && ig.Spec.Manager == kops.InstanceManagerCloudGroup {
 		spec := ig.Spec.MixedInstancesPolicy
 
 		if spec.InstanceRequirements != nil {

--- a/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
@@ -110,6 +110,12 @@ spec:
   manager: Karpenter
   maxSize: 2
   minSize: 2
+  mixedInstancesPolicy:
+    instanceRequirements:
+      cpu:
+        min: "2"
+      memory:
+        min: 2G
   nodeLabels:
     kops.k8s.io/instancegroup: nodes
   role: Node

--- a/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
@@ -106,16 +106,9 @@ spec:
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required
-  machineType: t2.medium
   manager: Karpenter
   maxSize: 2
   minSize: 2
-  mixedInstancesPolicy:
-    instanceRequirements:
-      cpu:
-        min: "2"
-      memory:
-        min: 2G
   nodeLabels:
     kops.k8s.io/instancegroup: nodes
   role: Node

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-default.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-default.minimal.example.com_user_data
@@ -157,9 +157,9 @@ __EOF_CLUSTER_SPEC
 cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
-InstanceGroupName: karpenter-nodes
+InstanceGroupName: karpenter-nodes-default
 InstanceGroupRole: Node
-NodeupConfigHash: t+F49agATFa5uzfEBWAy92YyGppKvMwc3MS9nlXVaY4=
+NodeupConfigHash: NtER4w+wD8tSbHFc3vxBJ1EomYSDw8Ie5hpVTurK7hg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-single-machinetype.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-single-machinetype.minimal.example.com_user_data
@@ -1,0 +1,167 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
+NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
+NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
+NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
+
+export AWS_REGION=us-test-1
+
+
+
+
+sysctl -w net.core.rmem_max=16777216 || true
+sysctl -w net.core.wmem_max=16777216 || true
+sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
+sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
+
+
+function ensure-install-dir() {
+  INSTALL_DIR="/opt/kops"
+  # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
+  if [[ -d /var/lib/toolbox ]]; then
+    INSTALL_DIR="/var/lib/toolbox/kops"
+  fi
+  mkdir -p ${INSTALL_DIR}/bin
+  mkdir -p ${INSTALL_DIR}/conf
+  cd ${INSTALL_DIR}
+}
+
+# Retry a download until we get it. args: name, sha, urls
+download-or-bust() {
+  local -r file="$1"
+  local -r hash="$2"
+  local -r urls=( $(split-commas "$3") )
+
+  if [[ -f "${file}" ]]; then
+    if ! validate-hash "${file}" "${hash}"; then
+      rm -f "${file}"
+    else
+      return 0
+    fi
+  fi
+
+  while true; do
+    for url in "${urls[@]}"; do
+      commands=(
+        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
+        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
+      )
+      for cmd in "${commands[@]}"; do
+        echo "Attempting download with: ${cmd} {url}"
+        if ! (${cmd} "${url}"); then
+          echo "== Download failed with ${cmd} =="
+          continue
+        fi
+        if ! validate-hash "${file}" "${hash}"; then
+          echo "== Hash validation of ${url} failed. Retrying. =="
+          rm -f "${file}"
+        else
+          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+          return 0
+        fi
+      done
+    done
+
+    echo "All downloads failed; sleeping before retrying"
+    sleep 60
+  done
+}
+
+validate-hash() {
+  local -r file="$1"
+  local -r expected="$2"
+  local actual
+
+  actual=$(sha256sum ${file} | awk '{ print $1 }') || true
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
+    return 1
+  fi
+}
+
+function split-commas() {
+  echo $1 | tr "," "\n"
+}
+
+function download-release() {
+  case "$(uname -m)" in
+  x86_64*|i?86_64*|amd64*)
+    NODEUP_URL="${NODEUP_URL_AMD64}"
+    NODEUP_HASH="${NODEUP_HASH_AMD64}"
+    ;;
+  aarch64*|arm64*)
+    NODEUP_URL="${NODEUP_URL_ARM64}"
+    NODEUP_HASH="${NODEUP_HASH_ARM64}"
+    ;;
+  *)
+    echo "Unsupported host arch: $(uname -m)" >&2
+    exit 1
+    ;;
+  esac
+
+  cd ${INSTALL_DIR}/bin
+  download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
+
+  chmod +x nodeup
+
+  echo "Running nodeup"
+  # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
+  ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
+}
+
+####################################################################################
+
+/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
+
+echo "== nodeup node config starting =="
+ensure-install-dir
+
+cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
+cloudConfig:
+  awsEBSCSIDriver:
+    enabled: false
+  manageStorageClasses: true
+containerRuntime: containerd
+containerd:
+  logLevel: info
+  version: 1.4.12
+docker:
+  skipInstall: true
+kubeProxy:
+  clusterCIDR: 100.96.0.0/11
+  cpuRequest: 100m
+  image: k8s.gcr.io/kube-proxy:v1.21.0
+  logLevel: 2
+kubelet:
+  anonymousAuth: false
+  cgroupDriver: systemd
+  cgroupRoot: /
+  cloudProvider: aws
+  clusterDNS: 100.64.0.10
+  clusterDomain: cluster.local
+  enableDebuggingHandlers: true
+  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+  kubeconfigPath: /var/lib/kubelet/kubeconfig
+  logLevel: 2
+  networkPluginName: cni
+  podManifestPath: /etc/kubernetes/manifests
+
+__EOF_CLUSTER_SPEC
+
+cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
+CloudProvider: aws
+ConfigBase: memfs://clusters.example.com/minimal.example.com
+InstanceGroupName: karpenter-nodes-single-machinetype
+InstanceGroupRole: Node
+NodeupConfigHash: Jp+yk9rmc2zJKlWuhKUtlznZb7S6YqW6m9XKsxRoceA=
+
+__EOF_KUBE_ENV
+
+download-release
+echo "== nodeup node config done =="

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: 64a10d731b689842b2c27d950841d2d4073448f6a9d5ea1fd371f0c28327d13c
+    manifestHash: e21c09e2b55aca845c28ce60c470ec78633e07f4842f146edb5a178354616958
     name: karpenter.sh
     selector:
       k8s-addon: karpenter.sh

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -897,11 +897,46 @@ metadata:
     addon.kops.k8s.io/name: karpenter.sh
     app.kubernetes.io/managed-by: kops
     k8s-addon: karpenter.sh
-  name: karpenter-nodes
+  name: karpenter-nodes-default
 spec:
   provider:
     instanceProfile: nodes.minimal.example.com
-    launchTemplate: karpenter-nodes.minimal.example.com
+    launchTemplate: karpenter-nodes-default.minimal.example.com
+    securityGroupSelector:
+      Name: nodes.minimal.example.com
+    subnetSelector:
+      KubernetesCluster: minimal.example.com
+      kubernetes.io/role/internal-elb: "1"
+  requirements:
+  - key: karpenter.sh/capacity-type
+    operator: In
+    values:
+    - spot
+  - key: kubernetes.io/arch
+    operator: In
+    values:
+    - amd64
+  - key: node.kubernetes.io/instance-type
+    operator: In
+    values:
+    - c5.large
+  ttlSecondsAfterEmpty: 30
+
+---
+
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: karpenter.sh
+    app.kubernetes.io/managed-by: kops
+    k8s-addon: karpenter.sh
+  name: karpenter-nodes-single-machinetype
+spec:
+  provider:
+    instanceProfile: nodes.minimal.example.com
+    launchTemplate: karpenter-nodes-single-machinetype.minimal.example.com
     securityGroupSelector:
       Name: nodes.minimal.example.com
     subnetSelector:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_nodeupconfig-karpenter-nodes-default_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_nodeupconfig-karpenter-nodes-default_content
@@ -1,0 +1,62 @@
+Assets:
+  amd64:
+  - 681c81b7934ae2bf38b9f12d891683972d1fbbf6d7d97e50940a47b139d41b35@https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubelet
+  - 9f74f2fa7ee32ad07e17211725992248470310ca1988214518806b39b1dad9f0@https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubectl
+  - 977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz
+  - f6120552408175ca332fd3b5d31c5edd115d8426d6731664e4ea3951c5eee3b4@https://github.com/containerd/containerd/releases/download/v1.4.12/cri-containerd-cni-1.4.12-linux-amd64.tar.gz
+  arm64:
+  - 17832b192be5ea314714f7e16efd5e5f65347974bbbf41def6b02f68931380c4@https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/arm64/kubelet
+  - a4dd7100f547a40d3e2f83850d0bab75c6ea5eb553f0a80adcf73155bef1fd0d@https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/arm64/kubectl
+  - ae13d7b5c05bd180ea9b5b68f44bdaa7bfb41034a2ef1d68fd8e1259797d642f@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.7/cni-plugins-linux-arm64-v0.8.7.tgz
+  - 87a4219c54552797ffd38790b72832372a90eceb7c8e451c36a682093d57dae6@https://download.docker.com/linux/static/stable/aarch64/docker-20.10.11.tgz
+CAs:
+  kubernetes-ca: |
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANqBD8NSD82AUSMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwODAwWhcNMzEwNzA3MDcw
+    ODAwWjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBANFI3zr0Tk8krsW8vwjfMpzJOlWQ8616vG3YPa2qAgI7V4oKwfV0yIg1
+    jt+H6f4P/wkPAPTPTfRp9Iy8oHEEFw0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFNG3zVjTcLlJwDsJ4/K9DV7KohUA
+    MA0GCSqGSIb3DQEBCwUAA0EAB8d03fY2w7WKpfO29qI295pu2C4ca9AiVGOpgSc8
+    tmQsq6rcxt3T+rb589PVtz0mw/cKTxOk6gH2CCC+yHfy2w==
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    MIIBbjCCARigAwIBAgIMFpANvmSa0OAlYmXKMA0GCSqGSIb3DQEBCwUAMBgxFjAU
+    BgNVBAMTDWt1YmVybmV0ZXMtY2EwHhcNMjEwNzA3MDcwOTM2WhcNMzEwNzA3MDcw
+    OTM2WjAYMRYwFAYDVQQDEw1rdWJlcm5ldGVzLWNhMFwwDQYJKoZIhvcNAQEBBQAD
+    SwAwSAJBAMF6F4aZdpe0RUpyykaBpWwZCnwbffhYGOw+fs6RdLuUq7QCNmJm/Eq7
+    WWOziMYDiI9SbclpD+6QiJ0N3EqppVUCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
+    MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFLImp6ARjPDAH6nhI+scWVt3Q9bn
+    MA0GCSqGSIb3DQEBCwUAA0EAVQVx5MUtuAIeePuP9o51xtpT2S6Fvfi8J4ICxnlA
+    9B7UD2ushcVFPtaeoL9Gfu8aY4KJBeqqg5ojl4qmRnThjw==
+    -----END CERTIFICATE-----
+ClusterName: minimal.example.com
+Hooks:
+- null
+- null
+KeypairIDs:
+  kubernetes-ca: "6982820025135291416230495506"
+KubeletConfig:
+  anonymousAuth: false
+  cgroupDriver: systemd
+  cgroupRoot: /
+  cloudProvider: aws
+  clusterDNS: 100.64.0.10
+  clusterDomain: cluster.local
+  enableDebuggingHandlers: true
+  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+  kubeconfigPath: /var/lib/kubelet/kubeconfig
+  logLevel: 2
+  networkPluginName: cni
+  nodeLabels:
+    karpenter.sh/provisioner-name: karpenter-nodes-default
+    kubernetes.io/role: node
+    node-role.kubernetes.io/node: ""
+  podManifestPath: /etc/kubernetes/manifests
+UpdatePolicy: automatic
+channels:
+- memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
+containerdConfig:
+  logLevel: info
+  version: 1.4.12

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_nodeupconfig-karpenter-nodes-single-machinetype_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_nodeupconfig-karpenter-nodes-single-machinetype_content
@@ -50,7 +50,7 @@ KubeletConfig:
   logLevel: 2
   networkPluginName: cni
   nodeLabels:
-    karpenter.sh/provisioner-name: karpenter-nodes
+    karpenter.sh/provisioner-name: karpenter-nodes-single-machinetype
     kubernetes.io/role: node
     node-role.kubernetes.io/node: ""
   podManifestPath: /etc/kubernetes/manifests

--- a/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/karpenter/in-v1alpha2.yaml
@@ -88,7 +88,7 @@ apiVersion: kops.k8s.io/v1alpha2
 kind: InstanceGroup
 metadata:
   creationTimestamp: "2016-12-10T22:42:28Z"
-  name: karpenter-nodes
+  name: karpenter-nodes-single-machinetype
   labels:
     kops.k8s.io/cluster: minimal.example.com
 spec:
@@ -96,6 +96,23 @@ spec:
   associatePublicIp: true
   image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   machineType: t2.medium
+  role: Node
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2016-12-10T22:42:28Z"
+  name: karpenter-nodes-default
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+spec:
+  manager: Karpenter
+  associatePublicIp: true
+  image: kope.io/k8s-1.4-debian-jessie-amd64-hvm-ebs-2016-10-21
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/update_cluster/karpenter/kubernetes.tf
+++ b/tests/integration/update_cluster/karpenter/kubernetes.tf
@@ -374,7 +374,7 @@ resource "aws_key_pair" "kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663
   }
 }
 
-resource "aws_launch_template" "karpenter-nodes-minimal-example-com" {
+resource "aws_launch_template" "karpenter-nodes-default-minimal-example-com" {
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
@@ -389,9 +389,8 @@ resource "aws_launch_template" "karpenter-nodes-minimal-example-com" {
   iam_instance_profile {
     name = aws_iam_instance_profile.nodes-minimal-example-com.id
   }
-  image_id      = "ami-12345678"
-  instance_type = "t2.medium"
-  key_name      = aws_key_pair.kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id
+  image_id = "ami-12345678"
+  key_name = aws_key_pair.kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id
   lifecycle {
     create_before_destroy = true
   }
@@ -404,7 +403,7 @@ resource "aws_launch_template" "karpenter-nodes-minimal-example-com" {
   monitoring {
     enabled = false
   }
-  name = "karpenter-nodes.minimal.example.com"
+  name = "karpenter-nodes-default.minimal.example.com"
   network_interfaces {
     associate_public_ip_address = true
     delete_on_termination       = true
@@ -415,12 +414,12 @@ resource "aws_launch_template" "karpenter-nodes-minimal-example-com" {
     resource_type = "instance"
     tags = {
       "KubernetesCluster"                                                           = "minimal.example.com"
-      "Name"                                                                        = "karpenter-nodes.minimal.example.com"
-      "k8s.io/cluster-autoscaler/node-template/label/karpenter.sh/provisioner-name" = "karpenter-nodes"
+      "Name"                                                                        = "karpenter-nodes-default.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/karpenter.sh/provisioner-name" = "karpenter-nodes-default"
       "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"            = "node"
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"  = ""
       "k8s.io/role/node"                                                            = "1"
-      "kops.k8s.io/instancegroup"                                                   = "karpenter-nodes"
+      "kops.k8s.io/instancegroup"                                                   = "karpenter-nodes-default"
       "kubernetes.io/cluster/minimal.example.com"                                   = "owned"
     }
   }
@@ -428,26 +427,101 @@ resource "aws_launch_template" "karpenter-nodes-minimal-example-com" {
     resource_type = "volume"
     tags = {
       "KubernetesCluster"                                                           = "minimal.example.com"
-      "Name"                                                                        = "karpenter-nodes.minimal.example.com"
-      "k8s.io/cluster-autoscaler/node-template/label/karpenter.sh/provisioner-name" = "karpenter-nodes"
+      "Name"                                                                        = "karpenter-nodes-default.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/karpenter.sh/provisioner-name" = "karpenter-nodes-default"
       "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"            = "node"
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"  = ""
       "k8s.io/role/node"                                                            = "1"
-      "kops.k8s.io/instancegroup"                                                   = "karpenter-nodes"
+      "kops.k8s.io/instancegroup"                                                   = "karpenter-nodes-default"
       "kubernetes.io/cluster/minimal.example.com"                                   = "owned"
     }
   }
   tags = {
     "KubernetesCluster"                                                           = "minimal.example.com"
-    "Name"                                                                        = "karpenter-nodes.minimal.example.com"
-    "k8s.io/cluster-autoscaler/node-template/label/karpenter.sh/provisioner-name" = "karpenter-nodes"
+    "Name"                                                                        = "karpenter-nodes-default.minimal.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/karpenter.sh/provisioner-name" = "karpenter-nodes-default"
     "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"            = "node"
     "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"  = ""
     "k8s.io/role/node"                                                            = "1"
-    "kops.k8s.io/instancegroup"                                                   = "karpenter-nodes"
+    "kops.k8s.io/instancegroup"                                                   = "karpenter-nodes-default"
     "kubernetes.io/cluster/minimal.example.com"                                   = "owned"
   }
-  user_data = filebase64("${path.module}/data/aws_launch_template_karpenter-nodes.minimal.example.com_user_data")
+  user_data = filebase64("${path.module}/data/aws_launch_template_karpenter-nodes-default.minimal.example.com_user_data")
+}
+
+resource "aws_launch_template" "karpenter-nodes-single-machinetype-minimal-example-com" {
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      throughput            = 125
+      volume_size           = 128
+      volume_type           = "gp3"
+    }
+  }
+  iam_instance_profile {
+    name = aws_iam_instance_profile.nodes-minimal-example-com.id
+  }
+  image_id = "ami-12345678"
+  key_name = aws_key_pair.kubernetes-minimal-example-com-c4a6ed9aa889b9e2c39cd663eb9c7157.id
+  lifecycle {
+    create_before_destroy = true
+  }
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_protocol_ipv6          = "disabled"
+    http_put_response_hop_limit = 1
+    http_tokens                 = "optional"
+  }
+  monitoring {
+    enabled = false
+  }
+  name = "karpenter-nodes-single-machinetype.minimal.example.com"
+  network_interfaces {
+    associate_public_ip_address = true
+    delete_on_termination       = true
+    ipv6_address_count          = 0
+    security_groups             = [aws_security_group.nodes-minimal-example-com.id]
+  }
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      "KubernetesCluster"                                                           = "minimal.example.com"
+      "Name"                                                                        = "karpenter-nodes-single-machinetype.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/karpenter.sh/provisioner-name" = "karpenter-nodes-single-machinetype"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"            = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"  = ""
+      "k8s.io/role/node"                                                            = "1"
+      "kops.k8s.io/instancegroup"                                                   = "karpenter-nodes-single-machinetype"
+      "kubernetes.io/cluster/minimal.example.com"                                   = "owned"
+    }
+  }
+  tag_specifications {
+    resource_type = "volume"
+    tags = {
+      "KubernetesCluster"                                                           = "minimal.example.com"
+      "Name"                                                                        = "karpenter-nodes-single-machinetype.minimal.example.com"
+      "k8s.io/cluster-autoscaler/node-template/label/karpenter.sh/provisioner-name" = "karpenter-nodes-single-machinetype"
+      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"            = "node"
+      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"  = ""
+      "k8s.io/role/node"                                                            = "1"
+      "kops.k8s.io/instancegroup"                                                   = "karpenter-nodes-single-machinetype"
+      "kubernetes.io/cluster/minimal.example.com"                                   = "owned"
+    }
+  }
+  tags = {
+    "KubernetesCluster"                                                           = "minimal.example.com"
+    "Name"                                                                        = "karpenter-nodes-single-machinetype.minimal.example.com"
+    "k8s.io/cluster-autoscaler/node-template/label/karpenter.sh/provisioner-name" = "karpenter-nodes-single-machinetype"
+    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"            = "node"
+    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"  = ""
+    "k8s.io/role/node"                                                            = "1"
+    "kops.k8s.io/instancegroup"                                                   = "karpenter-nodes-single-machinetype"
+    "kubernetes.io/cluster/minimal.example.com"                                   = "owned"
+  }
+  user_data = filebase64("${path.module}/data/aws_launch_template_karpenter-nodes-single-machinetype.minimal.example.com_user_data")
 }
 
 resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
@@ -780,10 +854,18 @@ resource "aws_s3_bucket_object" "minimal-example-com-addons-storage-aws-addons-k
   server_side_encryption = "AES256"
 }
 
-resource "aws_s3_bucket_object" "nodeupconfig-karpenter-nodes" {
+resource "aws_s3_bucket_object" "nodeupconfig-karpenter-nodes-default" {
   bucket                 = "testingBucket"
-  content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-karpenter-nodes_content")
-  key                    = "clusters.example.com/minimal.example.com/igconfig/node/karpenter-nodes/nodeupconfig.yaml"
+  content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-karpenter-nodes-default_content")
+  key                    = "clusters.example.com/minimal.example.com/igconfig/node/karpenter-nodes-default/nodeupconfig.yaml"
+  provider               = aws.files
+  server_side_encryption = "AES256"
+}
+
+resource "aws_s3_bucket_object" "nodeupconfig-karpenter-nodes-single-machinetype" {
+  bucket                 = "testingBucket"
+  content                = file("${path.module}/data/aws_s3_bucket_object_nodeupconfig-karpenter-nodes-single-machinetype_content")
+  key                    = "clusters.example.com/minimal.example.com/igconfig/node/karpenter-nodes-single-machinetype/nodeupconfig.yaml"
   provider               = aws.files
   server_side_encryption = "AES256"
 }

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -684,11 +684,8 @@ spec:
     - key: "node.kubernetes.io/instance-type"
       operator: In
       values:
-      - {{ $spec.MachineType }}
-      {{ with $spec.MixedInstancesPolicy }}
-      {{ range $key := .Instances }}
-      - {{ $key }}
-      {{ end }}
+      {{ range $type := KarpenterInstanceTypes $spec }}
+      - {{ $type }}
       {{ end }}
 {{ with $spec.Taints }}
   taints:

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -114,6 +114,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//:go_default_library",
+        "//cloudmock/aws/mockec2:go_default_library",
         "//dnsprovider/pkg/dnsprovider/rrstype:go_default_library",
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/validation:go_default_library",
@@ -136,6 +137,8 @@ go_test(
         "//util/pkg/hashing:go_default_library",
         "//util/pkg/mirrors:go_default_library",
         "//util/pkg/vfs:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/upup/pkg/fi/cloudup/awstasks/helper.go
+++ b/upup/pkg/fi/cloudup/awstasks/helper.go
@@ -26,6 +26,9 @@ import (
 
 // buildEphemeralDevices looks up the machine type and discovery any ephemeral device mappings
 func buildEphemeralDevices(cloud awsup.AWSCloud, machineType string) (map[string]*BlockDeviceMapping, error) {
+	if machineType == "" {
+		return nil, nil
+	}
 	mt, err := awsup.GetMachineTypeInfo(cloud, machineType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find instance type details on: %s, error: %s", machineType, err)

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate.go
@@ -152,9 +152,6 @@ func (t *LaunchTemplate) CheckChanges(a, e, changes *LaunchTemplate) error {
 	if e.ImageID == nil {
 		return fi.RequiredField("ImageID")
 	}
-	if e.InstanceType == nil {
-		return fi.RequiredField("InstanceType")
-	}
 
 	if a != nil {
 		if e.Name == nil {

--- a/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
+++ b/upup/pkg/fi/cloudup/awstasks/launchtemplate_target_api.go
@@ -62,11 +62,11 @@ func (t *LaunchTemplate) RenderAWS(c *awsup.AWSAPITarget, a, e, changes *LaunchT
 	// @step: add the actual block device mappings
 	rootDevices, err := t.buildRootDevice(c.Cloud)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to build root device: %w", err)
 	}
 	ephemeralDevices, err := buildEphemeralDevices(c.Cloud, fi.StringValue(t.InstanceType))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to build ephemeral devices: %w", err)
 	}
 	additionalDevices, err := buildAdditionalDevices(t.BlockDeviceMappings)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -876,24 +876,6 @@ func setupKarpenterNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSub
 		HTTPTokens:              fi.String("required"),
 	}
 
-	// Karpenter thinks all clusters run VPC CNI and schedules thinking Node Capacity is constrainted by number of ENIs.
-
-	// cpuMin is the reasonable lower limit for a Kubernetes Node
-	// Generally, it also avoids instances Karpenter thinks it can only schedule 4 Pods on.
-	cpuMin := resource.MustParse("2")
-	memoryMin := resource.MustParse(("2G"))
-
-	g.Spec.MixedInstancesPolicy = &api.MixedInstancesPolicySpec{
-		InstanceRequirements: &api.InstanceRequirementsSpec{
-			CPU: &api.MinMaxSpec{
-				Min: &cpuMin,
-			},
-			Memory: &api.MinMaxSpec{
-				Min: &memoryMin,
-			},
-		},
-	}
-
 	return []*api.InstanceGroup{g}, nil
 }
 

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -876,6 +876,24 @@ func setupKarpenterNodes(opt *NewClusterOptions, cluster *api.Cluster, zoneToSub
 		HTTPTokens:              fi.String("required"),
 	}
 
+	// Karpenter thinks all clusters run VPC CNI and schedules thinking Node Capacity is constrainted by number of ENIs.
+
+	// cpuMin is the reasonable lower limit for a Kubernetes Node
+	// Generally, it also avoids instances Karpenter thinks it can only schedule 4 Pods on.
+	cpuMin := resource.MustParse("2")
+	memoryMin := resource.MustParse(("2G"))
+
+	g.Spec.MixedInstancesPolicy = &api.MixedInstancesPolicySpec{
+		InstanceRequirements: &api.InstanceRequirementsSpec{
+			CPU: &api.MinMaxSpec{
+				Min: &cpuMin,
+			},
+			Memory: &api.MinMaxSpec{
+				Min: &memoryMin,
+			},
+		},
+	}
+
 	return []*api.InstanceGroup{g}, nil
 }
 

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -185,6 +185,9 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.InstanceGroup) (string, error) {
 	switch kops.CloudProviderID(cluster.Spec.CloudProvider) {
 	case kops.CloudProviderAWS:
+		if ig.Spec.Manager == kops.InstanceManagerKarpenter {
+			return "", nil
+		}
 
 		instanceType, err := cloud.(awsup.AWSCloud).DefaultInstanceType(cluster, ig)
 		if err != nil {
@@ -266,6 +269,10 @@ func defaultImage(cluster *kops.Cluster, channel *kops.Channel, architecture arc
 }
 
 func MachineArchitecture(cloud fi.Cloud, machineType string) (architectures.Architecture, error) {
+	if machineType == "" {
+		return architectures.ArchitectureAmd64, nil
+	}
+
 	switch cloud.ProviderID() {
 	case kops.CloudProviderAWS:
 		info, err := cloud.(awsup.AWSCloud).DescribeInstanceType(machineType)


### PR DESCRIPTION
This PR uses the getInstanceTypesFromInstanceRequirements API to add appropriate instance types to the Karpenter providers. This adds the flexibility one expects from using Karpenter without having to maintain ones own lists of instance types, and also allows us to ensure we have valid combinations of instance types (e.g not combining arm and amd).