### PR TITLE
use 1.23.1 ccm for openstack

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -744,6 +744,9 @@ func (tf *TemplateFunctions) OpenStackCCMTag() string {
 		if parsed.Minor == 13 {
 			// The bugfix release
 			tag = "1.13.1"
+		} else if parsed.Minor == 23 {
+			// The bugfix release, see https://github.com/kubernetes/cloud-provider-openstack/releases
+			tag = "1.23.1"
 		} else {
 			// otherwise we use always .0 ccm image, if needed that can be overrided using clusterspec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)


### PR DESCRIPTION
There are two known issues currently in 1.23.0 ccm
- https://github.com/kubernetes/cloud-provider-openstack/pull/1750
- https://github.com/kubernetes/cloud-provider-openstack/pull/1755

these will be (hopefully) cherry-picked to release-1.23 and we will get new patch release.

This PR can be merged if we can see the patch release to be released.

/hold