### PR TITLE
Automated cherry pick of #13050: Bump Cluster Autoscaler and update manifest

### DIFF
--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -46,9 +46,9 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 			case 23:
 				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.0"
 			case 22:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.1"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.2"
 			case 21:
-				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1"
+				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2"
 			case 20:
 				image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.1"
 			case 19:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
     balanceSimilarNodeGroups: false
     enabled: true
     expander: random
-    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
+    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 10afed066006ee64e85e5b9f3bc2bac645a2dcd756e074e1ae983bca45c43808
+    manifestHash: 0aba81e4fbb4b9063584261fe5c5fa346cc806f639ab5c911bbf9ab53b9d78b3
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -5,6 +5,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -18,12 +19,14 @@ spec:
 ---
 
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -38,6 +41,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -83,6 +87,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - pods
   - services
   - replicationcontrollers
@@ -141,8 +146,8 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
-  - csidrivers
   - csinodes
+  - csidrivers
   - csistoragecapacities
   verbs:
   - watch
@@ -174,12 +179,35 @@ rules:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -205,33 +233,13 @@ rules:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
-    app.kubernetes.io/managed-by: kops
-    k8s-addon: cluster-autoscaler.addons.k8s.io
-    k8s-app: cluster-autoscaler
-  name: cluster-autoscaler
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-autoscaler
-subjects:
-- kind: ServiceAccount
-  name: cluster-autoscaler
-  namespace: kube-system
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -247,6 +255,30 @@ subjects:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 8085
+    protocol: TCP
+    targetPort: 8085
+  selector:
+    app.kubernetes.io/name: cluster-autoscaler
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -254,6 +286,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -270,27 +303,10 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: cluster-autoscaler
+        app.kubernetes.io/name: cluster-autoscaler
+        k8s-addon: cluster-autoscaler.addons.k8s.io
+        k8s-app: cluster-autoscaler
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - cluster-autoscaler
-              topologyKey: topology.kubernetes.io/zone
-            weight: 100
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - cluster-autoscaler
-            topologyKey: kubernetes.com/hostname
       containers:
       - command:
         - ./cluster-autoscaler
@@ -305,8 +321,9 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
+        - --logtostderr=true
         - --stderrthreshold=info
-        - --v=2
+        - --v=4
         env:
         - name: AWS_REGION
           value: us-test-1
@@ -314,7 +331,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/cluster-autoscaler.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
+        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -337,10 +355,24 @@ spec:
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
           readOnly: true
+      dnsPolicy: ClusterFirst
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
       serviceAccountName: cluster-autoscaler
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: token-amazonaws-com
         projected:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,7 +31,7 @@ spec:
     balanceSimilarNodeGroups: false
     enabled: true
     expander: random
-    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
+    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 993474987e30132fe74c326659860055b2d06c5f74178e4f9f1e04be0e3c46f6
+    manifestHash: a53d19ef1b5e95d76851351578fb463cde98024b583a6fcf3dbd16a7833ceb4f
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -5,6 +5,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -18,12 +19,14 @@ spec:
 ---
 
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -38,6 +41,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -83,6 +87,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - pods
   - services
   - replicationcontrollers
@@ -141,8 +146,8 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
-  - csidrivers
   - csinodes
+  - csidrivers
   - csistoragecapacities
   verbs:
   - watch
@@ -174,12 +179,35 @@ rules:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -205,33 +233,13 @@ rules:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
-    app.kubernetes.io/managed-by: kops
-    k8s-addon: cluster-autoscaler.addons.k8s.io
-    k8s-app: cluster-autoscaler
-  name: cluster-autoscaler
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-autoscaler
-subjects:
-- kind: ServiceAccount
-  name: cluster-autoscaler
-  namespace: kube-system
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -247,6 +255,30 @@ subjects:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 8085
+    protocol: TCP
+    targetPort: 8085
+  selector:
+    app.kubernetes.io/name: cluster-autoscaler
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -254,6 +286,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -270,27 +303,10 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: cluster-autoscaler
+        app.kubernetes.io/name: cluster-autoscaler
+        k8s-addon: cluster-autoscaler.addons.k8s.io
+        k8s-app: cluster-autoscaler
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - cluster-autoscaler
-              topologyKey: topology.kubernetes.io/zone
-            weight: 100
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - cluster-autoscaler
-            topologyKey: kubernetes.com/hostname
       containers:
       - command:
         - ./cluster-autoscaler
