### PR TITLE
Automated cherry pick of #13093: fix ipv4+ipv6 sec groups/listeners in OpenStack

### DIFF
--- a/pkg/model/openstackmodel/BUILD.bazel
+++ b/pkg/model/openstackmodel/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Cherry pick of #13093 on release-1.23.

#13093: fix ipv4+ipv6 sec groups/listeners in OpenStack

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.