### PR TITLE
Bump cert-manager and related godep to 1.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.10.1
 	github.com/hashicorp/vault/api v1.1.1
 	github.com/jacksontj/memberlistmesh v0.0.0-20190905163944-93462b9d2bb7
-	github.com/jetstack/cert-manager v1.6.1
+	github.com/jetstack/cert-manager v1.6.2
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/sftp v1.13.4

--- a/go.sum
+++ b/go.sum
@@ -825,8 +825,8 @@ github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6t
 github.com/jacksontj/memberlistmesh v0.0.0-20190905163944-93462b9d2bb7 h1:q9rwMYjPWIFOSijnxXre4+RGo8xS0NVbJzXg+F0NMHc=
 github.com/jacksontj/memberlistmesh v0.0.0-20190905163944-93462b9d2bb7/go.mod h1:fFX3XoduobgoJsVtpzIFRTgKZAbNhsSJIDNOgeUU5g4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jetstack/cert-manager v1.6.1 h1:VME4bVID2gVTfebO5X4Nq9FvKvvi3+VLcA0mmtYlKuw=
-github.com/jetstack/cert-manager v1.6.1/go.mod h1:1nXjnzzsYcIFvl4eLTkVqpvh9NQogkCq4FaCmgvNDDY=
+github.com/jetstack/cert-manager v1.6.2 h1:g/8zxYdqygBwOq3pm27UKgsJadmU+C+4H3zBgCgr7gA=
+github.com/jetstack/cert-manager v1.6.2/go.mod h1:1nXjnzzsYcIFvl4eLTkVqpvh9NQogkCq4FaCmgvNDDY=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -999,7 +999,7 @@ github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jenkins-x/go-scm v1.5.79/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jetstack/cert-manager v1.6.1/go.mod h1:1nXjnzzsYcIFvl4eLTkVqpvh9NQogkCq4FaCmgvNDDY=
+github.com/jetstack/cert-manager v1.6.2/go.mod h1:1nXjnzzsYcIFvl4eLTkVqpvh9NQogkCq4FaCmgvNDDY=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
 github.com/jinzhu/gorm v1.9.12/go.mod h1:vhTjlKSJUTWNtcbQtrMBFCxy7eXTzeCAzfL5fBZT/Qs=

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 0ad47440355c822d443ae607d7a052e93eaa024d60f69e18d925785b7ec3b406
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificaterequests.cert-manager.io
 spec:
   conversion:
@@ -953,7 +953,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificates.cert-manager.io
 spec:
   conversion:
@@ -2803,7 +2803,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: challenges.acme.cert-manager.io
 spec:
   conversion:
@@ -10331,7 +10331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: clusterissuers.cert-manager.io
 spec:
   conversion:
@@ -20127,7 +20127,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: issuers.cert-manager.io
 spec:
   conversion:
@@ -29919,7 +29919,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: orders.acme.cert-manager.io
 spec:
   conversion:
@@ -30848,7 +30848,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -30866,7 +30866,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 
@@ -30884,7 +30884,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -30901,7 +30901,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -30980,7 +30980,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -31030,7 +31030,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -31080,7 +31080,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -31152,7 +31152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -31222,7 +31222,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -31331,7 +31331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -31405,7 +31405,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -31444,7 +31444,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -31486,7 +31486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -31512,7 +31512,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -31559,7 +31559,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -31582,7 +31582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31606,7 +31606,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31630,7 +31630,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31654,7 +31654,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31678,7 +31678,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31702,7 +31702,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31726,7 +31726,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31750,7 +31750,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31774,7 +31774,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31798,7 +31798,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31823,7 +31823,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -31875,7 +31875,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -31925,7 +31925,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -31960,7 +31960,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -31985,7 +31985,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -32011,7 +32011,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -32037,7 +32037,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32065,7 +32065,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32093,7 +32093,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -32110,7 +32110,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32121,7 +32121,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.6.1
+        image: quay.io/jetstack/cert-manager-cainjector:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -32148,7 +32148,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32169,7 +32169,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32182,7 +32182,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.6.1
+        image: quay.io/jetstack/cert-manager-controller:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -32212,7 +32212,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32229,7 +32229,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32243,7 +32243,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.6.1
+        image: quay.io/jetstack/cert-manager-webhook:v1.6.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -32296,7 +32296,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -32339,7 +32339,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 0ad47440355c822d443ae607d7a052e93eaa024d60f69e18d925785b7ec3b406
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificaterequests.cert-manager.io
 spec:
   conversion:
