### PR TITLE
CCM: use flagbuilder instead of manually building argv

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
-        - --v=2
-        - --cloud-provider=aws
-        - --cluster-name=minimal.example.com
-        - --cluster-cidr=172.20.0.0/16
         - --allocate-node-cidrs=true
+        - --cloud-provider=aws
+        - --cluster-cidr=172.20.0.0/16
+        - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
+        - --leader-elect=true
+        - --v=2
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ae683eed17198064263bec40e7c714f9421df2cf4ccfa9c25fa1171f17cfca18
+    manifestHash: 125c0926d4419badcfbb37a158c43ae76082af8ec0a2ad8472fe23c589db8f21
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
-        - --v=2
-        - --cloud-provider=aws
-        - --cluster-name=minimal.example.com
-        - --cluster-cidr=172.20.0.0/16
         - --allocate-node-cidrs=true
+        - --cloud-provider=aws
+        - --cluster-cidr=172.20.0.0/16
+        - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
+        - --leader-elect=true
+        - --v=2
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -125,7 +125,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 6ac9bc109e0c0fb54f2e887d10c3e8aea9dfbfcfeb2905f9b65d3e3d80e7ed23
+    manifestHash: 9f5f6f62f1171ae165d4978430d8b2eab07a93b617ae558bf281b92d78b2bc31
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
-        - --v=2
-        - --cloud-provider=aws
-        - --cluster-name=minimal.example.com
-        - --cluster-cidr=172.20.0.0/16
         - --allocate-node-cidrs=true
+        - --cloud-provider=aws
+        - --cluster-cidr=172.20.0.0/16
+        - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
+        - --leader-elect=true
+        - --v=2
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ff34946cf705444d6c43c3b4b17867cb85515f4d9257aac3ab126b2b6e9c1bde
+    manifestHash: 93c0e2452f299c6ebddf79d23d6830ddea81e4dd3ada6e2fed6b3e8d3c18de75
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,14 @@ spec:
     spec:
       containers:
       - args:
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=100.64.0.0/10
+        - --cluster-name=minimal.example.com
+        - --configure-cloud-routes=false
+        - --enable-leader-migration=true
+        - --leader-elect=true
         - --v=2
         - --cloud-provider=aws
-        - --cluster-name=minimal.example.com
-        - --cluster-cidr=100.64.0.0/10
-        - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: bae54c3f6353d5ce5935a6b767446d7ed402cb2e73247d4d736f4b4163533651
+    manifestHash: 6c9f3428adbcc61c3789eb32b6e3002212f0bb97ff0d5464c05779f7e7293b0c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=::/0
+        - --cluster-name=minimal-ipv6.example.com
+        - --configure-cloud-routes=false
+        - --leader-elect=true
         - --v=2
         - --cloud-provider=aws
-        - --cluster-name=minimal-ipv6.example.com
-        - --cluster-cidr=::/0
-        - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2177fcb1b508f6e280e888dd76cc8ac82847df6c25781e7ee90d563955a3cd9d
+    manifestHash: 46ccd369b04143630c18f81b14485c00c71e402567465991e2f089bac64a742d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=::/0
+        - --cluster-name=minimal-ipv6.example.com
+        - --configure-cloud-routes=false
+        - --leader-elect=true
         - --v=2
         - --cloud-provider=aws
-        - --cluster-name=minimal-ipv6.example.com
-        - --cluster-cidr=::/0
-        - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2177fcb1b508f6e280e888dd76cc8ac82847df6c25781e7ee90d563955a3cd9d
+    manifestHash: 46ccd369b04143630c18f81b14485c00c71e402567465991e2f089bac64a742d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=::/0
+        - --cluster-name=minimal-ipv6.example.com
+        - --configure-cloud-routes=false
+        - --leader-elect=true
         - --v=2
         - --cloud-provider=aws
