### PR TITLE
Automated cherry pick of #13187: always enable Leader Election
#13219: use pkg/flagbuilder to build argv

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -49,6 +49,10 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		return nil
 	}
 
+	// No significant downside to always doing a leader election.
+	// Also, having multiple control plane nodes requires leader election.
+	eccm.LeaderElection = &kops.LeaderElectionConfiguration{LeaderElect: fi.Bool(true)}
+
 	eccm.ClusterName = b.ClusterName
 
 	eccm.ClusterCIDR = clusterSpec.NonMasqueradeCIDR

--- a/pkg/model/components/gcpcloudcontrollermanager.go
+++ b/pkg/model/components/gcpcloudcontrollermanager.go
@@ -45,6 +45,11 @@ func (b *GCPCloudControllerManagerOptionsBuilder) BuildOptions(options interface
 	if ccmConfig == nil {
 		return nil
 	}
+
+	// No significant downside to always doing a leader election.
+	// Also, having multiple control plane nodes requires leader election.
+	ccmConfig.LeaderElection = &kops.LeaderElectionConfiguration{LeaderElect: fi.Bool(true)}
+
 	// CCM interacts directly with the GCP API, use the name safe for GCP
 	ccmConfig.ClusterName = gce.SafeClusterName(b.ClusterName)
 	ccmConfig.AllocateNodeCIDRs = fi.Bool(true)

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterAutoscaler:
     awsUseStaticInstanceList: false

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
-        - --v=2
-        - --cloud-provider=aws
-        - --cluster-name=minimal.example.com
-        - --cluster-cidr=172.20.0.0/16
         - --allocate-node-cidrs=true
+        - --cloud-provider=aws
+        - --cluster-cidr=172.20.0.0/16
+        - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
+        - --leader-elect=true
+        - --v=2
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ae683eed17198064263bec40e7c714f9421df2cf4ccfa9c25fa1171f17cfca18
+    manifestHash: 125c0926d4419badcfbb37a158c43ae76082af8ec0a2ad8472fe23c589db8f21
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterAutoscaler:
     awsUseStaticInstanceList: false

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
-        - --v=2
-        - --cloud-provider=aws
-        - --cluster-name=minimal.example.com
-        - --cluster-cidr=172.20.0.0/16
         - --allocate-node-cidrs=true
+        - --cloud-provider=aws
+        - --cluster-cidr=172.20.0.0/16
+        - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
+        - --leader-elect=true
+        - --v=2
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: ff34946cf705444d6c43c3b4b17867cb85515f4d9257aac3ab126b2b6e9c1bde
+    manifestHash: 93c0e2452f299c6ebddf79d23d6830ddea81e4dd3ada6e2fed6b3e8d3c18de75
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local
   configBase: memfs://clusters.example.com/minimal-ipv6.example.com

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=::/0
+        - --cluster-name=minimal-ipv6.example.com
+        - --configure-cloud-routes=false
+        - --leader-elect=true
         - --v=2
         - --cloud-provider=aws
-        - --cluster-name=minimal-ipv6.example.com
-        - --cluster-cidr=::/0
-        - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2177fcb1b508f6e280e888dd76cc8ac82847df6c25781e7ee90d563955a3cd9d
+    manifestHash: 46ccd369b04143630c18f81b14485c00c71e402567465991e2f089bac64a742d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local
   configBase: memfs://clusters.example.com/minimal-ipv6.example.com

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=::/0
+        - --cluster-name=minimal-ipv6.example.com
+        - --configure-cloud-routes=false
+        - --leader-elect=true
         - --v=2
         - --cloud-provider=aws
-        - --cluster-name=minimal-ipv6.example.com
-        - --cluster-cidr=::/0
-        - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2177fcb1b508f6e280e888dd76cc8ac82847df6c25781e7ee90d563955a3cd9d
+    manifestHash: 46ccd369b04143630c18f81b14485c00c71e402567465991e2f089bac64a742d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local
   configBase: memfs://clusters.example.com/minimal-ipv6.example.com

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=::/0
+        - --cluster-name=minimal-ipv6.example.com
+        - --configure-cloud-routes=false
+        - --leader-elect=true
         - --v=2
         - --cloud-provider=aws
-        - --cluster-name=minimal-ipv6.example.com
-        - --cluster-cidr=::/0
-        - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2177fcb1b508f6e280e888dd76cc8ac82847df6c25781e7ee90d563955a3cd9d
+    manifestHash: 46ccd369b04143630c18f81b14485c00c71e402567465991e2f089bac64a742d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -25,6 +25,8 @@ spec:
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
     image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    leaderElection:
+      leaderElect: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local
   configBase: memfs://clusters.example.com/minimal-ipv6.example.com

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=::/0
+        - --cluster-name=minimal-ipv6.example.com
+        - --configure-cloud-routes=false
+        - --leader-elect=true
         - --v=2
         - --cloud-provider=aws
-        - --cluster-name=minimal-ipv6.example.com
-        - --cluster-cidr=::/0
-        - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2177fcb1b508f6e280e888dd76cc8ac82847df6c25781e7ee90d563955a3cd9d
+    manifestHash: 46ccd369b04143630c18f81b14485c00c71e402567465991e2f089bac64a742d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/client/simple:go_default_library",
         "//pkg/dns:go_default_library",
         "//pkg/featureflag:go_default_library",
+        "//pkg/flagbuilder:go_default_library",
         "//pkg/kubemanifest:go_default_library",
         "//pkg/model:go_default_library",
         "//pkg/model/alimodel:go_default_library",

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/dns"
 	"k8s.io/kops/pkg/featureflag"
+	"k8s.io/kops/pkg/flagbuilder"
 	"k8s.io/kops/pkg/kubemanifest"
 	"k8s.io/kops/pkg/model"
 	"k8s.io/kops/pkg/model/components/kopscontroller"
@@ -354,41 +355,28 @@ func (tf *TemplateFunctions) CloudControllerConfigArgv() ([]string, error) {
 	if cluster.Spec.ExternalCloudControllerManager == nil {
 		return nil, fmt.Errorf("ExternalCloudControllerManager is nil")
 	}
-	var argv []string
 
-	if cluster.Spec.ExternalCloudControllerManager.Master != "" {
-		argv = append(argv, fmt.Sprintf("--master=%s", cluster.Spec.ExternalCloudControllerManager.Master))
+	argv, err := flagbuilder.BuildFlagsList(cluster.Spec.ExternalCloudControllerManager)
+	if err != nil {
+		return nil, err
 	}
-	if cluster.Spec.ExternalCloudControllerManager.LogLevel != 0 {
-		argv = append(argv, fmt.Sprintf("--v=%d", cluster.Spec.ExternalCloudControllerManager.LogLevel))
-	} else {
+
+	// default verbosity to 2
+	if cluster.Spec.ExternalCloudControllerManager.LogLevel == 0 {
 		argv = append(argv, "--v=2")
 	}
-	if cluster.Spec.ExternalCloudControllerManager.CloudProvider != "" {
-		argv = append(argv, fmt.Sprintf("--cloud-provider=%s", cluster.Spec.ExternalCloudControllerManager.CloudProvider))
-	} else if cluster.Spec.CloudProvider != "" {
-		argv = append(argv, fmt.Sprintf("--cloud-provider=%s", cluster.Spec.CloudProvider))
-	} else {
-		return nil, fmt.Errorf("Cloud Provider is not set")
+
+	// take the cloud provider value from clusterSpec if unset
+	if cluster.Spec.ExternalCloudControllerManager.CloudProvider == "" {
+		if cluster.Spec.CloudProvider != "" {
+			argv = append(argv, fmt.Sprintf("--cloud-provider=%s", cluster.Spec.CloudProvider))
+		} else {
+			return nil, fmt.Errorf("Cloud Provider is not set")
+		}
 	}
-	if cluster.Spec.ExternalCloudControllerManager.ClusterName != "" {
-		argv = append(argv, fmt.Sprintf("--cluster-name=%s", cluster.Spec.ExternalCloudControllerManager.ClusterName))
-	}
-	if cluster.Spec.ExternalCloudControllerManager.ClusterCIDR != "" {
-		argv = append(argv, fmt.Sprintf("--cluster-cidr=%s", cluster.Spec.ExternalCloudControllerManager.ClusterCIDR))
-	}
-	if cluster.Spec.ExternalCloudControllerManager.AllocateNodeCIDRs != nil {
-		argv = append(argv, fmt.Sprintf("--allocate-node-cidrs=%t", *cluster.Spec.ExternalCloudControllerManager.AllocateNodeCIDRs))
-	}
-	if cluster.Spec.ExternalCloudControllerManager.ConfigureCloudRoutes != nil {
-		argv = append(argv, fmt.Sprintf("--configure-cloud-routes=%t", *cluster.Spec.ExternalCloudControllerManager.ConfigureCloudRoutes))
-	}
-	if cluster.Spec.ExternalCloudControllerManager.CIDRAllocatorType != nil && *cluster.Spec.ExternalCloudControllerManager.CIDRAllocatorType != "" {
-		argv = append(argv, fmt.Sprintf("--cidr-allocator-type=%s", *cluster.Spec.ExternalCloudControllerManager.CIDRAllocatorType))
-	}
-	if cluster.Spec.ExternalCloudControllerManager.UseServiceAccountCredentials != nil {
-		argv = append(argv, fmt.Sprintf("--use-service-account-credentials=%t", *cluster.Spec.ExternalCloudControllerManager.UseServiceAccountCredentials))
-	} else {
+
+	// default use-service-account-credentials to true
+	if cluster.Spec.ExternalCloudControllerManager.UseServiceAccountCredentials == nil {
 		argv = append(argv, fmt.Sprintf("--use-service-account-credentials=%t", true))
 	}
 

--- a/upup/pkg/fi/cloudup/template_functions_test.go
+++ b/upup/pkg/fi/cloudup/template_functions_test.go
@@ -73,8 +73,8 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			},
 			expectedArgv: []string{
-				"--v=3",
 				"--cloud-provider=openstack",
+				"--v=3",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -99,9 +99,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--cluster-name=k8s",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--cluster-name=k8s",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -131,9 +131,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--cluster-cidr=10.0.0.0/24",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--cluster-cidr=10.0.0.0/24",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -147,9 +147,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--allocate-node-cidrs=true",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--allocate-node-cidrs=true",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -163,9 +163,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--configure-cloud-routes=true",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--configure-cloud-routes=true",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -179,9 +179,9 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--cidr-allocator-type=RangeAllocator",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--cidr-allocator-type=RangeAllocator",
 				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
@@ -195,9 +195,43 @@ func Test_TemplateFunctions_CloudControllerConfigArgv(t *testing.T) {
 				},
 			}},
 			expectedArgv: []string{
+				"--use-service-account-credentials=false",
 				"--v=2",
 				"--cloud-provider=openstack",
-				"--use-service-account-credentials=false",
+				"--cloud-config=/etc/kubernetes/cloud.config",
+			},
+		},
+		{
+			desc: "Leader Election",
+			cluster: &kops.Cluster{Spec: kops.ClusterSpec{
+				CloudProvider: string(kops.CloudProviderOpenstack),
+				ExternalCloudControllerManager: &kops.CloudControllerManagerConfig{
+					LeaderElection: &kops.LeaderElectionConfiguration{LeaderElect: fi.Bool(true)},
+				},
+			}},
+			expectedArgv: []string{
+				"--leader-elect=true",
+				"--v=2",
+				"--cloud-provider=openstack",
+				"--use-service-account-credentials=true",
+				"--cloud-config=/etc/kubernetes/cloud.config",
+			},
+		},
+		{
+			desc: "Leader Migration",
+			cluster: &kops.Cluster{Spec: kops.ClusterSpec{
+				CloudProvider: string(kops.CloudProviderOpenstack),
+				ExternalCloudControllerManager: &kops.CloudControllerManagerConfig{
+					LeaderElection:        &kops.LeaderElectionConfiguration{LeaderElect: fi.Bool(true)},
+					EnableLeaderMigration: fi.Bool(true),
+				},
+			}},
+			expectedArgv: []string{
+				"--enable-leader-migration=true",
+				"--leader-elect=true",
+				"--v=2",
+				"--cloud-provider=openstack",
+				"--use-service-account-credentials=true",
 				"--cloud-config=/etc/kubernetes/cloud.config",
 			},
 		},

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -20,12 +20,13 @@ spec:
     spec:
       containers:
       - args:
-        - --v=2
-        - --cloud-provider=aws
-        - --cluster-name=minimal.example.com
-        - --cluster-cidr=100.64.0.0/10
         - --allocate-node-cidrs=true
+        - --cloud-provider=aws
+        - --cluster-cidr=100.64.0.0/10
+        - --cluster-name=minimal.example.com
         - --configure-cloud-routes=false
+        - --leader-elect=true
+        - --v=2
         - --use-service-account-credentials=true
         - --cloud-config=/etc/kubernetes/cloud.config
         env:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 391449812abe527c7507ac098bc5c6169ba582a173655580831c4c424ed55161
+    manifestHash: c9f7e02d1cbd9645b36bb875cd79639bb619bd7d649fa7970b0f5022b62d8744
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #13187 #13219 on release-1.23.

#13187: always enable Leader Election
#13219: use pkg/flagbuilder to build argv

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.