### PR TITLE
Bump CCM 1.22 image. Use the 1.23 image for 1.24 due to latest being broken

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -94,8 +94,10 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		case 21:
 			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0"
 		case 22:
-			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.22.0-alpha.1"
+			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.22.0-alpha.2"
 		case 23:
+			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0"
+		case 24:
 			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0"
 		default:
 			eccm.Image = "gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest"

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -20,7 +20,7 @@ spec:
     clusterName: minimal.example.com
     configureCloudRoutes: false
     enableLeaderMigration: true
-    image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest
+    image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -35,7 +35,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest
+        image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 6ce20f3da58bc0e8ae3846539c315e48a7e6112073e6c54965d6df631231e961
+    manifestHash: a5eb17fbc815956fcb04cedb06f79b11fd0677b607e753ec48040af5b74e408b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
That CCM 1.22 branch is pushed to their latest breaks a sizeable portion of our e2e tests.

Possible culprit of the OIDC issues as well, as the failure (waiting for ELB to be ready, which never happens) may cause timeouts, which again may cause the cleanup never to happen.