### PR TITLE
Automated cherry pick of #13228: Bump aws-cni to 1.10.2

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e45d8969bb1f6e1a6778bfe6a716d35d3fefdda09dfb3399f9a088bd09bef109
+    manifestHash: 864cf50beed0c969e6127ca99c104063f922c5330120c4ee1fce7978f469f824
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -7,18 +7,43 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -31,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -71,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -80,8 +104,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -89,26 +113,18 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -121,7 +137,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -169,17 +185,16 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
-        imagePullPolicy: Always
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -189,10 +204,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -218,8 +233,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
-        imagePullPolicy: Always
+        - name: ENABLE_IPv6
+          value: "false"
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -254,21 +270,6 @@ spec:
           type: DirectoryOrCreate
         name: run-dir
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e45d8969bb1f6e1a6778bfe6a716d35d3fefdda09dfb3399f9a088bd09bef109
+    manifestHash: 864cf50beed0c969e6127ca99c104063f922c5330120c4ee1fce7978f469f824
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -7,18 +7,43 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -31,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -71,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -80,8 +104,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -89,26 +113,18 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -121,7 +137,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -169,17 +185,16 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
-        imagePullPolicy: Always
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -189,10 +204,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -218,8 +233,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
-        imagePullPolicy: Always
+        - name: ENABLE_IPv6
+          value: "false"
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -254,21 +270,6 @@ spec:
           type: DirectoryOrCreate
         name: run-dir
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -118,7 +118,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: e45d8969bb1f6e1a6778bfe6a716d35d3fefdda09dfb3399f9a088bd09bef109
+    manifestHash: 864cf50beed0c969e6127ca99c104063f922c5330120c4ee1fce7978f469f824
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-networking.amazon-vpc-routed-eni-k8s-1.16_content
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -7,18 +7,43 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -31,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -71,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -80,8 +104,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -89,26 +113,18 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -121,7 +137,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -169,17 +185,16 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
-        imagePullPolicy: Always
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -189,10 +204,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -218,8 +233,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
-        imagePullPolicy: Always
+        - name: ENABLE_IPv6
+          value: "false"
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -254,21 +270,6 @@ spec:
           type: DirectoryOrCreate
         name: run-dir
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,4 +1,4 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.9/aws-k8s-cni.yaml
+# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.10/aws-k8s-cni.yaml
 
 ---
 # Source: aws-vpc-cni/templates/clusterrolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -29,7 +29,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"
 rules:
   - apiGroups:
       - crd.k8s.amazonaws.com
@@ -62,7 +62,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -90,7 +90,7 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"
 spec:
   updateStrategy:
     type: OnDelete
@@ -109,7 +109,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: aws-vpc-cni-init
-        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1" }}"
+        image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2" }}"
         imagePullPolicy: Always
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
@@ -131,7 +131,7 @@ spec:
         {}
       containers:
         - name: aws-node
-          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1" }}"
+          image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2" }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 61678
@@ -279,4 +279,4 @@ metadata:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
-    app.kubernetes.io/version: "v1.9.3"
+    app.kubernetes.io/version: "v1.10.2"

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,24 +1,43 @@
 # Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.10/aws-k8s-cni.yaml
-
 ---
-# Source: aws-vpc-cni/templates/clusterrolebinding.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+# Source: aws-vpc-cni/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: aws-node
+  namespace: kube-system
   labels:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
     app.kubernetes.io/version: "v1.10.2"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-  - kind: ServiceAccount
-    name: aws-node
-    namespace: kube-system
+---
+# Source: aws-vpc-cni/templates/customresourcedefinition.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: eniconfigs.crd.k8s.amazonaws.com
+  labels:
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/instance: aws-vpc-cni
+    k8s-app: aws-node
+    app.kubernetes.io/version: "v1.10.2"
+spec:
+  scope: Cluster
+  group: crd.k8s.amazonaws.com
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+  names:
+    plural: eniconfigs
+    singular: eniconfig
+    kind: ENIConfig
 ---
 # Source: aws-vpc-cni/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,32 +72,24 @@ rules:
       - '*'
     verbs: ["list", "watch"]
 ---
