### PR TITLE
Support price and priority cluster-autoscaler expanders

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -46,7 +46,7 @@ spec:
     memoryRequest: "300Mi"
 ```
 
-Read more about cluster autoscaler in the [official documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
+Read more about cluster autoscaler in the [official documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler). The autoscaler supports five different expander strategies; the `priority` expander requires additional configuration in a ConfigMap as described in [its documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md).
 
 ##### Disabling cluster autoscaler for a given instance group
 {{ kops_feature_table(kops_added_default='1.20') }}

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -49,7 +49,9 @@ spec:
 Read more about cluster autoscaler in the [official documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
 
 ##### Expander strategies
-The cluster autoscaler supports five different [expander strategies](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders). The `price` expander is only supported on GCE. The `priority` expander requires additional configuration in a ConfigMap as described in [its documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md) - please ensure that you have deployed this ConfigMap before enabling the `priority` expander.
+Cluster autoscaler supports several different [expander strategies](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders).
+
+Note that the `priority` expander requires additional configuration through a ConfigMap as described in [its documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md) - you will need to create this ConfigMap in your cluster before selecting this expander.
 
 ##### Disabling cluster autoscaler for a given instance group
 {{ kops_feature_table(kops_added_default='1.20') }}

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -46,7 +46,10 @@ spec:
     memoryRequest: "300Mi"
 ```
 
