### PR TITLE
Automated cherry pick of #13113: Allow PrefixList for sshAccess and kubernetesApiAccess

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -257,6 +257,10 @@ spec:
     - 12.34.56.78/32
 ```
 
+{{ kops_feature_table(kops_added_default='1.23') }}
+
+In AWS, instead of listing all CIDRs, it is possible to specify a pre-existing [AWS Prefix List](https://docs.aws.amazon.com/vpc/latest/userguide/managed-prefix-lists.html) ID.
+
 ## kubernetesApiAccess
 
 This array configures the CIDRs that are able to access the kubernetes API. On AWS this is manifested as inbound security group rules on the ELB or master security groups.
@@ -268,6 +272,10 @@ spec:
   kubernetesApiAccess:
     - 12.34.56.78/32
 ```
+
+{{ kops_feature_table(kops_added_default='1.23') }}
+
+In AWS, instead of listing all CIDRs, it is possible to specify a pre-existing [AWS Prefix List](https://docs.aws.amazon.com/vpc/latest/userguide/managed-prefix-lists.html) ID.
 
 ## cluster.spec Subnet Keys
 

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -84,17 +84,35 @@ func validateClusterSpec(spec *kops.ClusterSpec, c *kops.Cluster, fieldPath *fie
 
 	// SSHAccess
 	for i, cidr := range spec.SSHAccess {
-		allErrs = append(allErrs, validateCIDR(cidr, fieldPath.Child("sshAccess").Index(i))...)
+		if strings.HasPrefix(cidr, "pl-") {
+			if kops.CloudProviderID(spec.CloudProvider) != kops.CloudProviderAWS {
+				allErrs = append(allErrs, field.Invalid(fieldPath.Child("sshAccess").Index(i), cidr, "Prefix List ID only supported for AWS"))
+			}
+		} else {
+			allErrs = append(allErrs, validateCIDR(cidr, fieldPath.Child("sshAccess").Index(i))...)
+		}
 	}
 
 	// KubernetesAPIAccess
 	for i, cidr := range spec.KubernetesAPIAccess {
-		allErrs = append(allErrs, validateCIDR(cidr, fieldPath.Child("kubernetesAPIAccess").Index(i))...)
+		if strings.HasPrefix(cidr, "pl-") {
+			if kops.CloudProviderID(spec.CloudProvider) != kops.CloudProviderAWS {
+				allErrs = append(allErrs, field.Invalid(fieldPath.Child("kubernetesAPIAccess").Index(i), cidr, "Prefix List ID only supported for AWS"))
+			}
+		} else {
+			allErrs = append(allErrs, validateCIDR(cidr, fieldPath.Child("kubernetesAPIAccess").Index(i))...)
+		}
 	}
 
 	// NodePortAccess
 	for i, cidr := range spec.NodePortAccess {
-		allErrs = append(allErrs, validateCIDR(cidr, fieldPath.Child("nodePortAccess").Index(i))...)
+		if strings.HasPrefix(cidr, "pl-") {
+			if kops.CloudProviderID(spec.CloudProvider) != kops.CloudProviderAWS {
+				allErrs = append(allErrs, field.Invalid(fieldPath.Child("nodePortAccess").Index(i), cidr, "Prefix List ID only supported for AWS"))
+			}
+		} else {
+			allErrs = append(allErrs, validateCIDR(cidr, fieldPath.Child("nodePortAccess").Index(i))...)
+		}
 	}
 
 	// AdditionalNetworkCIDRs

--- a/pkg/model/awsmodel/api_loadbalancer.go
+++ b/pkg/model/awsmodel/api_loadbalancer.go
@@ -19,6 +19,7 @@ package awsmodel
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -370,11 +371,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 					SecurityGroup: lbSG,
 					ToPort:        fi.Int64(443),
 				}
-				if utils.IsIPv6CIDR(cidr) {
-					t.IPv6CIDR = fi.String(cidr)
-				} else {
-					t.CIDR = fi.String(cidr)
-				}
+				t.SetCidrOrPrefix(cidr)
 				AddDirectionalGroupRule(c, t)
 			}
 
