### PR TITLE
Automated cherry pick of #12900: Simplify Flatcar containerd exec command

### DIFF
--- a/nodeup/pkg/model/containerd.go
+++ b/nodeup/pkg/model/containerd.go
@@ -252,9 +252,8 @@ func (b *ContainerdBuilder) buildSystemdServiceOverrideFlatcar(c *fi.ModelBuilde
 	lines := []string{
 		"[Service]",
 		"EnvironmentFile=/etc/environment",
-		"Environment=CONTAINERD_CONFIG=" + b.containerdConfigFilePath(),
 		"ExecStart=",
-		"ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}",
+		"ExecStart=/usr/bin/containerd --config " + b.containerdConfigFilePath(),
 	}
 	contents := strings.Join(lines, "\n")
 

--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
@@ -47,9 +47,8 @@ afterFiles:
 contents: |-
   [Service]
   EnvironmentFile=/etc/environment
-  Environment=CONTAINERD_CONFIG=/etc/containerd/config-kops.toml
   ExecStart=
-  ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}
+  ExecStart=/usr/bin/containerd --config /etc/containerd/config-kops.toml
 onChangeExecute:
 - - systemctl
   - daemon-reload


### PR DESCRIPTION
Cherry pick of #12900 on release-1.22.

#12900: Simplify Flatcar containerd exec command

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.