-        - --cluster-name=minimal-ipv6.example.com
-        - --cluster-cidr=::/0
-        - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b51a1eff1e3e891fd84e41c2c489c4f8089fb4b33a5c5a5489e60cd0a98f1b90
+    manifestHash: 594fb80c7d8fe36b3d6cb177ba5583dd5aed11e0b18b0227104c4c6849526b94
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=::/0
+        - --cluster-name=minimal-ipv6.example.com
+        - --configure-cloud-routes=false
+        - --leader-elect=true
         - --v=2
         - --cloud-provider=aws
-        - --cluster-name=minimal-ipv6.example.com
-        - --cluster-cidr=::/0
-        - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2177fcb1b508f6e280e888dd76cc8ac82847df6c25781e7ee90d563955a3cd9d
+    manifestHash: 46ccd369b04143630c18f81b14485c00c71e402567465991e2f089bac64a742d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/client/simple:go_default_library",
         "//pkg/dns:go_default_library",
         "//pkg/featureflag:go_default_library",
+        "//pkg/flagbuilder:go_default_library",
         "//pkg/kubemanifest:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/model/awsmodel:go_default_library",

--- a/upup/pkg/fi/cloudup/template_functions_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_test.go
@@ -77,8 +77,8 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			},
 			expectedArgv: []string{
-				"--v=3",
 				"--cloud-provider=openstack",
+				"--v=3",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -103,9 +103,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--cluster-name=k8s",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--cluster-name=k8s",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -135,9 +135,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--cluster-cidr=10.0.0.0/24",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--cluster-cidr=10.0.0.0/24",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -151,9 +151,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--allocate-node-cidrs=true",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--allocate-node-cidrs=true",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -167,9 +167,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--configure-cloud-routes=true",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--configure-cloud-routes=true",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -183,9 +183,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--cidr-allocator-type=RangeAllocator",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--cidr-allocator-type=RangeAllocator",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -199,9 +199,43 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--use-service-account-credentials=false",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--use-service-account-credentials=false",
+				"--cloud-config=/etc/kubernetes/cloud.config",
+			},
+		},
+		{
+			desc: "Leader Election",
+			cluster: &kops.Cluster{Spec: kops.ClusterSpec{
+				CloudProvider: string(kops.CloudProviderOpenstack),
+				ExternalCloudControllerManager: &kops.CloudControllerManagerConfig{
+					LeaderElection: &kops.LeaderElectionConfiguration{LeaderElect: fi.Bool(true)},
+				},
+			}},
+			expectedArgv: []string{
+				"--leader-elect=true",
+				"--v=2",
+				"--cloud-provider=openstack",
+				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
+			},
+		},
+		{
+			desc: "Leader Migration",
+			cluster: &kops.Cluster{Spec: kops.ClusterSpec{
+				CloudProvider: string(kops.CloudProviderOpenstack),
+				ExternalCloudControllerManager: &kops.CloudControllerManagerConfig{
+					LeaderElection:        &kops.LeaderElectionConfiguration{LeaderElect: fi.Bool(true)},
+					EnableLeaderMigration: fi.Bool(true),
+				},
+			}},
+			expectedArgv: []string{
+				"--enable-leader-migration=true",
+				"--leader-elect=true",
+				"--v=2",
+				"--cloud-provider=openstack",
+				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
-        - --v=2
-        - --cloud-provider=aws
-        - --cluster-name=minimal.example.com
-        - --cluster-cidr=100.64.0.0/10
         - --allocate-node-cidrs=true
+        - --cloud-provider=aws
+        - --cluster-cidr=100.64.0.0/10
+        - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
+        - --leader-elect=true
+        - --v=2
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 391449812abe527c7507ac098bc5c6169ba582a173655580831c4c424ed55161
+    manifestHash: c9f7e02d1cbd9645b36bb875cd79639bb619bd7d649fa7970b0f5022b62d8744
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
Because CCM did not use flagbuilder, flags defined in the configuration were not applied. Rewrite the argv building to use standard approach.  Also reorder flags in tests, and add tests for other flags.

/kind feature