### PR TITLE
Use short commit sha for default stage location instead of git-describe

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/build.go
+++ b/tests/e2e/kubetest2-kops/deployer/build.go
@@ -92,7 +92,7 @@ func defaultStageLocation(kopsRoot string) (string, error) {
 		jobName = defaultJobName
 	}
 
-	cmd := exec.Command("git", "describe", "--always")
+	cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
 	cmd.SetDir(kopsRoot)
 	output, err := exec.CombinedOutputLines(cmd)
 	if err != nil {


### PR DESCRIPTION
motivation for this is that I can remotely figure out the KOPS_BASE_URL to test a PR without having to locally fetch the branch and run `git describe` myself. With this change, I can just fetch the hash from the GH API.