### PR TITLE
Add featureflag: ContainerRegistryIsMirror to support nested mirrors

### DIFF
--- a/pkg/assets/BUILD.bazel
+++ b/pkg/assets/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/acls:go_default_library",
         "//pkg/apis/kops:go_default_library",
         "//pkg/apis/kops/util:go_default_library",
+        "//pkg/featureflag:go_default_library",
         "//pkg/kubemanifest:go_default_library",
         "//pkg/values:go_default_library",
         "//util/pkg/hashing:go_default_library",

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -88,6 +88,8 @@ var (
 	AlphaAllowGCE = new("AlphaAllowGCE", Bool(false))
 	// Karpenter enables karpenter-managed Instance Groups
 	Karpenter = new("Karpenter", Bool(false))
+	// ContainerRegistryIsMirror specifies that the containerRegistry supports nested image names (e.g. registry-sandbox.gcr.io)
+	ContainerRegistryIsMirror = new("ContainerRegistryIsMirror", Bool(false))
 )
 
 // FeatureFlag defines a feature flag


### PR DESCRIPTION
We are adding experimental support to validate the proposed
registry-sandbox.k8s.io container mirror / redirector.  We can do this
using the containerRegistry feature, but we want to turn off the
folder "flattening".

With this featureflag:

k8s.gcr.io/foo/bar => (mirror)/foo/bar, not (mirror)/foo-bar
