### PR TITLE
Automated cherry pick of #13027: Improve HA for various addons
#13033: LBC has to run on the control plane, so set replicas

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -582,7 +582,7 @@ metadata:
   name: ebs-csi-controller
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: ebs-csi-controller

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 0aba81e4fbb4b9063584261fe5c5fa346cc806f639ab5c911bbf9ab53b9d78b3
+    manifestHash: 015ff9a342e175aab3f26b5d4a6e06aac3e7569ebb5662a407fa991cd99ffd3c
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io
@@ -133,14 +133,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 8b58435bc8e9c29f2650dbdf9bcb0fbbec71781f2e3fe1f2614a03c1023976fe
+    manifestHash: 98d51338f6689e206535479f7579b6becd432f6aa1f3b44a2c53c41098cea3f4
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: a9781145d51aa191d5bd29bf31c535d17e50157e209ee0765ac20d6a7145eaf5
+    manifestHash: 005afa268578a742ba899964d0c92ce8843cb391c8a134a38a638bbddd711b07
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -292,7 +292,7 @@ metadata:
   name: cluster-autoscaler
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: cluster-autoscaler
@@ -355,7 +355,6 @@ spec:
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
           readOnly: true
-      dnsPolicy: ClusterFirst
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1254,7 +1254,7 @@ metadata:
   name: snapshot-validation-deployment
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: snapshot-validation
@@ -1276,6 +1276,19 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: snapshot-validation
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app: snapshot-validation
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: snapshot-validation-webhook-certs
         secret:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: a53d19ef1b5e95d76851351578fb463cde98024b583a6fcf3dbd16a7833ceb4f
+    manifestHash: 8f90239fed34a516fbd182aff2a4b0adfdcb58fcac75f3455c57fcec47314a86
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io
@@ -140,7 +140,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: a9781145d51aa191d5bd29bf31c535d17e50157e209ee0765ac20d6a7145eaf5
+    manifestHash: 005afa268578a742ba899964d0c92ce8843cb391c8a134a38a638bbddd711b07
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -347,7 +347,6 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
-      dnsPolicy: ClusterFirst
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1254,7 +1254,7 @@ metadata:
   name: snapshot-validation-deployment
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: snapshot-validation
@@ -1276,6 +1276,19 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: snapshot-validation
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app: snapshot-validation
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: snapshot-validation-webhook-certs
         secret:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: a53d19ef1b5e95d76851351578fb463cde98024b583a6fcf3dbd16a7833ceb4f
+    manifestHash: 8f90239fed34a516fbd182aff2a4b0adfdcb58fcac75f3455c57fcec47314a86
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io
@@ -133,7 +133,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: a9781145d51aa191d5bd29bf31c535d17e50157e209ee0765ac20d6a7145eaf5
+    manifestHash: 005afa268578a742ba899964d0c92ce8843cb391c8a134a38a638bbddd711b07
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -347,7 +347,6 @@ spec:
           requests:
             cpu: 100m
             memory: 300Mi
-      dnsPolicy: ClusterFirst
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1254,7 +1254,7 @@ metadata:
   name: snapshot-validation-deployment
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: snapshot-validation
@@ -1276,6 +1276,19 @@ spec:
         - mountPath: /etc/snapshot-validation-webhook/certs
           name: snapshot-validation-webhook-certs
           readOnly: true
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: snapshot-validation
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app: snapshot-validation
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: snapshot-validation-webhook-certs
         secret:

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -382,7 +382,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/version: {{ .Version }}
 spec:
-  replicas: {{ ControlPlaneControllerReplicas }}
+  replicas: {{ ControlPlaneControllerReplicas true }}
   selector:
     matchLabels:
       app: ebs-csi-controller

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
@@ -724,7 +724,7 @@ metadata:
   name: aws-load-balancer-controller
   namespace: kube-system
 spec:
-  replicas: {{ ControlPlaneControllerReplicas }}
+  replicas: {{ ControlPlaneControllerReplicas false }}
   selector:
     matchLabels:
       app.kubernetes.io/component: controller

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
@@ -725,7 +725,7 @@ metadata:
   name: aws-load-balancer-controller
   namespace: kube-system
 spec:
-  replicas: {{ ControlPlaneControllerReplicas true }}
+  replicas: {{ ControlPlaneControllerReplicas false }}
   selector:
     matchLabels:
       app.kubernetes.io/component: controller

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
@@ -725,7 +725,7 @@ metadata:
   name: aws-load-balancer-controller
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: {{ ControlPlaneControllerReplicas true }}
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
@@ -780,6 +780,21 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
         - operator: Exists
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: "topology.kubernetes.io/zone"
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: controller
+            app.kubernetes.io/name: aws-load-balancer-controller
+      - maxSkew: 1
+        topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: controller
+            app.kubernetes.io/name: aws-load-balancer-controller
       volumes:
       - name: cert
         secret:

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -265,7 +265,7 @@ metadata:
   name: cluster-autoscaler
   namespace: kube-system
 spec:
