### PR TITLE
Bump AWS CNI to 1.10.2

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 302d76bd06cc968ba03481ada5a894aa120c7687d7d41a02dd93f83c7a6cbb9f
+    manifestHash: 6f4d332e277fc7902448a11cca2691075541f871b6d3f5a78c3ee1c58d71911e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 6f4d332e277fc7902448a11cca2691075541f871b6d3f5a78c3ee1c58d71911e
+    manifestHash: b889c7d9626ba3edb3aeb476647ccab1d0758706c158d0ced7c2c9365b28f8b6
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: b889c7d9626ba3edb3aeb476647ccab1d0758706c158d0ced7c2c9365b28f8b6
+    manifestHash: 1ac77b31f90e17427e546a0d5a96f35c912d4cdeedd9072d59734e19278d9e95
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -11,14 +11,39 @@ metadata:
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -80,8 +105,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -92,23 +117,15 @@ metadata:
     app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -178,10 +195,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -191,10 +208,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -209,10 +226,10 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/aws-node
-          name: run-dir
         - mountPath: /var/run/dockershim.sock
           name: dockershim
+        - mountPath: /var/run/aws-node
+          name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
       hostNetwork: true
@@ -245,9 +262,6 @@ spec:
           path: /run/containerd/containerd.sock
         name: dockershim
       - hostPath:
-          path: /run/xtables.lock
-        name: xtables-lock
-      - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate
         name: log-dir
@@ -255,22 +269,10 @@ spec:
           path: /var/run/aws-node
           type: DirectoryOrCreate
         name: run-dir
+      - hostPath:
+          path: /run/xtables.lock
+        name: xtables-lock
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.10.2
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -96,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -189,7 +188,6 @@ spec:
         - name: CLUSTER_NAME
           value: minimal.example.com
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
-        imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
@@ -237,8 +235,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
+        - name: ENABLE_IPv6
+          value: "false"
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
-        imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -89,7 +89,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -121,7 +121,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -171,7 +171,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         imagePullPolicy: Always
         livenessProbe:
           exec:
@@ -220,7 +220,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -269,7 +269,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -117,7 +117,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 302d76bd06cc968ba03481ada5a894aa120c7687d7d41a02dd93f83c7a6cbb9f
+    manifestHash: 6f4d332e277fc7902448a11cca2691075541f871b6d3f5a78c3ee1c58d71911e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -117,7 +117,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: b889c7d9626ba3edb3aeb476647ccab1d0758706c158d0ced7c2c9365b28f8b6
+    manifestHash: 1ac77b31f90e17427e546a0d5a96f35c912d4cdeedd9072d59734e19278d9e95
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -117,7 +117,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 6f4d332e277fc7902448a11cca2691075541f871b6d3f5a78c3ee1c58d71911e
+    manifestHash: b889c7d9626ba3edb3aeb476647ccab1d0758706c158d0ced7c2c9365b28f8b6
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -11,14 +11,39 @@ metadata:
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -80,8 +105,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -92,23 +117,15 @@ metadata:
     app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -178,10 +195,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -191,10 +208,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -209,10 +226,10 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/aws-node
-          name: run-dir
         - mountPath: /var/run/dockershim.sock
           name: dockershim
+        - mountPath: /var/run/aws-node
+          name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
       hostNetwork: true
@@ -245,9 +262,6 @@ spec:
           path: /run/containerd/containerd.sock
         name: dockershim
       - hostPath:
-          path: /run/xtables.lock
-        name: xtables-lock
-      - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate
         name: log-dir
@@ -255,22 +269,10 @@ spec:
           path: /var/run/aws-node
           type: DirectoryOrCreate
         name: run-dir
+      - hostPath:
+          path: /run/xtables.lock
+        name: xtables-lock
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.10.2
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -96,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -189,7 +188,6 @@ spec:
         - name: CLUSTER_NAME
           value: minimal.example.com
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
-        imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
@@ -237,8 +235,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
+        - name: ENABLE_IPv6
+          value: "false"
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
-        imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -89,7 +89,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -121,7 +121,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -171,7 +171,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         imagePullPolicy: Always
         livenessProbe:
           exec:
