### PR TITLE
CCM: add livenessProbe for GCP CCM

### DIFF
--- a/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
@@ -41,6 +41,17 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: "127.0.0.1"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 10258
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         resources:
           requests:
             cpu: 200m


### PR DESCRIPTION
Our CCM addons are missing `livenessProbe`. This PR adds the probe to GCP CCM. Other cloud providers should do the same.