### PR TITLE
Always enable Leader Election for cloud-controller-manager

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -49,6 +49,10 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		return nil
 	}
 
+	// No significant downside to always doing a leader election.
+	// Also, having multiple control plane nodes requires leader election.
+	eccm.LeaderElection = &kops.LeaderElectionConfiguration{LeaderElect: fi.Bool(true)}
+
 	eccm.ClusterName = b.ClusterName
 
 	eccm.ClusterCIDR = clusterSpec.NonMasqueradeCIDR

--- a/pkg/model/components/gcpcloudcontrollermanager.go
+++ b/pkg/model/components/gcpcloudcontrollermanager.go
@@ -45,6 +45,11 @@ func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(options interface
 	if ccmConfig == nil {
 		return nil
 	}
+
+	// No significant downside to always doing a leader election.
+	// Also, having multiple control plane nodes requires leader election.
+	ccmConfig.LeaderElection = &kops.LeaderElectionConfiguration{LeaderElect: fi.Bool(true)}
+
 	// CCM interacts directly with the GCP API, use the name safe for GCP
 	ccmConfig.ClusterName = gce.SafeClusterName(b.ClusterName)
 	ccmConfig.AllocateNodeCIDRs = fi.Bool(true)

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterAutoscaler:
     awsUseStaticInstanceList: false

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -23,6 +23,8 @@ spec:
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterAutoscaler:
     awsUseStaticInstanceList: false

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterAutoscaler:
     awsUseStaticInstanceList: false

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -21,6 +21,8 @@ spec:
     configureCloudRoutes: false
     enableLeaderMigration: true
     image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local
   configBase: memfs://tests/minimal.example.com

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local
   configBase: memfs://clusters.example.com/minimal-ipv6.example.com

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local
   configBase: memfs://clusters.example.com/minimal-ipv6.example.com

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local
   configBase: memfs://clusters.example.com/minimal-ipv6.example.com

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local
   configBase: memfs://clusters.example.com/minimal-ipv6.example.com


### PR DESCRIPTION
... for aws & gcp cloud-controller-manager.
/kind feature

There is no significant downside. Plus, it is required for replicating the controller plane

Note that we already force leader election to be enabled for KCM.