### PR TITLE
Automated cherry pick of #13266: Validate taints in IG spec

### DIFF
--- a/pkg/apis/kops/util/BUILD.bazel
+++ b/pkg/apis/kops/util/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "labels.go",
+        "taints.go",
         "versions.go",
     ],
     importpath = "k8s.io/kops/pkg/apis/kops/util",

--- a/pkg/apis/kops/util/taints.go
+++ b/pkg/apis/kops/util/taints.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// parseTaint takes a string and returns a map of its value
+// it mimics the function from https://github.com/kubernetes/kubernetes/blob/master/pkg/util/taints/taints.go
+// but returns a map instead of a v1.Taint
+func ParseTaint(st string) (map[string]string, error) {
+	taint := make(map[string]string)
+
+	var key string
+	var value string
+	var effect string
+
+	parts := strings.Split(st, ":")
+	switch len(parts) {
+	case 1:
+		key = parts[0]
+	case 2:
+		effect = parts[1]
+
+		partsKV := strings.Split(parts[0], "=")
+		if len(partsKV) > 2 {
+			return taint, fmt.Errorf("invalid taint spec: %v", st)
+		}
+		key = partsKV[0]
+		if len(partsKV) == 2 {
+			value = partsKV[1]
+		}
+	default:
+		return taint, fmt.Errorf("invalid taint spec: %v", st)
+	}
+
+	taint["key"] = key
+	taint["value"] = value
+	taint["effect"] = effect
+
+	return taint, nil
+}

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -357,7 +357,7 @@ func TestValidTaints(t *testing.T) {
 		ig := createMinimalInstanceGroup()
 
 		ig.Spec.Taints = g.taints
-		errs := ValidateInstanceGroup(ig, nil, true)
+		errs := ValidateInstanceGroup(ig, nil)
 		testErrors(t, g.taints, errs, g.expected)
 	}
 }
@@ -471,4 +471,20 @@ func TestValidInstanceGroup(t *testing.T) {
 		errList := ValidateInstanceGroup(g.IG, nil)
 		testErrors(t, g.Description, errList, []string{})
 	}
+}
+
+func createMinimalInstanceGroup() *kops.InstanceGroup {
+	ig := &kops.InstanceGroup{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "some-ig",
+		},
+		Spec: kops.InstanceGroupSpec{
+			CloudLabels: make(map[string]string),
+			Role:        "Node",
+			MaxSize:     fi.Int32(1),
+			MinSize:     fi.Int32(1),
+			Image:       "my-image",
+		},
+	}
+	return ig
 }

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -334,6 +334,34 @@ func TestIGCloudLabelIsIGName(t *testing.T) {
 	}
 }
 
