### PR TITLE
Automated cherry pick of #13038: Kube components log to stdout

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -660,6 +660,7 @@ func (b *KubeAPIServerBuilder) buildPod(kubeAPIServer *kops.KubeAPIServerConfig)
 		container.Command = []string{"/go-runner"}
 		container.Args = []string{
 			"--log-file=/var/log/kube-apiserver.log",
+			"--also-stdout",
 			"/usr/local/bin/kube-apiserver",
 		}
 		container.Args = append(container.Args, sortedStrings(flags)...)

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -242,6 +242,7 @@ func (b *KubeControllerManagerBuilder) buildPod(kcm *kops.KubeControllerManagerC
 		container.Command = []string{"/go-runner"}
 		container.Args = []string{
 			"--log-file=/var/log/kube-controller-manager.log",
+			"--also-stdout",
 			"/usr/local/bin/kube-controller-manager",
 		}
 		container.Args = append(container.Args, sortedStrings(flags)...)

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -196,6 +196,7 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 		container.Command = []string{"/go-runner"}
 		container.Args = []string{
 			"--log-file=/var/log/kube-proxy.log",
+			"--also-stdout",
 			"/usr/local/bin/kube-proxy",
 		}
 		container.Args = append(container.Args, sortedStrings(flags)...)

--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -256,6 +256,7 @@ func (b *KubeSchedulerBuilder) buildPod(kubeScheduler *kops.KubeSchedulerConfig)
 		container.Command = []string{"/go-runner"}
 		container.Args = []string{
 			"--log-file=/var/log/kube-scheduler.log",
+			"--also-stdout",
 			"/usr/local/bin/kube-scheduler",
 		}
 		container.Args = append(container.Args, sortedStrings(flags)...)

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-apiserver.yaml
@@ -15,6 +15,7 @@ contents: |
     containers:
     - args:
       - --log-file=/var/log/kube-apiserver.log
+      - --also-stdout
       - /usr/local/bin/kube-apiserver
       - --allow-privileged=true
       - --anonymous-auth=false

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-controller-manager.yaml
@@ -11,6 +11,7 @@ contents: |
     containers:
     - args:
       - --log-file=/var/log/kube-controller-manager.log
+      - --also-stdout
       - /usr/local/bin/kube-controller-manager
       - --allocate-node-cidrs=true
       - --attach-detach-reconcile-sync-period=1m0s

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-proxy.yaml
@@ -12,6 +12,7 @@ contents: |
     containers:
     - args:
       - --log-file=/var/log/kube-proxy.log
+      - --also-stdout
       - /usr/local/bin/kube-proxy
       - --cluster-cidr=100.96.0.0/11
       - --conntrack-max-per-core=131072

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kube-scheduler.yaml
@@ -11,6 +11,7 @@ contents: |
     containers:
     - args:
       - --log-file=/var/log/kube-scheduler.log
+      - --also-stdout
       - /usr/local/bin/kube-scheduler
       - --authentication-kubeconfig=/var/lib/kube-scheduler/kubeconfig
       - --authorization-kubeconfig=/var/lib/kube-scheduler/kubeconfig


### PR DESCRIPTION
Cherry pick of #13038 on release-1.23.

#13038: Kube components log to stdout

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```