### PR TITLE
Automated cherry pick of #12805: Add action for automatically tagging releases #13071: Remove temporary restrictions on automatically tagging

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      #- 'release-*'
+      - 'release-*'
     paths:
       - version.go
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,23 @@
+name: tag-release
+
+on:
+  push:
+    branches:
+      - master
+      #- 'release-*'
+    paths:
+      - version.go
+
+jobs:
+  tag-release:
+    if: ${{ github.repository == 'kubernetes/kops' }}
+    runs-on: ubuntu-20.04
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: /usr/bin/git config --global user.email actions@github.com
+      - run: /usr/bin/git config --global user.name 'GitHub Actions Release Tagger'
+      - run: hack/tag-release.sh

--- a/hack/tag-release.sh
+++ b/hack/tag-release.sh
@@ -29,12 +29,6 @@ if [ "$(git tag -l "v${VERSION}")" ]; then
   exit 0
 fi
 
-# TODO remove this when we're comfortable with how it works
-if [[ ! "${VERSION}" =~ -alpha ]]; then
-  echo "Only automatically tagging alpha releases for now"
-  exit 1
-fi
-
 git tag -a -m "Release ${VERSION}" "v${VERSION}"
 git push origin "v${VERSION}"
 

--- a/hack/tag-release.sh
+++ b/hack/tag-release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -xe
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION=$(grep 'KOPS_RELEASE_VERSION\s*=' version.go  | awk '{print $3}' | sed -e 's_"__g')
+
+if [[ ! "${VERSION}" =~ ^([0-9]+[.][0-9]+)[.]([0-9]+)(-(alpha|beta)[.]([0-9]+))?$ ]]; then
+  echo "Version ${VERSION} must be 'X.Y.Z', 'X.Y.Z-alpha.N', or 'X.Y.Z-beta.N'"
+  exit 1
+fi
+
+MINOR=${BASH_REMATCH[1]}
+RELEASE_BRANCH="release-${MINOR}"
+
+if [ "$(git tag -l "v${VERSION}")" ]; then
+  echo "Tag v${VERSION} already exists"
+  exit 0
+fi
+
+# TODO remove this when we're comfortable with how it works
+if [[ ! "${VERSION}" =~ -alpha ]]; then
+  echo "Only automatically tagging alpha releases for now"
+  exit 1
+fi
+
+git tag -a -m "Release ${VERSION}" "v${VERSION}"
+git push origin "v${VERSION}"
+
+if [[ ! "${VERSION}" =~ .0-beta.1$ ]]; then
+  exit 0
+fi
+
+git branch "${RELEASE_BRANCH}"
+git push origin "${RELEASE_BRANCH}"


### PR DESCRIPTION
Cherry pick of #12805 #13071 on release-1.21.

#12805: Add action for automatically tagging releases
#13071: Remove temporary restrictions on automatically tagging

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.