### PR TITLE
Release 1.23.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,13 @@ GITSHA := $(shell cd ${KOPS_ROOT}; git describe --always)
 # We lock the versions of our controllers also
 # We need to keep in sync with:
 #   upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.23.0-beta.2
+DNS_CONTROLLER_TAG=1.23.0
 DNS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_DNS_CONTROLLER_TAG | awk '{print $$2}')
 #   upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/
-KOPS_CONTROLLER_TAG=1.23.0-beta.2
+KOPS_CONTROLLER_TAG=1.23.0
 KOPS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KOPS_CONTROLLER_TAG | awk '{print $$2}')
 #   pkg/model/components/kubeapiserver/model.go
-KUBE_APISERVER_HEALTHCHECK_TAG=1.23.0-beta.2
+KUBE_APISERVER_HEALTHCHECK_TAG=1.23.0
 KUBE_APISERVER_HEALTHCHECK_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KUBE_APISERVER_HEALTHCHECK_TAG | awk '{print $$2}')
 
 

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -79,7 +79,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -12,7 +12,7 @@ Contents: |
       - --client-key=/secrets/client.key
       command:
       - /kube-apiserver-healthcheck
-      image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+      image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 027731e95201688bd2bc4cfb53214f527db39d9519daa78ea7682023c791f5d9
+    manifestHash: 189be024ad6426b0679b2ab54fb633b74ef38047746792181720bfc5bb35e524
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3ecc075d65603af623de3d3ace6d0a7fc26a6539421fa24927dfb0ed52297fe2
+    manifestHash: 21512c4874cf7ee5a73d545ed7c81cfa38485f02c4ef1242e9da86382d1c870f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c591ad0d43c5a525d87f0b5f3a3b255377b4579c5c5fa94ec339d22b50e23cc5
+    manifestHash: 2635953e18b98c530d876ab0e2c2cb074606875a119b6b582ee2e57410857be7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2a41f5125dcc3f83be3a895e178b4e9b5457a6e73d3f030baf7b7acbaed2bb44
+    manifestHash: 3a1f5317f2adeba9c0421b7f3b139ea87316d3774bdbdf429cfd4ef1753a9e66
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: afcfd4f74e34feb16e9efff5aa7fe5816f4895bd9f8f7a70e40d80ebe6f6bc47
+    manifestHash: 1b9445ea9355455eacf456b0b9ad1b0570f942b42c95fa360ef4b327cd8b1655
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d9af72fde4da34b1439d6571fee4667df0a1bc85307258dc48ba80a650da3fb3
+    manifestHash: 4c89592f35840ba384daf964260bd8bb8e9f0ff1f977e3a6d51f14143de0b308
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2850de6dec46fd78dbe44fa68a8c41543cff58e017a73a8256f2b7c478e2dac0
+    manifestHash: 447dcbcc7a63652e3cdebae3ee724beec065c9b1d05a9bb32d47d7cc45b9f9c8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0e641528633d69aefa2bfc37aa03f5e03207f1b0c8dc69c854115f10f690c488
+    manifestHash: 554f80bbbee545b34733ee992c70139431137e464dbebcfc2c86ffbc06d5f4e2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 811c424366648be69d78b9b2104c25655417bad330fcc0b4fa822b3ad1e157ef
+    manifestHash: bcb9f5ba76bbd1c2ae4267980127d49c6fefe40e72c3caafaa65d971e6e62df5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dd5aef438c95fa7471ec6902e473439d26caa46d5a5ac6d452703d965439b68e
+    manifestHash: 65c0d641c84c8e87dcc6069e1de812fd6b2f611a7170fc41eecf8e2e70dbe328
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d913a1cf724ca9e09f861566ff861f954cb819b132e466958bc3811e76c32ca9
+    manifestHash: ce755708ec5bd70aab76336add958b2be9e2fe7299b346be5aff1e44f4e2fde7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7d2f9be06f22d6815c5ebb67dda2a3e9ea4b56867fdff6945c20e48c6e914fd2
+    manifestHash: 639ad8ad024304ffc132b0fe18d5f66156b3a2a8142d1845e2adf15fa66fe31b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 055e90bcc398d83a5b682f40227df4bcf154c9b9192e8151d69d12b80eb76714
+    manifestHash: 2fbecf7691c2498148073fbb1d444fed48cca06962e1083ef2a37466f492bb4e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3ecc075d65603af623de3d3ace6d0a7fc26a6539421fa24927dfb0ed52297fe2
+    manifestHash: 21512c4874cf7ee5a73d545ed7c81cfa38485f02c4ef1242e9da86382d1c870f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8ae57efd7b70597b1b799cb91f2bd496ab8a4d9c7982a7700de4a803c5867330
+    manifestHash: ac7394ab185d07932f0e1800b28146b4e03476580e7e8dcb5d77049d8b738dc1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5e2b76695a4d5f08f4e763c695396154a3f0cc3f5a4c11c9ecb2a0eb2c4c8041
+    manifestHash: 654cea457fbb2c51620ff88a4963ceb44e4c737f7631967290b22e9519625af9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4fd09783d406265871d9c9003a97bfe7690ae912ade39cc459da2d869ced023a
+    manifestHash: c3f709db07bd42c1da2b47a8a375789e68d576cb473044fa3235665cf51532bc
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5e2b76695a4d5f08f4e763c695396154a3f0cc3f5a4c11c9ecb2a0eb2c4c8041
+    manifestHash: 654cea457fbb2c51620ff88a4963ceb44e4c737f7631967290b22e9519625af9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4fd09783d406265871d9c9003a97bfe7690ae912ade39cc459da2d869ced023a
+    manifestHash: c3f709db07bd42c1da2b47a8a375789e68d576cb473044fa3235665cf51532bc
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5e2b76695a4d5f08f4e763c695396154a3f0cc3f5a4c11c9ecb2a0eb2c4c8041
+    manifestHash: 654cea457fbb2c51620ff88a4963ceb44e4c737f7631967290b22e9519625af9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4fd09783d406265871d9c9003a97bfe7690ae912ade39cc459da2d869ced023a
+    manifestHash: c3f709db07bd42c1da2b47a8a375789e68d576cb473044fa3235665cf51532bc
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5e2b76695a4d5f08f4e763c695396154a3f0cc3f5a4c11c9ecb2a0eb2c4c8041
+    manifestHash: 654cea457fbb2c51620ff88a4963ceb44e4c737f7631967290b22e9519625af9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4fd09783d406265871d9c9003a97bfe7690ae912ade39cc459da2d869ced023a
+    manifestHash: c3f709db07bd42c1da2b47a8a375789e68d576cb473044fa3235665cf51532bc
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d056c7c3ab19c9add2e1c07f48a419f444031e9da0930a0fc4dd3b6d6b747dbe
+    manifestHash: 1ecb457b4699207158c72babacb2fc4a4be252d77aa2888409a795dd64afe3b2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5c3a0cf4a04b4014a949d2f2f83357d101df108544c481b1d1fc1b0daebf0616
+    manifestHash: b57587dddd5c54fcd39d3543d4eeb8fee4450914ed06e9c12ab4360accbf27b1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 055e90bcc398d83a5b682f40227df4bcf154c9b9192e8151d69d12b80eb76714
+    manifestHash: 2fbecf7691c2498148073fbb1d444fed48cca06962e1083ef2a37466f492bb4e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 56f39d71bb70e48c0a4e29acb351445995f5f7e0fce4088d3b6397092c52b828
+    manifestHash: f502f5b72362208163ba86e00d7bcf9a7ca2efd313126ee8e7ebae904675fc8a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 055e90bcc398d83a5b682f40227df4bcf154c9b9192e8151d69d12b80eb76714
+    manifestHash: 2fbecf7691c2498148073fbb1d444fed48cca06962e1083ef2a37466f492bb4e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dbc3ed9294fdb404084103f00d731baee28f263f8ee9947de1f64fe5934aeb65
+    manifestHash: cfb5d05cb3f0da31e9ea96a8d00c47848805d6127fb8f16c403ebc16fabf251a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6c4625c38139bbbd8342fefe9b76b77693def5034cc5a2d73c57c7c0c3b4e804
+    manifestHash: 6532dbe6fa533256b7a66bd135302112ff55acd9d1037f4c7878a9ca80e8855d
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: dbc3ed9294fdb404084103f00d731baee28f263f8ee9947de1f64fe5934aeb65
+    manifestHash: cfb5d05cb3f0da31e9ea96a8d00c47848805d6127fb8f16c403ebc16fabf251a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 390929116b08d7679793dd6378d1e9d664a86b616efb1fa9c2e7116b30e21373
+    manifestHash: bbe47cab0ffbf294caa5ffaec305c7188bac1381abd09035b972626cb5bd55e8
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2b37ec7de123ed94df477e6d38438b09b192d9f346f25daab42295c4b7cb68dd
+    manifestHash: 6f61431c77ee89962a0c21f670a33e89f003f204c4a1e80cb3b9a36e6846d40a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2b37ec7de123ed94df477e6d38438b09b192d9f346f25daab42295c4b7cb68dd
+    manifestHash: 6f61431c77ee89962a0c21f670a33e89f003f204c4a1e80cb3b9a36e6846d40a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cffe853ea993e0fe79b5184613bd3fc672405c6283a3080e1b5901121b840742
+    manifestHash: 27199e55696751276d770eb0d84cb8a3f94141920d3a1534d28d95ce843177ae
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a7438ffac0f1d9c246a5fa03fcdec77aaa254b0952512b1f13c5dacc9494df94
+    manifestHash: 90e760caf4e1e98682343af8ac0baae6deab75bb63856d1fe481491b38279845
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fcf0a77515eb4a8e9e960fb6cd9268ccfb15554c852ed3c56dc181c11ead1987
+    manifestHash: ff547ce94672367fd718385512feb962389afb723f9a8c4971bd9c73eb005b14
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 82ddbdb76ffb07760b459fc09f08fa60d5a886e28b1ea8ea47393faa065517cf
+    manifestHash: 282dcfab42fa6685a11f1011057af8340aa8a64bf863e36f2182b854ba8a6589
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5e65709ef491e6c214f6fbc6fe627710840eefe819b91ab6c63af7bb307d36a7
+    manifestHash: 77d2a34c45a622765f3c073fa4e12c4fd893f7e25583918ef7efc9336d85854f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cd728b7a0525b597089db3c4f1cd3a1976373e23f2e4c9c8648c2bc7762bdec1
+    manifestHash: e2ae30a309cf4c7846869b3549a069770b06f3a31c90ae0c839c94d96869fb8f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4d35f25078cf746ef7567f26370a0f55e19405e68779b030b9601ec5e7606f83
+    manifestHash: 5f338ee1626372805de1d19a7323b5e4e53fab038a9e78743951eb2893926e2c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8293303d28069cec426735a59de12f9e4a33dd659c8cd15738f338e179f565b2
+    manifestHash: 9ba35c790e28e3a9606f2d6e87b899f0d1beb4391b38638f4314ac312d07e6c1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c0e795caeac9a9d821d7ca68c732de663b9b755142382e31fc68255a25d8998e
+    manifestHash: 9aed300acfb9c5f1f22456d96db57bd09cafb3125ff9ccf2230bd4bc247036b9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 90f7e750113554aec29ba432c5999c8e0d3d8ce39a04d57c72e3bd05e677e04e
+    manifestHash: ade8e7e1cdee17642ee3d62d397c00d0c5c571adbedc0d6fcafe320783db9ff3
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 075b0f038f5fb904eaa88dad043f1b15eb1583387ab4df50f377c15ba53602c7
+    manifestHash: 3567a41a73e79b3008df606d457e64c331a59c8a463b49d1a65f4a3016f9c9b6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e884c83e118b5f885b8d1aff729a4874f6ddd78792547abfe6134d4d06f0f68b
+    manifestHash: 1b8686b9829ba494652ef339576e852bfbf821d5a822347a8222a66b0b2ca943
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 23a603728e38cbdd1f6d5030d72ca6e4eac1d1ed77dfda602940671602df6c06
+    manifestHash: d2e12e3586a2c5263191d253475b1c29d9ffb153b91d994fd00e4db4f1f60606
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0124ca55cd05dc050c583ff54f75f0e59dfaa797fa47dd0377d257357dd64d6b
+    manifestHash: d16a90f97da18426a00b3262b2a1ef030489272b8d85ccb210ee438ff1dc05a7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a53e3ce2ba9005d72d9b50f7d2d54654b1f112e9ed71324e36dc9bb274cd529e
+    manifestHash: db1972115c9672b22763e1afb1ffd3dd27e1d00008bb2e6c8818c198a752debd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3ecc075d65603af623de3d3ace6d0a7fc26a6539421fa24927dfb0ed52297fe2
+    manifestHash: 21512c4874cf7ee5a73d545ed7c81cfa38485f02c4ef1242e9da86382d1c870f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0e0245145d1d52efc3ef8b5d5f95ec2a2e420d1a80b3d7af56a74ce973e707f7
+    manifestHash: c6b7807372be536c8f921da53892b75139f61a4ad8591c48f5dd0da6f050e1a9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ac5ccd0e7fbf0d27692a459875288c12bab2d6c7f9416816139f13f117135006
+    manifestHash: 0ee52701cb025dcbf027a8f6334e36e47433890fd68e7ca1c8cfdb2373563b58
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b7c91d63aeb5cc4d912e3227f1543d7a511c1b11ec2ab581287301dc0f95b7f6
+    manifestHash: 8d8c49d2b9f61a6a5577a37419212a1246c6c36165877491f35bcae20668a6fe
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0-beta.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.0
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 989740a7d5dfc6ed3837d9479cdab5b46b8ba8faa45412170faaa17e262524d3
+    manifestHash: a17a27400a0ee3f3283490761a31a10de8b646d6c8f167727d079e4e2fd047ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
 spec:
   replicas: 1
   strategy:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.23.0-beta.2
