### PR TITLE
More descriptive error message when public key file can't be opened

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/template.go
+++ b/tests/e2e/kubetest2-kops/deployer/template.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deployer
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -70,7 +71,7 @@ func (d *deployer) renderTemplate(values map[string]interface{}) error {
 func (d *deployer) templateValues(zones []string, publicIP string) (map[string]interface{}, error) {
 	publicKey, err := os.ReadFile(d.SSHPublicKeyPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading public key file: %q", err)
 	}
 	return map[string]interface{}{
 		"cloudProvider":     d.CloudProvider,


### PR DESCRIPTION
The error looks like:
```
Error: error reading public key file: "open : no such file or directory"
```
instead of:
```
Error: open : no such file or directory
```