### PR TITLE
Remove the v1alpha3 API version

### DIFF
--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -56,9 +56,6 @@ If this flag is used in AWS, it will enable IRSA.
 
 * If `externalDns.provider` is `external-dns`, then `externalDns.watchIngress` will now default to `true`.
 
-* This release introduces a `v1alpha3` API version. This API version is a work in progress and is likely to be replaced in kOps 1.24.
-It is recommended to keep using the `v1alpha2` API version.
-
 # Full change list since 1.22.0 release
 
 

--- a/pkg/apis/kops/install/BUILD.bazel
+++ b/pkg/apis/kops/install/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/v1alpha2:go_default_library",
-        "//pkg/apis/kops/v1alpha3:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
     ],

--- a/pkg/apis/kops/install/install.go
+++ b/pkg/apis/kops/install/install.go
@@ -23,12 +23,10 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/v1alpha2"
-	"k8s.io/kops/pkg/apis/kops/v1alpha3"
 )
 
 func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(kops.AddToScheme(scheme))
 	utilruntime.Must(v1alpha2.AddToScheme(scheme))
-	utilruntime.Must(v1alpha3.AddToScheme(scheme))
-	utilruntime.Must(scheme.SetVersionPriority(v1alpha2.SchemeGroupVersion, v1alpha3.SchemeGroupVersion))
+	utilruntime.Must(scheme.SetVersionPriority(v1alpha2.SchemeGroupVersion))
 }

--- a/tests/codecs/BUILD.bazel
+++ b/tests/codecs/BUILD.bazel
@@ -4,7 +4,7 @@ go_test(
     name = "go_default_test",
     srcs = ["componentconfig_test.go"],
     deps = [
-        "//pkg/apis/kops/v1alpha3:go_default_library",
+        "//pkg/apis/kops/v1alpha2:go_default_library",
         "//pkg/diff:go_default_library",
         "//pkg/kopscodecs:go_default_library",
     ],

--- a/tests/codecs/componentconfig_test.go
+++ b/tests/codecs/componentconfig_test.go
@@ -19,22 +19,22 @@ package codecs
 import (
 	"testing"
 
-	"k8s.io/kops/pkg/apis/kops/v1alpha3"
+	"k8s.io/kops/pkg/apis/kops/v1alpha2"
 	"k8s.io/kops/pkg/diff"
 	"k8s.io/kops/pkg/kopscodecs"
 )
 
 func TestSerializeEmptyCluster(t *testing.T) {
-	cluster := &v1alpha3.Cluster{}
-	cluster.Spec.Kubelet = &v1alpha3.KubeletConfigSpec{}
-	cluster.Spec.KubeControllerManager = &v1alpha3.KubeControllerManagerConfig{}
-	yaml, err := kopscodecs.ToVersionedYamlWithVersion(cluster, v1alpha3.SchemeGroupVersion)
+	cluster := &v1alpha2.Cluster{}
+	cluster.Spec.Kubelet = &v1alpha2.KubeletConfigSpec{}
+	cluster.Spec.KubeControllerManager = &v1alpha2.KubeControllerManagerConfig{}
+	yaml, err := kopscodecs.ToVersionedYamlWithVersion(cluster, v1alpha2.SchemeGroupVersion)
 	if err != nil {
 		t.Errorf("unexpected error marshaling Cluster: %v", err)
 	}
 
 	yamlString := string(yaml)
-	expected := `apiVersion: kops.k8s.io/v1alpha3
+	expected := `apiVersion: kops.k8s.io/v1alpha2
 kind: Cluster
 metadata:
   creationTimestamp: null

--- a/tests/integration/conversion/integration_test.go
+++ b/tests/integration/conversion/integration_test.go
@@ -34,23 +34,6 @@ import (
 // TestConversionMinimal runs the test on a minimum configuration, similar to kops create cluster minimal.example.com --zones us-west-1a
 func TestConversionMinimal(t *testing.T) {
 	runTest(t, "minimal", "legacy-v1alpha2", "v1alpha2")
-	runTest(t, "minimal", "v1alpha2", "v1alpha3")
-	runTest(t, "minimal", "v1alpha3", "v1alpha2")
-}
-
-func TestConversionAWS(t *testing.T) {
-	runTest(t, "aws", "v1alpha2", "v1alpha3")
-	runTest(t, "aws", "v1alpha3", "v1alpha2")
-}
-
-func TestConversionCanal(t *testing.T) {
-	runTest(t, "canal", "v1alpha2", "v1alpha3")
-	runTest(t, "canal", "v1alpha3", "v1alpha2")
-}
-
-func TestConversionCilium(t *testing.T) {
-	runTest(t, "cilium", "v1alpha2", "v1alpha3")
-	runTest(t, "cilium", "v1alpha3", "v1alpha2")
 }
 
 func runTest(t *testing.T, srcDir string, fromVersion string, toVersion string) {


### PR DESCRIPTION
There is no reason to release this work in progress with 1.23.