### PR TITLE
[Digital Ocean] e2e tests - Fix seeding for generating random zones

### DIFF
--- a/tests/e2e/kubetest2-kops/do/zones.go
+++ b/tests/e2e/kubetest2-kops/do/zones.go
@@ -19,6 +19,7 @@ package do
 import (
 	"errors"
 	"math/rand"
+	"time"
 )
 
 var allZones = []string{
@@ -46,7 +47,8 @@ func RandomZones(count int) ([]string, error) {
 		return nil, ErrMoreThanOneZone
 	}
 
-	n := rand.Int() % len(allZones)
+	rand.Seed(time.Now().UnixNano())
+	n := rand.Intn(1000) % len(allZones)
 	chosenZone := allZones[n]
 
 	chosenZones := make([]string, 0)


### PR DESCRIPTION
The e2e tests [here ](https://testgrid.k8s.io/google-aws#e2e-kops-do-calico)was always picking up the default zone (nyc1) since seed wasn't specified.
Hopefully this should fix the issue.