### PR TITLE
Automated cherry pick of #13188: Minor fix for json response to keep it consistent for single

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -692,7 +692,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 			}
 			return nil
 		case OutputJSON:
-			if err := fullOutputJSON(out, obj...); err != nil {
+			if err := fullOutputJSON(out, true, obj...); err != nil {
 				return fmt.Errorf("error writing cluster json to stdout: %v", err)
 			}
 			return nil

--- a/cmd/kops/create_instancegroup.go
+++ b/cmd/kops/create_instancegroup.go
@@ -221,7 +221,7 @@ func RunCreateInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer,
 			}
 			return nil
 		case OutputJSON:
-			if err := fullOutputJSON(out, ig); err != nil {
+			if err := fullOutputJSON(out, true, ig); err != nil {
 				return fmt.Errorf("error writing cluster json to stdout: %v", err)
 			}
 			return nil

--- a/cmd/kops/get.go
+++ b/cmd/kops/get.go
@@ -158,7 +158,7 @@ func RunGet(ctx context.Context, f commandutils.Factory, out io.Writer, options 
 		return nil
 
 	case OutputJSON:
-		if err := fullOutputJSON(out, allObjects...); err != nil {
+		if err := fullOutputJSON(out, false, allObjects...); err != nil {
 			return fmt.Errorf("error writing json to stdout: %v", err)
 		}
 		return nil

--- a/cmd/kops/get_instancegroups.go
+++ b/cmd/kops/get_instancegroups.go
@@ -113,8 +113,12 @@ func RunGetInstanceGroups(ctx context.Context, f commandutils.Factory, out io.Wr
 		return err
 	}
 
+	singleObject := false
+
 	if len(instancegroups) == 0 {
 		return fmt.Errorf("no InstanceGroup objects found")
+	} else if len(instancegroups) == 1 {
+		singleObject = true
 	}
 
 	var obj []runtime.Object
@@ -130,7 +134,7 @@ func RunGetInstanceGroups(ctx context.Context, f commandutils.Factory, out io.Wr
 	case OutputYaml:
 		return fullOutputYAML(out, obj...)
 	case OutputJSON:
-		return fullOutputJSON(out, obj...)
+		return fullOutputJSON(out, singleObject, obj...)
 	default:
 		return fmt.Errorf("unknown output format: %q", options.Output)
 	}

--- a/cmd/kops/toolbox_instance-selector.go
+++ b/cmd/kops/toolbox_instance-selector.go
@@ -332,7 +332,7 @@ func RunToolboxInstanceSelector(ctx context.Context, f *util.Factory, out io.Wri
 					return fmt.Errorf("error writing cluster yaml to stdout: %v", err)
 				}
 			case OutputJSON:
-				if err := fullOutputJSON(out, ig); err != nil {
+				if err := fullOutputJSON(out, true, ig); err != nil {
 					return fmt.Errorf("error writing cluster json to stdout: %v", err)
 				}
 			default:

--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -58,6 +58,8 @@ If this flag is used in AWS, it will enable IRSA.
 
 * The `kops rolling-update cluster` command has a new `--drain-timeout` flag for specifying the maximum amount of time to wait when attempting to drain a node. Previously, rolling-updates would attempt to drain a node for an indefinite amount of time. If `--drain-timeout` is not specified, a default of 15 minutes is applied.
 
+* Fix inconsistent output of `kops get clusters -ojson`. This will now always return a list (irrespective of a single or multiple clusters) to keep the format consistent. However, note that `kops get cluster dev.example.com -ojson` will continue to work as previously, and will return a single object.
+
 # Full change list since 1.22.0 release
 
 


### PR DESCRIPTION
Cherry pick of #13188 on release-1.23.

#13188: Minor fix for json response to keep it consistent for single

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```