### PR TITLE
Automated cherry pick of #13284: Do not create a cert-manager namespace

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
+    manifestHash: 442128e1970a7b60a7634e22b3a06d34d2216150a56bca16ba4321efd3552257
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -30609,17 +30609,6 @@ status:
 ---
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: certmanager.io
-    app.kubernetes.io/managed-by: kops
-  name: cert-manager
-
----
-
-apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
+    manifestHash: 442128e1970a7b60a7634e22b3a06d34d2216150a56bca16ba4321efd3552257
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -30609,17 +30609,6 @@ status:
 ---
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: certmanager.io
-    app.kubernetes.io/managed-by: kops
-  name: cert-manager
-
----
-
-apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 0ad47440355c822d443ae607d7a052e93eaa024d60f69e18d925785b7ec3b406
+    manifestHash: 78281c2d5d9aaaded5e035d2f7b5d00466c80f8ab55dfa2ad9f26216b2071108
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
+    manifestHash: 442128e1970a7b60a7634e22b3a06d34d2216150a56bca16ba4321efd3552257
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -30609,17 +30609,6 @@ status:
 ---
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: certmanager.io
-    app.kubernetes.io/managed-by: kops
-  name: cert-manager
-
----
-
-apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
+    manifestHash: 442128e1970a7b60a7634e22b3a06d34d2216150a56bca16ba4321efd3552257
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -30609,17 +30609,6 @@ status:
 ---
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  creationTimestamp: null
-  labels:
-    addon.kops.k8s.io/name: certmanager.io
-    app.kubernetes.io/managed-by: kops
-  name: cert-manager
-
----
-
-apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -16088,11 +16088,6 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cert-manager
----
 # Source: cert-manager/templates/cainjector-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
+    manifestHash: 442128e1970a7b60a7634e22b3a06d34d2216150a56bca16ba4321efd3552257
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 85a4d2a4e69f6e0c2d3bc23f76c1454a5e90f19f7515d0c4030d9ec9716f217f
+    manifestHash: 442128e1970a7b60a7634e22b3a06d34d2216150a56bca16ba4321efd3552257
     name: certmanager.io
     selector: null
     version: 9.99.0


### PR DESCRIPTION
Cherry pick of #13284 on release-1.22.

#13284: Do not create a cert-manager namespace

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```