### PR TITLE
Automated cherry pick of #13139: configure max-shared-lb in OpenStack

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -418,6 +418,8 @@ spec:
                             type: string
                           manageSecurityGroups:
                             type: boolean
+                          maxSharedLB:
+                            type: integer
                           method:
                             type: string
                           provider:

--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -158,7 +158,10 @@ func (b *CloudConfigBuilder) build(c *fi.ModelBuilderContext, inTree bool) error
 			if fi.StringValue(lb.IngressHostnameSuffix) != "" {
 				ingressHostnameSuffix = fi.StringValue(lb.IngressHostnameSuffix)
 			}
-
+			maxSharedLB := 0
+			if lb.MaxSharedLB != nil {
+				maxSharedLB = fi.IntValue(lb.MaxSharedLB)
+			}
 			lines = append(lines,
 				"[LoadBalancer]",
 				fmt.Sprintf("floating-network-id=%s", fi.StringValue(lb.FloatingNetworkID)),
@@ -168,6 +171,7 @@ func (b *CloudConfigBuilder) build(c *fi.ModelBuilderContext, inTree bool) error
 				fmt.Sprintf("manage-security-groups=%t", fi.BoolValue(lb.ManageSecGroups)),
 				fmt.Sprintf("enable-ingress-hostname=%t", fi.BoolValue(lb.EnableIngressHostname)),
 				fmt.Sprintf("ingress-hostname-suffix=%s", ingressHostnameSuffix),
+				fmt.Sprintf("max-shared-lb=%d", maxSharedLB),
 				"",
 			)
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -763,6 +763,7 @@ type OpenstackLoadbalancerConfig struct {
 	ManageSecGroups       *bool   `json:"manageSecurityGroups,omitempty"`
 	EnableIngressHostname *bool   `json:"enableIngressHostname,omitempty"`
 	IngressHostnameSuffix *string `json:"ingressHostnameSuffix,omitempty"`
+	MaxSharedLB           *int    `json:"maxSharedLB,omitempty"`
 }
 
 type OpenstackBlockStorageConfig struct {

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -762,6 +762,7 @@ type OpenstackLoadbalancerConfig struct {
 	ManageSecGroups       *bool   `json:"manageSecurityGroups,omitempty"`
 	EnableIngressHostname *bool   `json:"enableIngressHostname,omitempty"`
 	IngressHostnameSuffix *string `json:"ingressHostnameSuffix,omitempty"`
+	MaxSharedLB           *int    `json:"maxSharedLB,omitempty"`
 }
 
 type OpenstackBlockStorageConfig struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6374,6 +6374,7 @@ func autoConvert_v1alpha2_OpenstackLoadbalancerConfig_To_kops_OpenstackLoadbalan
 	out.ManageSecGroups = in.ManageSecGroups
 	out.EnableIngressHostname = in.EnableIngressHostname
 	out.IngressHostnameSuffix = in.IngressHostnameSuffix
+	out.MaxSharedLB = in.MaxSharedLB
 	return nil
 }
 
@@ -6393,6 +6394,7 @@ func autoConvert_kops_OpenstackLoadbalancerConfig_To_v1alpha2_OpenstackLoadbalan
 	out.ManageSecGroups = in.ManageSecGroups
 	out.EnableIngressHostname = in.EnableIngressHostname
 	out.IngressHostnameSuffix = in.IngressHostnameSuffix
