### PR TITLE
Remove snapshot controller dependency on ebs csi driver

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1640,9 +1640,6 @@ func validateSnapshotController(cluster *kops.Cluster, spec *kops.SnapshotContro
 		if !components.IsCertManagerEnabled(cluster) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("enabled"), "Snapshot controller requires that cert manager is enabled"))
 		}
-		if !hasAWSEBSCSIDriver(cluster.Spec) {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("enabled"), "Snapshot controller requires external CSI Driver"))
-		}
 	}
 	return allErrs
 }


### PR DESCRIPTION
There is no such dependency, and snapshot controller works on other cloud providers and with a host of other CSI drivers