### PR TITLE
Use prefix mode for VPC CNI on new clusters

### DIFF
--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -12,6 +12,8 @@ This is a document to gather the release notes prior to the release.
 being used, then Kubernetes Node resources will be named after their AWS instance ID instead of their domain name and
 managed subnets will be configured to launch instances with Resource Based Names.
 
+* Amazon VPC CNI will use [prefix mdoe](https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html) by default.
+
 # Breaking changes
 
 * Support for Kubernetes version 1.17 has been removed.

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -975,7 +975,18 @@ func setupNetworking(opt *NewClusterOptions, cluster *api.Cluster) error {
 		enabled := false
 		cluster.Spec.KubeProxy.Enabled = &enabled
 	case "amazonvpc", "amazon-vpc-routed-eni":
-		cluster.Spec.Networking.AmazonVPC = &api.AmazonVPCNetworkingSpec{}
+		cluster.Spec.Networking.AmazonVPC = &api.AmazonVPCNetworkingSpec{
+			Env: []api.EnvVar{
+				{
+					Name:  "ENABLE_PREFIX_DELEGATION",
+					Value: "true",
+				},
+				{
+					Name:  "WARM_PREFIX_TARGET",
+					Value: "1",
+				},
+			},
+		}
 	case "cilium":
 		addCiliumNetwork(cluster)
 	case "cilium-etcd":

--- a/upup/pkg/fi/cloudup/new_cluster_test.go
+++ b/upup/pkg/fi/cloudup/new_cluster_test.go
@@ -248,7 +248,18 @@ func TestSetupNetworking(t *testing.T) {
 			expected: api.Cluster{
 				Spec: api.ClusterSpec{
 					Networking: &api.NetworkingSpec{
-						AmazonVPC: &api.AmazonVPCNetworkingSpec{},
+						AmazonVPC: &api.AmazonVPCNetworkingSpec{
+							Env: []api.EnvVar{
+								{
+									Name:  "ENABLE_PREFIX_DELEGATION",
+									Value: "true",
+								},
+								{
+									Name:  "WARM_PREFIX_TARGET",
+									Value: "1",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -260,7 +271,18 @@ func TestSetupNetworking(t *testing.T) {
 			expected: api.Cluster{
 				Spec: api.ClusterSpec{
 					Networking: &api.NetworkingSpec{
-						AmazonVPC: &api.AmazonVPCNetworkingSpec{},
+						AmazonVPC: &api.AmazonVPCNetworkingSpec{
+							Env: []api.EnvVar{
+								{
+									Name:  "ENABLE_PREFIX_DELEGATION",
+									Value: "true",
+								},
+								{
+									Name:  "WARM_PREFIX_TARGET",
+									Value: "1",
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Some of the e2e tests require more pods than we have room for. 
I also cannot think of a reason why one wouldn't want this by default ...

This PR will only use prefix mode on new clusters. We may want to "upgrade" old clusters as well, but that can be done in a follow-up.