### PR TITLE
Automated cherry pick of #13213: Remove snapshot controller dependency on ebs csi driver

### DIFF
--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -1550,9 +1550,6 @@ func validateSnapshotController(cluster *kops.Cluster, spec *kops.SnapshotContro
 		if !components.IsCertManagerEnabled(cluster) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("enabled"), "Snapshot controller requires that cert manager is enabled"))
 		}
-		if !hasAWSEBSCSIDriver(cluster.Spec) {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("enabled"), "Snapshot controller requires external CSI Driver"))
-		}
 	}
 	return allErrs
 }


### PR DESCRIPTION
Cherry pick of #13213 on release-1.22.

#13213: Remove snapshot controller dependency on ebs csi driver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```