### PR TITLE
release 1.21.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,13 @@ GITSHA := $(shell cd ${KOPS_ROOT}; git describe --always)
 # We lock the versions of our controllers also
 # We need to keep in sync with:
 #   upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.21.4
+DNS_CONTROLLER_TAG=1.21.5
 DNS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_DNS_CONTROLLER_TAG | awk '{print $$2}')
 #   upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/
-KOPS_CONTROLLER_TAG=1.21.4
+KOPS_CONTROLLER_TAG=1.21.5
 KOPS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KOPS_CONTROLLER_TAG | awk '{print $$2}')
 #   pkg/model/components/kubeapiserver/model.go
-KUBE_APISERVER_HEALTHCHECK_TAG=1.21.4
+KUBE_APISERVER_HEALTHCHECK_TAG=1.21.5
 KUBE_APISERVER_HEALTHCHECK_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KUBE_APISERVER_HEALTHCHECK_TAG | awk '{print $$2}')
 
 

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -95,7 +95,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.21.4
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.21.5
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -12,7 +12,7 @@ Contents: |
       - --client-key=/secrets/client.key
       command:
       - /kube-apiserver-healthcheck
-      image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.21.4
+      image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.21.5
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.21.4
+    version: v1.21.5
 spec:
   replicas: 1
   strategy:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.21.4
+        version: v1.21.5
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -33,7 +33,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: k8s.gcr.io/kops/dns-controller:1.21.4
+        image: k8s.gcr.io/kops/dns-controller:1.21.5
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.21.4
+    version: v1.21.5
 spec:
   selector:
     matchLabels:
@@ -31,7 +31,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.21.4
+        version: v1.21.5
 {{ if UseKopsControllerForNodeBootstrap }}
       annotations:
         dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
