### PR TITLE
Add support for AB tests starting out with released kops version

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -66,9 +66,10 @@ func (d *deployer) verifyBuildFlags() error {
 		}
 		d.StageLocation = stageLocation
 	}
-	if d.KopsBaseURL == "" {
+	if d.KopsBaseURL == "" && os.Getenv("KOPS_BASE_URL") == "" {
 		d.KopsBaseURL = strings.Replace(d.StageLocation, "gs://", "https://storage.googleapis.com/", 1)
 	}
+
 	fi, err := os.Stat(d.KopsRoot)
 	if err != nil {
 		return err

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -156,19 +156,6 @@ func (d *deployer) verifyKopsFlags() error {
 		return errors.New("missing required --kops-binary-path when --kops-version-marker is not used")
 	}
 
-	// when we use a binary path, we want to use the corresponding nodeup et.al
-	if d.KopsBinaryPath != "" {
-		baseUrl := os.Getenv("KOPS_BASE_URL")
-		if baseUrl == "" {
-			stageLocation, err := defaultStageLocation(d.KopsRoot)
-			if err != nil {
-				return err
-			}
-			d.KopsBaseURL = strings.Replace(stageLocation, "gs://", "https://storage.googleapis.com/", 1)
-		}
-
-	}
-
 	switch d.CloudProvider {
 	case "aws":
 	case "gce":

--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -39,9 +39,16 @@ ${KUBETEST2} \
 		--down \
 		--kops-binary-path="${KOPS_B}" || echo "kubetest2 down failed"
 
-KOPS_BASE_URL=$(kops-base-from-marker "${KOPS_VERSION_A}")
-KOPS_A=$(kops-download-from-base)
-KOPS="${KOPS_A}"
+# First kOps version may be a released version. If so, it is prefixed with v
+if [[ "${KOPS_VERSION_A:0:1}" == "v" ]]; then
+  KOPS_BASE_URL=""
+  KOPS_A=$(kops-download-release "$KOPS_VERSION_A")
+  KOPS="${KOPS_A}"
+else
+  KOPS_BASE_URL=$(kops-base-from-marker "${KOPS_VERSION_A}")
+  KOPS_A=$(kops-download-from-base)
+  KOPS="${KOPS_A}"
+fi
 
 ${KUBETEST2} \
 		--up \


### PR DESCRIPTION
We need to get some version -> branch e2e testing in place. This should let us create upgrade tests that starts with a version and ends with a branch CI marker.