### PR TITLE
Containerd Config file path is now tweakable

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -691,6 +691,9 @@ spec:
                     description: ConfigOverride is the complete containerd config
                       file provided by the user.
                     type: string
+                  ConfigFilePath:
+                    description: ConfigFilePath Overwrites the containerd config file path by default
+                    type: string
                   logLevel:
                     description: LogLevel controls the logging details [trace, debug,
                       info, warn, error, fatal, panic] (default "info").

--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -221,11 +221,15 @@ func (b *ContainerdBuilder) buildSystemdService(sv semver.Version) *nodetasks.Se
 // We normally use a different path for clarity, but on some OSes we can't override the path.
 // TODO: Should we just use config.toml everywhere?
 func (b *ContainerdBuilder) containerdConfigFilePath() string {
-	switch b.Distribution {
-	case distributions.DistributionContainerOS:
-		return "/etc/containerd/config.toml"
-	default:
-		return "/etc/containerd/config-kops.toml"
+	if b.NodeupConfig.ContainerdConfig != nil && b.NodeupConfig.ContainerdConfig.ConfigFilePath != nil {
+		return fi.StringValue(b.NodeupConfig.ContainerdConfig.ConfigFilePath)
+	} else {
+		switch b.Distribution {
+		case distributions.DistributionContainerOS:
+			return "/etc/containerd/config.toml"
+		default:
+			return "/etc/containerd/config-kops.toml"
+		}
 	}
 }
 

--- a/pkg/apis/kops/containerdconfig.go
+++ b/pkg/apis/kops/containerdconfig.go
@@ -22,6 +22,8 @@ type ContainerdConfig struct {
 	Address *string `json:"address,omitempty" flag:"address"`
 	// ConfigOverride is the complete containerd config file provided by the user.
 	ConfigOverride *string `json:"configOverride,omitempty"`
+	// ConfigFilePath overwrites config file path (default "/etc/containerd/config-kops.toml").
+	ConfigFilePath *string `json:"configFilePath,omitempty"`
 	// LogLevel controls the logging details [trace, debug, info, warn, error, fatal, panic] (default "info").
 	LogLevel *string `json:"logLevel,omitempty" flag:"log-level"`
 	// Packages overrides the URL and hash for the packages.


### PR DESCRIPTION
Some containerd shims can be installed via daemonSets.
(eg. katacontainers)

Usually, these daemonsets  add the shims and modify the containerd config file on the fly
by adding the necessary parameters for their shims.

Example of such code
https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kata-deploy/scripts/kata-deploy.sh

The config file path is usually at /etc/containerd/config.toml but
kops has set the path to /etc/containerd/config-kops.toml

I felt it was necessary to add that option because changing the
config file path to the regular path could have been seen as
breaking change.