+func TestValidTaints(t *testing.T) {
+	grid := []struct {
+		taints   []string
+		expected []string
+	}{
+		{
+			taints: []string{
+				"nvidia.com/gpu:NoSchedule",
+			},
+		},
+		{
+			taints: []string{
+				"nvidia.com/gpu:NoSchedule",
+				"nvidia.com/gpu=1:NoSchedule",
+			},
+			expected: []string{"Forbidden::spec.taints[1]"},
+		},
+	}
+
+	for _, g := range grid {
+		ig := createMinimalInstanceGroup()
+
+		ig.Spec.Taints = g.taints
+		errs := ValidateInstanceGroup(ig, nil, true)
+		testErrors(t, g.taints, errs, g.expected)
+	}
+}
+
 func TestIGUpdatePolicy(t *testing.T) {
 	const unsupportedValueError = "Unsupported value::spec.updatePolicy"
 	for _, test := range []struct {

--- a/pkg/testutils/cluster.go
+++ b/pkg/testutils/cluster.go
@@ -33,6 +33,9 @@ func BuildMinimalCluster(clusterName string) *kops.Cluster {
 		{Name: "subnet-us-mock-1a", Zone: "us-mock-1a", CIDR: "172.20.1.0/24", Type: kops.SubnetTypePrivate},
 	}
 
+	c.Spec.ContainerRuntime = "containerd"
+	c.Spec.Containerd = &kops.ContainerdConfig{}
+
 	c.Spec.MasterPublicName = fmt.Sprintf("api.%v", clusterName)
 	c.Spec.MasterInternalName = fmt.Sprintf("internal.api.%v", clusterName)
 	c.Spec.KubernetesAPIAccess = []string{"0.0.0.0/0"}

--- a/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_cluster_spec_test.go
@@ -197,6 +197,7 @@ func build(c *kopsapi.Cluster) (*kopsapi.Cluster, error) {
 
 func TestPopulateCluster_Kubenet(t *testing.T) {
 	_, c := buildMinimalCluster()
+	c.Spec.ContainerRuntime = "docker"
 
 	full, err := build(c)
 	if err != nil {

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -18,6 +18,7 @@ package cloudup
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/blang/semver/v4"
@@ -173,7 +174,15 @@ func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup,
 					ig.Spec.NodeLabels = make(map[string]string)
 				}
 				ig.Spec.NodeLabels["kops.k8s.io/gpu"] = "1"
-				ig.Spec.Taints = append(ig.Spec.Taints, "nvidia.com/gpu:NoSchedule")
+				hasNvidiaTaint := false
+				for _, taint := range ig.Spec.Taints {
+					if strings.HasPrefix(taint, "nvidia.com/gpu") {
+						hasNvidiaTaint = true
+					}
+				}
+				if !hasNvidiaTaint {
+					ig.Spec.Taints = append(ig.Spec.Taints, "nvidia.com/gpu:NoSchedule")
+				}
 			}
 		}
 	}

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec_test.go
@@ -67,6 +67,7 @@ func TestPopulateInstanceGroup_Role_Required(t *testing.T) {
 func TestPopulateInstanceGroup_AddTaintsCollision(t *testing.T) {
 	_, cluster := buildMinimalCluster()
 	input := buildMinimalNodeInstanceGroup()
+	input.Spec.Image = "my-image"
 	input.Spec.Taints = []string{"nvidia.com/gpu:NoSchedule"}
 	input.Spec.MachineType = "g4dn.xlarge"
 	cluster.Spec.Containerd.NvidiaGPU = &kopsapi.NvidiaGPUConfig{Enabled: fi.Bool(true)}
@@ -89,6 +90,7 @@ func TestPopulateInstanceGroup_AddTaintsCollision(t *testing.T) {
 func TestPopulateInstanceGroup_AddTaints(t *testing.T) {
 	_, cluster := buildMinimalCluster()
 	input := buildMinimalNodeInstanceGroup()
+	input.Spec.Image = "my-image"
 	input.Spec.MachineType = "g4dn.xlarge"
 	cluster.Spec.Containerd.NvidiaGPU = &kopsapi.NvidiaGPUConfig{Enabled: fi.Bool(true)}
 

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	kopsapi "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/util/pkg/architectures"
 )
 
@@ -61,6 +62,49 @@ func TestPopulateInstanceGroup_Role_Required(t *testing.T) {
 	channel := &kopsapi.Channel{}
 
 	expectErrorFromPopulateInstanceGroup(t, cluster, g, channel, "spec.role")
+}
+
+func TestPopulateInstanceGroup_AddTaintsCollision(t *testing.T) {
+	_, cluster := buildMinimalCluster()
+	input := buildMinimalNodeInstanceGroup()
+	input.Spec.Taints = []string{"nvidia.com/gpu:NoSchedule"}
+	input.Spec.MachineType = "g4dn.xlarge"
+	cluster.Spec.Containerd.NvidiaGPU = &kopsapi.NvidiaGPUConfig{Enabled: fi.Bool(true)}
+
+	channel := &kopsapi.Channel{}
+
+	cloud, err := BuildCloud(cluster)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+	output, err := PopulateInstanceGroupSpec(cluster, input, cloud, channel)
+	if err != nil {
+		t.Fatalf("error from PopulateInstanceGropuSpec: %v", err)
+	}
+	if len(output.Spec.Taints) != 1 {
+		t.Errorf("Expected only 1 taint, got %d", len(output.Spec.Taints))
+	}
+}
+
+func TestPopulateInstanceGroup_AddTaints(t *testing.T) {
+	_, cluster := buildMinimalCluster()
+	input := buildMinimalNodeInstanceGroup()
+	input.Spec.MachineType = "g4dn.xlarge"
+	cluster.Spec.Containerd.NvidiaGPU = &kopsapi.NvidiaGPUConfig{Enabled: fi.Bool(true)}
+
+	channel := &kopsapi.Channel{}
+
+	cloud, err := BuildCloud(cluster)
+	if err != nil {
+		t.Fatalf("error from BuildCloud: %v", err)
+	}
+	output, err := PopulateInstanceGroupSpec(cluster, input, cloud, channel)
+	if err != nil {
+		t.Fatalf("error from PopulateInstanceGropuSpec: %v", err)
+	}
+	if len(output.Spec.Taints) != 1 {
+		t.Errorf("Expected only 1 taint, got %d", len(output.Spec.Taints))
+	}
 }
 
 func expectErrorFromPopulateInstanceGroup(t *testing.T, cluster *kopsapi.Cluster, g *kopsapi.InstanceGroup, channel *kopsapi.Channel, message string) {

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -281,6 +281,8 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 		dest["EnableSQSTerminationDraining"] = func() bool { return *cluster.Spec.NodeTerminationHandler.EnableSQSTerminationDraining }
 	}
 
+	dest["ParseTaint"] = util.ParseTaint
+
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #13266 on release-1.23.

#13266: Validate taints in IG spec

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```