-# Source: aws-vpc-cni/templates/customresourcedefinition.yaml
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+# Source: aws-vpc-cni/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  name: eniconfigs.crd.k8s.amazonaws.com
+  name: aws-node
   labels:
     app.kubernetes.io/name: aws-node
     app.kubernetes.io/instance: aws-vpc-cni
     k8s-app: aws-node
     app.kubernetes.io/version: "v1.10.2"
-spec:
-  scope: Cluster
-  group: crd.k8s.amazonaws.com
-  preserveUnknownFields: false
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-  names:
-    plural: eniconfigs
-    singular: eniconfig
-    kind: ENIConfig
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+  - kind: ServiceAccount
+    name: aws-node
+    namespace: kube-system
 ---
 # Source: aws-vpc-cni/templates/daemonset.yaml
 kind: DaemonSet
@@ -93,7 +104,9 @@ metadata:
     app.kubernetes.io/version: "v1.10.2"
 spec:
   updateStrategy:
-    type: OnDelete
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
   selector:
     matchLabels:
       k8s-app: aws-node
@@ -123,7 +136,6 @@ spec:
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir
-
       terminationGracePeriodSeconds: 10
       tolerations:
         - operator: Exists
@@ -141,19 +153,19 @@ spec:
               command:
               - /app/grpc-health-probe
               - -addr=:50051
-              - -connect-timeout=2s
-              - -rpc-timeout=2s
+              - -connect-timeout=5s
+              - -rpc-timeout=5s
             initialDelaySeconds: 60
-            timeoutSeconds: 5
+            timeoutSeconds: 10
           readinessProbe:
             exec:
               command:
               - /app/grpc-health-probe
               - -addr=:50051
-              - -connect-timeout=2s
-              - -rpc-timeout=2s
+              - -connect-timeout=5s
+              - -rpc-timeout=5s
             initialDelaySeconds: 1
-            timeoutSeconds: 5
+            timeoutSeconds: 10
           env:
             {{- range $name, $value := AmazonVpcEnvVars }}
             - "name": "{{ $name }}"
@@ -268,15 +280,3 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
----
-# Source: aws-vpc-cni/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: aws-node
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/instance: aws-vpc-cni
-    k8s-app: aws-node
-    app.kubernetes.io/version: "v1.10.2"

--- a/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.amazon-vpc-routed-eni/k8s-1.16.yaml.template
@@ -1,4 +1,4 @@
-# Vendored from https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.10/aws-k8s-cni.yaml
+# Vendored from https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.10/config/master/aws-k8s-cni.yaml
 ---
 # Source: aws-vpc-cni/templates/serviceaccount.yaml
 apiVersion: v1
@@ -67,7 +67,7 @@ rules:
     resources:
       - nodes
     verbs: ["list", "watch", "get", "update"]
-  - apiGroups: ["extensions", "apps"]
+  - apiGroups: ["extensions"]
     resources:
       - '*'
     verbs: ["list", "watch"]
@@ -123,14 +123,11 @@ spec:
       initContainers:
       - name: aws-vpc-cni-init
         image: "{{- or .Networking.AmazonVPC.InitImage "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2" }}"
-        imagePullPolicy: Always
         env:
           - name: DISABLE_TCP_EARLY_DEMUX
             value: "false"
-          {{- if IsIPv6Only }}
           - name: ENABLE_IPv6
-            value: "true"
-          {{- end }}
+            value: "{{ IsIPv6Only }}"
         securityContext:
             privileged: true
         volumeMounts:
@@ -144,7 +141,6 @@ spec:
       containers:
         - name: aws-node
           image: "{{- or .Networking.AmazonVPC.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2" }}"
