### PR TITLE
enable pruning for CCM

### DIFF
--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -800,12 +800,13 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*Addon
 				{
 					id := "k8s-1.23"
 					location := key + "/" + id + ".yaml"
-					addons.Add(&channelsapi.AddonSpec{
+					addon := addons.Add(&channelsapi.AddonSpec{
 						Name:     fi.String(key),
 						Manifest: fi.String(location),
 						Selector: map[string]string{"k8s-addon": key},
 						Id:       id,
 					})
+					addon.BuildPrune = true
 				}
 			}
 		}


### PR DESCRIPTION
This will allow pruning CCM addon during a rollback. 

This PR is part of the Leader Migration upgrade/rollback test.