### PR TITLE
upgrade cluster: support comma separated list for machineType [1.21]

### DIFF
--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/spf13/cobra"
@@ -174,9 +175,14 @@ func (c *UpgradeClusterCmd) Run(ctx context.Context, args []string) error {
 	// Prompt to upgrade image
 	if proposedKubernetesVersion != nil {
 		for _, ig := range instanceGroups {
-			architecture, err := cloudup.MachineArchitecture(cloud, ig.Spec.MachineType)
+			// Before kops v1.23, Spotinst uses the "ig.Spec.MachineType" field as a comma separated list to determine (among other) the allowed spot types.
+			// A list is allowed only if all the items are with the same arch.
+			// Therefore, it should be enough to check the arch for the first (possibly only) item
+			machineType := strings.Split(ig.Spec.MachineType, ",")[0]
+
+			architecture, err := cloudup.MachineArchitecture(cloud, machineType)
 			if err != nil {
-				klog.Warningf("Error finding architecture for machine type %q: %v", ig.Spec.MachineType, err)
+				klog.Warningf("Error finding architecture for machine type %q: %v", machineType, err)
 				continue
 			}
 			image := channel.FindImage(cloud.ProviderID(), *proposedKubernetesVersion, architecture)


### PR DESCRIPTION
Solves #13171 for v1.21

Not needed in v1.23, since instance types for spotinst are moved to `mixedInstancesPolicy`: #12549 
