### PR TITLE
Automated cherry pick of #12966: add instance connection draining for NLBs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -219,12 +219,8 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/mod v0.5.1 // indirect
-<<<<<<< HEAD
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-=======
-	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
->>>>>>> run make gomod
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
 	google.golang.org/api v0.57.0
 	gopkg.in/gcfg.v1 v1.2.3
@@ -218,8 +219,12 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/mod v0.5.1 // indirect
+<<<<<<< HEAD
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+=======
+	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
+>>>>>>> run make gomod
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.6 // indirect

--- a/upup/pkg/fi/cloudup/awsup/BUILD.bazel
+++ b/upup/pkg/fi/cloudup/awsup/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/service/sqs:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/sqs/sqsiface:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/sts:go_default_library",
+        "//vendor/golang.org/x/sync/errgroup:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/eventbridge/eventbridgeiface"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -543,6 +544,11 @@ func deleteInstance(c AWSCloud, i *cloudinstances.CloudInstance) error {
 		return fmt.Errorf("id was not set on CloudInstance: %v", i)
 	}
 
+	err := deregisterInstance(c, i)
+	if err != nil {
+		return fmt.Errorf("failed to deregister instance from loadBalancer before terminating: %v", err)
+	}
+
 	request := &ec2.TerminateInstancesInput{
 		InstanceIds: []*string{aws.String(id)},
 	}
@@ -557,6 +563,131 @@ func deleteInstance(c AWSCloud, i *cloudinstances.CloudInstance) error {
 
 	klog.V(8).Infof("deleted aws ec2 instance %q", id)
 
+	return nil
+}
+
+// deregisterInstance ensures that the instance is fully drained/removed from all associated loadBalancers and targetGroups before termination.
+func deregisterInstance(c AWSCloud, i *cloudinstances.CloudInstance) error {
+	asg := i.CloudInstanceGroup.Raw.(*autoscaling.Group)
+
+	asgDetails, err := c.Autoscaling().DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{asg.AutoScalingGroupName},
+	})
+	if err != nil {
+		return fmt.Errorf("error describing autoScalingGroups: %v", err)
+	}
+
+	if len(asgDetails.AutoScalingGroups) == 0 {
+		return nil
+	}
+
+	// there will always be only one ASG in the DescribeAutoScalingGroups response.
+	loadBalancerNames := aws.StringValueSlice(asgDetails.AutoScalingGroups[0].LoadBalancerNames)
+	targetGroupArns := aws.StringValueSlice(asgDetails.AutoScalingGroups[0].TargetGroupARNs)
+
+	eg, _ := errgroup.WithContext(aws.BackgroundContext())
+
+	if len(loadBalancerNames) != 0 {
+		eg.Go(func() error {
+			return deregisterInstanceFromClassicLoadBalancer(c, loadBalancerNames, i.ID)
+		})
+	}
+
+	if len(targetGroupArns) != 0 {
+		eg.Go(func() error {
+			return deregisterInstanceFromTargetGroups(c, targetGroupArns, i.ID)
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("failed to deregister instance from load balancers: %v", err)
+	}
+
+	return nil
+}
+
+// deregisterInstanceFromClassicLoadBalancer ensures that connectionDraining completes for the associated classic loadBalancer to ensure no dropped connections.
+func deregisterInstanceFromClassicLoadBalancer(c AWSCloud, loadBalancerNames []string, instanceId string) error {
+	klog.Infof("Deregistering instance from classic loadBalancers: %v", loadBalancerNames)
+
+	for {
+		instanceDraining := false
+		for _, loadBalancerName := range loadBalancerNames {
+			response, err := c.ELB().DescribeInstanceHealth(&elb.DescribeInstanceHealthInput{
+				LoadBalancerName: aws.String(loadBalancerName),
+				Instances: []*elb.Instance{{
+					InstanceId: aws.String(instanceId),
+				}},
+			})
+			if err != nil {
+				return fmt.Errorf("error describing instance health: %v", err)
+			}
+
+			// describeInstanceHealth can return an empty list if the instance was already terminated.
+			if len(response.InstanceStates) == 0 {
+				continue
+			}
+
+			// there will be only one instance in the DescribeInstanceHealth response.
+			if aws.StringValue(response.InstanceStates[0].State) == instanceInServiceState {
+				c.ELB().DeregisterInstancesFromLoadBalancer(&elb.DeregisterInstancesFromLoadBalancerInput{
+					LoadBalancerName: aws.String(loadBalancerName),
+					Instances: []*elb.Instance{{
+						InstanceId: aws.String(instanceId),
+					}},
+				})
+				instanceDraining = true
+			}
+		}
+
+		if !instanceDraining {
+			break
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+	return nil
+}
+
+// deregisterInstanceFromTargetGroups ensures that instances are fully unused in the corresponding targetGroups before instance termination.
+// this ensures that connections are fully drained from the instance before terminating.
+func deregisterInstanceFromTargetGroups(c AWSCloud, targetGroupArns []string, instanceId string) error {
+	klog.Infof("Deregistering instance from targetGroups: %v", targetGroupArns)
+
+	for {
+		instanceDraining := false
+		for _, targetGroupArn := range targetGroupArns {
+			response, err := c.ELBV2().DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
+				TargetGroupArn: aws.String(targetGroupArn),
+				Targets: []*elbv2.TargetDescription{{
+					Id: aws.String(instanceId),
+				}},
+			})
+
+			if err != nil {
+				return fmt.Errorf("error describing target health: %v", err)
+			}
+
+			// there will be only one target in the DescribeTargetHealth response.
+			// DescribeTargetHealth response will contain a target even if the targetId doesn't exist.
+			// all other states besides TargetHealthStateUnused means that the instance may still be serving traffic.
+			if aws.StringValue(response.TargetHealthDescriptions[0].TargetHealth.State) != elbv2.TargetHealthStateEnumUnused {
+				c.ELBV2().DeregisterTargets(&elbv2.DeregisterTargetsInput{
+					TargetGroupArn: aws.String(targetGroupArn),
+					Targets: []*elbv2.TargetDescription{{
+						Id: aws.String(instanceId),
+					}},
+				})
+				instanceDraining = true
+			}
+		}
+
+		if !instanceDraining {
+			break
+		}
+
+		time.Sleep(5 * time.Second)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #12966 on release-1.23.

#12966: add instance connection draining for NLBs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```