### PR TITLE
Do not return a '-1' exit if no keys found and json/yaml output

### DIFF
--- a/cmd/kops/get_sshpublickeys.go
+++ b/cmd/kops/get_sshpublickeys.go
@@ -105,12 +105,12 @@ func RunGetSSHPublicKeys(ctx context.Context, f *util.Factory, out io.Writer, op
 		items = append(items, item)
 	}
 
-	if len(items) == 0 {
-		return fmt.Errorf("no SSH public key found")
-	}
 	switch options.Output {
 
 	case OutputTable:
+		if len(items) == 0 {
+			return fmt.Errorf("no SSH public key found")
+		}
 		t := &tables.Table{}
 		t.AddColumn("ID", func(i *SSHKeyItem) string {
 			return i.ID


### PR DESCRIPTION
In our CI scripts we wanted to adapt to the new `sshpublickey` command, however for a new cluster this will exit non-successfully if there are no keys yet. It is possible to work around this with some ugly hacks, however for scripts I think we should return successfully if there are no public keys. It's not like something bad happened.

This PR ensures that for json/yaml output, which is for machine consumption, that even for an empty list it will exit with a `0` exit code if no errors happen.