### PR TITLE
use own function to define CSI image version

### DIFF
--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -328,7 +328,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: cinder-csi-plugin
-          image: "{{- if .CloudConfig.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudConfig.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} docker.io/k8scloudprovider/cinder-csi-plugin:{{OpenStackCCMTag}} {{- end -}}"
+          image: "{{- if .CloudConfig.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudConfig.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} docker.io/k8scloudprovider/cinder-csi-plugin:{{OpenStackCSITag}} {{- end -}}"
           args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"
@@ -472,7 +472,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: "{{- if .CloudConfig.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudConfig.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} docker.io/k8scloudprovider/cinder-csi-plugin:{{OpenStackCCMTag}} {{- end -}}"
+          image: "{{- if .CloudConfig.Openstack.BlockStorage.CSIPluginImage -}} {{ .CloudConfig.Openstack.BlockStorage.CSIPluginImage }} {{- else -}} docker.io/k8scloudprovider/cinder-csi-plugin:{{OpenStackCSITag}} {{- end -}}"
           args :
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -155,6 +155,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 
 	// will return openstack external ccm image location for current kubernetes version
 	dest["OpenStackCCMTag"] = tf.OpenStackCCMTag
+	dest["OpenStackCSITag"] = tf.OpenStackCSITag
 	dest["ProxyEnv"] = tf.ProxyEnv
 
 	dest["KopsSystemEnv"] = tf.KopsSystemEnv
@@ -734,11 +735,25 @@ func (tf *TemplateFunctions) OpenStackCCMTag() string {
 			tag = "1.13.1"
 		} else if parsed.Minor == 23 {
 			// The bugfix release, see https://github.com/kubernetes/cloud-provider-openstack/releases
-			tag = "1.23.1"
+			tag = "v1.23.1"
 		} else {
 			// otherwise we use always .0 ccm image, if needed that can be overrided using clusterspec
 			tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)
 		}
+	}
+	return tag
+}
+
+// OpenStackCSI returns OpenStack csi current image
+// with tag specified to k8s version
+func (tf *TemplateFunctions) OpenStackCSITag() string {
+	var tag string
+	parsed, err := util.ParseKubernetesVersion(tf.Cluster.Spec.KubernetesVersion)
+	if err != nil {
+		tag = "latest"
+	} else {
+		// otherwise we use always .0 csi image, if needed that can be overrided using cloud config spec
+		tag = fmt.Sprintf("v%d.%d.0", parsed.Major, parsed.Minor)
 	}
 	return tag
 }


### PR DESCRIPTION
this PR fixes 2 bugs:

1) there is typo in CCM tag, it should be `v1.23.1` not `1.23.1`
2) currently kOps assumes that CSI uses same version than CCM uses in OpenStack. However, that is not true currently.