### PR TITLE
KCM should not run with leader migraton when aws ccm is enabled

### DIFF
--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -76,25 +76,29 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 	}
 
 	kcm.ClusterName = b.ClusterName
-	switch kops.CloudProviderID(clusterSpec.CloudProvider) {
-	case kops.CloudProviderAWS:
-		kcm.CloudProvider = "aws"
-
-	case kops.CloudProviderGCE:
-		kcm.CloudProvider = "gce"
-		kcm.ClusterName = gce.SafeClusterName(b.ClusterName)
-
-	case kops.CloudProviderDO:
+	if b.IsKubernetesGTE("1.24") {
 		kcm.CloudProvider = "external"
+	} else {
+		switch kops.CloudProviderID(clusterSpec.CloudProvider) {
+		case kops.CloudProviderAWS:
+			kcm.CloudProvider = "aws"
 
-	case kops.CloudProviderOpenstack:
-		kcm.CloudProvider = "openstack"
+		case kops.CloudProviderGCE:
+			kcm.CloudProvider = "gce"
+			kcm.ClusterName = gce.SafeClusterName(b.ClusterName)
 
-	case kops.CloudProviderAzure:
-		kcm.CloudProvider = "azure"
+		case kops.CloudProviderDO:
+			kcm.CloudProvider = "external"
 
-	default:
-		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)
+		case kops.CloudProviderOpenstack:
+			kcm.CloudProvider = "openstack"
+
+		case kops.CloudProviderAzure:
+			kcm.CloudProvider = "azure"
+
+		default:
+			return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)
+		}
 	}
 
 	if clusterSpec.ExternalCloudControllerManager == nil {

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -196,7 +196,6 @@ kubeControllerManager:
   clusterCIDR: 100.96.0.0/11
   clusterName: minimal.example.com
   configureCloudRoutes: false
-  enableLeaderMigration: true
   featureGates:
     CSIMigrationAWS: "true"
     InTreePluginAWSUnregister: "true"

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -113,7 +113,6 @@ spec:
     clusterCIDR: 100.96.0.0/11
     clusterName: minimal.example.com
     configureCloudRoutes: false
-    enableLeaderMigration: true
     featureGates:
       CSIMigrationAWS: "true"
       InTreePluginAWSUnregister: "true"


### PR DESCRIPTION
AWS CCM is enabled by default in k8s 1.24, and KCM builder is now aware of that and will not enabled leader migration.

Fixes #12723
(again)