@@ -220,7 +220,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -269,7 +269,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 302d76bd06cc968ba03481ada5a894aa120c7687d7d41a02dd93f83c7a6cbb9f
+    manifestHash: 6f4d332e277fc7902448a11cca2691075541f871b6d3f5a78c3ee1c58d71911e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 6f4d332e277fc7902448a11cca2691075541f871b6d3f5a78c3ee1c58d71911e
+    manifestHash: b889c7d9626ba3edb3aeb476647ccab1d0758706c158d0ced7c2c9365b28f8b6
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: b889c7d9626ba3edb3aeb476647ccab1d0758706c158d0ced7c2c9365b28f8b6
+    manifestHash: 1ac77b31f90e17427e546a0d5a96f35c912d4cdeedd9072d59734e19278d9e95
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -11,14 +11,39 @@ metadata:
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -80,8 +105,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -92,23 +117,15 @@ metadata:
     app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -178,10 +195,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -191,10 +208,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -209,10 +226,10 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/aws-node
-          name: run-dir
         - mountPath: /var/run/dockershim.sock
           name: dockershim
+        - mountPath: /var/run/aws-node
+          name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
       hostNetwork: true
@@ -245,9 +262,6 @@ spec:
           path: /run/containerd/containerd.sock
         name: dockershim
       - hostPath:
-          path: /run/xtables.lock
-        name: xtables-lock
-      - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate
         name: log-dir
@@ -255,22 +269,10 @@ spec:
           path: /var/run/aws-node
           type: DirectoryOrCreate
         name: run-dir
+      - hostPath:
+          path: /run/xtables.lock
+        name: xtables-lock
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.10.2
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -96,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -189,7 +188,6 @@ spec:
         - name: CLUSTER_NAME
           value: minimal.example.com
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
-        imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
@@ -237,8 +235,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
+        - name: ENABLE_IPv6
+          value: "false"
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
-        imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -89,7 +89,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -121,7 +121,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -171,7 +171,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         imagePullPolicy: Always
         livenessProbe:
           exec:
@@ -220,7 +220,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -269,7 +269,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 302d76bd06cc968ba03481ada5a894aa120c7687d7d41a02dd93f83c7a6cbb9f
+    manifestHash: 6f4d332e277fc7902448a11cca2691075541f871b6d3f5a78c3ee1c58d71911e
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 6f4d332e277fc7902448a11cca2691075541f871b6d3f5a78c3ee1c58d71911e
+    manifestHash: b889c7d9626ba3edb3aeb476647ccab1d0758706c158d0ced7c2c9365b28f8b6
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: b889c7d9626ba3edb3aeb476647ccab1d0758706c158d0ced7c2c9365b28f8b6
+    manifestHash: 1ac77b31f90e17427e546a0d5a96f35c912d4cdeedd9072d59734e19278d9e95
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -11,14 +11,39 @@ metadata:
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -80,8 +105,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -92,23 +117,15 @@ metadata:
     app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -178,10 +195,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -191,10 +208,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -209,10 +226,10 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/aws-node
-          name: run-dir
         - mountPath: /var/run/dockershim.sock
           name: dockershim
+        - mountPath: /var/run/aws-node
+          name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
       hostNetwork: true
@@ -245,9 +262,6 @@ spec:
           path: /run/containerd/containerd.sock
         name: dockershim
       - hostPath:
-          path: /run/xtables.lock
-        name: xtables-lock
-      - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate
         name: log-dir
@@ -255,22 +269,10 @@ spec:
           path: /var/run/aws-node
           type: DirectoryOrCreate
         name: run-dir
+      - hostPath:
+          path: /run/xtables.lock
+        name: xtables-lock
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.10.2
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -96,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -189,7 +188,6 @@ spec:
         - name: CLUSTER_NAME
           value: minimal.example.com
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
-        imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
@@ -237,8 +235,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
+        - name: ENABLE_IPv6
+          value: "false"
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
-        imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -89,7 +89,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -121,7 +121,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -171,7 +171,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         imagePullPolicy: Always
         livenessProbe:
           exec:
@@ -220,7 +220,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -269,7 +269,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,4 +1,4 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.9/aws-k8s-cni.yaml
+# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.10/aws-k8s-cni.yaml
 
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -29,7 +29,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -62,7 +62,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -90,7 +90,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"
 spec:
   updateStrategy:
     type: OnDelete
@@ -109,7 +109,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2" }}"
         imagePullPolicy: Always
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
@@ -131,7 +131,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2" }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 61678
@@ -279,4 +279,4 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -235,10 +235,10 @@ spec:
             name: cni-net-dir
           - mountPath: /host/var/log/aws-routed-eni
             name: log-dir
-          - mountPath: /var/run/aws-node
-            name: run-dir
           - mountPath: /var/run/dockershim.sock
             name: dockershim
+          - mountPath: /var/run/aws-node
+            name: run-dir
           - mountPath: /run/xtables.lock
             name: xtables-lock
       volumes:
