### PR TITLE
Automated cherry pick of #13284: Do not create a cert-manager namespace

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 1ca310cbf412e8713fd99fb9203f8f4f5010b903f990103a74316c7f42b3e560
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -30826,17 +30826,6 @@ spec:
 ---
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: certmanager.io
-    app.kubernetes.io/managed-by: kops
-  name: cert-manager
-
----
-
-apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 1ca310cbf412e8713fd99fb9203f8f4f5010b903f990103a74316c7f42b3e560
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -30826,17 +30826,6 @@ spec:
 ---
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: certmanager.io
-    app.kubernetes.io/managed-by: kops
-  name: cert-manager
-
----
-
-apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 1ca310cbf412e8713fd99fb9203f8f4f5010b903f990103a74316c7f42b3e560
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -30826,17 +30826,6 @@ spec:
 ---
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: certmanager.io
-    app.kubernetes.io/managed-by: kops
-  name: cert-manager
-
----
-
-apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 1ca310cbf412e8713fd99fb9203f8f4f5010b903f990103a74316c7f42b3e560
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -30826,17 +30826,6 @@ spec:
 ---
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: certmanager.io
-    app.kubernetes.io/managed-by: kops
-  name: cert-manager
-
----
-
-apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -16232,11 +16232,6 @@ spec:
       served: true
       storage: true
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cert-manager
----
 # Source: cert-manager/templates/cainjector-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 1ca310cbf412e8713fd99fb9203f8f4f5010b903f990103a74316c7f42b3e560
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 71dcc0409edb49a5b9bf52416ccdca68bc075167dc9604441cb3bd73b7bba149
+    manifestHash: 1ca310cbf412e8713fd99fb9203f8f4f5010b903f990103a74316c7f42b3e560
     name: certmanager.io
     selector: null
     version: 9.99.0


### PR DESCRIPTION
Cherry pick of #13284 on release-1.23.

#13284: Do not create a cert-manager namespace

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```