+        version: v1.23.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -38,7 +38,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
 spec:
   selector:
     matchLabels:
@@ -31,7 +31,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.23.0-beta.2
+        version: v1.23.0
 {{ if UseKopsControllerForNodeBootstrap }}
       annotations:
         dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
@@ -53,7 +53,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f7b9d22aa15f01e7bd20b5ddae0139fd88d83d5e888cc5df9d0de38055c4a1d4
+    manifestHash: eb8d299430c700c957df6d8edbe4196a899eb8e2358c968b9dd3fdc061b9c3fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f7b9d22aa15f01e7bd20b5ddae0139fd88d83d5e888cc5df9d0de38055c4a1d4
+    manifestHash: eb8d299430c700c957df6d8edbe4196a899eb8e2358c968b9dd3fdc061b9c3fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f7b9d22aa15f01e7bd20b5ddae0139fd88d83d5e888cc5df9d0de38055c4a1d4
+    manifestHash: eb8d299430c700c957df6d8edbe4196a899eb8e2358c968b9dd3fdc061b9c3fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.0
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3ecc075d65603af623de3d3ace6d0a7fc26a6539421fa24927dfb0ed52297fe2
+    manifestHash: 21512c4874cf7ee5a73d545ed7c81cfa38485f02c4ef1242e9da86382d1c870f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.0-beta.2
+    version: v1.23.0
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.0-beta.2
+        version: v1.23.0
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.0-beta.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.0
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 946bdab6f86ed0bd07898ebb4b4cba19949632cbb20abed5ac84d109d84ebed9
+    manifestHash: 0196f4e6dcd33dfa39210e15b87cf132590c0755ae52c5879a8a6dfdac7a0aa1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: b26bddffb8bf35db2ecd654ca4a4692b74f9a48da99a4798a8257a3b64f6244c
+    manifestHash: fe9d513965af54aa455aaac420f88ff743ac0a2776f5acd30a1e0b8aa8381729
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/urls_test.go
+++ b/upup/pkg/fi/cloudup/urls_test.go
@@ -36,29 +36,29 @@ func Test_BuildMirroredAsset(t *testing.T) {
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-amd64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.0-beta.2/images/protokube-linux-amd64",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.0-beta.2/images-protokube-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.0/images/protokube-linux-amd64",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.0/images-protokube-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-arm64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.0-beta.2/images/protokube-linux-arm64",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.0-beta.2/images-protokube-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.0/images/protokube-linux-arm64",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.0/images-protokube-linux-arm64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/amd64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.0-beta.2/linux/amd64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.0-beta.2/nodeup-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.0/linux/amd64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.0/nodeup-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/arm64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.0-beta.2/linux/arm64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.0-beta.2/nodeup-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.0/linux/arm64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.0/nodeup-linux-arm64",
 			},
 		},
 	}