@@ -420,35 +417,36 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 						SecurityGroup: masterGroup.Task,
 						ToPort:        fi.Int64(443),
 					}
-					if utils.IsIPv6CIDR(cidr) {
-						t.IPv6CIDR = fi.String(cidr)
-					} else {
-						t.CIDR = fi.String(cidr)
-					}
+					t.SetCidrOrPrefix(cidr)
 					AddDirectionalGroupRule(c, t)
 				}
 
-				// Allow ICMP traffic required for PMTU discovery
-				if utils.IsIPv6CIDR(cidr) {
-					c.AddTask(&awstasks.SecurityGroupRule{
+				if strings.HasPrefix(cidr, "pl-") {
+					// In case of a prefix list we do not add a rule for ICMP traffic for PMTU discovery.
+					// This would require calling out to AWS to check whether the prefix list is IPv4 or IPv6.
+				} else if utils.IsIPv6CIDR(cidr) {
+					// Allow ICMP traffic required for PMTU discovery
+					t := &awstasks.SecurityGroupRule{
 						Name:          fi.String("icmpv6-pmtu-api-elb-" + cidr),
 						Lifecycle:     b.SecurityLifecycle,
-						IPv6CIDR:      fi.String(cidr),
 						FromPort:      fi.Int64(-1),
 						Protocol:      fi.String("icmpv6"),
 						SecurityGroup: masterGroup.Task,
 						ToPort:        fi.Int64(-1),
-					})
+					}
+					t.SetCidrOrPrefix(cidr)
+					c.AddTask(t)
 				} else {
-					c.AddTask(&awstasks.SecurityGroupRule{
+					t := &awstasks.SecurityGroupRule{
 						Name:          fi.String("icmp-pmtu-api-elb-" + cidr),
 						Lifecycle:     b.SecurityLifecycle,
-						CIDR:          fi.String(cidr),
 						FromPort:      fi.Int64(3),
 						Protocol:      fi.String("icmp"),
 						SecurityGroup: masterGroup.Task,
 						ToPort:        fi.Int64(4),
-					})
+					}
+					t.SetCidrOrPrefix(cidr)
+					c.AddTask(t)
 				}
 
 				if b.Cluster.Spec.API != nil && b.Cluster.Spec.API.LoadBalancer != nil && b.Cluster.Spec.API.LoadBalancer.SSLCertificate != "" {
@@ -461,11 +459,7 @@ func (b *APILoadBalancerBuilder) Build(c *fi.ModelBuilderContext) error {
 						SecurityGroup: masterGroup.Task,
 						ToPort:        fi.Int64(8443),
 					}
-					if utils.IsIPv6CIDR(cidr) {
-						t.IPv6CIDR = fi.String(cidr)
-					} else {
-						t.CIDR = fi.String(cidr)
-					}
+					t.SetCidrOrPrefix(cidr)
 					c.AddTask(t)
 				}
 			}

--- a/pkg/model/awsmodel/bastion.go
+++ b/pkg/model/awsmodel/bastion.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
-	"k8s.io/kops/upup/pkg/fi/utils"
 )
 
 const (
@@ -219,11 +218,7 @@ func (b *BastionModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			FromPort:      fi.Int64(22),
 			ToPort:        fi.Int64(22),
 		}
-		if utils.IsIPv6CIDR(sshAccess) {
-			t.IPv6CIDR = fi.String(sshAccess)
-		} else {
-			t.CIDR = fi.String(sshAccess)
-		}
+		t.SetCidrOrPrefix(sshAccess)
 		AddDirectionalGroupRule(c, t)
 	}
 

