### PR TITLE
Identify pending instances

### DIFF
--- a/pkg/nodeidentity/aws/identify.go
+++ b/pkg/nodeidentity/aws/identify.go
@@ -133,7 +133,7 @@ func (i *nodeIdentifier) IdentifyNode(ctx context.Context, node *corev1.Node) (*
 	if instance.State != nil {
 		instanceState = aws.StringValue(instance.State.Name)
 	}
-	if instanceState != ec2.InstanceStateNameRunning {
+	if instanceState != ec2.InstanceStateNameRunning && instanceState != ec2.InstanceStateNamePending {
 		return nil, fmt.Errorf("found instance %q, but state is %q", instanceID, instanceState)
 	}
 


### PR DESCRIPTION
Since karpenter creates the node object immediately after ec2.RunInstance return, the instance is likely in Pending state when kops-controller first tries to identify. By allowing Pending instances to be identified, we avoid some DescribeInstance churn. 