### PR TITLE
Replace deprecated aws.BackgroundContext with context.Background

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -17,6 +17,7 @@ limitations under the License.
 package awsup
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -594,7 +595,7 @@ func deregisterInstance(c AWSCloud, i *cloudinstances.CloudInstance) error {
 	loadBalancerNames := aws.StringValueSlice(asgDetails.AutoScalingGroups[0].LoadBalancerNames)
 	targetGroupArns := aws.StringValueSlice(asgDetails.AutoScalingGroups[0].TargetGroupARNs)
 
-	eg, _ := errgroup.WithContext(aws.BackgroundContext())
+	eg, _ := errgroup.WithContext(context.Background())
 
 	if len(loadBalancerNames) != 0 {
 		eg.Go(func() error {


### PR DESCRIPTION
aws.BackgroundContext was intended for go 1.6 and earlier.