### PR TITLE
Automated cherry pick of #13106: Don't try to add node name to instances without node object

### DIFF
--- a/cmd/kops/get_instances.go
+++ b/cmd/kops/get_instances.go
@@ -56,7 +56,7 @@ var (
 
 type renderableCloudInstance struct {
 	ID            string   `json:"id"`
-	NodeName      string   `json:"nodeName"`
+	NodeName      string   `json:"nodeName,omitempty"`
 	Status        string   `json:"status"`
 	Roles         []string `json:"roles"`
 	InternalIP    string   `json:"internalIP"`
@@ -217,13 +217,15 @@ func asRenderable(instances []*cloudinstances.CloudInstance) []*renderableCloudI
 	for i, ci := range instances {
 		arr[i] = &renderableCloudInstance{
 			ID:            ci.ID,
-			NodeName:      ci.Node.Name,
 			Status:        ci.Status,
 			Roles:         ci.Roles,
 			InternalIP:    ci.PrivateIP,
 			InstanceGroup: ci.CloudInstanceGroup.HumanName,
 			MachineType:   ci.MachineType,
 			State:         string(ci.State),
+		}
+		if ci.Node != nil {
+			arr[i].NodeName = ci.Node.Name
 		}
 	}
 	return arr


### PR DESCRIPTION
Cherry pick of #13106 on release-1.23.

#13106: Don't try to add node name to instances without node object

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```