@@ -305,12 +321,14 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
+        - --logtostderr=true
         - --stderrthreshold=info
-        - --v=2
+        - --v=4
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
+        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -329,6 +347,7 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
+      dnsPolicy: ClusterFirst
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -336,3 +355,16 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     balanceSimilarNodeGroups: false
     enabled: true
     expander: random
-    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
+    image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
     scaleDownDelayAfterAdd: 10m0s

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 993474987e30132fe74c326659860055b2d06c5f74178e4f9f1e04be0e3c46f6
+    manifestHash: a53d19ef1b5e95d76851351578fb463cde98024b583a6fcf3dbd16a7833ceb4f
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -5,6 +5,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -18,12 +19,14 @@ spec:
 ---
 
 apiVersion: v1
+automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -38,6 +41,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -83,6 +87,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - pods
   - services
   - replicationcontrollers
@@ -141,8 +146,8 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
-  - csidrivers
   - csinodes
+  - csidrivers
   - csistoragecapacities
   verbs:
   - watch
@@ -174,12 +179,35 @@ rules:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: cluster-autoscaler
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -205,33 +233,13 @@ rules:
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
-    app.kubernetes.io/managed-by: kops
-    k8s-addon: cluster-autoscaler.addons.k8s.io
-    k8s-app: cluster-autoscaler
-  name: cluster-autoscaler
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-autoscaler
-subjects:
-- kind: ServiceAccount
-  name: cluster-autoscaler
-  namespace: kube-system
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -247,6 +255,30 @@ subjects:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  ports:
+  - name: http
+    port: 8085
+    protocol: TCP
+    targetPort: 8085
+  selector:
+    app.kubernetes.io/name: cluster-autoscaler
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -254,6 +286,7 @@ metadata:
   labels:
     addon.kops.k8s.io/name: cluster-autoscaler.addons.k8s.io
     app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: cluster-autoscaler
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -270,27 +303,10 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app: cluster-autoscaler
+        app.kubernetes.io/name: cluster-autoscaler
+        k8s-addon: cluster-autoscaler.addons.k8s.io
+        k8s-app: cluster-autoscaler
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - cluster-autoscaler
-              topologyKey: topology.kubernetes.io/zone
-            weight: 100
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - cluster-autoscaler
-            topologyKey: kubernetes.com/hostname
       containers:
       - command:
         - ./cluster-autoscaler
@@ -305,12 +321,14 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
+        - --logtostderr=true
         - --stderrthreshold=info
-        - --v=2
+        - --v=4
         env:
         - name: AWS_REGION
           value: us-test-1
-        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1
+        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -329,6 +347,7 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
+      dnsPolicy: ClusterFirst
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -336,3 +355,16 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -6,6 +6,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    app.kubernetes.io/name: "cluster-autoscaler"
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
@@ -13,25 +14,30 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: "cluster-autoscaler"
+      k8s-app: cluster-autoscaler
   maxUnavailable: 1
 ---
+# Source: cluster-autoscaler/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/name: "cluster-autoscaler"
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
   name: cluster-autoscaler
   namespace: kube-system
+automountServiceAccountToken: true
 ---
+# Source: cluster-autoscaler/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cluster-autoscaler
   labels:
+    app.kubernetes.io/name: "cluster-autoscaler"
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
 rules:
   - apiGroups:
       - ""
@@ -74,6 +80,7 @@ rules:
   - apiGroups:
     - ""
     resources:
+      - namespaces
       - pods
       - services
       - replicationcontrollers
@@ -132,8 +139,8 @@ rules:
     - storage.k8s.io
     resources:
     - storageclasses
-    - csidrivers
     - csinodes
+    - csidrivers
     - csistoragecapacities
     verbs:
     - watch
@@ -162,14 +169,34 @@ rules:
     - get
     - update
 ---
+# Source: cluster-autoscaler/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: "cluster-autoscaler"
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+---
+# Source: cluster-autoscaler/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: cluster-autoscaler
-  namespace: kube-system
   labels:
