### PR TITLE
Automated cherry pick of #13136: use 1.23.1 ccm for openstack

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -717,6 +717,9 @@ func (tf *TemplateFunctions) OpenStackCCMTag() string {
 		if parsed.Minor == 13 {
 			// The bugfix release
 			tag = "1.13.1"
+		} else if parsed.Minor == 23 {
+			// The bugfix release, see https://github.com/kubernetes/cloud-provider-openstack/releases
+			tag = "1.23.1"
 		} else {
 			// otherwise we use always .0 ccm image, if needed that can be overrided using clusterspec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)


### PR DESCRIPTION
Cherry pick of #13136 on release-1.23.

#13136: use 1.23.1 ccm for openstack

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.