### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/protokube/pkg/gossip/dns/hosts/hosts_test.go
+++ b/protokube/pkg/gossip/dns/hosts/hosts_test.go
@@ -112,16 +112,7 @@ func TestRecoversFromBadNesting(t *testing.T) {
 }
 
 func runTest(t *testing.T, in string, expected string) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("error creating temp dir: %v", err)
-	}
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			t.Errorf("failed to remove temp dir %q: %v", dir, err)
-		}
-	}()
+	dir := t.TempDir()
 
 	p := filepath.Join(dir, "hosts")
 	namesToAddresses := map[string][]string{

--- a/upup/pkg/fi/cloudup/awstasks/render_test.go
+++ b/upup/pkg/fi/cloudup/awstasks/render_test.go
@@ -35,17 +35,7 @@ type renderTest struct {
 }
 
 func doRenderTests(t *testing.T, method string, cases []*renderTest) {
-	outdir, err := os.MkdirTemp("", "kops-render-")
-	if err != nil {
-		t.Errorf("failed to create local render directory: %s", err)
-		t.FailNow()
-	}
-	defer func() {
-		err := os.RemoveAll(outdir)
-		if err != nil {
-			t.Errorf("failed to remove temp dir %q: %v", outdir, err)
-		}
-	}()
+	outdir := t.TempDir()
 
 	for i, c := range cases {
 		var filename string

--- a/upup/pkg/fi/files_test.go
+++ b/upup/pkg/fi/files_test.go
@@ -31,16 +31,7 @@ func TestWriteFile(t *testing.T) {
 	// Clear the umask so an unusual umask doesn't break our test (for directory mode)
 	syscall.Umask(0)
 
-	tempDir, err := os.MkdirTemp("", "fitest")
-	if err != nil {
-		t.Fatalf("error creating temp dir: %v", err)
-	}
-	defer func() {
-		err := os.RemoveAll(tempDir)
-		if err != nil {
-			t.Errorf("failed to remove temp dir %q: %v", tempDir, err)
-		}
-	}()
+	tempDir := t.TempDir()
 
 	tests := []struct {
 		path     string

--- a/util/pkg/vfs/fs_test.go
+++ b/util/pkg/vfs/fs_test.go
@@ -24,16 +24,7 @@ import (
 )
 
 func TestCreateFile(t *testing.T) {
-	TempDir, err := os.MkdirTemp("", "test")
-	if err != nil {
-		t.Fatalf("error creating temp dir: %v", err)
-	}
-	defer func() {
-		err := os.RemoveAll(TempDir)
-		if err != nil {
-			t.Errorf("failed to remove temp dir %q: %v", TempDir, err)
-		}
-	}()
+	TempDir := t.TempDir()
 
 	tests := []struct {
 		path string
@@ -70,16 +61,7 @@ func TestCreateFile(t *testing.T) {
 }
 
 func TestWriteTo(t *testing.T) {
-	TempDir, err := os.MkdirTemp("", "test")
-	if err != nil {
-		t.Fatalf("error creating temp dir: %v", err)
-	}
-	defer func() {
-		err := os.RemoveAll(TempDir)
-		if err != nil {
-			t.Errorf("failed to remove temp dir %q: %v", TempDir, err)
-		}
-	}()
+	TempDir := t.TempDir()
 
 	tests := []struct {
 		path string


### PR DESCRIPTION
A small testing enhancement here.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir