### PR TITLE
always enable Leader Election for openstack CCM

### DIFF
--- a/pkg/model/components/openstack.go
+++ b/pkg/model/components/openstack.go
@@ -59,7 +59,12 @@ func (b *OpenStackOptionsBulder) BuildOptions(o interface{}) error {
 	}
 
 	if clusterSpec.ExternalCloudControllerManager == nil {
-		clusterSpec.ExternalCloudControllerManager = &kops.CloudControllerManagerConfig{}
+		clusterSpec.ExternalCloudControllerManager = &kops.CloudControllerManagerConfig{
+			// No significant downside to always doing a leader election.
+			// Also, having a replicated (HA) control plane requires leader election.
+			LeaderElection: &kops.LeaderElectionConfiguration{LeaderElect: fi.Bool(true)},
+		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
Leader Election is a must-have for replicated/HA control plane.

Kind of scary to think of current HA clusters running without leader election.

Needs https://github.com/kubernetes/kops/pull/13219 to be merged first.