### PR TITLE
Do not enable graceful shutdown if k8s version < 1.21

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -744,6 +744,8 @@ spec:
 
 ### Graceful Node Shutdown
 
+{{ kops_feature_table(kops_added_default='1.23', k8s_min='1.21') }}
+
 Graceful node shutdown allows kubelet to prevent instance shutdown until Pods have been safely terminated or a timeout has been reached.
 
 For all CNIs except `amazonaws`, kOps will try to add a 30 second timeout for 30 seconds where the first 20 seconds is reserved for normal Pods and the last 10 seconds for critical Pods. When using `amazonaws` this feature is disabled, as it leads to [leaking ENIs](https://github.com/aws/amazon-vpc-cni-k8s/issues/1223).

--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -12,7 +12,7 @@ This is a document to gather the release notes prior to the release.
 being used, then Kubernetes Node resources will be named after their AWS instance ID instead of their domain name and
 managed subnets will be configured to launch instances with Resource Based Names.
 
-* Support for [ShutdownGracePeriod and ShutdownGracePeriodCriticalPods](https://kubernetes.io/blog/2021/04/21/graceful-node-shutdown-beta/).
+* Support for [ShutdownGracePeriod and ShutdownGracePeriodCriticalPods](https://kubernetes.io/blog/2021/04/21/graceful-node-shutdown-beta/). By default, kOps will set ShutdownGracePeriod to 30 seconds and ShutdownGracePeriodCriticalPods to 10 seconds if the Kubernetes version is above 1.21.
 
 # Breaking changes
 

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -210,7 +210,8 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	// We do not enable graceful shutdown when using amazonaws due to leaking ENIs.
-	if clusterSpec.Kubelet.ShutdownGracePeriod == nil && clusterSpec.Networking.AmazonVPC == nil {
+	// Graceful shutdown is also not available by default on k8s < 1.21
+	if b.IsKubernetesGTE("1.21") && clusterSpec.Kubelet.ShutdownGracePeriod == nil && clusterSpec.Networking.AmazonVPC == nil {
 		clusterSpec.Kubelet.ShutdownGracePeriod = &metav1.Duration{Duration: time.Duration(30 * time.Second)}
 		clusterSpec.Kubelet.ShutdownGracePeriodCriticalPods = &metav1.Duration{Duration: time.Duration(10 * time.Second)}
 	} else if clusterSpec.Networking.AmazonVPC != nil {

--- a/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
+++ b/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
@@ -217,8 +217,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupDriver: systemd
@@ -234,8 +232,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -244,7 +240,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/123.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: J7HDRYAIuJWhdixA+IqT7bOJ1wsUtFkrZ6/iPi1zvlw=
+NodeupConfigHash: xkXj5hf7g25YOcXKMpRcpS4NgLPxLAf47YRt7q5K3qE=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data
+++ b/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data
@@ -152,8 +152,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -162,7 +160,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/123.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 6e98Ytqyqs2WYsctaYSQ0s7jfYGDLqOnKx319Bbmixw=
+NodeupConfigHash: UJn620o4qQOsZQNbWS3AVAv+NSobIxS6Nzo3jLsioiI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -158,8 +158,6 @@ spec:
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.20.0
@@ -179,8 +177,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.123.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -251,8 +251,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/123.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -54,8 +54,6 @@ KubeletConfig:
     node-role.kubernetes.io/node: ""
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/123.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -217,8 +217,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupDriver: systemd
@@ -234,8 +232,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -244,7 +240,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: 5u1o1dFSIN6KiNBeVKxDrB7Zpjs04Od8iZ3ICyw/rrk=
+NodeupConfigHash: GCdBGwZ0l6o9BjDiDc1TtrQ3/hRkti/dJrLCEfZC5Ws=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -152,8 +152,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -162,7 +160,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: yXHJhmdKjCNpUG5Ii6uRBCp+i0YpxyTFnjCN6gRMGwo=
+NodeupConfigHash: svplkzpFwqgG/NmT/+NdFIfn9VcbG6RAPkTbRGBGLq8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -163,8 +163,6 @@ spec:
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.20.0
@@ -184,8 +182,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -251,8 +251,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -54,8 +54,6 @@ KubeletConfig:
     node-role.kubernetes.io/node: ""
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/irsa119/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa119/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -228,8 +228,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupRoot: /
@@ -244,8 +242,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -254,7 +250,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: nQvphE4sW8b7xIY0c6OMWWn9gTcEisgofnNQLnpvnrI=
+NodeupConfigHash: yugCig9gPASCPcVtJsR1ek4Kmq9sr1zhkcCKwOOpwUg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa119/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa119/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -160,8 +160,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -170,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: FdAyEZDPymhWv4tCZIb8I181mfR11//UrLLUzwGEGcs=
+NodeupConfigHash: ggQw8fU8hL+hHWwBNTs/MFZ3Ns2CjFOjegL65szcumY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -174,8 +174,6 @@ spec:
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.19.0
@@ -194,8 +192,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -253,8 +253,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -53,8 +53,6 @@ KubeletConfig:
     node-role.kubernetes.io/node: ""
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
@@ -219,8 +219,6 @@
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterKubelet:
     anonymousAuth: false
     cgroupDriver: systemd
@@ -236,8 +234,6 @@
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
 
   __EOF_CLUSTER_SPEC
 
@@ -246,7 +242,7 @@
   ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
   InstanceGroupName: master-us-test-1a
   InstanceGroupRole: Master
-  NodeupConfigHash: 8uGBpw4KbDSuN88SWoGR6fF2alk7n9h6JScvCz9sYwI=
+  NodeupConfigHash: p1qnqow7b5pLLiw11iGBshHMcudgM/yPr8DsLgwcc0M=
 
   __EOF_KUBE_ENV
 
@@ -407,8 +403,6 @@ Resources.AWSEC2LaunchTemplatenodesnthsqsresourceslongclusternameexamplecom.Prop
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
 
   __EOF_CLUSTER_SPEC
 
@@ -417,7 +411,7 @@ Resources.AWSEC2LaunchTemplatenodesnthsqsresourceslongclusternameexamplecom.Prop
   ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: oL0djrIXylA8CIJjygVvd+wzFrx3i4h4/2XBAwlNILQ=
+  NodeupConfigHash: n5iJXLRDo3rgJQY+RP2ZuVVfTA80DRLaqI9cYvLKxjA=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_master-us-test-1a.masters.nthsqsresources.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_master-us-test-1a.masters.nthsqsresources.longclustername.example.com_user_data
@@ -217,8 +217,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupDriver: systemd
@@ -234,8 +232,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -244,7 +240,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: 8uGBpw4KbDSuN88SWoGR6fF2alk7n9h6JScvCz9sYwI=
+NodeupConfigHash: p1qnqow7b5pLLiw11iGBshHMcudgM/yPr8DsLgwcc0M=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.longclustername.example.com_user_data
@@ -152,8 +152,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -162,7 +160,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: oL0djrIXylA8CIJjygVvd+wzFrx3i4h4/2XBAwlNILQ=
+NodeupConfigHash: n5iJXLRDo3rgJQY+RP2ZuVVfTA80DRLaqI9cYvLKxjA=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -136,8 +136,6 @@ spec:
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.20.0
@@ -157,8 +155,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.nthsqsresources.longclustername.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -251,8 +251,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/nthsqsresources.longclustername.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -54,8 +54,6 @@ KubeletConfig:
     node-role.kubernetes.io/node: ""
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/nthsqsresources.longclustername.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
@@ -224,8 +224,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterKubelet:
     anonymousAuth: false
     cgroupRoot: /
@@ -240,8 +238,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
 
   __EOF_CLUSTER_SPEC
 
@@ -250,7 +246,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
   ConfigBase: memfs://clusters.example.com/privatecilium.example.com
   InstanceGroupName: master-us-test-1a
   InstanceGroupRole: Master
-  NodeupConfigHash: DDzy/t2gCKdvv/Ij+C4Md0+rZYTsVSsclIsdaeH6bhQ=
+  NodeupConfigHash: FcYo+jXX2CHtiQSnsEqP1N/+ssJtONbuxTpv65chq1o=
 
   __EOF_KUBE_ENV
 
@@ -419,8 +415,6 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
 
   __EOF_CLUSTER_SPEC
 
@@ -429,7 +423,7 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
   ConfigBase: memfs://clusters.example.com/privatecilium.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: Auhcri4NZRNAPTv3pc3TlTxJr7q7iHYfgc1XHEO4RKc=
+  NodeupConfigHash: 3nc3P2ho8FpMe+fyURGD/ZqCAhzC9JHHGJdJj1EBiCY=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -222,8 +222,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupRoot: /
@@ -238,8 +236,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -248,7 +244,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: DDzy/t2gCKdvv/Ij+C4Md0+rZYTsVSsclIsdaeH6bhQ=
+NodeupConfigHash: FcYo+jXX2CHtiQSnsEqP1N/+ssJtONbuxTpv65chq1o=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -160,8 +160,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -170,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: Auhcri4NZRNAPTv3pc3TlTxJr7q7iHYfgc1XHEO4RKc=
+NodeupConfigHash: 3nc3P2ho8FpMe+fyURGD/ZqCAhzC9JHHGJdJj1EBiCY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -143,8 +143,6 @@ spec:
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.19.0
@@ -163,8 +161,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.privatecilium.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -247,8 +247,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/privatecilium.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -53,8 +53,6 @@ KubeletConfig:
     node-role.kubernetes.io/node: ""
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/privatecilium.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -228,8 +228,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupRoot: /
@@ -244,8 +242,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -254,7 +250,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: nQvphE4sW8b7xIY0c6OMWWn9gTcEisgofnNQLnpvnrI=
+NodeupConfigHash: yugCig9gPASCPcVtJsR1ek4Kmq9sr1zhkcCKwOOpwUg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -160,8 +160,6 @@ kubelet:
   networkPluginName: cni
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -170,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: FdAyEZDPymhWv4tCZIb8I181mfR11//UrLLUzwGEGcs=
+NodeupConfigHash: ggQw8fU8hL+hHWwBNTs/MFZ3Ns2CjFOjegL65szcumY=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -148,8 +148,6 @@ spec:
     networkPluginName: cni
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.19.0
@@ -168,8 +166,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -253,8 +253,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -53,8 +53,6 @@ KubeletConfig:
     node-role.kubernetes.io/node: ""
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml


### PR DESCRIPTION
Should fix failing tests.