### PR TITLE
wait for all targetGroups to drain

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -720,6 +720,8 @@ func deregisterInstanceFromTargetGroup(c AWSCloud, targetGroupArn string, instan
 		time.Sleep(5 * time.Second)
 	}
 
+	klog.Infof("Successfully drained instance from targetGroup: %s", targetGroupArn)
+
 	return nil
 }
 

--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -662,12 +662,44 @@ func deregisterInstanceFromClassicLoadBalancer(c AWSCloud, loadBalancerNames []s
 // deregisterInstanceFromTargetGroups ensures that instances are fully unused in the corresponding targetGroups before instance termination.
 // this ensures that connections are fully drained from the instance before terminating.
 func deregisterInstanceFromTargetGroups(c AWSCloud, targetGroupArns []string, instanceId string) error {
-	klog.Infof("Deregistering instance from targetGroups: %v", targetGroupArns)
+	eg, _ := errgroup.WithContext(context.Background())
+
+	for _, targetGroupArn := range targetGroupArns {
+		arn := targetGroupArn
+		eg.Go(func() error {
+			return deregisterInstanceFromTargetGroup(c, arn, instanceId)
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("failed to register instance from targetGroups: %w", err)
+	}
+
+	return nil
+}
+
+func deregisterInstanceFromTargetGroup(c AWSCloud, targetGroupArn string, instanceId string) error {
+	klog.Infof("Deregistering instance from targetGroup: %s", targetGroupArn)
 
 	for {
 		instanceDraining := false
-		for _, targetGroupArn := range targetGroupArns {
-			response, err := c.ELBV2().DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
+
+		response, err := c.ELBV2().DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
+			TargetGroupArn: aws.String(targetGroupArn),
+			Targets: []*elbv2.TargetDescription{{
+				Id: aws.String(instanceId),
+			}},
+		})
+
+		if err != nil {
+			return fmt.Errorf("error describing target health: %w", err)
+		}
+
+		// there will be only one target in the DescribeTargetHealth response.
+		// DescribeTargetHealth response will contain a target even if the targetId doesn't exist.
+		// all other states besides TargetHealthStateUnused means that the instance may still be serving traffic.
+		if aws.StringValue(response.TargetHealthDescriptions[0].TargetHealth.State) != elbv2.TargetHealthStateEnumUnused {
+			_, err = c.ELBV2().DeregisterTargets(&elbv2.DeregisterTargetsInput{
 				TargetGroupArn: aws.String(targetGroupArn),
 				Targets: []*elbv2.TargetDescription{{
 					Id: aws.String(instanceId),
@@ -675,21 +707,10 @@ func deregisterInstanceFromTargetGroups(c AWSCloud, targetGroupArns []string, in
 			})
 
 			if err != nil {
-				return fmt.Errorf("error describing target health: %v", err)
+				return fmt.Errorf("error deregistering target: %w", err)
 			}
 
-			// there will be only one target in the DescribeTargetHealth response.
-			// DescribeTargetHealth response will contain a target even if the targetId doesn't exist.
-			// all other states besides TargetHealthStateUnused means that the instance may still be serving traffic.
-			if aws.StringValue(response.TargetHealthDescriptions[0].TargetHealth.State) != elbv2.TargetHealthStateEnumUnused {
-				c.ELBV2().DeregisterTargets(&elbv2.DeregisterTargetsInput{
-					TargetGroupArn: aws.String(targetGroupArn),
-					Targets: []*elbv2.TargetDescription{{
-						Id: aws.String(instanceId),
-					}},
-				})
-				instanceDraining = true
-			}
+			instanceDraining = true
 		}
 
 		if !instanceDraining {
@@ -698,6 +719,7 @@ func deregisterInstanceFromTargetGroups(c AWSCloud, targetGroupArns []string, in
 
 		time.Sleep(5 * time.Second)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Problem**
Currently, `deregisterInstanceFromTargetGroups` attempts to drain a given instance from all corresponding targetGroups. However, it'll complete once _any_ of the targetGroups report that the instance is drained. This can potentially cause interruptions in other tagetGroups that haven't fully drained before the node is terminated. 

**Solution**
This PR ensures that all targetGroups have an instance fully drained before moving to delete the instance. In the event that a goroutine fails to drain the instance from a targetGroup, `deregisterInstanceFromTargetGroups` will stop all goroutines, return the corresponding error, and prevent the instance from being deleted.


**Example Execution**
```
❯ ~/go/bin/kops rolling-update cluster --instance-groups <redacted> --force --yes
I0315 11:15:11.241014   41018 featureflag.go:158] FeatureFlag "ExperimentalClusterDNS"=true
NAME                            STATUS  NEEDUPDATE      READY   MIN     TARGET  MAX     NODES
<redacted>                      Ready   0               1       1       1       3       1
<redacted>                      Ready   0               1       1       1       3       1
<redacted>                      Ready   0               1       1       1       3       1
I0315 11:15:18.493585   41018 instancegroups.go:468] Validating the cluster.
I0315 11:15:29.607343   41018 instancegroups.go:501] Cluster validated.
I0315 11:15:29.607365   41018 instancegroups.go:310] Tainting 1 node in "<redacted>" instancegroup.
I0315 11:15:29.644800   41018 instancegroups.go:566] Detaching instance "i-0eca6363a6cf3db87", node "ip-10-4-151-148.us-west-2.compute.internal", in group "<redacted>".
I0315 11:15:30.001241   41018 instancegroups.go:171] waiting for 15s after detaching instance
I0315 11:15:45.001610   41018 instancegroups.go:468] Validating the cluster.
I0315 11:15:59.840360   41018 instancegroups.go:524] Cluster did not pass validation, will retry in "30s": machine "i-082567458881183b7" has not yet joined cluster.
I0315 11:16:41.704813   41018 instancegroups.go:524] Cluster did not pass validation, will retry in "30s": machine "i-082567458881183b7" has not yet joined cluster.
I0315 11:17:22.889704   41018 instancegroups.go:524] Cluster did not pass validation, will retry in "30s": machine "i-082567458881183b7" has not yet joined cluster.
I0315 11:18:05.238719   41018 instancegroups.go:524] Cluster did not pass validation, will retry in "30s": <redacted>
I0315 11:18:49.072479   41018 instancegroups.go:504] Cluster validated; revalidating in 10s to make sure it does not flap.
I0315 11:19:09.965612   41018 instancegroups.go:501] Cluster validated.
I0315 11:19:09.965645   41018 instancegroups.go:399] Draining the node: "ip-10-4-151-148.us-west-2.compute.internal".
I0315 11:19:10.125846   41018 aws_cloud.go:682] Deregistering instance from targetGroup: <redacted>
I0315 11:19:10.125880   41018 aws_cloud.go:682] Deregistering instance from targetGroup: <redacted>
I0315 11:19:10.125911   41018 aws_cloud.go:682] Deregistering instance from targetGroup: <redacted>
I0315 11:20:31.820469   41018 aws_cloud.go:723] Successfully drained instance from targetGroup: <redacted>
I0315 11:20:31.840069   41018 aws_cloud.go:723] Successfully drained instance from targetGroup: <redacted>
I0315 11:20:31.977280   41018 aws_cloud.go:723] Successfully drained instance from targetGroup: <redacted>
I0315 11:20:39.607981   41018 instancegroups.go:658] Waiting for 5s for pods to stabilize after draining.
I0315 11:20:44.608571   41018 instancegroups.go:589] Stopping instance "i-0eca6363a6cf3db87", node "ip-10-4-151-148.us-west-2.compute.internal", in group "<redacted>" (this may take a while).
I0315 11:20:44.880486   41018 instancegroups.go:435] waiting for 15s after terminating instance
I0315 11:20:59.881468   41018 instancegroups.go:468] Validating the cluster.
I0315 11:21:13.688457   41018 instancegroups.go:504] Cluster validated; revalidating in 10s to make sure it does not flap.
```