-  replicas: {{ ControlPlaneControllerReplicas }}
+  replicas: {{ ControlPlaneControllerReplicas true }}
   selector:
     matchLabels:
       app: cluster-autoscaler
@@ -280,8 +280,28 @@ spec:
         k8s-app: cluster-autoscaler
         app.kubernetes.io/name: "cluster-autoscaler"
     spec:
-      priorityClassName: "system-cluster-critical"
-      dnsPolicy: "ClusterFirst"
+      priorityClassName: system-cluster-critical
+      serviceAccountName: cluster-autoscaler
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: "topology.kubernetes.io/zone"
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+      - maxSkew: 1
+        topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: cluster-autoscaler
+      {{ if not UseServiceAccountExternalPermissions }}
+      tolerations:
+      - operator: "Exists"
+        key: node-role.kubernetes.io/master
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      {{ end }}
       containers:
         - name: cluster-autoscaler
           image: "{{ .Image }}"

--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -183,6 +183,19 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: "topology.kubernetes.io/zone"
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
+      - maxSkew: 1
+        topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
       volumes:
 {{ if not (WithDefaultBool .MetricsServer.Insecure true) }}
       - name: certs

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -908,7 +908,7 @@ metadata:
   name: cilium-operator
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: {{ ControlPlaneControllerReplicas false }}
   selector:
     matchLabels:
       io.cilium/app: operator
@@ -1027,7 +1027,7 @@ metadata:
     k8s-app: hubble-relay
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       k8s-app: hubble-relay
@@ -1089,6 +1089,19 @@ spec:
       terminationGracePeriodSeconds: 0
       tolerations:
       - operator: Exists
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: "topology.kubernetes.io/zone"
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            k8s-app: hubble-relay
+      - maxSkew: 1
+        topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            k8s-app: hubble-relay
       volumes:
       - hostPath:
           path: /var/run/cilium

--- a/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
+++ b/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
@@ -1190,7 +1190,7 @@ metadata:
   labels:
     app: snapshot-validation
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: snapshot-validation
@@ -1210,6 +1210,19 @@ spec:
           - name: snapshot-validation-webhook-certs
             mountPath: /etc/snapshot-validation-webhook/certs
             readOnly: true
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: "topology.kubernetes.io/zone"
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: snapshot-validation
+      - maxSkew: 1
+        topologyKey: "kubernetes.io/hostname"
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: snapshot-validation
       volumes:
         - name: snapshot-validation-webhook-certs
           secret:

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -320,7 +320,12 @@ func (tf *TemplateFunctions) GetInstanceGroup(name string) (*kops.InstanceGroup,
 
 // ControlPlaneControllerReplicas returns the amount of replicas for a controllers that should run in the cluster
 // If the cluster has a highly available control plane, this function will return 2, if it has 1 control plane node, it will return 1
-func (tf *TemplateFunctions) ControlPlaneControllerReplicas() int {
+// deployOnWorkersIfExternalPermissons should be true if a controller runs on worker nodes when external IAM permissions is enabled for the cluster.
+// In this case it is assumed that it can run 2 replicas.
+func (tf *TemplateFunctions) ControlPlaneControllerReplicas(deployOnWorkersIfExternalPermissons bool) int {
+	if deployOnWorkersIfExternalPermissons && fi.BoolValue(tf.Cluster.Spec.IAM.UseServiceAccountExternalPermissions) {
+		return 2
+	}
 	if tf.HasHighlyAvailableControlPlane() {
 		return 2
 	}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: edda11094163a5cf06f13412aac22c289182a25004abb2e3f7e17fc3d881b720
+    manifestHash: 17909ec3ec7a451e80ab934d58b01d9d63f74f2a59e7f25627fe452872ceb2f4
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -208,6 +208,19 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - emptyDir: {}
         name: tmp-dir

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: edda11094163a5cf06f13412aac22c289182a25004abb2e3f7e17fc3d881b720
+    manifestHash: 17909ec3ec7a451e80ab934d58b01d9d63f74f2a59e7f25627fe452872ceb2f4
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -208,6 +208,19 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - emptyDir: {}
         name: tmp-dir

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 650aae104655b86ec6ccefc4f2d7c723703f4a39e5ffd1223a1cfe45c11e4dbe
+    manifestHash: 8b0e29d0a3e12c5d112a3119dc9ad012d6e29dab2e28f80baf7f7a920cac0392
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -211,6 +211,19 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: certs
         secret:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 4404a283ef24baedfdb7bd5a739fc0f0ca82a46800ceb8fd303f94e523a08861
+    manifestHash: ed07ce88fa4e68289ddeabe8dffbc1a5a959810fcd03c10ab7b5f4b0a487d629
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -210,6 +210,19 @@ spec:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            k8s-app: metrics-server
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - name: certs
         secret:


### PR DESCRIPTION
Cherry pick of #13027 #13033 on release-1.23.

#13027: Improve HA for various addons
#13033: LBC has to run on the control plane, so set replicas

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```