@@ -953,7 +953,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificates.cert-manager.io
 spec:
   conversion:
@@ -2803,7 +2803,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: challenges.acme.cert-manager.io
 spec:
   conversion:
@@ -10331,7 +10331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: clusterissuers.cert-manager.io
 spec:
   conversion:
@@ -20127,7 +20127,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: issuers.cert-manager.io
 spec:
   conversion:
@@ -29919,7 +29919,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: orders.acme.cert-manager.io
 spec:
   conversion:
@@ -30848,7 +30848,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -30866,7 +30866,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 
@@ -30884,7 +30884,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -30901,7 +30901,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -30980,7 +30980,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -31030,7 +31030,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -31080,7 +31080,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -31152,7 +31152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -31222,7 +31222,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -31331,7 +31331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -31405,7 +31405,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -31444,7 +31444,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -31486,7 +31486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -31512,7 +31512,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -31559,7 +31559,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -31582,7 +31582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31606,7 +31606,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31630,7 +31630,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31654,7 +31654,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31678,7 +31678,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31702,7 +31702,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31726,7 +31726,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31750,7 +31750,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31774,7 +31774,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31798,7 +31798,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31823,7 +31823,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -31875,7 +31875,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -31925,7 +31925,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -31960,7 +31960,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -31985,7 +31985,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -32011,7 +32011,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -32037,7 +32037,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32065,7 +32065,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32093,7 +32093,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -32110,7 +32110,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32121,7 +32121,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.6.1
+        image: quay.io/jetstack/cert-manager-cainjector:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -32148,7 +32148,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32169,7 +32169,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32182,7 +32182,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.6.1
+        image: quay.io/jetstack/cert-manager-controller:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -32212,7 +32212,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32229,7 +32229,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32243,7 +32243,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.6.1
+        image: quay.io/jetstack/cert-manager-webhook:v1.6.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -32296,7 +32296,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -32339,7 +32339,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 0ad47440355c822d443ae607d7a052e93eaa024d60f69e18d925785b7ec3b406
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificaterequests.cert-manager.io
 spec:
   conversion:
@@ -953,7 +953,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificates.cert-manager.io
 spec:
   conversion:
@@ -2803,7 +2803,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: challenges.acme.cert-manager.io
 spec:
   conversion:
@@ -10331,7 +10331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: clusterissuers.cert-manager.io
 spec:
   conversion:
@@ -20127,7 +20127,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: issuers.cert-manager.io
 spec:
   conversion:
@@ -29919,7 +29919,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: orders.acme.cert-manager.io
 spec:
   conversion:
@@ -30848,7 +30848,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -30866,7 +30866,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 
@@ -30884,7 +30884,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -30901,7 +30901,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -30980,7 +30980,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -31030,7 +31030,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -31080,7 +31080,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -31152,7 +31152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -31222,7 +31222,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -31331,7 +31331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -31405,7 +31405,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -31444,7 +31444,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -31486,7 +31486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -31512,7 +31512,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -31559,7 +31559,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -31582,7 +31582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31606,7 +31606,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31630,7 +31630,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31654,7 +31654,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31678,7 +31678,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31702,7 +31702,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31726,7 +31726,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31750,7 +31750,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31774,7 +31774,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31798,7 +31798,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31823,7 +31823,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -31875,7 +31875,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -31925,7 +31925,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -31960,7 +31960,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -31985,7 +31985,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -32011,7 +32011,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -32037,7 +32037,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32065,7 +32065,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32093,7 +32093,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -32110,7 +32110,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32121,7 +32121,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.6.1
+        image: quay.io/jetstack/cert-manager-cainjector:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -32148,7 +32148,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32169,7 +32169,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32182,7 +32182,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.6.1
+        image: quay.io/jetstack/cert-manager-controller:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -32212,7 +32212,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32229,7 +32229,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32243,7 +32243,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.6.1
+        image: quay.io/jetstack/cert-manager-webhook:v1.6.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -32296,7 +32296,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -32339,7 +32339,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 0ad47440355c822d443ae607d7a052e93eaa024d60f69e18d925785b7ec3b406
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificaterequests.cert-manager.io
 spec:
   conversion:
