### PR TITLE
decrease the openstack monitoring default timeout

### DIFF
--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -405,8 +405,8 @@ func setupVPC(opt *NewClusterOptions, cluster *api.Cluster) error {
 				IgnoreAZ: fi.Bool(opt.OpenstackStorageIgnoreAZ),
 			},
 			Monitor: &api.OpenstackMonitor{
-				Delay:      fi.String("1m"),
-				Timeout:    fi.String("30s"),
+				Delay:      fi.String("15s"),
+				Timeout:    fi.String("10s"),
 				MaxRetries: fi.Int(3),
 			},
 		}


### PR DESCRIPTION
old default values were pretty high - it took 3 minutes to get failing node dropped from the load. Now it takes about 45 seconds with new default settings which is much better.

note! this does not affect existing loadbalancers in clusters, it will affect only new loadbalancers that are created by kubernetes. The value can be overriden in kOps configuration