### PR TITLE
Automated cherry pick of #13166: JWKS / IRSA: Expose public ACLs to terraform

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
+++ b/tests/integration/update_cluster/aws-lb-controller/kubernetes.tf
@@ -569,6 +569,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
 }
 
 resource "aws_s3_bucket_object" "discovery-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
@@ -593,6 +594,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
 }
 
 resource "aws_s3_bucket_object" "keys-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"

--- a/tests/integration/update_cluster/digit/kubernetes.tf
+++ b/tests/integration/update_cluster/digit/kubernetes.tf
@@ -568,6 +568,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
 }
 
 resource "aws_s3_bucket_object" "discovery-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/123.example.com/.well-known/openid-configuration"
@@ -592,6 +593,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
 }
 
 resource "aws_s3_bucket_object" "keys-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/123.example.com/openid/v1/jwks"

--- a/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/external_dns_irsa/kubernetes.tf
@@ -543,6 +543,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
 }
 
 resource "aws_s3_bucket_object" "discovery-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
@@ -567,6 +568,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
 }
 
 resource "aws_s3_bucket_object" "keys-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"

--- a/tests/integration/update_cluster/irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/irsa/kubernetes.tf
@@ -593,6 +593,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
 }
 
 resource "aws_s3_bucket_object" "discovery-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
@@ -617,6 +618,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
 }
 
 resource "aws_s3_bucket_object" "keys-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/kubernetes.tf
@@ -673,6 +673,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
 }
 
 resource "aws_s3_bucket_object" "discovery-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
@@ -697,6 +698,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
 }
 
 resource "aws_s3_bucket_object" "keys-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"

--- a/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
+++ b/tests/integration/update_cluster/public-jwks-apiserver/kubernetes.tf
@@ -543,6 +543,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
 }
 
 resource "aws_s3_bucket_object" "discovery-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
@@ -567,6 +568,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
 }
 
 resource "aws_s3_bucket_object" "keys-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"

--- a/tests/integration/update_cluster/vfs-said/kubernetes.tf
+++ b/tests/integration/update_cluster/vfs-said/kubernetes.tf
@@ -517,6 +517,7 @@ resource "aws_s3_bucket_object" "cluster-completed-spec" {
 }
 
 resource "aws_s3_bucket_object" "discovery-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_discovery.json_content")
   key                    = "discovery.example.com/minimal.example.com/.well-known/openid-configuration"
@@ -541,6 +542,7 @@ resource "aws_s3_bucket_object" "etcd-cluster-spec-main" {
 }
 
 resource "aws_s3_bucket_object" "keys-json" {
+  acl                    = "public-read"
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_bucket_object_keys.json_content")
   key                    = "discovery.example.com/minimal.example.com/openid/v1/jwks"


### PR DESCRIPTION
Cherry pick of #13166 on release-1.22.

#13166: JWKS / IRSA: Expose public ACLs to terraform

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.