@@ -953,7 +953,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificates.cert-manager.io
 spec:
   conversion:
@@ -2803,7 +2803,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: challenges.acme.cert-manager.io
 spec:
   conversion:
@@ -10331,7 +10331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: clusterissuers.cert-manager.io
 spec:
   conversion:
@@ -20127,7 +20127,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: issuers.cert-manager.io
 spec:
   conversion:
@@ -29919,7 +29919,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: orders.acme.cert-manager.io
 spec:
   conversion:
@@ -30848,7 +30848,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -30866,7 +30866,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 
@@ -30884,7 +30884,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -30901,7 +30901,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -30980,7 +30980,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -31030,7 +31030,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -31080,7 +31080,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -31152,7 +31152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -31222,7 +31222,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -31331,7 +31331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -31405,7 +31405,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -31444,7 +31444,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -31486,7 +31486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -31512,7 +31512,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -31559,7 +31559,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -31582,7 +31582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31606,7 +31606,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31630,7 +31630,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31654,7 +31654,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31678,7 +31678,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31702,7 +31702,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31726,7 +31726,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31750,7 +31750,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31774,7 +31774,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31798,7 +31798,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31823,7 +31823,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -31875,7 +31875,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -31925,7 +31925,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -31960,7 +31960,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -31985,7 +31985,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -32011,7 +32011,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -32037,7 +32037,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32065,7 +32065,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32093,7 +32093,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -32110,7 +32110,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32121,7 +32121,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.6.1
+        image: quay.io/jetstack/cert-manager-cainjector:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -32148,7 +32148,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32169,7 +32169,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32182,7 +32182,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.6.1
+        image: quay.io/jetstack/cert-manager-controller:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -32212,7 +32212,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32229,7 +32229,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32243,7 +32243,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.6.1
+        image: quay.io/jetstack/cert-manager-webhook:v1.6.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -32296,7 +32296,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -32339,7 +32339,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 0ad47440355c822d443ae607d7a052e93eaa024d60f69e18d925785b7ec3b406
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificaterequests.cert-manager.io
 spec:
   conversion:
@@ -953,7 +953,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: certificates.cert-manager.io
 spec:
   conversion:
@@ -2803,7 +2803,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: challenges.acme.cert-manager.io
 spec:
   conversion:
@@ -10331,7 +10331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: clusterissuers.cert-manager.io
 spec:
   conversion:
@@ -20127,7 +20127,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: issuers.cert-manager.io
 spec:
   conversion:
@@ -29919,7 +29919,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: orders.acme.cert-manager.io
 spec:
   conversion:
@@ -30848,7 +30848,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 
@@ -30866,7 +30866,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 
@@ -30884,7 +30884,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 
@@ -30901,7 +30901,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 rules:
 - apiGroups:
@@ -30980,7 +30980,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:
@@ -31030,7 +31030,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:
@@ -31080,7 +31080,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:
@@ -31152,7 +31152,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 rules:
 - apiGroups:
@@ -31222,7 +31222,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:
@@ -31331,7 +31331,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:
@@ -31405,7 +31405,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -31444,7 +31444,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit
@@ -31486,7 +31486,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:
@@ -31512,7 +31512,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:
@@ -31559,7 +31559,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:
@@ -31582,7 +31582,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31606,7 +31606,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31630,7 +31630,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31654,7 +31654,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31678,7 +31678,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31702,7 +31702,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31726,7 +31726,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31750,7 +31750,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31774,7 +31774,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31798,7 +31798,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -31823,7 +31823,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:
@@ -31875,7 +31875,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:
@@ -31925,7 +31925,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 rules:
@@ -31960,7 +31960,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:
@@ -31985,7 +31985,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:
@@ -32011,7 +32011,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook:dynamic-serving
   namespace: kube-system
 roleRef:
@@ -32037,7 +32037,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32065,7 +32065,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32093,7 +32093,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-cainjector
   namespace: kube-system
 spec:
@@ -32110,7 +32110,7 @@ spec:
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32121,7 +32121,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.6.1
+        image: quay.io/jetstack/cert-manager-cainjector:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}
@@ -32148,7 +32148,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager
   namespace: kube-system
 spec:
@@ -32169,7 +32169,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32182,7 +32182,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-controller:v1.6.1
+        image: quay.io/jetstack/cert-manager-controller:v1.6.2
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:
@@ -32212,7 +32212,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
   namespace: kube-system
 spec:
