### PR TITLE
Fix nilpointer when graceful shutdown is not configured

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -216,9 +216,12 @@ func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
 }
 
 func buildKubeletComponentConfig(kubeletConfig *kops.KubeletConfigSpec) (*nodetasks.File, error) {
-	componentConfig := kubelet.KubeletConfiguration{
-		ShutdownGracePeriod:             *kubeletConfig.ShutdownGracePeriod,
-		ShutdownGracePeriodCriticalPods: *kubeletConfig.ShutdownGracePeriodCriticalPods,
+	componentConfig := kubelet.KubeletConfiguration{}
+	if kubeletConfig.ShutdownGracePeriod != nil {
+		componentConfig.ShutdownGracePeriod = *kubeletConfig.ShutdownGracePeriod
+	}
+	if kubeletConfig.ShutdownGracePeriodCriticalPods != nil {
+		componentConfig.ShutdownGracePeriodCriticalPods = *kubeletConfig.ShutdownGracePeriodCriticalPods
 	}
 
 	s := runtime.NewScheme()


### PR DESCRIPTION
Should fix the 1.19 test.