### PR TITLE
Prefix karpenter logging-config name

### DIFF
--- a/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: add3827e7fd4382feed5338116b4eb5a0342722c76f1f095c62ef403e0a4f554
+    manifestHash: 64a10d731b689842b2c27d950841d2d4073448f6a9d5ea1fd371f0c28327d13c
     name: karpenter.sh
     selector:
       k8s-addon: karpenter.sh

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_bucket_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/part-of: karpenter
     k8s-addon: karpenter.sh
-  name: config-logging
+  name: karpenter-config-logging
   namespace: kube-system
 
 ---
@@ -619,6 +619,8 @@ spec:
           value: minimal.example.com
         - name: CLUSTER_ENDPOINT
           value: https://api.internal.minimal.example.com
+        - name: CONFIG_LOGGING_NAME
+          value: karpenter-config-logging
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:
@@ -730,6 +732,8 @@ spec:
           value: minimal.example.com
         - name: CLUSTER_ENDPOINT
           value: https://api.internal.minimal.example.com
+        - name: CONFIG_LOGGING_NAME
+          value: karpenter-config-logging
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -229,7 +229,7 @@ data: {} # Injected by karpenter-webhook
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-logging
+  name: karpenter-config-logging
   namespace: kube-system
   labels:
     app.kubernetes.io/part-of: karpenter
@@ -473,6 +473,8 @@ spec:
               value: {{ ClusterName }}
             - name: CLUSTER_ENDPOINT
               value: https://{{ .MasterInternalName }}
+            - name: CONFIG_LOGGING_NAME
+              value: "karpenter-config-logging"
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -558,6 +560,8 @@ spec:
               value: {{ ClusterName }}
             - name: CLUSTER_ENDPOINT
               value: https://{{ .MasterInternalName }}
+            - name: CONFIG_LOGGING_NAME
+              value: "karpenter-config-logging"
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
The default name Karpenter/knative is using has a high chance of colliding with something else. This PR adds a prefix to it and configures karpenter accordingly.