### PR TITLE
Automated cherry pick of #13104: Create helper function for ec2 create/tag-on-create IAM

### DIFF
--- a/pkg/model/iam/tests/iam_builder_master_strict.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict.json
@@ -52,6 +52,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "iam-builder-test.k8s.local",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -65,8 +66,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
         }
@@ -166,6 +173,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -52,6 +52,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "iam-builder-test.k8s.local",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -65,8 +66,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "iam-builder-test.k8s.local"
         }
@@ -173,6 +180,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json
@@ -1331,6 +1331,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "minimal.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1344,8 +1345,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
                 }
@@ -1439,6 +1446,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_iam_role_policy_masters.bastionuserdata.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "bastionuserdata.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "bastionuserdata.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -1694,6 +1694,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "complex.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1707,8 +1708,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "complex.example.com"
                 }
@@ -1802,6 +1809,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
+++ b/tests/integration/update_cluster/complex/data/aws_iam_role_policy_masters.complex.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "complex.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "complex.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
+++ b/tests/integration/update_cluster/compress/data/aws_iam_role_policy_masters.compress.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "compress.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "compress.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json
@@ -1066,6 +1066,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "containerd.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1079,8 +1080,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "containerd.example.com"
                 }
@@ -1174,6 +1181,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/containerd/cloudformation.json
+++ b/tests/integration/update_cluster/containerd/cloudformation.json
@@ -1066,6 +1066,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "containerd.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1079,8 +1080,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "containerd.example.com"
                 }
@@ -1174,6 +1181,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
+++ b/tests/integration/update_cluster/digit/data/aws_iam_role_policy_masters.123.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "123.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "123.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json
@@ -1066,6 +1066,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "docker.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1079,8 +1080,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "docker.example.com"
                 }
@@ -1174,6 +1181,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
+++ b/tests/integration/update_cluster/existing_sg/data/aws_iam_role_policy_masters.existingsg.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "existingsg.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "existingsg.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/external_dns/cloudformation.json
+++ b/tests/integration/update_cluster/external_dns/cloudformation.json
@@ -1066,6 +1066,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "minimal.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1079,8 +1080,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
                 }
@@ -1174,6 +1181,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/external_dns/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/externallb/cloudformation.json
+++ b/tests/integration/update_cluster/externallb/cloudformation.json
@@ -1082,6 +1082,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "externallb.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1095,8 +1096,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "externallb.example.com"
                 }
@@ -1190,6 +1197,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
+++ b/tests/integration/update_cluster/externallb/data/aws_iam_role_policy_masters.externallb.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "externallb.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "externallb.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_iam_role_policy_masters.externalpolicies.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "externalpolicies.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "externalpolicies.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
+++ b/tests/integration/update_cluster/ha/data/aws_iam_role_policy_masters.ha.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "ha.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "ha.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/irsa/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_ebs-csi-controller-sa.kube-system.sa.minimal.example.com_policy
@@ -4,6 +4,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -17,8 +18,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -61,7 +68,10 @@
       "Resource": "*"
     },
     {
-      "Action": "ec2:CreateVolume",
+      "Action": [
+        "ec2:CreateSnapshot",
+        "ec2:CreateVolume"
+      ],
       "Condition": {
         "StringEquals": {
           "aws:RequestTag/KubernetesCluster": "minimal.example.com"

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -98,6 +98,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -111,8 +112,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -254,6 +261,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -254,6 +261,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -229,6 +236,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-etcd/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-etcd/cloudformation.json
@@ -1066,6 +1066,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "minimal-etcd.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1079,8 +1080,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "minimal-etcd.example.com"
                 }
@@ -1174,6 +1181,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json
@@ -1062,6 +1062,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "minimal.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1075,8 +1076,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
                 }
@@ -1170,6 +1177,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json
@@ -1351,6 +1351,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1364,8 +1365,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "minimal-ipv6.example.com"
                 }
@@ -1478,6 +1485,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -98,6 +98,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -111,8 +112,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal-ipv6.example.com"
         }
@@ -225,6 +232,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json
@@ -1337,6 +1337,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1350,8 +1351,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "minimal-ipv6.example.com"
                 }
@@ -1463,6 +1470,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -98,6 +98,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -111,8 +112,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal-ipv6.example.com"
         }
@@ -224,6 +231,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -98,6 +98,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -111,8 +112,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal-ipv6.example.com"
         }
@@ -224,6 +231,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
+++ b/tests/integration/update_cluster/minimal-ipv6/cloudformation.json
@@ -1337,6 +1337,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1350,8 +1351,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "minimal-ipv6.example.com"
                 }
@@ -1463,6 +1470,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_iam_role_policy_masters.minimal-ipv6.example.com_policy
@@ -98,6 +98,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal-ipv6.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -111,8 +112,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal-ipv6.example.com"
         }
@@ -224,6 +231,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_iam_role_policy_masters.minimal-warmpool.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal-warmpool.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal-warmpool.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal/cloudformation.json
+++ b/tests/integration/update_cluster/minimal/cloudformation.json
@@ -1066,6 +1066,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "minimal.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1079,8 +1080,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
                 }
@@ -1174,6 +1181,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/minimal/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_iam_role_policy_masters.minimal.k8s.local_policy
@@ -84,6 +84,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.k8s.local",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -97,8 +98,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.k8s.local"
         }
@@ -192,6 +199,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -1785,6 +1785,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "mixedinstances.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1798,8 +1799,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
                 }
@@ -1893,6 +1900,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "mixedinstances.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json
@@ -1786,6 +1786,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "mixedinstances.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1799,8 +1800,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
                 }
