### PR TITLE
alpha channel: recommend kOps 1.22.4

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -135,7 +135,7 @@ spec:
     #requiredVersion: 1.22.0
     kubernetesVersion: 1.23.4
   - range: ">=1.22.0-alpha.1"
-    recommendedVersion: "1.22.3"
+    recommendedVersion: "1.22.4"
     #requiredVersion: 1.22.0
     kubernetesVersion: 1.22.7
   - range: ">=1.21.0-alpha.1"


### PR DESCRIPTION
Includes fixes for etcd 3.5.0 vs 3.5.1
