### PR TITLE
allow specify GCP project via env.

### DIFF
--- a/tests/e2e/scenarios/lib/common.sh
+++ b/tests/e2e/scenarios/lib/common.sh
@@ -64,6 +64,10 @@ fi
 KUBETEST2="kubetest2 kops -v=2 --cloud-provider=${CLOUD_PROVIDER} --cluster-name=${CLUSTER_NAME:-} --kops-root=${REPO_ROOT}"
 KUBETEST2="${KUBETEST2} --admin-access=${ADMIN_ACCESS:-} --env=KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS}"
 
+if [[ -n "${GCP_PROJECT-}" ]]; then
+  KUBETEST2="${KUBETEST2} --gcp-project=${GCP_PROJECT}"
+fi
+
 # Always tear-down the cluster when we're done
 function kops-finish {
     # shellcheck disable=SC2153


### PR DESCRIPTION
`kubetest2 kops` require a gcp project even for `--build`, which is not true for other providers. This PR allows setting the project manually (instead of borrowing from boskos) to allow easier local development.