--- a/pkg/model/awsmodel/external_access.go
+++ b/pkg/model/awsmodel/external_access.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
-	"k8s.io/kops/upup/pkg/fi/utils"
 )
 
 // ExternalAccessModelBuilder configures security group rules for external access
@@ -71,11 +70,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 					FromPort:      fi.Int64(22),
 					ToPort:        fi.Int64(22),
 				}
-				if utils.IsIPv6CIDR(sshAccess) {
-					t.IPv6CIDR = fi.String(sshAccess)
-				} else {
-					t.CIDR = fi.String(sshAccess)
-				}
+				t.SetCidrOrPrefix(sshAccess)
 				AddDirectionalGroupRule(c, t)
 			}
 
@@ -89,11 +84,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 					FromPort:      fi.Int64(22),
 					ToPort:        fi.Int64(22),
 				}
-				if utils.IsIPv6CIDR(sshAccess) {
-					t.IPv6CIDR = fi.String(sshAccess)
-				} else {
-					t.CIDR = fi.String(sshAccess)
-				}
+				t.SetCidrOrPrefix(sshAccess)
 				AddDirectionalGroupRule(c, t)
 			}
 		}
@@ -116,11 +107,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 					FromPort:      fi.Int64(int64(nodePortRange.Base)),
 					ToPort:        fi.Int64(int64(nodePortRange.Base + nodePortRange.Size - 1)),
 				}
-				if utils.IsIPv6CIDR(nodePortAccess) {
-					t.IPv6CIDR = fi.String(nodePortAccess)
-				} else {
-					t.CIDR = fi.String(nodePortAccess)
-				}
+				t.SetCidrOrPrefix(nodePortAccess)
 				c.AddTask(t)
 			}
 			{
@@ -132,11 +119,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 					FromPort:      fi.Int64(int64(nodePortRange.Base)),
 					ToPort:        fi.Int64(int64(nodePortRange.Base + nodePortRange.Size - 1)),
 				}
-				if utils.IsIPv6CIDR(nodePortAccess) {
-					t.IPv6CIDR = fi.String(nodePortAccess)
-				} else {
-					t.CIDR = fi.String(nodePortAccess)
-				}
+				t.SetCidrOrPrefix(nodePortAccess)
 				c.AddTask(t)
 			}
 		}
@@ -159,11 +142,7 @@ func (b *ExternalAccessModelBuilder) Build(c *fi.ModelBuilderContext) error {
 					FromPort:      fi.Int64(443),
 					ToPort:        fi.Int64(443),
 				}
-				if utils.IsIPv6CIDR(apiAccess) {
-					t.IPv6CIDR = fi.String(apiAccess)
-				} else {
-					t.CIDR = fi.String(apiAccess)
-				}
+				t.SetCidrOrPrefix(apiAccess)
 				AddDirectionalGroupRule(c, t)
 			}
 		}

--- a/tests/integration/update_cluster/complex/cloudformation.json
+++ b/tests/integration/update_cluster/complex/cloudformation.json
@@ -721,6 +721,42 @@
         "CidrIp": "0.0.0.0/0"
       }
     },
+    "AWSEC2SecurityGroupIngressfrom00000ingresstcp22to22masterscomplexexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 22,
+        "ToPort": 22,
+        "IpProtocol": "tcp",
+        "SourcePrefixListId": "pl-66666666"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfrom00000ingresstcp22to22nodescomplexexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupnodescomplexexamplecom"
+        },
+        "FromPort": 22,
+        "ToPort": 22,
+        "IpProtocol": "tcp",
+        "SourcePrefixListId": "pl-66666666"
+      }
+    },
+    "AWSEC2SecurityGroupIngressfrom00000ingresstcp443to443masterscomplexexamplecom": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp",
+        "SourcePrefixListId": "pl-44444444"
+      }
+    },
     "AWSEC2SecurityGroupIngressfrom111024ingresstcp443to443masterscomplexexamplecom": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -961,6 +997,18 @@
         "ToPort": 8443,
         "IpProtocol": "tcp",
         "CidrIp": "1.1.1.0/24"