+	out.MaxSharedLB = in.MaxSharedLB
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4644,6 +4644,11 @@ func (in *PackagesConfig) DeepCopyInto(out *PackagesConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MaxSharedLB != nil {
+		in, out := &in.MaxSharedLB, &out.MaxSharedLB
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4487,6 +4487,11 @@ func (in *OpenstackLoadbalancerConfig) DeepCopyInto(out *OpenstackLoadbalancerCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.MaxSharedLB != nil {
+		in, out := &in.MaxSharedLB, &out.MaxSharedLB
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 
@@ -4642,11 +4647,6 @@ func (in *PackagesConfig) DeepCopyInto(out *PackagesConfig) {
 	if in.UrlArm64 != nil {
 		in, out := &in.UrlArm64, &out.UrlArm64
 		*out = new(string)
-		**out = **in
-	}
-	if in.MaxSharedLB != nil {
-		in, out := &in.MaxSharedLB, &out.MaxSharedLB
-		*out = new(int)
 		**out = **in
 	}
 	return

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -760,6 +760,7 @@ type OpenstackLoadbalancerConfig struct {
 	ManageSecGroups       *bool   `json:"manageSecurityGroups,omitempty"`
 	EnableIngressHostname *bool   `json:"enableIngressHostname,omitempty"`
 	IngressHostnameSuffix *string `json:"ingressHostnameSuffix,omitempty"`
+	MaxSharedLB           *int    `json:"maxSharedLB,omitempty"`
 }
 
 type OpenstackBlockStorageConfig struct {

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6124,6 +6124,7 @@ func autoConvert_v1alpha3_OpenstackLoadbalancerConfig_To_kops_OpenstackLoadbalan
 	out.ManageSecGroups = in.ManageSecGroups
 	out.EnableIngressHostname = in.EnableIngressHostname
 	out.IngressHostnameSuffix = in.IngressHostnameSuffix
+	out.MaxSharedLB = in.MaxSharedLB
 	return nil
 }
 
@@ -6143,6 +6144,7 @@ func autoConvert_kops_OpenstackLoadbalancerConfig_To_v1alpha3_OpenstackLoadbalan
 	out.ManageSecGroups = in.ManageSecGroups
 	out.EnableIngressHostname = in.EnableIngressHostname
 	out.IngressHostnameSuffix = in.IngressHostnameSuffix
+	out.MaxSharedLB = in.MaxSharedLB
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4470,6 +4470,11 @@ func (in *PackagesConfig) DeepCopyInto(out *PackagesConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MaxSharedLB != nil {
+		in, out := &in.MaxSharedLB, &out.MaxSharedLB
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4313,6 +4313,11 @@ func (in *OpenstackLoadbalancerConfig) DeepCopyInto(out *OpenstackLoadbalancerCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.MaxSharedLB != nil {
+		in, out := &in.MaxSharedLB, &out.MaxSharedLB
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 
@@ -4468,11 +4473,6 @@ func (in *PackagesConfig) DeepCopyInto(out *PackagesConfig) {
 	if in.UrlArm64 != nil {
 		in, out := &in.UrlArm64, &out.UrlArm64
 		*out = new(string)
-		**out = **in
-	}
-	if in.MaxSharedLB != nil {
-		in, out := &in.MaxSharedLB, &out.MaxSharedLB
-		*out = new(int)
 		**out = **in
 	}
 	return

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4740,6 +4740,11 @@ func (in *PackagesConfig) DeepCopyInto(out *PackagesConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MaxSharedLB != nil {
+		in, out := &in.MaxSharedLB, &out.MaxSharedLB
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4583,6 +4583,11 @@ func (in *OpenstackLoadbalancerConfig) DeepCopyInto(out *OpenstackLoadbalancerCo
 		*out = new(string)
 		**out = **in
 	}
+	if in.MaxSharedLB != nil {
+		in, out := &in.MaxSharedLB, &out.MaxSharedLB
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 
@@ -4738,11 +4743,6 @@ func (in *PackagesConfig) DeepCopyInto(out *PackagesConfig) {
 	if in.UrlArm64 != nil {
 		in, out := &in.UrlArm64, &out.UrlArm64
 		*out = new(string)
-		**out = **in
-	}
-	if in.MaxSharedLB != nil {
-		in, out := &in.MaxSharedLB, &out.MaxSharedLB
-		*out = new(int)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
Cherry pick of #13139 on release-1.23.

#13139: configure max-shared-lb in OpenStack

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.