### PR TITLE
Automated cherry pick of #13111: No need to set kubelet in tests

### DIFF
--- a/pkg/apis/kops/v1alpha2/defaults.go
+++ b/pkg/apis/kops/v1alpha2/defaults.go
@@ -86,12 +86,6 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 		obj.Authorization.AlwaysAllow = &AlwaysAllowAuthorizationSpec{}
 	}
 
-	if obj.IAM == nil {
-		obj.IAM = &IAMSpec{
-			Legacy: true,
-		}
-	}
-
 	if obj.Networking != nil {
 		if obj.Networking.Flannel != nil {
 			// Populate with legacy default value; new clusters will be created with "vxlan" by

--- a/pkg/apis/kops/v1alpha3/defaults.go
+++ b/pkg/apis/kops/v1alpha3/defaults.go
@@ -86,12 +86,6 @@ func SetDefaults_ClusterSpec(obj *ClusterSpec) {
 		obj.Authorization.AlwaysAllow = &AlwaysAllowAuthorizationSpec{}
 	}
 
-	if obj.IAM == nil {
-		obj.IAM = &IAMSpec{
-			Legacy: true,
-		}
-	}
-
 	if obj.Networking != nil {
 		if obj.Networking.Flannel != nil {
 			// Populate with legacy default value; new clusters will be created with "vxlan" by

--- a/tests/integration/update_cluster/minimal/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal/cloudformation.json.extracted.yaml
@@ -205,7 +205,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
       leaderElect: true
     logLevel: 2
   kubelet:
-    anonymousAuth: false
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: aws
@@ -219,7 +218,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
     nonMasqueradeCIDR: 100.64.0.0/10
     podManifestPath: /etc/kubernetes/manifests
   masterKubelet:
-    anonymousAuth: false
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: aws
@@ -241,7 +239,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: master-us-test-1a
   InstanceGroupRole: Master
-  NodeupConfigHash: LFwTDQ1M/AxVLdvKc8ZPsktDgr836JEsdQRwn2TU+iM=
+  NodeupConfigHash: eIKJajpYSH1kKEG8Ah7zdvIqBC9cGdqI4mj1KYaE0VA=
 
   __EOF_KUBE_ENV
 
@@ -389,7 +387,6 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
     image: k8s.gcr.io/kube-proxy:v1.21.0
     logLevel: 2
   kubelet:
-    anonymousAuth: false
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: aws
@@ -410,7 +407,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
   ConfigBase: memfs://clusters.example.com/minimal.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: ehZK5PooPMXQw0YD3dy5oARwClEXIj8ymh6DR1XYbQ0=
+  NodeupConfigHash: X3GTskTs5A1Xa9K+ujEWoAJd1PidV/fSdfPuDfuLLHA=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -204,7 +204,6 @@ kubeScheduler:
     leaderElect: true
   logLevel: 2
 kubelet:
-  anonymousAuth: false
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: aws
@@ -218,7 +217,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podManifestPath: /etc/kubernetes/manifests
 masterKubelet:
-  anonymousAuth: false
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: aws
@@ -240,7 +238,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: LFwTDQ1M/AxVLdvKc8ZPsktDgr836JEsdQRwn2TU+iM=
+NodeupConfigHash: eIKJajpYSH1kKEG8Ah7zdvIqBC9cGdqI4mj1KYaE0VA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -139,7 +139,6 @@ kubeProxy:
   image: k8s.gcr.io/kube-proxy:v1.21.0
   logLevel: 2
 kubelet:
-  anonymousAuth: false
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: aws
@@ -160,7 +159,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: ehZK5PooPMXQw0YD3dy5oARwClEXIj8ymh6DR1XYbQ0=
+NodeupConfigHash: X3GTskTs5A1Xa9K+ujEWoAJd1PidV/fSdfPuDfuLLHA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -123,7 +123,6 @@ spec:
       leaderElect: true
     logLevel: 2
   kubelet:
-    anonymousAuth: false
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: aws
@@ -141,7 +140,6 @@ spec:
   kubernetesVersion: 1.21.0
   masterInternalName: api.internal.minimal.example.com
   masterKubelet:
-    anonymousAuth: false
     cgroupDriver: systemd
     cgroupRoot: /
     cloudProvider: aws

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -41,8 +41,6 @@ spec:
     version: 3.4.13
   externalDns:
     provider: dns-controller
-  iam:
-    legacy: false
   keyStore: memfs://clusters.example.com/minimal.example.com/pki
   kubeAPIServer:
     allowPrivileged: true

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -231,7 +231,6 @@ KeypairIDs:
   kubernetes-ca: "6982820025135291416230495506"
   service-account: "2"
 KubeletConfig:
-  anonymousAuth: false
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: aws

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -38,7 +38,6 @@ Hooks:
 KeypairIDs:
   kubernetes-ca: "6982820025135291416230495506"
 KubeletConfig:
-  anonymousAuth: false
   cgroupDriver: systemd
   cgroupRoot: /
   cloudProvider: aws

--- a/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
@@ -19,8 +19,6 @@ spec:
       name: us-test-1a
     name: events
   iam: {}
-  kubelet:
-    anonymousAuth: false
   kubernetesVersion: v1.21.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com

--- a/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal/in-v1alpha2.yaml
@@ -18,7 +18,6 @@ spec:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
     name: events
-  iam: {}
   kubernetesVersion: v1.21.0
   masterInternalName: api.internal.minimal.example.com
   masterPublicName: api.minimal.example.com


### PR DESCRIPTION
Cherry pick of #13111 on release-1.23.

#13111: No need to set kubelet in tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```