### PR TITLE
Enable RBN with AWS CCM 1.22.0-alpha.1

### DIFF
--- a/docs/networking/ipv6.md
+++ b/docs/networking/ipv6.md
@@ -25,8 +25,8 @@ Public and utility subnets are expected to be dual-stack. Subnets of type `Priva
 There is a new type of subnet `DualStack` which is like `Private` but is dual-stack.
 The `DualStack` subnets are used by default for the control plane and APIServer nodes.
 
-IPv6-only subnets require Kubernetes 1.23 or later. For this reason, private topology on an IPv6 cluster also
-requires Kubernetes 1.23 or later.
+IPv6-only subnets require Kubernetes 1.22 or later. For this reason, private topology on an IPv6 cluster also
+requires Kubernetes 1.22 or later.
 
 ## Routing and NAT64
 

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -340,8 +340,8 @@ func ValidateCluster(c *kops.Cluster, strict bool) field.ErrorList {
 				if requiresSubnetCIDR && strict {
 					if !strings.Contains(c.Spec.NonMasqueradeCIDR, ":") || s.IPv6CIDR == "" {
 						allErrs = append(allErrs, field.Required(fieldSubnet.Child("cidr"), "subnet did not have a cidr set"))
-					} else if c.IsKubernetesLT("1.23") {
-						allErrs = append(allErrs, field.Required(fieldSubnet.Child("cidr"), "IPv6-only subnets require Kubernetes 1.23+"))
+					} else if c.IsKubernetesLT("1.22") {
+						allErrs = append(allErrs, field.Required(fieldSubnet.Child("cidr"), "IPv6-only subnets require Kubernetes 1.22+"))
 					}
 				}
 			} else {

--- a/pkg/apis/kops/validation/validation.go
+++ b/pkg/apis/kops/validation/validation.go
@@ -388,8 +388,8 @@ func validateTopology(c *kops.Cluster, topology *kops.TopologySpec, fieldPath *f
 	} else {
 		allErrs = append(allErrs, IsValidValue(fieldPath.Child("nodes"), &topology.Nodes, kops.SupportedTopologies)...)
 
-		if topology.Nodes == "private" && c.Spec.IsIPv6Only() && c.IsKubernetesLT("1.23") {
-			allErrs = append(allErrs, field.Forbidden(fieldPath.Child("nodes"), "private topology in IPv6 clusters requires Kubernetes 1.23+"))
+		if topology.Nodes == "private" && c.Spec.IsIPv6Only() && c.IsKubernetesLT("1.22") {
+			allErrs = append(allErrs, field.Forbidden(fieldPath.Child("nodes"), "private topology in IPv6 clusters requires Kubernetes 1.22+"))
 		}
 	}
 

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -216,7 +216,7 @@ func NewConfig(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) (*Confi
 }
 
 func UsesInstanceIDForNodeName(cluster *kops.Cluster) bool {
-	return cluster.Spec.ExternalCloudControllerManager != nil && cluster.IsKubernetesGTE("1.23") && kops.CloudProviderID(cluster.Spec.CloudProvider) == kops.CloudProviderAWS
+	return cluster.Spec.ExternalCloudControllerManager != nil && cluster.IsKubernetesGTE("1.22") && kops.CloudProviderID(cluster.Spec.CloudProvider) == kops.CloudProviderAWS
 }
 
 func filterFileAssets(f []kops.FileAssetSpec, role kops.InstanceGroupRole) []kops.FileAssetSpec {

--- a/pkg/model/awsmodel/network.go
+++ b/pkg/model/awsmodel/network.go
@@ -270,7 +270,7 @@ func (b *NetworkModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			Tags:             tags,
 		}
 
-		if b.Cluster.Spec.ExternalCloudControllerManager != nil && b.Cluster.IsKubernetesGTE("1.23") {
+		if b.Cluster.Spec.ExternalCloudControllerManager != nil && b.Cluster.IsKubernetesGTE("1.22") {
 			subnet.ResourceBasedNaming = fi.Bool(true)
 		}
 

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -600,7 +600,7 @@ func (tf *TemplateFunctions) KopsControllerConfig() (string, error) {
 				Region:     tf.Region,
 			}
 
-			if cluster.Spec.ExternalCloudControllerManager != nil && cluster.IsKubernetesGTE("1.23") {
+			if cluster.Spec.ExternalCloudControllerManager != nil && cluster.IsKubernetesGTE("1.22") {
 				config.Server.UseInstanceIDForNodeName = true
 			}
 


### PR DESCRIPTION
Now that CCM for Kubernetes 1.22 has been upgraded to 1.22-alpha.1, we can enable RBN on that version of Kubernetes.