### PR TITLE
Automated cherry pick of #13242: Do not enable graceful shutdown if k8s version < 1.21
#13246: Fix nilpointer when graceful shutdown is not configured

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -744,6 +744,8 @@ spec:
 
 ### Graceful Node Shutdown
 
+{{ kops_feature_table(kops_added_default='1.23', k8s_min='1.21') }}
+
 Graceful node shutdown allows kubelet to prevent instance shutdown until Pods have been safely terminated or a timeout has been reached.
 
 For all CNIs except `amazonaws`, kOps will try to add a 30 second timeout for 30 seconds where the first 20 seconds is reserved for normal Pods and the last 10 seconds for critical Pods. When using `amazonaws` this feature is disabled, as it leads to [leaking ENIs](https://github.com/aws/amazon-vpc-cni-k8s/issues/1223).

--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -11,7 +11,7 @@ This is a document to gather the release notes prior to the release.
 * If the Kubernetes version is 1.23 or later and the external AWS Cloud Controller Manager is
 being used, then Kubernetes Node resources will be named after their AWS instance ID instead of their domain name.
 
-* Support for [ShutdownGracePeriod and ShutdownGracePeriodCriticalPods](https://kubernetes.io/blog/2021/04/21/graceful-node-shutdown-beta/).
+* Support for [ShutdownGracePeriod and ShutdownGracePeriodCriticalPods](https://kubernetes.io/blog/2021/04/21/graceful-node-shutdown-beta/). By default, kOps will set ShutdownGracePeriod to 30 seconds and ShutdownGracePeriodCriticalPods to 10 seconds if the Kubernetes version is above 1.21.
 
 # Breaking changes
 

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -179,9 +179,12 @@ func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
 }
 
 func buildKubeletComponentConfig(kubeletConfig *kops.KubeletConfigSpec) (*nodetasks.File, error) {
-	componentConfig := kubelet.KubeletConfiguration{
-		ShutdownGracePeriod:             *kubeletConfig.ShutdownGracePeriod,
-		ShutdownGracePeriodCriticalPods: *kubeletConfig.ShutdownGracePeriodCriticalPods,
+	componentConfig := kubelet.KubeletConfiguration{}
+	if kubeletConfig.ShutdownGracePeriod != nil {
+		componentConfig.ShutdownGracePeriod = *kubeletConfig.ShutdownGracePeriod
+	}
+	if kubeletConfig.ShutdownGracePeriodCriticalPods != nil {
+		componentConfig.ShutdownGracePeriodCriticalPods = *kubeletConfig.ShutdownGracePeriodCriticalPods
 	}
 
 	s := runtime.NewScheme()

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -37,8 +37,8 @@ contents: |
   nodeStatusReportFrequency: 0s
   nodeStatusUpdateFrequency: 0s
   runtimeRequestTimeout: 0s
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
+  shutdownGracePeriod: 0s
+  shutdownGracePeriodCriticalPods: 0s
   streamingConnectionIdleTimeout: 0s
   syncFrequency: 0s
   volumeStatsAggPeriod: 0s

--- a/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
@@ -37,8 +37,8 @@ contents: |
   nodeStatusReportFrequency: 0s
   nodeStatusUpdateFrequency: 0s
   runtimeRequestTimeout: 0s
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
+  shutdownGracePeriod: 0s
+  shutdownGracePeriodCriticalPods: 0s
   streamingConnectionIdleTimeout: 0s
   syncFrequency: 0s
   volumeStatsAggPeriod: 0s

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -216,7 +216,8 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	// We do not enable graceful shutdown when using amazonaws due to leaking ENIs.
-	if clusterSpec.Kubelet.ShutdownGracePeriod == nil && clusterSpec.Networking.AmazonVPC == nil {
+	// Graceful shutdown is also not available by default on k8s < 1.21
+	if b.IsKubernetesGTE("1.21") && clusterSpec.Kubelet.ShutdownGracePeriod == nil && clusterSpec.Networking.AmazonVPC == nil {
 		clusterSpec.Kubelet.ShutdownGracePeriod = &metav1.Duration{Duration: time.Duration(30 * time.Second)}
 		clusterSpec.Kubelet.ShutdownGracePeriodCriticalPods = &metav1.Duration{Duration: time.Duration(10 * time.Second)}
 	} else if clusterSpec.Networking.AmazonVPC != nil {

--- a/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
+++ b/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
@@ -218,8 +218,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupDriver: systemd
@@ -236,8 +234,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -246,7 +242,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/123.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: 9Op78Tu3pc5eypp8vvA0yKQBH3D88NDPrZZJU3GKNfk=
+NodeupConfigHash: 8khDAaeAU735+C4rlMO+AXGMFY+xXciCuXbi8ot81y4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data
+++ b/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data
@@ -153,8 +153,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -163,7 +161,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/123.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: 4dnuk9OehLVqSX4a4STM/6x9jqkRSyDH2Ydfe35tylo=
+NodeupConfigHash: gB02PD7nECaohwisSjTMVHbgVUT3zczemDWz2F9hKR0=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -159,8 +159,6 @@ spec:
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.20.0
@@ -181,8 +179,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.123.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -252,8 +252,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/123.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -55,8 +55,6 @@ KubeletConfig:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/123.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -218,8 +218,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupDriver: systemd
@@ -236,8 +234,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -246,7 +242,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: rbHvJ5YZr9hAKXPmHXctDZuP3s3YXAN032dHms+Mbwk=
+NodeupConfigHash: s/kJN9k/FxUMsTxGnE09IB/49LYliZqBEvT5iggGUF8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -153,8 +153,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -163,7 +161,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: AwPdpsHH8V0a2gN9YnhPXIZVERm4d50FSWe2TmMFbnQ=
+NodeupConfigHash: iRrwh/kwVwPKFlz1frej6HJdvDfONC2bPbuQLjFwpJg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -164,8 +164,6 @@ spec:
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.20.0
@@ -186,8 +184,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -252,8 +252,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -55,8 +55,6 @@ KubeletConfig:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/irsa119/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa119/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -228,8 +228,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupRoot: /
@@ -245,8 +243,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -255,7 +251,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: kzmPbsYhDAJ74Qk8f4jZV5yFFaEn1HnIfmDTE81jufo=
+NodeupConfigHash: jQpgWZ/DvlMsdPWobSQFlkWnjIDnHwN2KLyi5C8i/gc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa119/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa119/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -161,8 +161,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -171,7 +169,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: un54rnz9pX4pTFF/UNeWsLUZpdbJTC+MG1vLEQfStf4=
+NodeupConfigHash: 2k4dSAIrmh5iR2rYE2wVF3BA/SDJIM4XP/05RJzgET8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -174,8 +174,6 @@ spec:
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.19.0
@@ -195,8 +193,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -253,8 +253,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -54,8 +54,6 @@ KubeletConfig:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
@@ -220,8 +220,6 @@
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterKubelet:
     anonymousAuth: false
     cgroupDriver: systemd
@@ -238,8 +236,6 @@
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
 
   __EOF_CLUSTER_SPEC
 
@@ -248,7 +244,7 @@
   ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
   InstanceGroupName: master-us-test-1a
   InstanceGroupRole: Master
-  NodeupConfigHash: BXs2agovC4L+9VgDP1s1eCHEazS6Kvvwcu1rOPK609c=
+  NodeupConfigHash: LzT7pTrMK8MveFAlVWg3DZj4aMWlVBiHOABBV2s3kRI=
 
   __EOF_KUBE_ENV
 
@@ -410,8 +406,6 @@ Resources.AWSEC2LaunchTemplatenodesnthsqsresourceslongclusternameexamplecom.Prop
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
 
   __EOF_CLUSTER_SPEC
 
@@ -420,7 +414,7 @@ Resources.AWSEC2LaunchTemplatenodesnthsqsresourceslongclusternameexamplecom.Prop
   ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: EdLGW0z1uFUPkIbghUjqJLBz/M1KWVFGLl6dHHxZchg=
+  NodeupConfigHash: cDp13EQZwGreb4r3f728YlIFiCrdyEtbRHawih64C5c=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_master-us-test-1a.masters.nthsqsresources.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_master-us-test-1a.masters.nthsqsresources.longclustername.example.com_user_data
@@ -218,8 +218,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupDriver: systemd
@@ -236,8 +234,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -246,7 +242,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: BXs2agovC4L+9VgDP1s1eCHEazS6Kvvwcu1rOPK609c=
+NodeupConfigHash: LzT7pTrMK8MveFAlVWg3DZj4aMWlVBiHOABBV2s3kRI=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.longclustername.example.com_user_data
@@ -153,8 +153,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -163,7 +161,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: EdLGW0z1uFUPkIbghUjqJLBz/M1KWVFGLl6dHHxZchg=
+NodeupConfigHash: cDp13EQZwGreb4r3f728YlIFiCrdyEtbRHawih64C5c=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -137,8 +137,6 @@ spec:
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.20.0
@@ -159,8 +157,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.nthsqsresources.longclustername.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -252,8 +252,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/nthsqsresources.longclustername.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -55,8 +55,6 @@ KubeletConfig:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/nthsqsresources.longclustername.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
@@ -224,8 +224,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterKubelet:
     anonymousAuth: false
     cgroupRoot: /
@@ -241,8 +239,6 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
 
   __EOF_CLUSTER_SPEC
 
@@ -251,7 +247,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Prope
   ConfigBase: memfs://clusters.example.com/privatecilium.example.com
   InstanceGroupName: master-us-test-1a
   InstanceGroupRole: Master
-  NodeupConfigHash: 1qrCecE4+oNr21P2VJdr+OGDWWrTPDvY8QXeopz5/Lc=
+  NodeupConfigHash: rOvxDwVhwvVbV9fuvj+u57YN42HS5huSPAmR9ZFO1M8=
 
   __EOF_KUBE_ENV
 
@@ -421,8 +417,6 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
 
   __EOF_CLUSTER_SPEC
 
@@ -431,7 +425,7 @@ Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemp
   ConfigBase: memfs://clusters.example.com/privatecilium.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: d0mEbEMY91+rTTmi83cuJpwEM9D7u3BiVMQkfCGPKW0=
+  NodeupConfigHash: lZ8j6pCPQ3z7xofTYlmLc0WNkDxw1EWLcy3+hsegLjs=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -222,8 +222,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupRoot: /
@@ -239,8 +237,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -249,7 +245,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: 1qrCecE4+oNr21P2VJdr+OGDWWrTPDvY8QXeopz5/Lc=
+NodeupConfigHash: rOvxDwVhwvVbV9fuvj+u57YN42HS5huSPAmR9ZFO1M8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -161,8 +161,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -171,7 +169,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/privatecilium.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: d0mEbEMY91+rTTmi83cuJpwEM9D7u3BiVMQkfCGPKW0=
+NodeupConfigHash: lZ8j6pCPQ3z7xofTYlmLc0WNkDxw1EWLcy3+hsegLjs=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -143,8 +143,6 @@ spec:
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.18.15
@@ -164,8 +162,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.privatecilium.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -247,8 +247,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/privatecilium.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -56,8 +56,6 @@ KubeletConfig:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/privatecilium.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -228,8 +228,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 masterKubelet:
   anonymousAuth: false
   cgroupRoot: /
@@ -245,8 +243,6 @@ masterKubelet:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -255,7 +251,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: kzmPbsYhDAJ74Qk8f4jZV5yFFaEn1HnIfmDTE81jufo=
+NodeupConfigHash: jQpgWZ/DvlMsdPWobSQFlkWnjIDnHwN2KLyi5C8i/gc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -161,8 +161,6 @@ kubelet:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 
 __EOF_CLUSTER_SPEC
 
@@ -171,7 +169,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: un54rnz9pX4pTFF/UNeWsLUZpdbJTC+MG1vLEQfStf4=
+NodeupConfigHash: 2k4dSAIrmh5iR2rYE2wVF3BA/SDJIM4XP/05RJzgET8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -148,8 +148,6 @@ spec:
     nonMasqueradeCIDR: 100.64.0.0/10
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 0.0.0.0/0
   kubernetesVersion: 1.19.0
@@ -169,8 +167,6 @@ spec:
     podInfraContainerImage: k8s.gcr.io/pause:3.6
     podManifestPath: /etc/kubernetes/manifests
     registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
   masterPublicName: api.minimal.example.com
   networkCIDR: 172.20.0.0/16
   networking:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -253,8 +253,6 @@ KubeletConfig:
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
   registerSchedulable: false
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -54,8 +54,6 @@ KubeletConfig:
   nonMasqueradeCIDR: 100.64.0.0/10
   podInfraContainerImage: k8s.gcr.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
 UpdatePolicy: automatic
 channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml


### PR DESCRIPTION
Cherry pick of #13242 #13246 on release-1.23.

#13242: Do not enable graceful shutdown if k8s version < 1.21
#13246: Fix nilpointer when graceful shutdown is not configured

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```