### PR TITLE
Automated cherry pick of #13262: Update containerd to v1.6.0

### DIFF
--- a/pkg/model/components/containerd.go
+++ b/pkg/model/components/containerd.go
@@ -47,7 +47,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o interface{}) error {
 		// Set version based on Kubernetes version
 		if fi.StringValue(containerd.Version) == "" {
 			if b.IsKubernetesGTE("1.23") {
-				containerd.Version = fi.String("1.6.0-rc.4")
+				containerd.Version = fi.String("1.6.0")
 			} else if b.IsKubernetesGTE("1.19") {
 				containerd.Version = fi.String("1.4.12")
 			} else {

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -131,7 +131,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -261,7 +261,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: rt9avKhUovSI+7yPODXaKyheXKYWKU8aZ/agBN0rpG4=
+NodeupConfigHash: CmPRFmdKEVo5hDrXqJJR1lTciXHLHgCb3YR6LfkVrTc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -44,7 +44,7 @@ spec:
   containerRuntime: containerd
   containerd:
     logLevel: info
-    version: 1.6.0-rc.4
+    version: 1.6.0
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 55d0c0abbe6008ce6f687c8b7ad5527256a07b4d1b56414cc467e0d793b9a3b5@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-amd64.tar.gz
+  - f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-amd64.tar.gz
   - ab1c67fbcbdddbe481e48a55cf0ef9a86b38b166b5079e0010737fd87d7454bb@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9fb80ef87a2fd56bef1fac6b8061541cf9f8339a3d3b73312733fc5f5b16f60a@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-arm64.tar.gz
+  - 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-arm64.tar.gz
   - 9ec8e68feabc4e7083a4cfa45ebe4d529467391e0b03ee7de7ddda5770b05e68@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -268,7 +268,7 @@ channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 etcdManifests:
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main.yaml
 - memfs://clusters.example.com/minimal.example.com/manifests/etcd/events.yaml

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 55d0c0abbe6008ce6f687c8b7ad5527256a07b4d1b56414cc467e0d793b9a3b5@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-amd64.tar.gz
+  - f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-amd64.tar.gz
   - ab1c67fbcbdddbe481e48a55cf0ef9a86b38b166b5079e0010737fd87d7454bb@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9fb80ef87a2fd56bef1fac6b8061541cf9f8339a3d3b73312733fc5f5b16f60a@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-arm64.tar.gz
+  - 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-arm64.tar.gz
   - 9ec8e68feabc4e7083a4cfa45ebe4d529467391e0b03ee7de7ddda5770b05e68@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,5 +68,5 @@ channels:
 - memfs://clusters.example.com/minimal.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -131,7 +131,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -269,7 +269,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: FkwoHIb7oLi3QKItubLwWIae+U2xsZMONal0BEC+h+4=
+NodeupConfigHash: nEQALWAj8GDLg8K2q+CB1sr9ZqsVpO0kJ//jCHzmFOo=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -131,7 +131,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 docker:
   skipInstall: true
 kubeProxy:
@@ -168,7 +168,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: zualqCIBdeTTl3wcEPdIJ2CoMlQLjdCG4SsH84HSYdQ=
+NodeupConfigHash: a7mWC40og84dwhgNIbVnzvNXVTyk/HgPi9LRbqfrqsM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -21,7 +21,7 @@ spec:
   containerRuntime: containerd
   containerd:
     logLevel: info
-    version: 1.6.0-rc.4
+    version: 1.6.0
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 55d0c0abbe6008ce6f687c8b7ad5527256a07b4d1b56414cc467e0d793b9a3b5@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-amd64.tar.gz
+  - f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-amd64.tar.gz
   - ab1c67fbcbdddbe481e48a55cf0ef9a86b38b166b5079e0010737fd87d7454bb@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9fb80ef87a2fd56bef1fac6b8061541cf9f8339a3d3b73312733fc5f5b16f60a@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-arm64.tar.gz
+  - 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-arm64.tar.gz
   - 9ec8e68feabc4e7083a4cfa45ebe4d529467391e0b03ee7de7ddda5770b05e68@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -269,7 +269,7 @@ channels:
 - memfs://tests/minimal.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 etcdManifests:
 - memfs://tests/minimal.example.com/manifests/etcd/main.yaml
 - memfs://tests/minimal.example.com/manifests/etcd/events.yaml

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - 4756ff345dd80704b749d87efb8eb294a143a1f4a251ec586197d26ad20ea518@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubelet
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 55d0c0abbe6008ce6f687c8b7ad5527256a07b4d1b56414cc467e0d793b9a3b5@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-amd64.tar.gz
+  - f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-amd64.tar.gz
   - ab1c67fbcbdddbe481e48a55cf0ef9a86b38b166b5079e0010737fd87d7454bb@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9fb80ef87a2fd56bef1fac6b8061541cf9f8339a3d3b73312733fc5f5b16f60a@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-arm64.tar.gz
+  - 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-arm64.tar.gz
   - 9ec8e68feabc4e7083a4cfa45ebe4d529467391e0b03ee7de7ddda5770b05e68@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -69,4 +69,4 @@ channels:
 - memfs://tests/minimal.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -131,7 +131,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -265,7 +265,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: Qwxa54YQRobLlo8pJehemdPa5ttqbjZlMncNmzhpVFo=
+NodeupConfigHash: xc23VwEzVlv7hJ1JDAcxFulCAv+aU1gUv7US2PLzBnc=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -131,7 +131,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 docker:
   skipInstall: true
 kubeProxy:
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: Q6eXVFXXFcm/f29RhyaNgsVlL8WUKZU4vMy5JjN4uEY=
+NodeupConfigHash: aIa3i2k3PFWrD7Z0ycow2b/OYWLp7CJC+tc1FcPBkag=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -30,7 +30,7 @@ spec:
   containerRuntime: containerd
   containerd:
     logLevel: info
-    version: 1.6.0-rc.4
+    version: 1.6.0
   dnsZone: Z1AFAKE1ZON3YO
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_nodeupconfig-master-us-test-1a_content
@@ -58,7 +58,7 @@ Assets:
   - ba0685edd32a41cbf256ea6ba4957e1381c1a924cd2d8278ff86d2d88b901e3f@https://storage.googleapis.com/kubernetes-release/release/v1.24.0-alpha.1/bin/linux/amd64/kubelet
   - d36c259706f15424c3b6afef38e724333fca0f1f5c44fcba5263a3b8da133ffd@https://storage.googleapis.com/kubernetes-release/release/v1.24.0-alpha.1/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 55d0c0abbe6008ce6f687c8b7ad5527256a07b4d1b56414cc467e0d793b9a3b5@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-amd64.tar.gz
+  - f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-amd64.tar.gz
   - ab1c67fbcbdddbe481e48a55cf0ef9a86b38b166b5079e0010737fd87d7454bb@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -66,7 +66,7 @@ Assets:
   - c0e578be05655e0ecb364fea3834809d9b940c9bcd6b6f99b319beed002cb4b2@https://storage.googleapis.com/kubernetes-release/release/v1.24.0-alpha.1/bin/linux/arm64/kubelet
   - d57a24ecd03e56c13791549186669c5fc60e3e13faa3c08b7a12a02f42d9c646@https://storage.googleapis.com/kubernetes-release/release/v1.24.0-alpha.1/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9fb80ef87a2fd56bef1fac6b8061541cf9f8339a3d3b73312733fc5f5b16f60a@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-arm64.tar.gz
+  - 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-arm64.tar.gz
   - 9ec8e68feabc4e7083a4cfa45ebe4d529467391e0b03ee7de7ddda5770b05e68@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -267,7 +267,7 @@ channels:
 - memfs://tests/minimal.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 etcdManifests:
 - memfs://tests/minimal.example.com/manifests/etcd/main.yaml
 - memfs://tests/minimal.example.com/manifests/etcd/events.yaml

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -3,13 +3,13 @@ Assets:
   - ba0685edd32a41cbf256ea6ba4957e1381c1a924cd2d8278ff86d2d88b901e3f@https://storage.googleapis.com/kubernetes-release/release/v1.24.0-alpha.1/bin/linux/amd64/kubelet
   - d36c259706f15424c3b6afef38e724333fca0f1f5c44fcba5263a3b8da133ffd@https://storage.googleapis.com/kubernetes-release/release/v1.24.0-alpha.1/bin/linux/amd64/kubectl
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 55d0c0abbe6008ce6f687c8b7ad5527256a07b4d1b56414cc467e0d793b9a3b5@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-amd64.tar.gz
+  - f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-amd64.tar.gz
   - ab1c67fbcbdddbe481e48a55cf0ef9a86b38b166b5079e0010737fd87d7454bb@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
   arm64:
   - c0e578be05655e0ecb364fea3834809d9b940c9bcd6b6f99b319beed002cb4b2@https://storage.googleapis.com/kubernetes-release/release/v1.24.0-alpha.1/bin/linux/arm64/kubelet
   - d57a24ecd03e56c13791549186669c5fc60e3e13faa3c08b7a12a02f42d9c646@https://storage.googleapis.com/kubernetes-release/release/v1.24.0-alpha.1/bin/linux/arm64/kubectl
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9fb80ef87a2fd56bef1fac6b8061541cf9f8339a3d3b73312733fc5f5b16f60a@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-arm64.tar.gz
+  - 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-arm64.tar.gz
   - 9ec8e68feabc4e7083a4cfa45ebe4d529467391e0b03ee7de7ddda5770b05e68@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -67,5 +67,5 @@ channels:
 - memfs://tests/minimal.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 useInstanceIDForNodeName: true

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -22,7 +22,7 @@ spec:
   containerRuntime: containerd
   containerd:
     logLevel: info
-    version: 1.6.0-rc.4
+    version: 1.6.0
   dnsZone: "1"
   docker:
     skipInstall: true

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-master-us-test1-a_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-master-us-test1-a_content
@@ -56,7 +56,7 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 55d0c0abbe6008ce6f687c8b7ad5527256a07b4d1b56414cc467e0d793b9a3b5@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-amd64.tar.gz
+  - f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-amd64.tar.gz
   - ab1c67fbcbdddbe481e48a55cf0ef9a86b38b166b5079e0010737fd87d7454bb@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
   - f90ed6dcef534e6d1ae17907dc7eb40614b8945ad4af7f0e98d2be7cde8165c6@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-amd64
   - 9992e7eb2a2e93f799e5a9e98eb718637433524bc65f630357201a79f49b13d0@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-amd64
@@ -65,7 +65,7 @@ Assets:
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9fb80ef87a2fd56bef1fac6b8061541cf9f8339a3d3b73312733fc5f5b16f60a@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-arm64.tar.gz
+  - 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-arm64.tar.gz
   - 9ec8e68feabc4e7083a4cfa45ebe4d529467391e0b03ee7de7ddda5770b05e68@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.arm64
   - 2f599c3d54f4c4bdbcc95aaf0c7b513a845d8f9503ec5b34c9f86aa1bc34fc0c@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/protokube,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/protokube-linux-arm64
   - 9d842e3636a95de2315cdea2be7a282355aac0658ef0b86d5dc2449066538f13@https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/channels,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/channels-linux-arm64
@@ -265,7 +265,7 @@ channels:
 - memfs://tests/minimal-gce.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 etcdManifests:
 - memfs://tests/minimal-gce.example.com/manifests/etcd/main.yaml
 - memfs://tests/minimal-gce.example.com/manifests/etcd/events.yaml

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_nodeupconfig-nodes_content
@@ -4,14 +4,14 @@ Assets:
   - 2d0f5ba6faa787878b642c151ccb2c3390ce4c1e6c8e2b59568b3869ba407c4f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
   - ab63ef67b254a2eae51782106593c266e0b054ac2248e2cb913f6d165afae83c@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/mounter
   - 962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz
-  - 55d0c0abbe6008ce6f687c8b7ad5527256a07b4d1b56414cc467e0d793b9a3b5@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-amd64.tar.gz
+  - f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-amd64.tar.gz
   - ab1c67fbcbdddbe481e48a55cf0ef9a86b38b166b5079e0010737fd87d7454bb@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
   arm64:
   - a546fb7ccce69c4163e4a0b19a31f30ea039b4e4560c23fd6e3016e2b2dfd0d9@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubelet
   - 1d77d6027fc8dfed772609ad9bd68f611b7e4ce73afa949f27084ad3a92b15fe@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/kubectl
   - 6ef5620ad47035a168bf28335aa39a09f246e17f5d6e42f0d8daba7d90fc4e9f@https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/arm64/mounter
   - ef17764ffd6cdcb16d76401bac1db6acc050c9b088f1be5efa0e094ea3b01df0@https://storage.googleapis.com/k8s-artifacts-cni/release/v0.9.1/cni-plugins-linux-arm64-v0.9.1.tgz
-  - 9fb80ef87a2fd56bef1fac6b8061541cf9f8339a3d3b73312733fc5f5b16f60a@https://github.com/containerd/containerd/releases/download/v1.6.0-rc.4/containerd-1.6.0-rc.4-linux-arm64.tar.gz
+  - 6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a@https://github.com/containerd/containerd/releases/download/v1.6.0/containerd-1.6.0-linux-arm64.tar.gz
   - 9ec8e68feabc4e7083a4cfa45ebe4d529467391e0b03ee7de7ddda5770b05e68@https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.arm64
 CAs:
   kubernetes-ca: |
@@ -68,4 +68,4 @@ channels:
 - memfs://tests/minimal-gce.example.com/addons/bootstrap-channel.yaml
 containerdConfig:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -132,7 +132,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 docker:
   skipInstall: true
 encryptionConfig: null
@@ -253,7 +253,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce.example.com
 InstanceGroupName: master-us-test1-a
 InstanceGroupRole: Master
-NodeupConfigHash: 0xwkgBV+u0U3WUVC4B7CrINUsoTQqSFVuiq9ynOy6Uk=
+NodeupConfigHash: S6Njcj5LiSloQsJuHEwNzUeM3QZ+ShKrnoHhDtjRVyk=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -132,7 +132,7 @@ cloudConfig:
 containerRuntime: containerd
 containerd:
   logLevel: info
-  version: 1.6.0-rc.4
+  version: 1.6.0
 docker:
   skipInstall: true
 kubeProxy:
@@ -167,7 +167,7 @@ CloudProvider: gce
 ConfigBase: memfs://tests/minimal-gce.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: MTeUJm3hVkDI+/MVxllSLnEs4FBQuw4HimhG2LfmXn0=
+NodeupConfigHash: gk2uDrZJvOFKH//0KBN8n6/kWbYjl4R5D9LKgFPEPmU=
 
 __EOF_KUBE_ENV
 

--- a/upup/pkg/fi/cloudup/containerd.go
+++ b/upup/pkg/fi/cloudup/containerd.go
@@ -119,7 +119,7 @@ func findContainerdVersionUrl(arch architectures.Architecture, version string) (
 	var u string
 	switch arch {
 	case architectures.ArchitectureAmd64:
-		if sv.GTE(semver.MustParse("1.6.0-beta.2")) {
+		if sv.GTE(semver.MustParse("1.6.0")) {
 			u = fmt.Sprintf(containerdReleaseUrlAmd64, version, version)
 		} else if sv.GTE(semver.MustParse("1.3.8")) {
 			u = fmt.Sprintf(containerdBundleUrlAmd64, version, version)
@@ -127,7 +127,7 @@ func findContainerdVersionUrl(arch architectures.Architecture, version string) (
 			u = fmt.Sprintf(containerdLegacyUrlAmd64, version)
 		}
 	case architectures.ArchitectureArm64:
-		if sv.GTE(semver.MustParse("1.6.0-beta.2")) {
+		if sv.GTE(semver.MustParse("1.6.0")) {
 			u = fmt.Sprintf(containerdReleaseUrlArm64, version, version)
 		} else if findAllContainerdHashesAmd64()[version] != "" {
 			if findAllContainerdDockerMappings()[version] != "" {
@@ -161,7 +161,7 @@ func findContainerdVersionHash(arch architectures.Architecture, version string) 
 	case architectures.ArchitectureAmd64:
 		h = findAllContainerdHashesAmd64()[version]
 	case architectures.ArchitectureArm64:
-		if sv.GTE(semver.MustParse("1.6.0-beta.2")) {
+		if sv.GTE(semver.MustParse("1.6.0")) {
 			h = findAllContainerdHashesArm64()[version]
 		} else if findAllContainerdHashesAmd64()[version] != "" {
 			if findAllContainerdDockerMappings()[version] != "" {
@@ -183,33 +183,33 @@ func findContainerdVersionHash(arch architectures.Architecture, version string) 
 
 func findAllContainerdHashesAmd64() map[string]string {
 	hashes := map[string]string{
-		"1.3.4":      "4616971c3ad21c24f2f2320fa1c085577a91032a068dd56a41c7c4b71a458087",
-		"1.3.9":      "96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75",
-		"1.3.10":     "69e23e49cdf1232d475a77bf7ecd7145ff4a80295154e190125c4d8a20e241da",
-		"1.4.0":      "b379f29417efd583f77e095173d4d0bd6bb001f0081b2a63d152ee7aef653ce1",
-		"1.4.1":      "757efb93a4f3161efc447a943317503d8a7ded5cb4cc0cba3f3318d7ce1542ed",
-		"1.4.2":      "9d0fd5f4d2bc58b345728432b7daac75fc99c1da91afa4f41e6103f618e74012",
-		"1.4.3":      "2697a342e3477c211ab48313e259fd7e32ad1f5ded19320e6a559f50a82bff3d",
-		"1.4.4":      "96641849cb78a0a119223a427dfdc1ade88412ef791a14193212c8c8e29d447b",
-		"1.4.5":      "f8155278fd256526ca9804219e1ee46f5db11c6ddf455086b04c0887c868822a",
-		"1.4.6":      "6ae4763598c9583f8b50605f19d6c7e9ef93c216706465e73dfc84ee6b63a238",
-		"1.4.7":      "daa14638344fe0772f645e190e4d8eb9549b52743364cb8000521490f9e410b8",
-		"1.4.8":      "96e815c9ab664a02dd5be35e31d15890ea6bef04dfaa39f99f14676c3d6561e8",
-		"1.4.9":      "9911479f86012d6eab7e0f532da8f807a8b0f555ee09ef89367d8c31243073bb",
-		"1.4.10":     "5b256b372a02fd37c84939c87a6a81cae06058a7881a60d682525c11f6dea7d1",
-		"1.4.11":     "a4a4af4776316833cad5996c66d59f8b4a2af4da716b7902b7a2d5f5ac362dcc",
-		"1.4.12":     "f6120552408175ca332fd3b5d31c5edd115d8426d6731664e4ea3951c5eee3b4",
-		"1.5.0":      "aee7b553ab88842fdafe43955757abe746b8e9995b2be55c603f0a236186ff9b",
-		"1.5.1":      "2fd97916b24396c13849cfcd89805170e1ef0265a2f7fce8e74ae044a6a6a169",
-		"1.5.2":      "e7adbb6c6f6e67639460579a8aa991e9ce4de2062ed36d3261e6e4865574d947",
-		"1.5.3":      "32a9bf1b7ab2adbd9d2a16b17bf1aa6e61592938655adfb5114c40d527aa9be7",
-		"1.5.4":      "591e4e087ea2f5007e6c64deb382df58d419b7b6922eab45a1923d843d57615f",
-		"1.5.5":      "45f02cfc65db47cf088c95555906e1dcba7baf5a3fbad3d947dd6b9af476a144",
-		"1.5.6":      "afc51718ebe46cb9b985edac816e63fe86c07e37d28cdd21b2c0302dec6fa7ae",
-		"1.5.7":      "7fce75bab43a39d6f9efb3c370de2da49723f0e1dbaa9732d68fa7f620d720c8",
-		"1.5.8":      "5dbb7f43c0ac1fda79999ff63e648926e3464d7d1034402ee2117e6a93868431",
-		"1.5.9":      "f64c8e3b736b370c963b08c33ac70f030fc311bc48fcfd00461465af2fff3488",
-		"1.6.0-rc.4": "55d0c0abbe6008ce6f687c8b7ad5527256a07b4d1b56414cc467e0d793b9a3b5",
+		"1.3.4":  "4616971c3ad21c24f2f2320fa1c085577a91032a068dd56a41c7c4b71a458087",
+		"1.3.9":  "96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75",
+		"1.3.10": "69e23e49cdf1232d475a77bf7ecd7145ff4a80295154e190125c4d8a20e241da",
+		"1.4.0":  "b379f29417efd583f77e095173d4d0bd6bb001f0081b2a63d152ee7aef653ce1",
+		"1.4.1":  "757efb93a4f3161efc447a943317503d8a7ded5cb4cc0cba3f3318d7ce1542ed",
+		"1.4.2":  "9d0fd5f4d2bc58b345728432b7daac75fc99c1da91afa4f41e6103f618e74012",
+		"1.4.3":  "2697a342e3477c211ab48313e259fd7e32ad1f5ded19320e6a559f50a82bff3d",
+		"1.4.4":  "96641849cb78a0a119223a427dfdc1ade88412ef791a14193212c8c8e29d447b",
+		"1.4.5":  "f8155278fd256526ca9804219e1ee46f5db11c6ddf455086b04c0887c868822a",
+		"1.4.6":  "6ae4763598c9583f8b50605f19d6c7e9ef93c216706465e73dfc84ee6b63a238",
+		"1.4.7":  "daa14638344fe0772f645e190e4d8eb9549b52743364cb8000521490f9e410b8",
+		"1.4.8":  "96e815c9ab664a02dd5be35e31d15890ea6bef04dfaa39f99f14676c3d6561e8",
+		"1.4.9":  "9911479f86012d6eab7e0f532da8f807a8b0f555ee09ef89367d8c31243073bb",
+		"1.4.10": "5b256b372a02fd37c84939c87a6a81cae06058a7881a60d682525c11f6dea7d1",
+		"1.4.11": "a4a4af4776316833cad5996c66d59f8b4a2af4da716b7902b7a2d5f5ac362dcc",
+		"1.4.12": "f6120552408175ca332fd3b5d31c5edd115d8426d6731664e4ea3951c5eee3b4",
+		"1.5.0":  "aee7b553ab88842fdafe43955757abe746b8e9995b2be55c603f0a236186ff9b",
+		"1.5.1":  "2fd97916b24396c13849cfcd89805170e1ef0265a2f7fce8e74ae044a6a6a169",
+		"1.5.2":  "e7adbb6c6f6e67639460579a8aa991e9ce4de2062ed36d3261e6e4865574d947",
+		"1.5.3":  "32a9bf1b7ab2adbd9d2a16b17bf1aa6e61592938655adfb5114c40d527aa9be7",
+		"1.5.4":  "591e4e087ea2f5007e6c64deb382df58d419b7b6922eab45a1923d843d57615f",
+		"1.5.5":  "45f02cfc65db47cf088c95555906e1dcba7baf5a3fbad3d947dd6b9af476a144",
+		"1.5.6":  "afc51718ebe46cb9b985edac816e63fe86c07e37d28cdd21b2c0302dec6fa7ae",
+		"1.5.7":  "7fce75bab43a39d6f9efb3c370de2da49723f0e1dbaa9732d68fa7f620d720c8",
+		"1.5.8":  "5dbb7f43c0ac1fda79999ff63e648926e3464d7d1034402ee2117e6a93868431",
+		"1.5.9":  "f64c8e3b736b370c963b08c33ac70f030fc311bc48fcfd00461465af2fff3488",
+		"1.6.0":  "f77725e4f757523bf1472ec3b9e02b09303a5d99529173be0f11a6d39f5676e9",
 	}
 
 	return hashes
@@ -217,7 +217,7 @@ func findAllContainerdHashesAmd64() map[string]string {
 
 func findAllContainerdHashesArm64() map[string]string {
 	hashes := map[string]string{
-		"1.6.0-rc.4": "9fb80ef87a2fd56bef1fac6b8061541cf9f8339a3d3b73312733fc5f5b16f60a",
+		"1.6.0": "6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a",
 	}
 
 	return hashes

--- a/upup/pkg/fi/cloudup/runc.go
+++ b/upup/pkg/fi/cloudup/runc.go
@@ -46,7 +46,7 @@ func findRuncAsset(c *kops.Cluster, assetBuilder *assets.AssetBuilder, arch arch
 	}
 	// The a compatible runc binary is bundled with containerd builds < v1.6.0
 	// https://github.com/containerd/containerd/issues/6541
-	if containerdVersion.LT(semver.MustParse("1.6.0-beta.2")) {
+	if containerdVersion.LT(semver.MustParse("1.6.0")) {
 		return nil, nil, nil
 	}
 


### PR DESCRIPTION
Cherry pick of #13262 on release-1.23.

#13262: Update containerd to v1.6.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.