### PR TITLE
initialize cloudInstance.Roles

### DIFF
--- a/pkg/cloudinstances/cloud_instance_group.go
+++ b/pkg/cloudinstances/cloud_instance_group.go
@@ -48,6 +48,7 @@ func (c *CloudInstanceGroup) NewCloudInstance(instanceId string, status string, 
 	cm := &CloudInstance{
 		ID:                 instanceId,
 		CloudInstanceGroup: c,
+		Roles:              []string{},
 	}
 
 	if status == CloudInstanceStatusUpToDate {


### PR DESCRIPTION
related to: https://github.com/kubernetes/kops/issues/13250

I don't have the full root cause into https://github.com/kubernetes/kops/issues/13250, but TLDR:

when calling `kops get instances -o json`, we attempt to marshal the following struct (which can result in a segFault)

```
type renderableCloudInstance struct {
	ID            string   `json:"id"`
	NodeName      string   `json:"nodeName,omitempty"`
	Status        string   `json:"status"`
	Roles         []string `json:"roles"`
	InternalIP    string   `json:"internalIP"`
	InstanceGroup string   `json:"instanceGroup"`
	MachineType   string   `json:"machineType"`
	State         string   `json:"state"`
}
```

The only field here which can result in a segfault is `Roles` when the slice isn't initialized. The slice is initialized here: https://github.com/kubernetes/kops/blob/master/upup/pkg/fi/cloudup/awsup/aws_cloud.go#L1180-L1188

In the event that the role tags are missing from the instance, we ultimately fail to initialize the `renderableCloudInstance.Roles` slice, causing a segfault.

This isn't the root cause as to why instances may be missing these tags, but it'll at least prevent segfaults in the future.