+    app.kubernetes.io/name: "cluster-autoscaler"
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
 rules:
   - apiGroups:
       - ""
@@ -188,31 +215,16 @@ rules:
       - get
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cluster-autoscaler
-  labels:
-    k8s-addon: cluster-autoscaler.addons.k8s.io
-    k8s-app: cluster-autoscaler
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-autoscaler
-subjects:
-  - kind: ServiceAccount
-    name: cluster-autoscaler
-    namespace: kube-system
-
----
+# Source: cluster-autoscaler/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cluster-autoscaler
-  namespace: kube-system
   labels:
+    app.kubernetes.io/name: "cluster-autoscaler"
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -221,15 +233,37 @@ subjects:
   - kind: ServiceAccount
     name: cluster-autoscaler
     namespace: kube-system
-
 ---
+# Source: cluster-autoscaler/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: "cluster-autoscaler"
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+spec:
+  ports:
+    - port: 8085
+      protocol: TCP
+      targetPort: 8085
+      name: http
+  selector:
+    app.kubernetes.io/name: "cluster-autoscaler"
+  type: "ClusterIP"
+---
+# Source: cluster-autoscaler/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/name: "cluster-autoscaler"
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
   name: cluster-autoscaler
   namespace: kube-system
-  labels:
-    k8s-app: cluster-autoscaler
 spec:
   replicas: {{ ControlPlaneControllerReplicas }}
   selector:
@@ -237,48 +271,21 @@ spec:
       app: cluster-autoscaler
   template:
     metadata:
-      labels:
-        app: cluster-autoscaler
       annotations:
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
+      labels:
+        app: cluster-autoscaler
+        k8s-addon: cluster-autoscaler.addons.k8s.io
+        k8s-app: cluster-autoscaler
+        app.kubernetes.io/name: "cluster-autoscaler"
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - cluster-autoscaler
-            topologyKey: kubernetes.com/hostname
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - cluster-autoscaler
-              topologyKey: topology.kubernetes.io/zone
-      priorityClassName: system-cluster-critical
-      serviceAccountName: cluster-autoscaler
-      {{ if not UseServiceAccountExternalPermissions }}
-      tolerations:
-      - operator: "Exists"
-        key: node-role.kubernetes.io/master
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      {{ end }}
+      priorityClassName: "system-cluster-critical"
+      dnsPolicy: "ClusterFirst"
       containers:
-        - image: {{ .Image }}
-          name: cluster-autoscaler
-          resources:
-            requests:
-              cpu: {{ or .CPURequest "100m"}}
-              memory: {{ or .MemoryRequest "300Mi"}}
+        - name: cluster-autoscaler
+          image: "{{ .Image }}"
+          imagePullPolicy: "IfNotPresent"
           command:
             - ./cluster-autoscaler
             - --balance-similar-node-groups={{ .BalanceSimilarNodeGroups }}
@@ -298,15 +305,12 @@ spec:
             - --scale-down-delay-after-add={{ .ScaleDownDelayAfterAdd }}
             - --new-pod-scale-up-delay={{ .NewPodScaleUpDelay }}
             - --max-node-provision-time={{ .MaxNodeProvisionTime }}
+            - --logtostderr=true
             - --stderrthreshold=info
-            - --v=2
+            - --v=4
           env:
             - name: AWS_REGION
-              value: {{ Region }}
-          ports:
-          - containerPort: 8085
-            protocol: TCP
-            name: http
+              value: "{{ Region }}"
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -316,4 +320,35 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          ports:
+            - containerPort: 8085
+              name: http
+              protocol: TCP
+          resources:
+            requests:
+              cpu: {{ or .CPURequest "100m"}}
+              memory: {{ or .MemoryRequest "300Mi"}}
+      {{ if not UseServiceAccountExternalPermissions }}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      {{ end }}
+      serviceAccountName: cluster-autoscaler
+      {{ if not UseServiceAccountExternalPermissions }}
+      tolerations:
+      - operator: "Exists"
+        key: node-role.kubernetes.io/master
+      {{ end }}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: "topology.kubernetes.io/zone"
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+      - maxSkew: 1
+        topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
 {{ end }}


### PR DESCRIPTION
Cherry pick of #13050 on release-1.23.

#13050: Bump Cluster Autoscaler and update manifest

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```