@@ -32229,7 +32229,7 @@ spec:
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.6.1
+        app.kubernetes.io/version: v1.6.2
     spec:
       containers:
       - args:
@@ -32243,7 +32243,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.6.1
+        image: quay.io/jetstack/cert-manager-webhook:v1.6.2
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -32296,7 +32296,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:
@@ -32339,7 +32339,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.6.1
+    app.kubernetes.io/version: v1.6.2
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   group: cert-manager.io
   names:
@@ -753,7 +753,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   group: cert-manager.io
   names:
@@ -2074,7 +2074,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   group: acme.cert-manager.io
   names:
@@ -6006,7 +6006,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   group: cert-manager.io
   names:
@@ -10787,7 +10787,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   group: cert-manager.io
   names:
@@ -15568,7 +15568,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   group: acme.cert-manager.io
   names:
@@ -16249,7 +16249,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -16263,7 +16263,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -16277,7 +16277,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 ---
 # Source: cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16289,7 +16289,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -16324,7 +16324,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -16350,7 +16350,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -16376,7 +16376,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -16411,7 +16411,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -16449,7 +16449,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -16509,7 +16509,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -16546,7 +16546,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -16568,7 +16568,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -16590,7 +16590,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -16610,7 +16610,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -16636,7 +16636,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -16652,7 +16652,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16672,7 +16672,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16692,7 +16692,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16712,7 +16712,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16732,7 +16732,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16752,7 +16752,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16772,7 +16772,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16792,7 +16792,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16812,7 +16812,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16832,7 +16832,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -16855,7 +16855,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -16889,7 +16889,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
   # Used for leader election by the controller
   # See also: https://github.com/kubernetes-sigs/controller-runtime/pull/1144#discussion_r480173688
@@ -16919,7 +16919,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -16944,7 +16944,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16967,7 +16967,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -16989,7 +16989,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17011,7 +17011,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   type: ClusterIP
   ports:
@@ -17035,7 +17035,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   type: ClusterIP
   ports:
@@ -17059,7 +17059,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   replicas: 1
   selector:
@@ -17074,7 +17074,7 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.6.1"
+        app.kubernetes.io/version: "v1.6.2"
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -17087,7 +17087,7 @@ spec:
         operator: Exists
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.6.1"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.6.2"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -17111,7 +17111,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   replicas: 1
   selector:
@@ -17126,7 +17126,7 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.6.1"
+        app.kubernetes.io/version: "v1.6.2"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -17143,7 +17143,7 @@ spec:
         operator: Exists
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v1.6.1"
+          image: "quay.io/jetstack/cert-manager-controller:v1.6.2"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -17177,7 +17177,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
 spec:
   replicas: 1
   selector:
@@ -17192,7 +17192,7 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.6.1"
+        app.kubernetes.io/version: "v1.6.2"
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -17205,7 +17205,7 @@ spec:
         operator: Exists
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-webhook:v1.6.1"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.6.2"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -17255,7 +17255,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
   annotations:
     cert-manager.io/inject-ca-from-secret: "kube-system/cert-manager-webhook-ca"
 webhooks:
@@ -17304,7 +17304,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/version: "v1.6.2"
   annotations:
     cert-manager.io/inject-ca-from-secret: "kube-system/cert-manager-webhook-ca"
 webhooks:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 0ad47440355c822d443ae607d7a052e93eaa024d60f69e18d925785b7ec3b406
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -508,7 +508,7 @@ github.com/inconshreveable/mousetrap
 ## explicit; go 1.12
 github.com/jacksontj/memberlistmesh
 github.com/jacksontj/memberlistmesh/clusterpb
-# github.com/jetstack/cert-manager v1.6.1
+# github.com/jetstack/cert-manager v1.6.2
 ## explicit; go 1.17
 github.com/jetstack/cert-manager/pkg/apis/acme
 github.com/jetstack/cert-manager/pkg/apis/acme/v1


### PR DESCRIPTION
Should anyone be curious why I am not bumping to 1.7.0, it is because 1.7.0 removes the code for parsing earlier CRD versions meaning if any certificate stored in etcd with those older versions, they will be gone. Want to see how this plays out before forcing our users onto something like that. Many probably migrated from very old self-managed cert managers and then migrated to our addon.