### PR TITLE
Automated cherry pick of #13114: Add DescribeRegions to nodeup privs

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -758,6 +758,7 @@ func (b *PolicyBuilder) addNodeupPermissions(p *Policy, enableHookSupport bool) 
 	addKMSGenerateRandomPolicies(p)
 	addASLifecyclePolicies(p, enableHookSupport)
 	p.unconditionalAction.Insert(
+		"ec2:DescribeRegions",
 		"ec2:DescribeInstances", // aws.go
 		"ec2:DescribeInstanceTypes",
 	)

--- a/pkg/model/iam/tests/iam_builder_node_strict.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict.json
@@ -31,6 +31,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -31,6 +31,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json
@@ -1194,6 +1194,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"
@@ -1497,6 +1498,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_apiservers.minimal.example.com_policy
@@ -24,6 +24,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_nodes.bastionuserdata.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -1860,6 +1860,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_nodes.complex.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_nodes.compress.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json
@@ -1232,6 +1232,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/containerd/cloudformation.json
+++ b/tests/integration/update_cluster/containerd/cloudformation.json
@@ -1232,6 +1232,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_nodes.123.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json
@@ -1232,6 +1232,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_nodes.existingsg.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/external_dns/cloudformation.json
+++ b/tests/integration/update_cluster/external_dns/cloudformation.json
@@ -1232,6 +1232,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -1248,6 +1248,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_nodes.externallb.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_nodes.externalpolicies.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_nodes.ha.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -113,6 +113,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeRegions",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",
         "ec2:DetachNetworkInterface",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -43,6 +43,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeRegions",
         "ec2:DescribeTags",
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -43,6 +43,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeRegions",
         "ec2:DescribeTags",
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -43,6 +43,7 @@
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
         "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeRegions",
         "ec2:DescribeTags",
         "ec2:DetachNetworkInterface",
         "ec2:ModifyNetworkInterfaceAttribute",

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:DescribeRepositories",

--- a/tests/integration/update_cluster/minimal-etcd/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-etcd/cloudformation.json
@@ -1232,6 +1232,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json
@@ -1228,6 +1228,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json
@@ -1537,6 +1537,7 @@
                 "ec2:AssignIpv6Addresses",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "ec2:ModifyNetworkInterfaceAttribute",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -30,6 +30,7 @@
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "ec2:ModifyNetworkInterfaceAttribute",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json
@@ -1522,6 +1522,7 @@
                 "ec2:AssignIpv6Addresses",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -30,6 +30,7 @@
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -30,6 +30,7 @@
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
@@ -1522,6 +1522,7 @@
                 "ec2:AssignIpv6Addresses",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_nodes.minimal-ipv6.example.com_policy
@@ -30,6 +30,7 @@
         "ec2:AssignIpv6Addresses",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_nodes.minimal-warmpool.example.com_policy
@@ -30,6 +30,7 @@
         "autoscaling:DescribeLifecycleHooks",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal/cloudformation.json
+++ b/tests/integration/update_cluster/minimal/cloudformation.json
@@ -1232,6 +1232,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_iam_role_policy_nodes.minimal.k8s.local_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -1951,6 +1951,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -1952,6 +1952,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_nodes.mixedinstances.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
@@ -1373,6 +1373,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_nodes.nthsqsresources.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_nodes.nthsqsresources.longclustername.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/nvidia/cloudformation.json
+++ b/tests/integration/update_cluster/nvidia/cloudformation.json
@@ -1245,6 +1245,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -1752,6 +1752,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_nodes.private-shared-ip.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_nodes.private-shared-subnet.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -1909,6 +1909,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "ec2:ModifyNetworkInterfaceAttribute",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_nodes.privatecalico.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "ec2:ModifyNetworkInterfaceAttribute",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_nodes.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_nodes.privatecanal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -1894,6 +1894,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -1896,6 +1896,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_nodes.privatecilium.example.com_policy
@@ -31,6 +31,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -1946,6 +1946,7 @@
                 "autoscaling:DescribeAutoScalingInstances",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeRegions",
                 "iam:GetServerCertificate",
                 "iam:ListServerCertificates",
                 "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_nodes.privateciliumadvanced.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_nodes.privatedns1.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_nodes.privatedns2.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_nodes.privateflannel.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_nodes.privatekopeio.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_nodes.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_nodes.privateweave.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_nodes.sharedsubnet.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_nodes.sharedvpc.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_nodes.unmanaged.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_nodes.minimal.example.com_policy
@@ -29,6 +29,7 @@
         "autoscaling:DescribeAutoScalingInstances",
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
         "iam:GetServerCertificate",
         "iam:ListServerCertificates",
         "kms:GenerateRandom"


### PR DESCRIPTION
Cherry pick of #13114 on release-1.23.

#13114: Add DescribeRegions to nodeup privs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```