--- a/version.go
+++ b/version.go
@@ -21,8 +21,8 @@ var Version = KOPS_RELEASE_VERSION
 
 // These constants are parsed by build tooling - be careful about changing the formats
 const (
-	KOPS_RELEASE_VERSION = "1.23.0-beta.2"
-	KOPS_CI_VERSION      = "1.23.0-beta.3"
+	KOPS_RELEASE_VERSION = "1.23.0"
+	KOPS_CI_VERSION      = "1.23.1"
 )
 
 // GitVersion should be replaced by the makefile


### PR DESCRIPTION
- Make service topology for cilium configurable
- Remove support for Weave as of k8s 1.23
- Update Go to v1.17.5
- Update controller-runtime to v0.11.0
- Update containerd to v1.6.0-beta.4
- Run hack/update-expected.sh
- Ignore images hosted in private ECR repositories as containerd cannot actually pull these
- Prevent creation of unsupported etcd clusters
- Update k8s dependencies to v1.23.1
- Remove TerraformJSON feature flag and functionality
- Remove unused json field tags from terraform structs
- Remove remaining references to TerraformJSON feature flag
- Add managed-by label to static kube-proxy pods
- Kube components log to stdout
- Fix OpenStack SecurityGroupRule/LB with IPv6 CIDR
- external CCM for GCE
- generated: ./hack/update-bazel.sh
- update deps
- Migrate to GCE CCM in k8s 1.24
- Bump Cluster Autoscaler and update manifest
- Remove the v1alpha3 API version
- force update dependencies
- Add action for automatically tagging releases
- Remove temporary restrictions on automatically tagging releases
- Bump external-snapshotted to v5.0.0
- Support price and priority cluster-autoscaler expanders.
- Fix CRDs, clarify docs, and add cloud provider check for price expander.
- Warn that the price expander is only supported on GCE in the docs.
- Less crashing when validating.
- Fix StringValue nit
- Keep docs DRY.
- fix ipv4+ipv6 sec groups/listeners in OpenStack
- make gazelle
- Update containerd to v1.6.0-beta.5
- Run hack/update-expected.sh
- Update containerd to v1.6.0-rc.0
- Run hack/update-expected.sh
- Don't try to add node name to instances without node object
- Do not create an IAM role for dns-controller on gossip clusters
- Add DescribeRegions to nodeup privs
- Create helper function for ec2 create/tag-on-create IAM permissions
- Remove tag condition on listeners
- Update to aws-sdk-go to v1.42.37
- use 1.23.1 ccm for openstack
- expose external ccm metrics for OpenStack
- OpenStack - Add loadbalancer pool monitor to API LB
- Bump CCM images
- No need to set kubelet in tests
- Don't set legacy IAM by default
- Update pause image to v3.6
- Run hack/update-expected.sh
- Bump etcd-manager to v3.0.20220128
- JWKS / IRSA: Expose public ACLs to terraform
- add drain-timeout flag to rolling-update cluster
- Use etcd-manager pre-release until final release has been cut
- Update Calico to v3.21.2
- Update Canal to v3.21.2
- Run hack/update-expected.sh
- Update Calico to v3.21.4
- Update Canal to v3.21.4
- Run hack/update-expected.sh
- Fix etcd-manager for ipv6
- Update containerd to v1.6.0-rc.2
- Run hack/update-expected.sh
- Fix CSI migration feature gates
- Remove snapshot controller dependency on ebs csi driver
- always enable Leader Election
- always enable Leader Election
- generated: ./hack/update-expected.sh
- use pkg/flagbuilder to build argv
- update test ordering and tests for leader election.
- generated: ./hack/update-bazel.sh
- generated: ./hack/update-expected.sh
- Update containerd to v1.6.0-rc.3
- Run hack/update-expected.sh
- always enable Leader Election
- Minor fix for json response to keep it consistent for single or multiple clusters
- Fix irsa for k8s < 1.20
- Add test for irsa on k8s 1.19
- Refactor serviceaccountissuerdiscovery validation
- Add support for graceful node shutdown
- hack update-expected
- Install runc from opencontainers/runc
- Run hack/update-expected.sh
- Do not enable graceful shutdown if k8s version < 1.21
- Fix nilpointer when graceful shutdown is not configured
- update expected
- Install contained from the release package
- Run hack/update-expected.sh
- Bump aws-cni to 1.10.2
- Align manifest with master of aws-cni repo
- Apply suggestions
- Run hack/update-expected.sh
- Allow PrefixList for sshAccess and kubernetesApiAccess
- Update containerd to v1.6.0
- Run hack/update-expected.sh
- Update LBC to 2.4.0
- Disable some flags in kube-apiserver when logging-format is not text
- Enable RBN with AWS CCM 1.22.0-alpha.1
- Improve HA for various addons
- LBC has to run on the control plane, so set replicas accordingly
- Validate taints in IG spec
- Prevent populate ig from adding nvidia taint if it has already been set
- Fix backporting issues
- Do not create a cert-manager namespace
- Add missing permissions to aws lbc for irsa
- Initial changes for vpc
- Release 1.23.0-beta.2
- Update to etcd-manager v3.0.20220203
- Update expected test output for etcd-manager bump
- use own function to define CSI image version
- Add support to install EKS Pod Identity Webhook
- Add managed-by label to addon pods
- Use cert-manager and pod-identity-webhook in integration test of irsa
- Update addons document for Pod Identity Webhook
- Add PodDisruptionBudget and topologySpreadConstraints for eks-pod-identity-webhook
- Minor cleanup of the Deployment
- Update expected test data
- check if UsePolicyConfigMap flag is true
- use suggested changes
- add support for ed25519 keys
- Bump AWS SDK to v1.43.11
- Update containerd to v1.6.1
- Run hack/update-expected.sh
- Use proper image and add health check
- Release 1.23.0
