### PR TITLE
Add support for ed25519 keys in AWS

### DIFF
--- a/pkg/pki/sshkey_test.go
+++ b/pkg/pki/sshkey_test.go
@@ -54,6 +54,11 @@ func Test_AWSFingerprint_RsaKeyEncrypted(t *testing.T) {
 	checkAWSFingerprintEqual(t, key, "c9:c5:05:5e:ea:54:fc:a4:7c:7c:75:5c:d2:71:5e:40")
 }
 
+func Test_AWSFingerprint_Ed25519Key(t *testing.T) {
+	key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBoB6Gtu8zPAPO1yF4OwysWUD8ZSEQYzMpOT0YvF9qJV user@example"
+	checkAWSFingerprintEqual(t, key, "SHA256:HvE7+gmH78VS53+iPuRDh/gKjVo26OzYU/qOnJWAgyk")
+}
+
 func Test_AWSFingerprint_TrickyWhitespace(t *testing.T) {
 	// No name, \r instead of whitespace
 	key := "ssh-rsa\rAAAAB3NzaC1yc2EAAAADAQABAAABAQCySdqIU+FhCWl3BNrAvPaOe5VfL2aCARUWwy91ZP+T7LBwFa9lhdttfjp/VX1D1/PVwntn2EhN079m8c2kfdmiZ/iCHqrLyIGSd+BOiCz0lT47znvANSfxYjLUuKrWWWeaXqerJkOsAD4PHchRLbZGPdbfoBKwtb/WT4GMRQmb9vmiaZYjsfdPPM9KkWI9ECoWFGjGehA8D+iYIPR711kRacb1xdYmnjHqxAZHFsb5L8wDWIeAyhy49cBD+lbzTiioq2xWLorXuFmXh6Do89PgzvHeyCLY6816f/kCX6wIFts8A2eaEHFL4rAOsuh6qHmSxGCR9peSyuRW8DxV725x\r"
@@ -62,12 +67,7 @@ func Test_AWSFingerprint_TrickyWhitespace(t *testing.T) {
 
 func Test_AWSFingerprint_DsaKey(t *testing.T) {
 	key := "ssh-dss AAAAB3NzaC1kc3MAAACBAIcCTu3vi9rNjsnhCrHeII7jSN6/FmnIdy09pQAsMAGGvCS9HBOteCKbIyYQQ0+Gi76Oui7cJ2VQojdxOxeZPoSP+QYnA+CVYhnowVVLeRA9VBQG3ZLInoXaqe3nR4/OXhY75GmYShBBPTQ+/fWGX9ltoXfygSc4KjhBNudvj75VAAAAFQDiw8A4MhY0aHSX/mtpa7XV8+iS6wAAAIAXyQaxM/dk0o1vBV3H0V0lGhog3mF7EJPdw7jagYvXQP1tAhzNofxZVhXHr4wGfiTQv9j5plDqQzCI/15a6DRyo9zI+zdPTR41W3dGrk56O2/Qxsz3/vNip5OwpOJ88yMmBX9m36gg0WrOXcZDgErhvZWRt5cXa9QjVg/KpxYLPAAAAIB8e5M82IiRLi+k1k4LsELKArQGzVkPgynESfnEXX0TKGiR7PJvBNGaKnPJtJ0Rrc38w/hLTeklroJt9Rdey/NI9b6tc+ur2pmJdnYppnNCm03WszU4oFD/7KIqR84Hf0fMbWd1hRvznpZhngZ505KNsL+ck0+Tlq6Hdhe2baXJcA== justin@machine"
-	checkAWSFingerprintError(t, key, "AWS can only import RSA keys")
-}
-
-func Test_AWSFingerprint_Ed25519Key(t *testing.T) {
-	key := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFpyraYd4rUFftiEKzUO4wKFAgTkXxuJcRZwVcsuZJ8G justin@machine"
-	checkAWSFingerprintError(t, key, "AWS can only import RSA keys")
+	checkAWSFingerprintError(t, key, "AWS can only import RSA and ed25519 keys")
 }
 
 func checkOpenSSHFingerprintEqual(t *testing.T, publicKey string, fingerprint string) {


### PR DESCRIPTION
AWS EC2 supports `ed25519` keys from the start of this year [(blog)](https://aws.amazon.com/about-aws/whats-new/2022/01/ed25519-keys-authentication-ec2-instance-connect/), updating the `ComputeAWSKeyFingerprint` func to match this.

## Implementation notes
I trimmed the "SHA256" prefix that the `ssh.FingerprintSHA256` call adds to keep it consistent with the fingerprint format presented both in the console and the API. Happy to undo this if folks think this is incorrect :smile: 
![image](https://user-images.githubusercontent.com/19669095/155541904-2895ba51-4e8b-4739-ac4d-ae2b53db9bc3.png)

```
$ aws ec2 describe-key-pairs --key-names jake-test-ed25519
{
    "KeyPairs": [
        {
            ...
            "KeyFingerprint": "HvE7+gmH78VS53+iPuRDh/gKjVo26OzYU/qOnJWAgyk=",
            "KeyName": "jake-test-ed25519",
            "KeyType": "ed25519",
        }
    ]
}
```

This issue was originally discovered here https://github.com/weaveworks/eksctl/issues/4779