### PR TITLE
service account workaround for gce

### DIFF
--- a/tests/e2e/scenarios/upgrade-ha-leader-migration/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ha-leader-migration/run-test.sh
@@ -24,7 +24,11 @@ OVERRIDES=("--node-count=1" "--master-count=3")
 case "${CLOUD_PROVIDER}" in
 gce)
   export KOPS_FEATURE_FLAGS=AlphaAllowGCE,SpecOverrideFlag
-  OVERRIDES+=("--zones=us-central1-a,us-central1-b,us-central1-c" "--master-zones=us-central1-a,us-central1-b,us-central1-c")
+  OVERRIDES+=(
+    "--zones=us-central1-a,us-central1-b,us-central1-c"
+    "--master-zones=us-central1-a,us-central1-b,us-central1-c"
+    "--gce-service-account=default" # see test-infra#24749
+  )
   ;;
 *) ;;
 


### PR DESCRIPTION
see https://github.com/kubernetes/test-infra/pull/24755

This flag is unfortunately needed for all tests on GCE.