-          imagePullPolicy: Always
           ports:
             - containerPort: 61678
               name: metrics

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 76438b822817f225ab6fef37503012029f06c3fbee07f1c982ef068cc34388e2
+    manifestHash: 118162fa41e1e79545a66566ff276c010f7a63a1936d4873eab35c9b2cc20b1f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -7,18 +7,43 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -31,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -71,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -80,8 +104,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -89,26 +113,18 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -121,7 +137,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -173,17 +189,16 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
-        imagePullPolicy: Always
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -193,10 +208,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -222,8 +237,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
-        imagePullPolicy: Always
+        - name: ENABLE_IPv6
+          value: "false"
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -258,21 +274,6 @@ spec:
           type: DirectoryOrCreate
         name: run-dir
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.amazon-vpc-routed-eni/k8s-1.16.yaml
-    manifestHash: 76438b822817f225ab6fef37503012029f06c3fbee07f1c982ef068cc34388e2
+    manifestHash: 118162fa41e1e79545a66566ff276c010f7a63a1936d4873eab35c9b2cc20b1f
     name: networking.amazon-vpc-routed-eni
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/networking.amazon-vpc-routed-eni-k8s-1.16.yaml
@@ -1,5 +1,5 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
@@ -7,18 +7,43 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aws-node
-subjects:
-- kind: ServiceAccount
-  name: aws-node
   namespace: kube-system
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
+    app.kubernetes.io/instance: aws-vpc-cni
+    app.kubernetes.io/managed-by: kops
+    app.kubernetes.io/name: aws-node
+    app.kubernetes.io/version: v1.10.2
+    k8s-app: aws-node
+    role.kubernetes.io/networking: "1"
+  name: eniconfigs.crd.k8s.amazonaws.com
+spec:
+  group: crd.k8s.amazonaws.com
+  names:
+    kind: ENIConfig
+    plural: eniconfigs
+    singular: eniconfig
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
 
 ---
 
@@ -31,7 +56,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -71,7 +96,6 @@ rules:
   - update
 - apiGroups:
   - extensions
-  - apps
   resources:
   - '*'
   verbs:
@@ -80,8 +104,8 @@ rules:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
@@ -89,26 +113,18 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
-  name: eniconfigs.crd.k8s.amazonaws.com
-spec:
-  group: crd.k8s.amazonaws.com
-  names:
-    kind: ENIConfig
-    plural: eniconfigs
-    singular: eniconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: true
-    storage: true
+  name: aws-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-node
+subjects:
+- kind: ServiceAccount
+  name: aws-node
+  namespace: kube-system
 
 ---
 
@@ -121,7 +137,7 @@ metadata:
     app.kubernetes.io/instance: aws-vpc-cni
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
+    app.kubernetes.io/version: v1.10.2
     k8s-app: aws-node
     role.kubernetes.io/networking: "1"
   name: aws-node
@@ -173,17 +189,16 @@ spec:
               fieldPath: spec.nodeName
         - name: CLUSTER_NAME
           value: minimal.example.com
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.1
-        imagePullPolicy: Always
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.10.2
         livenessProbe:
           exec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         name: aws-node
         ports:
         - containerPort: 61678
@@ -193,10 +208,10 @@ spec:
             command:
             - /app/grpc-health-probe
             - -addr=:50051
-            - -connect-timeout=2s
-            - -rpc-timeout=2s
+            - -connect-timeout=5s
+            - -rpc-timeout=5s
           initialDelaySeconds: 1
-          timeoutSeconds: 5
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 10m
@@ -222,8 +237,9 @@ spec:
       - env:
         - name: DISABLE_TCP_EARLY_DEMUX
           value: "false"
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.1
-        imagePullPolicy: Always
+        - name: ENABLE_IPv6
+          value: "false"
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.10.2
         name: aws-vpc-cni-init
         securityContext:
           privileged: true
@@ -258,21 +274,6 @@ spec:
           type: DirectoryOrCreate
         name: run-dir
   updateStrategy:
-    type: OnDelete
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: networking.amazon-vpc-routed-eni
-    app.kubernetes.io/instance: aws-vpc-cni
-    app.kubernetes.io/managed-by: kops
-    app.kubernetes.io/name: aws-node
-    app.kubernetes.io/version: v1.9.3
-    k8s-app: aws-node
-    role.kubernetes.io/networking: "1"
-  name: aws-node
-  namespace: kube-system
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate


### PR DESCRIPTION
Cherry pick of #13228 on release-1.23.

#13228: Bump aws-cni to 1.10.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.