### PR TITLE
Upgrade aws-iam-authenticator to v0.5.5

### DIFF
--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -158,7 +158,7 @@ spec:
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
       - name: aws-iam-authenticator
-        image: {{ or .Authentication.AWS.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.3-debian-stretch" }}
+        image: {{ or .Authentication.AWS.Image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.5" }}
         args:
         - server
         {{- if or (not .Authentication.AWS.BackendMode) (contains "MountedFile" .Authentication.AWS.BackendMode) }}
@@ -177,6 +177,8 @@ spec:
           capabilities:
             drop:
             - ALL
+          runAsUser: 10000
+          runAsGroup: 10000
 
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
@@ -168,7 +168,7 @@ spec:
         - --state-dir=/var/aws-iam-authenticator
         - --kubeconfig-pregenerated=true
         - --backend-mode=CRD,MountedFile
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.3-debian-stretch
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.5
         livenessProbe:
           httpGet:
             host: 127.0.0.1
@@ -188,6 +188,8 @@ spec:
           capabilities:
             drop:
             - ALL
+          runAsGroup: 10000
+          runAsUser: 10000
         volumeMounts:
         - mountPath: /etc/aws-iam-authenticator/
           name: config

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: be732bf4954841f475a1a1ca9fd46e2c2d5b27d63bbeb41e40c755d1cd894619
+    manifestHash: ed004e8c71d751324c97b3015c97f1e81178a5423587184fa26579b2e84a6f92
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
@@ -167,7 +167,7 @@ spec:
         - --state-dir=/var/aws-iam-authenticator
         - --kubeconfig-pregenerated=true
         - --backend-mode=CRD
-        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.3-debian-stretch
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.5
         livenessProbe:
           httpGet:
             host: 127.0.0.1
@@ -187,6 +187,8 @@ spec:
           capabilities:
             drop:
             - ALL
+          runAsGroup: 10000
+          runAsUser: 10000
         volumeMounts:
         - mountPath: /var/aws-iam-authenticator/
           name: state

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: 535d30c08759079526ef0b1db108eefb412d523ab72b9a9e4b9b863f9b4e9379
+    manifestHash: b23a547c9b8cce314129b07f4b7ec2f2e926732dde89938d12977d80004b309b
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
AWS IAM Authenticator has been released to v0.5.5 bringing ARM64 compatible container image.

With this version, the run user and group are not fixed anymore. 
Since we are forcing the certificates to be generated with user and group to 10000 in [kube_apiserver.go](https://github.com/kubernetes/kops/blob/master/nodeup/pkg/model/kube_apiserver.go#L297), 
I also added a `securityContext.runAsUser` and `securityContext.runAsGroup` to match the owner.