### PR TITLE
E2E HA Upgrade/Rollback for Leader Migration

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/octago/sflags v0.2.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.1
+	k8s.io/client-go v9.0.0+incompatible
 	k8s.io/klog/v2 v2.30.0
 	k8s.io/kops v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc
@@ -53,6 +55,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gophercloud/gophercloud v0.24.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
@@ -78,6 +81,7 @@ require (
 	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -111,8 +115,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	k8s.io/api v0.23.1 // indirect
-	k8s.io/client-go v9.0.0+incompatible // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/release v0.7.1-0.20210204090829-09fb5e3883b8 // indirect
 	k8s.io/test-infra v0.0.0-20200617221206-ea73eaeab7ff // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -535,6 +535,7 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -870,6 +871,7 @@ github.com/googleapis/gnostic v0.2.2/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
+github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.24.0 h1:jDsIMGJ1KZpAjYfQgGI2coNQj5Q83oPzuiGJRFWgMzw=
@@ -1186,6 +1188,7 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mmarkdown/mmark v2.0.40+incompatible/go.mod h1:Uvmoz7tvsWpr7bMVxIpqZPyN3FbOtzDmnsJDFp7ltJs=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=

--- a/tests/e2e/scenarios/upgrade-ha-leader-migration/cmd/recorder/main.go
+++ b/tests/e2e/scenarios/upgrade-ha-leader-migration/cmd/recorder/main.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+var Namespace = "kube-system"
+var KCMPrefix = "kube-controller-manager"
+var CCMPrefix = "cloud-controller-manager"
+var CheckInterval = 30 * time.Second
+
+func run(ctx context.Context) error {
+	r, err := NewRecorder()
+	if err != nil {
+		return err
+	}
+	ticker := time.NewTicker(CheckInterval)
+	defer ticker.Stop()
+	for {
+		err := r.Observe(ctx)
+		if err != nil {
+			if err == ErrConflictDetected {
+				err = r.Observe(ctx)
+				if err == ErrConflictDetected {
+					klog.ErrorS(err, "conflicts detected twice in a row, test failed")
+					os.Exit(1)
+				}
+			}
+			if err != nil {
+				klog.ErrorS(err, "fail to observe")
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func main() {
+	flag.StringVar(&Namespace, "namespace", Namespace, "the namespace that contains system daemon sets.")
+	flag.StringVar(&KCMPrefix, "kcm", KCMPrefix, "the prefix of KCM pods.")
+	flag.StringVar(&CCMPrefix, "ccm", CCMPrefix, "the prefix of CCM pods.")
+	flag.DurationVar(&CheckInterval, "interval", CheckInterval, "the interval between two checks.")
+	flag.Parse()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	err := run(ctx)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/tests/e2e/scenarios/upgrade-ha-leader-migration/cmd/recorder/recorder.go
+++ b/tests/e2e/scenarios/upgrade-ha-leader-migration/cmd/recorder/recorder.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+	"k8s.io/klog/v2"
+)
+
+const portForwardSubresource = "portforward"
+
+var ErrConflictDetected = fmt.Errorf("conflict detected")
+
+type recorder struct {
+	config         *rest.Config
+	clientset      *kubernetes.Clientset
+	insecureClient *http.Client
+}
+
+type assignment struct {
+	controller string
+	pod        string
+}
+
+// Pods lists pods belonging to KCM and CCM
+// because CCM labels are inconsistent among providers, use the pod name instead
+func (r *recorder) Pods(ctx context.Context) (kcmPods []v1.Pod, ccmPods []v1.Pod, err error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second) // should be a quick request
+	defer cancel()
+	pods, err := r.clientset.CoreV1().Pods(Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+	for _, pod := range pods.Items {
+		if strings.HasPrefix(pod.Name, KCMPrefix) {
+			kcmPods = append(kcmPods, pod)
+			continue
+		}
+		if strings.HasPrefix(pod.Name, CCMPrefix) {
+			ccmPods = append(ccmPods, pod)
+			continue
+		}
+		// we don't care about other pods
+	}
+	return
+}
+
+// healthCheckPort returns the port for /healthz by parsing the livenessProbe
+// field
+func healthCheckPort(pod v1.Pod) (int, error) {
+	if len(pod.Spec.Containers) == 0 {
+		return 0, fmt.Errorf("pod has no container")
+	}
+	container := pod.Spec.Containers[0]
+	if container.LivenessProbe == nil {
+		return 0, fmt.Errorf("container has no liveness probe")
+	}
+	httpGet := container.LivenessProbe.HTTPGet
+	if httpGet == nil {
+		return 0, fmt.Errorf("container has no HttpGet probe")
+	}
+	if httpGet.Port.Type != intstr.Int {
+		return 0, fmt.Errorf("container has no numberic probe port")
+	}
+	return httpGet.Port.IntValue(), nil
+}
+
+func (r *recorder) Observe(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	kcmPods, ccmPods, err := r.Pods(ctx)
+	if err != nil {
+		klog.ErrorS(err, "cannot fetch pods")
+	}
+	klog.InfoS("starting check", "kcm-pods", len(kcmPods), "ccm-pods", len(ccmPods))
+	aChan := make(chan assignment, 128)
+	var wg sync.WaitGroup
+	observe := func(ctx context.Context, pod v1.Pod, counter *int64, aChan chan<- assignment) {
+		defer wg.Done()
+		b, err := r.HealthCheck(ctx, pod)
+		if err != nil {
+			klog.ErrorS(err, "unhealthy", "pod", pod.Name)
+		} else {
+			klog.InfoS("healthy", "pod", pod.Name)
+			controllers, _ := parseHealthz(b)
+			for _, controller := range controllers {
+				aChan <- assignment{
+					controller: controller,
+					pod:        pod.Name,
+				}
+			}
+			atomic.AddInt64(counter, 1)
+		}
+	}
+	var kcmHealthy, ccmHealthy int64
+	wg.Add(len(kcmPods))
+	for _, pod := range kcmPods {
+		go observe(ctx, pod, &kcmHealthy, aChan)
+	}
+	wg.Add(len(ccmPods))
+	for _, pod := range ccmPods {
+		go observe(ctx, pod, &ccmHealthy, aChan)
+	}
+	go func() {
+		wg.Wait()
+		close(aChan)
+	}()
+	assignments := make(map[string][]string) // controller -> pods map
+	for a := range aChan {
+		assignments[a.controller] = append(assignments[a.controller], a.pod)
+	}
+	var conflictingPods sets.String
+	for c, pods := range assignments {
+		if len(pods) == 1 {
+			klog.InfoS("observed", "controller", c, "pods", pods)
+		} else {
+			klog.InfoS("conflict", "controller", c, "pods", pods)
+			conflictingPods.Insert(pods...)
+		}
+	}
+	if conflictingPods.Len() != 0 {
+		klog.InfoS("controller may be running under multiple controller managers", "pods", conflictingPods.List())
+		return ErrConflictDetected
+	}
+	return nil
+}
+
+// HealthCheck performs a health check on the given Pod by port-forwarding into the Pod
+// returns the content from /healthz
+func (r *recorder) HealthCheck(ctx context.Context, pod v1.Pod) (string, error) {
+	req := r.clientset.RESTClient().Post().Resource("pods").Namespace(Namespace).
+		Name(pod.Name).SubResource(portForwardSubresource)
+	stopChan, readyChan := make(chan struct{}), make(chan struct{})
+	errChan := make(chan error)
+	defer close(stopChan)
+	transport, upgrader, err := spdy.RoundTripperFor(r.config)
+	if err != nil {
+		return "", err
+	}
+	url := req.URL()
+	url.Path = "/api/v1" + url.Path // manually add the api root
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, url)
+	port, err := healthCheckPort(pod)
+	if err != nil {
+		return "", err
+	}
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", 0, port)}, stopChan, readyChan, io.Discard, io.Discard)
+	if err != nil {
+		return "", err
+	}
+	go func() {
+		err := fw.ForwardPorts()
+		if err != nil {
+			errChan <- err
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case err := <-errChan:
+		return "", err
+	case <-readyChan:
+		ports, err := fw.GetPorts()
+		if err != nil {
+			return "", err
+		}
+		localPort := ports[0].Local
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			fmt.Sprintf("https://localhost:%d/healthz?verbose=1", localPort),
+			nil)
+		if err != nil {
+			return "", err
+		}
+		resp, err := r.insecureClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("health check status %d", resp.StatusCode)
+		}
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+}
+
+func NewRecorder() (*recorder, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	insecureClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	return &recorder{config: config, clientset: clientset, insecureClient: insecureClient}, nil
+}
+
+func parseHealthz(body string) (controllers []string, err error) {
+	const leaderElectionHealthCheck = "leaderElection"
+	const healthCheckPrefix = "[+]"
+	const healthCheckSuffix = " ok"
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "[+]") {
+			controller := strings.TrimSuffix(strings.TrimPrefix(line, healthCheckPrefix), healthCheckSuffix)
+			if controller != leaderElectionHealthCheck {
+				controllers = append(controllers, controller)
+			}
+		}
+	}
+	return
+}

--- a/tests/e2e/scenarios/upgrade-ha-leader-migration/resources.yaml
+++ b/tests/e2e/scenarios/upgrade-ha-leader-migration/resources.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: recorder
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: recorder
+rules:
+  - apiGroups: [ "" ]
+    resources:
+      - pods
+      - pods/portforward # for port forwarding to the controller manager pods
+    verbs: [ "get", "list", "create" ]
+  - nonResourceURLs:
+      - /healthz   # this should be accessible by default, but adding it here for clarity
+      - /healthz/* # allow access to pre-controller health checks
+    verbs: [ "get" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: recorder
+subjects:
+  - kind: ServiceAccount
+    name: recorder
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: recorder
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: recorder
+spec:
+  serviceAccountName: recorder
+  restartPolicy: Never
+  containers:
+    - image: debian
+      name: debian-recorder
+      args:
+        - bash
+        - -c
+        - 'while [[ ! -f /usr/local/bin/recorder ]]; do sleep 1; done; exec /usr/local/bin/recorder'

--- a/tests/e2e/scenarios/upgrade-ha-leader-migration/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ha-leader-migration/run-test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCENARIO_ROOT="${REPO_ROOT}/tests/e2e/scenarios/upgrade-ha-leader-migration"
+
+source "${REPO_ROOT}"/tests/e2e/scenarios/lib/common.sh
+
+OVERRIDES=("--node-count=1" "--master-count=3")
+
+case "${CLOUD_PROVIDER}" in
+gce)
+  export KOPS_FEATURE_FLAGS=AlphaAllowGCE,SpecOverrideFlag
+  OVERRIDES+=("--zones=us-central1-a,us-central1-b,us-central1-c" "--master-zones=us-central1-a,us-central1-b,us-central1-c")
+  ;;
+*) ;;
+
+esac
+
+kops-acquire-latest
+
+# the migration in this test case is KCM to KCM+CCM, which should happen
+# during the upgrade from 1.23 to 1.24
+K8S_VERSION_A=$(curl https://storage.googleapis.com/kubernetes-release/release/stable-1.23.txt)
+K8S_VERSION_B=$(curl https://storage.googleapis.com/kubernetes-release/release/latest-1.24.txt)
+
+# spin up the 1.23 cluster
+OVERRIDES="${OVERRIDES[*]}" K8S_VERSION="${K8S_VERSION_A}" kops-up
+
+# create the recorder pod
+kubectl create -f "${SCENARIO_ROOT}/resources.yaml"
+(cd "${SCENARIO_ROOT}/cmd/recorder/" && go build -o "${WORKSPACE}/recorder")
+kubectl wait --for=condition=ready pod/recorder
+kubectl cp "${WORKSPACE}/recorder" recorder:/tmp/recorder
+rm "${WORKSPACE}/recorder"
+kubectl exec recorder -- /usr/bin/env sh -c 'mv /tmp/recorder /usr/local/bin/recorder'
+
+# prepare for the upgrade
+# workaround current state of node IPAM controller
+"${KOPS}" edit cluster \
+  '--set=cluster.spec.kubeControllerManager.enableLeaderMigration=false' \
+  '--set=cluster.spec.cloudControllerManager.enableLeaderMigration=true' \
+  '--set=cluster.spec.cloudControllerManager.controllers=*' \
+  '--set=cluster.spec.cloudControllerManager.controllers=-nodeipam' \
+  "--set=cluster.spec.kubernetesVersion=${K8S_VERSION_B}"
+
+# perform the upgrade
+"${KOPS}" update cluster
+"${KOPS}" update cluster --admin --yes
+"${KOPS}" update cluster
+
+# perform the rolling upgrade, we only care about the control plane
+"${KOPS}" rolling-update cluster
+"${KOPS}" rolling-update cluster --yes --validation-timeout=30m --instance-group-roles=master
+
+# check recorder status
+phase=$(kubectl get pod -o go-template="{{.status.phase}}" recorder)
+
+# if the recorder fails, which means a conflict is detected, dump log and exit
+if [[ ! "$phase" == Running ]]; then
+    kubectl logs recorder
+    kubectl delete -f "${SCENARIO_ROOT}/resources.yaml" # clean up
+    echo "upgrade failed"
+    exit 1
+fi
+
+# prepare for the rollback
+"${KOPS}" edit cluster \
+  '--set=cluster.spec.kubeControllerManager.enableLeaderMigration=true' \
+  '--unset=cluster.spec.cloudControllerManager' \
+  "--set=cluster.spec.kubernetesVersion=${K8S_VERSION_A}"
+
+# perform the rollback
+"${KOPS}" update cluster
+"${KOPS}" update cluster --admin --yes
+"${KOPS}" update cluster
+
+# perform the rolling rollback of the control plane
+"${KOPS}" rolling-update cluster
+"${KOPS}" rolling-update cluster --yes --validation-timeout=30m --instance-group-roles=master
+
+# dump recorder output
+kubectl logs recorder
+
+# check recorder status, again
+phase=$(kubectl get pod -o go-template="{{.status.phase}}" recorder)
+
+# clean up
+kubectl delete -f "${SCENARIO_ROOT}/resources.yaml"
+
+if [[ ! "$phase" == Running ]]; then
+  echo "rollback failed"
+  exit 1
+fi


### PR DESCRIPTION
This PR adds a new scenario that
- create a 1.23 cluster with 3 control plane nodes
- upgrade and rolling-upgrade the control plane to 1.24, performing Leader Migration between 1.23 KCM to 1.24 CCM
- rollback and rolling-upgrade the control plane back to 1.23, performing Leader Migration between 1.23 KCM to 1.24 CCM

This PR implements a controller-to-manager recorder with `client-go` that runs in the cluster, because connections from the 
test host to the cluster may be interrupted during the rolling-upgrade. Also, this is a good way to ensure the data plane is not disturbed during the control plane upgrade.

This test also uses (and thus covers) per-controller health-check implemented as https://github.com/kubernetes/kubernetes/pull/104667

This PR is designed to run as a periodic job in GCE. Other providers support TODO.

Current status: passing, using my own GCP project.