### PR TITLE
Remove networking flags as of k8s 1.24

### DIFF
--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -162,7 +162,7 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		if networking == nil {
 			return fmt.Errorf("no networking mode set")
 		}
-		if UsesKubenet(networking) {
+		if UsesKubenet(networking) && b.IsKubernetesLT("1.24") {
 			clusterSpec.Kubelet.NetworkPluginName = "kubenet"
 			clusterSpec.Kubelet.NetworkPluginMTU = fi.Int32(9001)
 			clusterSpec.Kubelet.NonMasqueradeCIDR = clusterSpec.NonMasqueradeCIDR

--- a/pkg/model/components/networking.go
+++ b/pkg/model/components/networking.go
@@ -44,7 +44,9 @@ func (b *NetworkingOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if UsesCNI(networking) {
-		options.Kubelet.NetworkPluginName = "cni"
+		if b.Context.IsKubernetesLT("1.24") {
+			options.Kubelet.NetworkPluginName = "cni"
+		}
 
 		// ConfigureCBR0 flag removed from 1.5
 		options.Kubelet.ConfigureCBR0 = nil

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -225,7 +225,6 @@ kubelet:
     InTreePluginAWSUnregister: "true"
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
-  networkPluginName: cni
   podManifestPath: /etc/kubernetes/manifests
   protectKernelDefaults: true
 masterKubelet:
@@ -242,7 +241,6 @@ masterKubelet:
     InTreePluginAWSUnregister: "true"
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
-  networkPluginName: cni
   podManifestPath: /etc/kubernetes/manifests
   protectKernelDefaults: true
   registerSchedulable: false
@@ -254,7 +252,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: G19o8iyxYuu/a0e4dRh4FGU9ZGX0YqfzaRdqEGn2qZs=
+NodeupConfigHash: CDzdXl/0qObw/fUKEXHnAs4vwUckB0u6Sb9hv98SEys=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -153,7 +153,6 @@ kubelet:
     InTreePluginAWSUnregister: "true"
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
-  networkPluginName: cni
   podManifestPath: /etc/kubernetes/manifests
   protectKernelDefaults: true
 
@@ -164,7 +163,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 761GI5NIkJH7vSaSF2Igb/MV8d3cz873JAmFTzT2RX0=
+NodeupConfigHash: kRdGVRLcd+t+PYT5YSR/lQ8ci9q7DtvS3nNI26+EcPc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -154,7 +154,6 @@ spec:
       InTreePluginAWSUnregister: "true"
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginName: cni
     podManifestPath: /etc/kubernetes/manifests
     protectKernelDefaults: true
   kubernetesApiAccess:
@@ -176,7 +175,6 @@ spec:
       InTreePluginAWSUnregister: "true"
     kubeconfigPath: /var/lib/kubelet/kubeconfig
     logLevel: 2
-    networkPluginName: cni
     podManifestPath: /etc/kubernetes/manifests
     protectKernelDefaults: true
     registerSchedulable: false

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -244,7 +244,6 @@ KubeletConfig:
     InTreePluginAWSUnregister: "true"
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
-  networkPluginName: cni
   nodeLabels:
     kops.k8s.io/instancegroup: master-us-test-1a
     kops.k8s.io/kops-controller-pki: ""

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -51,7 +51,6 @@ KubeletConfig:
     InTreePluginAWSUnregister: "true"
   kubeconfigPath: /var/lib/kubelet/kubeconfig
   logLevel: 2
-  networkPluginName: cni
   nodeLabels:
     kops.k8s.io/instancegroup: nodes-us-test-1a
     kubernetes.io/role: node


### PR DESCRIPTION
K/k master is currently failing because the network plugin flags et.al got removed.