### PR TITLE
Pull k8s-custom-iptables from k8s.gcr.io

### DIFF
--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 836437191be1c5ee97beef4a52eeb0aaad953f217d4c727c26dc92ff5e6c28cd
+    manifestHash: 5c102419027aaf514dffc652de803fd15cf966ec045c0cee47a037762bada484
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -97,7 +97,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: gcr.io/google_containers/k8s-custom-iptables:1.0
+        image: k8s.gcr.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 836437191be1c5ee97beef4a52eeb0aaad953f217d4c727c26dc92ff5e6c28cd
+    manifestHash: 5c102419027aaf514dffc652de803fd15cf966ec045c0cee47a037762bada484
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -97,7 +97,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: gcr.io/google_containers/k8s-custom-iptables:1.0
+        image: k8s.gcr.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: v0.1.12
     manifest: metadata-proxy.addons.k8s.io/v0.1.12.yaml
-    manifestHash: 836437191be1c5ee97beef4a52eeb0aaad953f217d4c727c26dc92ff5e6c28cd
+    manifestHash: 5c102419027aaf514dffc652de803fd15cf966ec045c0cee47a037762bada484
     name: metadata-proxy.addons.k8s.io
     selector:
       k8s-addon: metadata-proxy.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-metadata-proxy.addons.k8s.io-v0.1.12_content
@@ -97,7 +97,7 @@ spec:
           ip addr add dev lo 169.254.169.252/32
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 80 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:988
           iptables -w -t nat -I PREROUTING -p tcp -d 169.254.169.254 ! -i "${PRIMARY_DEV}" --dport 8080 -m comment --comment "metadata-concealment: bridge traffic to metadata server goes to metadata proxy" -j DNAT --to-destination 169.254.169.252:987
-        image: gcr.io/google_containers/k8s-custom-iptables:1.0
+        image: k8s.gcr.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         name: update-ipdtables
         securityContext:

--- a/upup/models/cloudup/resources/addons/metadata-proxy.addons.k8s.io/v0.1.12.yaml
+++ b/upup/models/cloudup/resources/addons/metadata-proxy.addons.k8s.io/v0.1.12.yaml
@@ -48,7 +48,7 @@ spec:
       - name: update-ipdtables
         securityContext:
           privileged: true
-        image: gcr.io/google_containers/k8s-custom-iptables:1.0
+        image: k8s.gcr.io/k8s-custom-iptables:1.0
         imagePullPolicy: Always
         command:
         - "/bin/sh"


### PR DESCRIPTION
This is more correct anyway, but also ensures it will be rewritten
correctly by mirroring.

Only used on GCE.