+      }
+    },
+    "AWSEC2SecurityGroupIngresstcpapipl44444444": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "AWSEC2SecurityGroupmasterscomplexexamplecom"
+        },
+        "FromPort": 8443,
+        "ToPort": 8443,
+        "IpProtocol": "tcp",
+        "SourcePrefixListId": "pl-44444444"
       }
     },
     "AWSEC2SecurityGroupapielbcomplexexamplecom": {

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -167,6 +167,7 @@ spec:
     shutdownGracePeriodCriticalPods: 10s
   kubernetesApiAccess:
   - 1.1.1.0/24
+  - pl-44444444
   kubernetesVersion: 1.21.0
   masterInternalName: api.internal.complex.example.com
   masterKubelet:
@@ -200,6 +201,7 @@ spec:
   serviceClusterIPRange: 100.64.0.0/13
   sshAccess:
   - 1.1.1.1/32
+  - pl-66666666
   sshKeyName: ""
   subnets:
   - cidr: 172.20.32.0/19

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -21,6 +21,7 @@ spec:
         bucket: access-log-example
   kubernetesApiAccess:
   - 1.1.1.0/24
+  - pl-44444444
   channel: stable
   cloudProvider: aws
   cloudLabels:
@@ -66,6 +67,7 @@ spec:
       - 990F4193972F2BECF12DDEDA5237F9C952F20D9E
   sshAccess:
   - 1.1.1.1/32
+  - pl-66666666
   sshKeyName: ""
   target:
     terraform:

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -21,6 +21,7 @@ spec:
         bucket: access-log-example
   kubernetesApiAccess:
   - 1.1.1.0/24
+  - pl-44444444
   channel: stable
   cloudProvider: aws
   cloudLabels:
@@ -66,6 +67,8 @@ spec:
       - 990F4193972F2BECF12DDEDA5237F9C952F20D9E
   sshAccess:
   - 1.1.1.1/32
+  - pl-66666666
+
   sshKeyName: ""
   target:
     terraform:

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -857,6 +857,33 @@ resource "aws_security_group" "nodes-complex-example-com" {
   vpc_id = aws_vpc.complex-example-com.id
 }
 
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-masters-complex-example-com" {
+  from_port         = 22
+  prefix_list_ids   = ["pl-66666666"]
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 22
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-22to22-nodes-complex-example-com" {
+  from_port         = 22
+  prefix_list_ids   = ["pl-66666666"]
+  protocol          = "tcp"
+  security_group_id = aws_security_group.nodes-complex-example-com.id
+  to_port           = 22
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "from-0-0-0-0--0-ingress-tcp-443to443-masters-complex-example-com" {
+  from_port         = 443
+  prefix_list_ids   = ["pl-44444444"]
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 443
+  type              = "ingress"
+}
+
 resource "aws_security_group_rule" "from-1-1-1-0--24-ingress-tcp-443to443-masters-complex-example-com" {
   cidr_blocks       = ["1.1.1.0/24"]
   from_port         = 443
@@ -1058,6 +1085,15 @@ resource "aws_security_group_rule" "nodeport-udp-external-to-node-10-20-30-0--24
 resource "aws_security_group_rule" "tcp-api-1-1-1-0--24" {
   cidr_blocks       = ["1.1.1.0/24"]
   from_port         = 8443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.masters-complex-example-com.id
+  to_port           = 8443
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "tcp-api-pl-44444444" {
+  from_port         = 8443
+  prefix_list_ids   = ["pl-44444444"]
   protocol          = "tcp"
   security_group_id = aws_security_group.masters-complex-example-com.id
   to_port           = 8443


### PR DESCRIPTION
Cherry pick of #13113 on release-1.23.

#13113: Allow PrefixList for sshAccess and kubernetesApiAccess

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.