### PR TITLE
Automated cherry pick of #13032: Fix OpenStack SecurityGroupRule/LB with IPv6 CIDR

### DIFF
--- a/upup/pkg/fi/cloudup/openstacktasks/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/openstacktasks/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/subnets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Cherry pick of #13032 on release-1.23.

#13032: Fix OpenStack SecurityGroupRule/LB with IPv6 CIDR

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```