@@ -1894,6 +1901,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_iam_role_policy_masters.mixedinstances.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "mixedinstances.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "mixedinstances.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json
@@ -1204,6 +1204,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "nthsqsresources.longclustername.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1217,8 +1218,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "nthsqsresources.longclustername.example.com"
                 }
@@ -1315,6 +1322,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_masters.nthsqsresources.longclustername.example.com_policy
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_iam_role_policy_masters.nthsqsresources.longclustername.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "nthsqsresources.longclustername.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "nthsqsresources.longclustername.example.com"
         }
@@ -225,6 +232,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/nvidia/cloudformation.json
+++ b/tests/integration/update_cluster/nvidia/cloudformation.json
@@ -1079,6 +1079,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "minimal.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1092,8 +1093,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
                 }
@@ -1187,6 +1194,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/nvidia/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json
@@ -1586,6 +1586,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "private-shared-ip.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1599,8 +1600,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "private-shared-ip.example.com"
                 }
@@ -1694,6 +1701,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_iam_role_policy_masters.private-shared-ip.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "private-shared-ip.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "private-shared-ip.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_iam_role_policy_masters.private-shared-subnet.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "private-shared-subnet.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "private-shared-subnet.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json
@@ -1742,6 +1742,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "privatecalico.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1755,8 +1756,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "privatecalico.example.com"
                 }
@@ -1851,6 +1858,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
+++ b/tests/integration/update_cluster/privatecalico/data/aws_iam_role_policy_masters.privatecalico.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privatecalico.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privatecalico.example.com"
         }
@@ -223,6 +230,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
+++ b/tests/integration/update_cluster/privatecanal/data/aws_iam_role_policy_masters.privatecanal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privatecanal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privatecanal.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json
@@ -1728,6 +1728,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "privatecilium.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1741,8 +1742,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "privatecilium.example.com"
                 }
@@ -1836,6 +1843,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privatecilium.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privatecilium.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json
@@ -1728,6 +1728,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "privatecilium.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1741,8 +1742,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "privatecilium.example.com"
                 }
@@ -1836,6 +1843,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_iam_role_policy_masters.privatecilium.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privatecilium.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privatecilium.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json
@@ -1771,6 +1771,7 @@
               "Action": "ec2:CreateTags",
               "Condition": {
                 "StringEquals": {
+                  "aws:RequestTag/KubernetesCluster": "privateciliumadvanced.example.com",
                   "ec2:CreateAction": [
                     "CreateVolume",
                     "CreateSnapshot"
@@ -1784,8 +1785,14 @@
               ]
             },
             {
-              "Action": "ec2:DeleteTags",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+              ],
               "Condition": {
+                "Null": {
+                  "aws:RequestTag/KubernetesCluster": "true"
+                },
                 "StringEquals": {
                   "aws:ResourceTag/KubernetesCluster": "privateciliumadvanced.example.com"
                 }
@@ -1888,6 +1895,7 @@
             {
               "Action": [
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateSnapshot",
                 "ec2:CreateVolume",
                 "elasticloadbalancing:CreateListener",
                 "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_iam_role_policy_masters.privateciliumadvanced.example.com_policy
@@ -124,6 +124,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privateciliumadvanced.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -137,8 +138,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privateciliumadvanced.example.com"
         }
@@ -241,6 +248,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
+++ b/tests/integration/update_cluster/privatedns1/data/aws_iam_role_policy_masters.privatedns1.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privatedns1.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privatedns1.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
+++ b/tests/integration/update_cluster/privatedns2/data/aws_iam_role_policy_masters.privatedns2.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privatedns2.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privatedns2.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
+++ b/tests/integration/update_cluster/privateflannel/data/aws_iam_role_policy_masters.privateflannel.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privateflannel.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privateflannel.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_iam_role_policy_masters.privatekopeio.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privatekopeio.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privatekopeio.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
+++ b/tests/integration/update_cluster/privateweave/data/aws_iam_role_policy_masters.privateweave.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "privateweave.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "privateweave.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_iam_role_policy_masters.sharedsubnet.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "sharedsubnet.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "sharedsubnet.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_iam_role_policy_masters.sharedvpc.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "sharedvpc.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "sharedvpc.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
+++ b/tests/integration/update_cluster/unmanaged/data/aws_iam_role_policy_masters.unmanaged.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "unmanaged.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "unmanaged.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",

--- a/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
+++ b/tests/integration/update_cluster/vfs-said/data/aws_iam_role_policy_masters.minimal.example.com_policy
@@ -114,6 +114,7 @@
       "Action": "ec2:CreateTags",
       "Condition": {
         "StringEquals": {
+          "aws:RequestTag/KubernetesCluster": "minimal.example.com",
           "ec2:CreateAction": [
             "CreateVolume",
             "CreateSnapshot"
@@ -127,8 +128,14 @@
       ]
     },
     {
-      "Action": "ec2:DeleteTags",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
       "Condition": {
+        "Null": {
+          "aws:RequestTag/KubernetesCluster": "true"
+        },
         "StringEquals": {
           "aws:ResourceTag/KubernetesCluster": "minimal.example.com"
         }
@@ -222,6 +229,7 @@
     {
       "Action": [
         "ec2:CreateSecurityGroup",
+        "ec2:CreateSnapshot",
         "ec2:CreateVolume",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",


### PR DESCRIPTION
Cherry pick of #13104 on release-1.23.

#13104: Create helper function for ec2 create/tag-on-create IAM

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```