### PR TITLE
Use KUBETEST2_RUN_DIR for binaries if set

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -97,7 +97,7 @@ func (d *deployer) initialize() error {
 				d.boskos,
 				"gce-project",
 				5*time.Minute,
-				5*time.Minute,
+				10*time.Second,
 				d.boskosHeartbeatClose,
 			)
 			if err != nil {

--- a/tests/e2e/pkg/tester/kubectl.go
+++ b/tests/e2e/pkg/tester/kubectl.go
@@ -83,9 +83,14 @@ func (t *Tester) extractBinaries(downloadPath string) (string, error) {
 	}
 	tarReader := tar.NewReader(gzf)
 
-	kubectlDir, err := os.MkdirTemp("", "kubectl")
-	if err != nil {
-		return "", err
+	var kubectlDir string
+	if dir, ok := os.LookupEnv("KUBETEST2_RUN_DIR"); ok {
+		kubectlDir = dir
+	} else {
+		kubectlDir, err = os.MkdirTemp("", "kubectl")
+		if err != nil {
+			return "", err
+		}
 	}
 
 	// this is the expected path of the package inside the tar

--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -467,6 +467,10 @@ func (t *Tester) execute() error {
 
 	t.TestArgs += " --disable-log-dump"
 
+	if dir, ok := os.LookupEnv("KUBETEST2_RUN_DIR"); ok {
+		t.SetRunDir(dir)
+	}
+
 	return t.Test()
 }
 


### PR DESCRIPTION
* Allow the environment variable `KUBETEST2_RUN_DIR` to be used for expected binary locations.
* If set, it is set as the `runDir` in the `execute()` method.  This is similar to what the ginkgo tester does in its `Execute()` method, which we don't use ([ref](https://github.com/kubernetes-sigs/kubetest2/blob/67b31b5cf8c6c559f6d5e6221164210912a6b65d/pkg/testers/ginkgo/ginkgo.go#L179-L182)). 
* This makes it easier to use `--use-built-binaries` in the ginkgo kubetest2 tester.
* This requires a change to kubetest2 to allow us to set `runDir` via a new `SetRunDir()` method (see https://github.com/kubernetes-sigs/kubetest2/pull/182)