@@ -251,9 +251,6 @@ spec:
       - name: dockershim
         hostPath:
           path: "{{ if eq .ContainerRuntime "containerd" }}/run/containerd/containerd.sock{{ else }}/var/run/dockershim.sock{{ end }}"
-      - name: xtables-lock
-        hostPath:
-          path: /run/xtables.lock
       - name: log-dir
         hostPath:
           path: /var/log/aws-routed-eni
@@ -262,6 +259,9 @@ spec:
         hostPath:
           path: /var/run/aws-node
           type: DirectoryOrCreate
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,24 +1,43 @@
 # Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.10/aws-k8s-cni.yaml
-
 ---
-# Source: aws-vpc-cni/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+# Source: aws-vpc-cni/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: aws-node
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
     app.kubernetes.io/version: "v1.10.2"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-  - kind: ServiceAccount
-    name: aws-node
-    namespace: kube-system
+---
+# Source: aws-vpc-cni/templates/customresourcedefinition.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: eniconfigs.crd.k8s.amazonaws.com
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.10.2"
+spec:
+  scope: Cluster
+  group: crd.k8s.amazonaws.com
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+  names:
+    plural: eniconfigs
+    singular: eniconfig
+    kind: ENIConfig
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,32 +72,24 @@ rules:
       - '*'
     verbs: ["list", "watch"]
 ---
-# Source: aws-vpc-cni/templates/customresourcedefinition.yaml
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+# Source: aws-vpc-cni/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  name: eniconfigs.crd.k8s.amazonaws.com
+  name: aws-node
   labels:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
     app.kubernetes.io/version: "v1.10.2"
-spec:
-  scope: Cluster
-  group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-  names:
-    plural: eniconfigs
-    singular: eniconfig
-    kind: ENIConfig
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+  - kind: ServiceAccount
+    name: aws-node
+    namespace: kube-system
 ---
 # Source: aws-vpc-cni/templates/daemonset.yaml
 kind: DaemonSet
@@ -93,7 +104,9 @@ metadata:
     app.kubernetes.io/version: "v1.10.2"
 spec:
   updateStrategy:
-    type: OnDelete
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
   selector:
     matchLabels:
       k8s-app: aws-node
@@ -123,7 +136,6 @@ spec:
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
-
       terminationGracePeriodSeconds: 10
       tolerations:
         - operator: Exists
@@ -141,19 +153,19 @@ spec:
               command:
               - /app/grpc-health-probe
               - -addr=:50051
-              - -connect-timeout=2s
-              - -rpc-timeout=2s
+              - -connect-timeout=5s
+              - -rpc-timeout=5s
             initialDelaySeconds: 60
-            timeoutSeconds: 5
+            timeoutSeconds: 10
           readinessProbe:
             exec:
               command:
               - /app/grpc-health-probe
               - -addr=:50051
-              - -connect-timeout=2s
-              - -rpc-timeout=2s
+              - -connect-timeout=5s
+              - -rpc-timeout=5s
             initialDelaySeconds: 1
-            timeoutSeconds: 5
+            timeoutSeconds: 10
           env:
             {{- range $name, $value := AmazonVpcEnvVars }}
             - "name": "{{ $name }}"
@@ -268,15 +280,3 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
----
-# Source: aws-vpc-cni/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: aws-node
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/instance: aws-vpc-cni
-    k8s-app: aws-node
-    app.kubernetes.io/version: "v1.10.2"

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,4 +1,4 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.10/aws-k8s-cni.yaml
+# Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.10/config/master/aws-k8s-cni.yaml
 ---
 # Source: aws-vpc-cni/templates/serviceaccount.yaml
 apiVersion: v1
@@ -67,7 +67,7 @@ rules:
     resources:
       - nodes
     verbs: ["list", "watch", "get", "update"]
-  - apiGroups: ["extensions", "apps"]
+  - apiGroups: ["extensions"]
     resources:
       - '*'
     verbs: ["list", "watch"]
@@ -123,14 +123,11 @@ spec:
       initContainers:
       - name: aws-vpc-cni-init
         image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2" }}"
-        imagePullPolicy: Always
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
-          {{- if IsIPv6Only }}
           - name: ENABLE_IPv6
-            value: "true"
-          {{- end }}
+            value: "{{ IsIPv6Only }}"
         securityContext:
             privileged: true
         volumeMounts:
@@ -144,7 +141,6 @@ spec:
       containers:
         - name: aws-node
           image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2" }}"
