### PR TITLE
Automated cherry pick of #13039: Add managed-by label to static kube-proxy pods

### DIFF
--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -63,6 +63,8 @@ func (b *KubeProxyBuilder) Build(c *fi.ModelBuilderContext) error {
 			return fmt.Errorf("error building kube-proxy manifest: %v", err)
 		}
 
+		pod.ObjectMeta.Labels["kubernetes.io/managed-by"] = "nodeup"
+
 		manifest, err := k8scodecs.ToVersionedYaml(pod)
 		if err != nil {
 			return fmt.Errorf("error marshaling manifest to yaml: %v", err)

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
@@ -5,6 +5,7 @@ contents: |
     creationTimestamp: null
     labels:
       k8s-app: kube-proxy
+      kubernetes.io/managed-by: nodeup
       tier: node
     name: kube-proxy
     namespace: kube-system

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-amd64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-amd64.yaml
@@ -5,6 +5,7 @@ contents: |
     creationTimestamp: null
     labels:
       k8s-app: kube-proxy
+      kubernetes.io/managed-by: nodeup
       tier: node
     name: kube-proxy
     namespace: kube-system

--- a/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-arm64.yaml
+++ b/nodeup/pkg/model/tests/golden/side-loading/tasks-kube-proxy-arm64.yaml
@@ -5,6 +5,7 @@ contents: |
     creationTimestamp: null
     labels:
       k8s-app: kube-proxy
+      kubernetes.io/managed-by: nodeup
       tier: node
     name: kube-proxy
     namespace: kube-system


### PR DESCRIPTION
Cherry pick of #13039 on release-1.23.

#13039: Add managed-by label to static kube-proxy pods

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```