-Read more about cluster autoscaler in the [official documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler). The autoscaler supports five different expander strategies; the `priority` expander requires additional configuration in a ConfigMap as described in [its documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md) - please ensure that you have deployed this ConfigMap before enabling the `priority` expander.
+Read more about cluster autoscaler in the [official documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
+
+##### Expander strategies
+The cluster autoscaler supports five different [expander strategies](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders). The `price` expander is only supported on GCE. The `priority` expander requires additional configuration in a ConfigMap as described in [its documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md) - please ensure that you have deployed this ConfigMap before enabling the `priority` expander.
 
 ##### Disabling cluster autoscaler for a given instance group
 {{ kops_feature_table(kops_added_default='1.20') }}

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -46,7 +46,7 @@ spec:
     memoryRequest: "300Mi"
 ```
 
-Read more about cluster autoscaler in the [official documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler). The autoscaler supports five different expander strategies; the `priority` expander requires additional configuration in a ConfigMap as described in [its documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md).
+Read more about cluster autoscaler in the [official documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler). The autoscaler supports five different expander strategies; the `priority` expander requires additional configuration in a ConfigMap as described in [its documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md) - please ensure that you have deployed this ConfigMap before enabling the `priority` expander.
 
 ##### Disabling cluster autoscaler for a given instance group
 {{ kops_feature_table(kops_added_default='1.20') }}

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -622,7 +622,8 @@ spec:
                   expander:
                     description: 'Expander determines the strategy for which instance
                       group gets expanded. Supported values: least-waste, most-pods,
-                      random. Default: least-waste'
+                      random, price, priority. The priority expander requires additional 
+                      configuration via a ConfigMap. Default: least-waste'
                     type: string
                   image:
                     description: 'Image is the docker container used. Default: the

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -622,7 +622,7 @@ spec:
                   expander:
                     description: 'Expander determines the strategy for which instance
                       group gets expanded. Supported values: least-waste, most-pods,
-                      random, price, priority. The priority expander requires additional 
+                      random, price, priority. The priority expander requires additional
                       configuration via a ConfigMap. Default: least-waste'
                     type: string
                   image:

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -622,8 +622,9 @@ spec:
                   expander:
                     description: 'Expander determines the strategy for which instance
                       group gets expanded. Supported values: least-waste, most-pods,
-                      random, price, priority. The priority expander requires additional
-                      configuration via a ConfigMap. Default: least-waste'
+                      random, price, priority. The price expander is only supported
+                      on GCE. The priority expander requires additional configuration
+                      via a ConfigMap. Default: least-waste'
                     type: string
                   image:
                     description: 'Image is the docker container used. Default: the

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -961,6 +961,7 @@ type ClusterAutoscalerConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Expander determines the strategy for which instance group gets expanded.
 	// Supported values: least-waste, most-pods, random, price, priority.
+	// The priority expander requires additional configuration via a ConfigMap.
 	// Default: least-waste
 	Expander *string `json:"expander,omitempty"`
 	// BalanceSimilarNodeGroups makes cluster autoscaler treat similar node groups as one.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -960,7 +960,7 @@ type ClusterAutoscalerConfig struct {
 	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
 	// Expander determines the strategy for which instance group gets expanded.
-	// Supported values: least-waste, most-pods, random.
+	// Supported values: least-waste, most-pods, random, price, priority.
 	// Default: least-waste
 	Expander *string `json:"expander,omitempty"`
 	// BalanceSimilarNodeGroups makes cluster autoscaler treat similar node groups as one.

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -961,6 +961,7 @@ type ClusterAutoscalerConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Expander determines the strategy for which instance group gets expanded.
 	// Supported values: least-waste, most-pods, random, price, priority.
+	// The price expander is only supported on GCE.
 	// The priority expander requires additional configuration via a ConfigMap.
 	// Default: least-waste
 	Expander *string `json:"expander,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -981,6 +981,7 @@ type ClusterAutoscalerConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Expander determines the strategy for which instance group gets expanded.
 	// Supported values: least-waste, most-pods, random, price, priority.
+	// The price expander is only supported on GCE.
 	// The priority expander requires additional configuration via a ConfigMap.
 	// Default: least-waste
 	Expander *string `json:"expander,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -980,7 +980,7 @@ type ClusterAutoscalerConfig struct {
 	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
 	// Expander determines the strategy for which instance group gets expanded.
-	// Supported values: least-waste, most-pods, random.
+	// Supported values: least-waste, most-pods, random, price, priority.
 	// Default: least-waste
 	Expander *string `json:"expander,omitempty"`
 	// BalanceSimilarNodeGroups makes cluster autoscaler treat similar node groups as one.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -981,6 +981,7 @@ type ClusterAutoscalerConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Expander determines the strategy for which instance group gets expanded.
 	// Supported values: least-waste, most-pods, random, price, priority.
+	// The priority expander requires additional configuration via a ConfigMap.
 	// Default: least-waste
 	Expander *string `json:"expander,omitempty"`
 	// BalanceSimilarNodeGroups makes cluster autoscaler treat similar node groups as one.

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -957,7 +957,7 @@ type ClusterAutoscalerConfig struct {
 	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
 	// Expander determines the strategy for which instance group gets expanded.
-	// Supported values: least-waste, most-pods, random.
+	// Supported values: least-waste, most-pods, random, price, priority.
 	// Default: least-waste
 	Expander *string `json:"expander,omitempty"`
 	// BalanceSimilarNodeGroups makes cluster autoscaler treat similar node groups as one.

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -958,6 +958,7 @@ type ClusterAutoscalerConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Expander determines the strategy for which instance group gets expanded.
 	// Supported values: least-waste, most-pods, random, price, priority.
+	// The price expander is only supported on GCE.
 	// The priority expander requires additional configuration via a ConfigMap.
 	// Default: least-waste
 	Expander *string `json:"expander,omitempty"`

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -958,6 +958,7 @@ type ClusterAutoscalerConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Expander determines the strategy for which instance group gets expanded.
 	// Supported values: least-waste, most-pods, random, price, priority.
+	// The priority expander requires additional configuration via a ConfigMap.
 	// Default: least-waste
 	Expander *string `json:"expander,omitempty"`
 	// BalanceSimilarNodeGroups makes cluster autoscaler treat similar node groups as one.

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1519,7 +1519,7 @@ func validateNodeLocalDNS(spec *kops.ClusterSpec, fldpath *field.Path) field.Err
 func validateClusterAutoscaler(cluster *kops.Cluster, spec *kops.ClusterAutoscalerConfig, fldPath *field.Path) (allErrs field.ErrorList) {
 	allErrs = append(allErrs, IsValidValue(fldPath.Child("expander"), spec.Expander, []string{"least-waste", "random", "most-pods", "price", "priority"})...)
 
-	if spec.Expander != nil && *spec.Expander == "price" && kops.CloudProviderID(cluster.Spec.CloudProvider) != kops.CloudProviderGCE {
+	if fi.StringValue(spec.Expander) == "price" && kops.CloudProviderID(cluster.Spec.CloudProvider) != kops.CloudProviderGCE {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("expander"), "Cluster autoscaler price expander is only supported on GCE"))
 	}
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1519,6 +1519,10 @@ func validateNodeLocalDNS(spec *kops.ClusterSpec, fldpath *field.Path) field.Err
 func validateClusterAutoscaler(cluster *kops.Cluster, spec *kops.ClusterAutoscalerConfig, fldPath *field.Path) (allErrs field.ErrorList) {
 	allErrs = append(allErrs, IsValidValue(fldPath.Child("expander"), spec.Expander, []string{"least-waste", "random", "most-pods", "price", "priority"})...)
 
+	if *spec.Expander == "price" && kops.CloudProviderID(cluster.Spec.CloudProvider) != kops.CloudProviderGCE {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("expander"), "Cluster autoscaler price expander is only supported on GCE"))
+	}
+
 	if kops.CloudProviderID(cluster.Spec.CloudProvider) == kops.CloudProviderOpenstack {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "Cluster autoscaler is not supported on OpenStack"))
 	}

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1519,7 +1519,7 @@ func validateNodeLocalDNS(spec *kops.ClusterSpec, fldpath *field.Path) field.Err
 func validateClusterAutoscaler(cluster *kops.Cluster, spec *kops.ClusterAutoscalerConfig, fldPath *field.Path) (allErrs field.ErrorList) {
 	allErrs = append(allErrs, IsValidValue(fldPath.Child("expander"), spec.Expander, []string{"least-waste", "random", "most-pods", "price", "priority"})...)
 
-	if *spec.Expander == "price" && kops.CloudProviderID(cluster.Spec.CloudProvider) != kops.CloudProviderGCE {
+	if spec.Expander != nil && *spec.Expander == "price" && kops.CloudProviderID(cluster.Spec.CloudProvider) != kops.CloudProviderGCE {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("expander"), "Cluster autoscaler price expander is only supported on GCE"))
 	}
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1517,7 +1517,7 @@ func validateNodeLocalDNS(spec *kops.ClusterSpec, fldpath *field.Path) field.Err
 }
 
 func validateClusterAutoscaler(cluster *kops.Cluster, spec *kops.ClusterAutoscalerConfig, fldPath *field.Path) (allErrs field.ErrorList) {
-	allErrs = append(allErrs, IsValidValue(fldPath.Child("expander"), spec.Expander, []string{"least-waste", "random", "most-pods"})...)
+	allErrs = append(allErrs, IsValidValue(fldPath.Child("expander"), spec.Expander, []string{"least-waste", "random", "most-pods", "price", "priority"})...)
 
 	if kops.CloudProviderID(cluster.Spec.CloudProvider) == kops.CloudProviderOpenstack {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "Cluster autoscaler is not supported on OpenStack"))


### PR DESCRIPTION
This PR adds support for both of the remaining cluster-autoscaler expanders kops doesn't currently support. The `price` expander requires no additional configuration. The `priority` expander requires configuration in a separate ConfigMap, so I've added notes to the docs to that effect.