-          imagePullPolicy: Always
           ports:
             - containerPort: 61678
               name: metrics

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: d64882a03f56d8d3d6e2005d4836afd7ad5b7caa5b70d5318044219d0108742a
+    manifestHash: b6a1854acab634178c8b597174227ec544af6d58614dfd85b5d192305cdbc590
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: d4b0e9e79cc423d88692001ecb77f67a180b79635d111902db562fefc0b7e05f
+    manifestHash: d64882a03f56d8d3d6e2005d4836afd7ad5b7caa5b70d5318044219d0108742a
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e1481a4e469c4be8ef19de5bdf81e5bc852dfc2376bdf6b8b1ecc7c5dccd8e64
+    manifestHash: d4b0e9e79cc423d88692001ecb77f67a180b79635d111902db562fefc0b7e05f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -89,7 +89,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -121,7 +121,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -175,7 +175,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         imagePullPolicy: Always
         livenessProbe:
           exec:
@@ -224,7 +224,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -273,7 +273,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -96,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -193,7 +192,6 @@ spec:
         - name: CLUSTER_NAME
           value: minimal.example.com
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
-        imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
@@ -241,8 +239,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
+        - name: ENABLE_IPv6
+          value: "false"
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
-        imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -11,14 +11,39 @@ metadata:
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -80,8 +105,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -92,23 +117,15 @@ metadata:
     app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -182,10 +199,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -195,10 +212,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -213,10 +230,10 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/aws-node
-          name: run-dir
         - mountPath: /var/run/dockershim.sock
           name: dockershim
+        - mountPath: /var/run/aws-node
+          name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
       hostNetwork: true
@@ -249,9 +266,6 @@ spec:
           path: /run/containerd/containerd.sock
         name: dockershim
       - hostPath:
-          path: /run/xtables.lock
-        name: xtables-lock
-      - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate
         name: log-dir
@@ -259,22 +273,10 @@ spec:
           path: /var/run/aws-node
           type: DirectoryOrCreate
         name: run-dir
+      - hostPath:
+          path: /run/xtables.lock
+        name: xtables-lock
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.10.2
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: d64882a03f56d8d3d6e2005d4836afd7ad5b7caa5b70d5318044219d0108742a
+    manifestHash: b6a1854acab634178c8b597174227ec544af6d58614dfd85b5d192305cdbc590
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: d4b0e9e79cc423d88692001ecb77f67a180b79635d111902db562fefc0b7e05f
+    manifestHash: d64882a03f56d8d3d6e2005d4836afd7ad5b7caa5b70d5318044219d0108742a
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e1481a4e469c4be8ef19de5bdf81e5bc852dfc2376bdf6b8b1ecc7c5dccd8e64
+    manifestHash: d4b0e9e79cc423d88692001ecb77f67a180b79635d111902db562fefc0b7e05f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -31,7 +31,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -89,7 +89,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: eniconfigs.crd.k8s.amazonaws.com
@@ -121,7 +121,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -175,7 +175,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         imagePullPolicy: Always
         livenessProbe:
           exec:
@@ -224,7 +224,7 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
@@ -273,7 +273,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -96,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -193,7 +192,6 @@ spec:
         - name: CLUSTER_NAME
           value: minimal.example.com
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
-        imagePullPolicy: Always
         livenessProbe:
           exec:
             command:
@@ -241,8 +239,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
+        - name: ENABLE_IPv6
+          value: "false"
         image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
-        imagePullPolicy: Always
         name: aws-vpc-cni-init
         securityContext:
           privileged: true

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -11,14 +11,39 @@ metadata:
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -80,8 +105,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -92,23 +117,15 @@ metadata:
     app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -182,10 +199,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -195,10 +212,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -213,10 +230,10 @@ spec:
           name: cni-net-dir
         - mountPath: /host/var/log/aws-routed-eni
           name: log-dir
-        - mountPath: /var/run/aws-node
-          name: run-dir
         - mountPath: /var/run/dockershim.sock
           name: dockershim
+        - mountPath: /var/run/aws-node
+          name: run-dir
         - mountPath: /run/xtables.lock
           name: xtables-lock
       hostNetwork: true
@@ -249,9 +266,6 @@ spec:
           path: /run/containerd/containerd.sock
         name: dockershim
       - hostPath:
-          path: /run/xtables.lock
-        name: xtables-lock
-      - hostPath:
           path: /var/log/aws-routed-eni
           type: DirectoryOrCreate
         name: log-dir
@@ -259,22 +273,10 @@ spec:
           path: /var/run/aws-node
           type: DirectoryOrCreate
         name: run-dir
+      - hostPath:
+          path: /run/xtables.lock
+        name: xtables-lock
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.10.2
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate


### PR DESCRIPTION
Version 1.10.2 was released 4 days ago - https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.10.2