### PR TITLE
Fix introduced version for pod-identity-webhook in docs

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -249,7 +249,7 @@ spec:
 
 #### EKS Pod Identity Webhook
 
-{{ kops_feature_table(kops_added_default='1.24') }}
+{{ kops_feature_table(kops_added_default='1.23') }}
 
 kOps can install EKS Pod Identity Webhook for IAM Role for Service Accounts.
 You need to enable cert-manager to use this feature.


### PR DESCRIPTION
Recently, I added EKS pod identity webhook addon: https://github.com/kubernetes/kops/pull/13176 . In that PR, I updated addons docs.
And that PR was backported to 1.23: https://github.com/kubernetes/kops/pull/13315
That means we can use the addon, since kOps 1.23. So I fix the docs.