### PR TITLE
If image is empty, have kops upgrade fill it in

### DIFF
--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -193,7 +193,7 @@ func RunUpgradeCluster(ctx context.Context, f *util.Factory, out io.Writer, opti
 				klog.Warningf("No matching images specified in channel; cannot prompt for upgrade")
 				continue
 			}
-			if channel.HasUpstreamImagePrefix(ig.Spec.Image) {
+			if ig.Spec.Image == "" || channel.HasUpstreamImagePrefix(ig.Spec.Image) {
 				if ig.Spec.Image != image.Name {
 					target := ig
 					actions = append(actions, &upgradeAction{


### PR DESCRIPTION
We don't allow empty image anymore, but some users may already have this in the state store.
Fixes #12630