### PR TITLE
fix KCM LogLevel setting not honored

### DIFF
--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -105,7 +105,9 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 		kcm.CloudProvider = "external"
 	}
 
-	kcm.LogLevel = 2
+	if kcm.LogLevel == 0 {
+		kcm.LogLevel = 2
+	}
 
 	image, err := Image("kube-controller-manager", clusterSpec, b.AssetBuilder)
 	if err != nil {


### PR DESCRIPTION
The LogLevel was forced to be 2, which can be painful for troubleshooting. Changed to make it default to 2 but the value will be honored if set.

Downside is that there is no way to disable logging by setting `-v=0`. However muting logging should be rarely used.