@@ -49,7 +49,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: k8s.gcr.io/kops/kops-controller:1.21.4
+        image: k8s.gcr.io/kops/kops-controller:1.21.5
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -211,7 +211,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 
 	{
 		key := "kops-controller.addons.k8s.io"
-		version := "1.21.4"
+		version := "1.21.5"
 
 		{
 			location := key + "/k8s-1.16.yaml"
@@ -386,7 +386,7 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*chann
 	if externalDNS == nil || !externalDNS.Disable {
 		{
 			key := "dns-controller.addons.k8s.io"
-			version := "1.21.4"
+			version := "1.21.5"
 
 			{
 				location := key + "/k8s-1.12.yaml"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4882f7eb53d6e6bd4fefeb429ec710d4f8437c66
+    manifestHash: f801b988f2ce44c55d249182893646108f14c8b5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -48,11 +48,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4882f7eb53d6e6bd4fefeb429ec710d4f8437c66
+    manifestHash: f801b988f2ce44c55d249182893646108f14c8b5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -48,11 +48,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cacb4bd2303985e203deef8e311a1f2528fd0742
+    manifestHash: 1b9b4625eb40e3955548ebbf1acc4b623fb180d3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -41,11 +41,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cacb4bd2303985e203deef8e311a1f2528fd0742
+    manifestHash: 1b9b4625eb40e3955548ebbf1acc4b623fb180d3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -41,11 +41,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,11 +4,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.21.4
+    version: v1.21.5
   name: dns-controller
   namespace: kube-system
 spec:
@@ -25,7 +25,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.21.4
+        version: v1.21.5
     spec:
       containers:
       - command:
@@ -38,7 +38,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.21.4
+        image: k8s.gcr.io/kops/dns-controller:1.21.5
         name: dns-controller
         resources:
           requests:
@@ -63,7 +63,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
   name: dns-controller
@@ -77,7 +77,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
   name: kops:dns-controller
@@ -111,7 +111,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
   name: kops:dns-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -21,11 +21,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.21.4
+    version: v1.21.5
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.21.4
+        version: v1.21.5
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.21.4
+        image: k8s.gcr.io/kops/kops-controller:1.21.5
         name: kops-controller
         resources:
           requests:
@@ -89,7 +89,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -103,7 +103,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -126,7 +126,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -147,7 +147,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -194,7 +194,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4882f7eb53d6e6bd4fefeb429ec710d4f8437c66
+    manifestHash: f801b988f2ce44c55d249182893646108f14c8b5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -48,11 +48,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/jwks/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/jwks/manifest.yaml
@@ -19,7 +19,7 @@ spec:
     name: anonymous-access.addons.k8s.io
     selector:
       k8s-addon: anonymous-access.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 3ffe9ac576f9eec72e2bdfbd2ea17d56d9b17b90
     name: core.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4882f7eb53d6e6bd4fefeb429ec710d4f8437c66
+    manifestHash: f801b988f2ce44c55d249182893646108f14c8b5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -48,11 +48,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
     manifestHash: a760a68f4d76cfddb5a2cd9afa9afdb0b301d187

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cacb4bd2303985e203deef8e311a1f2528fd0742
+    manifestHash: 1b9b4625eb40e3955548ebbf1acc4b623fb180d3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -41,11 +41,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
     manifestHash: a760a68f4d76cfddb5a2cd9afa9afdb0b301d187

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4882f7eb53d6e6bd4fefeb429ec710d4f8437c66
+    manifestHash: f801b988f2ce44c55d249182893646108f14c8b5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -48,11 +48,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
     manifestHash: d4a188bdcd03921d7852fa12f4dbb7d996b7edb5

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cacb4bd2303985e203deef8e311a1f2528fd0742
+    manifestHash: 1b9b4625eb40e3955548ebbf1acc4b623fb180d3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -41,11 +41,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
     manifestHash: 3795901da096a90916f4258aec1dc656f16d2b8f

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,11 +4,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.21.4
+    version: v1.21.5
   name: dns-controller
   namespace: kube-system
 spec:
@@ -25,7 +25,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.21.4
+        version: v1.21.5
     spec:
       containers:
       - command:
@@ -42,7 +42,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.21.4
+        image: k8s.gcr.io/kops/dns-controller:1.21.5
         name: dns-controller
         resources:
           requests:
@@ -82,7 +82,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
   name: dns-controller
@@ -96,7 +96,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
   name: kops:dns-controller
@@ -130,7 +130,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
   name: kops:dns-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -21,11 +21,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.21.4
+    version: v1.21.5
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.21.4
+        version: v1.21.5
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.21.4
+        image: k8s.gcr.io/kops/kops-controller:1.21.5
         name: kops-controller
         resources:
           requests:
@@ -89,7 +89,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -103,7 +103,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -126,7 +126,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -147,7 +147,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -194,7 +194,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4882f7eb53d6e6bd4fefeb429ec710d4f8437c66
+    manifestHash: f801b988f2ce44c55d249182893646108f14c8b5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -48,11 +48,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 15ce192161325b0be1986be142b33a4f4019817f
+    manifestHash: 5cfeee9a007f5cd1c10cdfee51af9e2cfdd501ac
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -4,11 +4,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.21.4
+    version: v1.21.5
   name: dns-controller
   namespace: kube-system
 spec:
@@ -25,7 +25,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.21.4
+        version: v1.21.5
     spec:
       containers:
       - command:
@@ -38,7 +38,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.21.4
+        image: k8s.gcr.io/kops/dns-controller:1.21.5
         name: dns-controller
         resources:
           requests:
@@ -63,7 +63,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
   name: dns-controller
@@ -77,7 +77,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
   name: kops:dns-controller
@@ -111,7 +111,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: dns-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
   name: kops:dns-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -21,11 +21,11 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.21.4
+    version: v1.21.5
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.21.4
+        version: v1.21.5
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.21.4
+        image: k8s.gcr.io/kops/kops-controller:1.21.5
         name: kops-controller
         resources:
           requests:
@@ -91,7 +91,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -105,7 +105,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -128,7 +128,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -149,7 +149,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller
@@ -196,7 +196,7 @@ metadata:
   creationTimestamp: null
   labels:
     addon.kops.k8s.io/name: kops-controller.addons.k8s.io
-    addon.kops.k8s.io/version: 1.21.4
+    addon.kops.k8s.io/version: 1.21.5
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
   name: kops-controller

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cacb4bd2303985e203deef8e311a1f2528fd0742
+    manifestHash: 1b9b4625eb40e3955548ebbf1acc4b623fb180d3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -41,11 +41,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -7,12 +7,12 @@ spec:
   - id: k8s-1.16
     kubernetesVersion: '>=1.16.0-alpha.0'
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cacb4bd2303985e203deef8e311a1f2528fd0742
+    manifestHash: 1b9b4625eb40e3955548ebbf1acc4b623fb180d3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
       k8s-addon: kops-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - manifest: core.addons.k8s.io/v1.4.0.yaml
     manifestHash: 75dd91a5b15ade4a61ebc1de8c35714376dfbed4
     name: core.addons.k8s.io
@@ -41,11 +41,11 @@ spec:
     version: 1.5.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f011be3908d29b3291ade5ca5e52f1d7d7ef928c
+    manifestHash: b8c86fa84f1be1a5379d526d01f403427280bd96
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
-    version: 1.21.4
+    version: 1.21.5
   - id: v1.15.0
     kubernetesVersion: '>=1.15.0'
     manifest: storage-aws.addons.k8s.io/v1.15.0.yaml

--- a/upup/pkg/fi/cloudup/urls_test.go
+++ b/upup/pkg/fi/cloudup/urls_test.go
@@ -36,29 +36,29 @@ func Test_BuildMirroredAsset(t *testing.T) {
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-amd64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.21.4/images/protokube-linux-amd64",
-				"https://github.com/kubernetes/kops/releases/download/v1.21.4/images-protokube-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.21.5/images/protokube-linux-amd64",
+				"https://github.com/kubernetes/kops/releases/download/v1.21.5/images-protokube-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-arm64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.21.4/images/protokube-linux-arm64",
-				"https://github.com/kubernetes/kops/releases/download/v1.21.4/images-protokube-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.21.5/images/protokube-linux-arm64",
+				"https://github.com/kubernetes/kops/releases/download/v1.21.5/images-protokube-linux-arm64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/amd64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.21.4/linux/amd64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.21.4/nodeup-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.21.5/linux/amd64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.21.5/nodeup-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/arm64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.21.4/linux/arm64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.21.4/nodeup-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.21.5/linux/arm64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.21.5/nodeup-linux-arm64",
 			},
 		},
 	}

--- a/version.go
+++ b/version.go
@@ -21,8 +21,8 @@ var Version = KOPS_RELEASE_VERSION
 
 // These constants are parsed by build tooling - be careful about changing the formats
 const (
-	KOPS_RELEASE_VERSION = "1.21.4"
-	KOPS_CI_VERSION      = "1.21.5"
+	KOPS_RELEASE_VERSION = "1.21.5"
+	KOPS_CI_VERSION      = "1.21.6"
 )
 
 // GitVersion should be replaced by the makefile


### PR DESCRIPTION
- Release 1.21.0-beta.1
- Use etcd-manager built from etcdadm repo
- Use etcd-backup built from etcdadm repo
- Simplify use of hack/set-version
- Verify all versions are set correctly
- Bump to GA release
- Update verify-terraform to use 0.15.3
- Create new clusters without forcing a container runtime
- Sort --extra-tags of ebs-csi-driver
- Allow AWS instance types with multiple architectures
- Add support for CAS 1.21.0
- upup: gcetasks: fix diffs in instance template and router
- upup: gcetasks: force send AutoCreateSubnetworks field when set to false
- Announce k8s removals two kOps versions in advance
- Update cert-manager
- Set priorityClassName on critical addons
- fix(coredns/rbac): add permission to list and watch endpointslices
- tests: fixing the coredns manifest hash
- feat(spot/addon): bump ocean-controller to 1.0.75
- bump aws lb controller to 2.2.0
- Add e2e test for aws-lb-controller
- Set default fstype for ebs volumes to ext4
- enable prometheus scraping
- Update upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.8.yaml.template
- Update upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
- Update upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
- fix missing quote function with printf
- 
- Update containerd to v1.4.6
- Run hack/update-expected.sh
- Delete IAM roles no longer in the model
- Delete cluster-owned service account roles upon cluster deletion
- Release images bundle instead of separate images
- Bump patch version
- Bump manifests to latest stable version 1.8.3
- Update CAS manifest
- Make the events etcd cluster optional
- Run ./hack/update-expected.sh
- Bump default cilium to 1.9.7
- Bump snapshot-controller version
- Add snapshot-controller
- Allow using insecure TLS for metrics-server with Kubernetes 1.19+
- Update metrics-server to v0.4.4
- Fix deletion of IAM roles and policies
- Release 1.21.0-beta.2
- Allow Spotinst to use comma separated instance types
- Only allow deletion of snapshots owned by the cluster
- Only update kubeconfig user when we have user info
- Update Calico to v3.19.1
- Use the OnDelete updateStrategy for AWS VPC CNI DaemonSet
- add init image field
- Fix duplicate CopyFile tasks
- Update Go to v1.16.4
- Set lifecycle on WarmPool task
- Consolidate CSI livenessprobe images for multi-arch support
- Fix issuer and jwks object path for IRSA
- Fix integration test for oidc because the object path is changed
- Set canonical location for downloads to artifacts.k8s.io
- Add support for Docker v20.10.7
- Run hack/update-expected.sh
- Drop trailing slash from oidc issuer
- Update Go to v1.16.5
- Release 1.21.0-beta.3
- Fix set-version leaving backup files with "-e" suffix
- Fix the CSI EBS DS CRB.
- Add proxy envs to calico to make possible usage of AWS source destination check
- Generate AWSEBSCSIDriver model only when using AWS
- Use quay images for cilium
- Compare OpenStack security groups deterministically
- Make forwardToKubeDNS work in the NodeLocal DNSCache template
- fix enable default SC when EBS driver is not installed
- Bump the cas addon version.
- Don't try to build etcd-manager secrets for cilium twice
- Use internal name for cilium etcd if we do not enable api server nodes
- Also set haveUserInfo=true in case --user was provided in "kops export kubecfg"
- bump the version of gophercloud
- Pre-add hooks integration test
- Handle containerExec hooks when using containerd
- Avoid spurious changes for ASG InstanceProtection and LT InstanceMonitoring
- support large/slow downloads
- Set download timeout to 3 minutes
- Include GCP Project in terraform HCL2 output
- Release 1.21.0
- Add log rotation for etcd-cilium.log
- Capture logs from the etcd-cilium pod
- check if the instance is under an asg
- Enable k8s event handover when kvstore is used
- Add auto compaction to new cilium etcd clusters and to docs
- Use regional STS endpoint
- Update containerd to v1.4.8
- Update cfn-lint to v1.52.0
- Update containerd to v1.4.9
- Update core-dns to v1.8.4
- Update Docker to v20.10.8
- Make metrics-server insecure if insecure is true
- Update Calico to v3.19.2
- Fix cases when the VPC doesn't exist yet
- Test if update_service behaves as intended
- Fix disabling unattended upgrades
- Support Debian 11 Bullseye
- Debian 11: python-apt is not available
- Bump cilium to 1.9.9
- leverage proxy env variables
- Reconcile if managedFile is public or not
- Update Go to v1.16.7
- Debian 11: Release AMIs use same AWS Owner ID as Buster
- Log s3 acl in additional cases
- Hardcode Flatcar containerd exec command
- Backport moving updatePolicy to nodeup config
- Add option in Cluster Autoscaler AddOn for AWS EC2 Static instance list
- Release 1.21.1
- Update Calico to v3.19.3
- Lengthen NTH integration test cluster name
- Truncate cluster name prefix used in event bridge rules
- Fix example permissions boundary ARN
- Don't ignore channel value in toolbox template
- Add latest hashes for containerd and Docker
- Update the default version for containerd and Docker
- Run hack/update-expected.sh
- Release 1.21.2 (#12511)
- Increase upup http response header timeout
- set calico-node readiness/liveness timeout to 10s
- Fix out of bounds error when instance detach fails
- Fix that states AWS IAM Instance Profile blocks IAM Role
- Add hash for containerd v1.4.12
- Add hash for containerd v1.5.8
- Add hashes for Docker v20.10.10
- Add hashes for Docker v20.10.11
- Shorten filenames in the asset store
- Update containerd to v1.4.12
- Run hack/update-expected.sh
- Bump etcd-manager version
- Update test data for etcd-manager bump
- Add test for ratio bug
- Fix correct ratio checks for EBS volumes
- Update Go to v1.16.8
- Update Go to v1.16.10
- Release 1.21.4
- Add support for --dns flag in Docker config
- Update etcd-manager to v3.0.20211124
- Run hack/update-expected.sh
- Update Go to v1.16.11
- Update Go to v1.16.12
- Prevent creation of unsupported etcd clusters
- Add action for automatically tagging releases
- Remove temporary restrictions on automatically tagging releases
- Fix CSI migration feature gates
- upgrade cluster: support comma separated list for machineType
- Simplify Flatcar containerd exec command
- Update to etcd-manager v3.0.20220203
- Update expected test output for etcd-manager bump
- Release 1.21.5
