### PR TITLE
[Digital Ocean] Remove sfo2 region from the list of supported DO regions

### DIFF
--- a/docs/getting_started/digitalocean.md
+++ b/docs/getting_started/digitalocean.md
@@ -28,7 +28,7 @@ export S3_SECRET_ACCESS_KEY=<secret-key>  # where <secret-key> is the Spaces API
 ## Creating a Single Master Cluster
 
 In the following examples, `example.com` should be replaced with the DigitalOcean domain you created when going through the [Requirements](#requirements).
-Note that you kOps will only be able to successfully provision clusters in regions that support block storage (AMS3, BLR1, FRA1, LON1, NYC1, NYC3, SFO2, SFO3, SGP1 and TOR1).
+Note that you kOps will only be able to successfully provision clusters in regions that support block storage (AMS3, BLR1, FRA1, LON1, NYC1, NYC3, SFO3, SGP1 and TOR1).
 
 ```bash
 # debian (the default) + flannel overlay cluster in tor1

--- a/pkg/zones/wellknown.go
+++ b/pkg/zones/wellknown.go
@@ -273,7 +273,6 @@ var doZones = []string{
 	"nyc3",
 
 	"sfo1",
-	"sfo2",
 	"sfo3",
 
 	"ams2",

--- a/tests/e2e/kubetest2-kops/do/zones.go
+++ b/tests/e2e/kubetest2-kops/do/zones.go
@@ -24,13 +24,17 @@ import (
 
 var allZones = []string{
 	"nyc1",
+	"nyc2",
 	"nyc3",
-	"sfo3",
 	"tor1",
 	"lon1",
 	"sgp1",
 	"blr1",
+	"sfo1",
 	"sfo3",
+	"ams2",
+	"ams3",
+	"fra1",
 }
 
 // ErrNoEligibleRegion indicates the requested number of zones is not available in any region

--- a/tests/e2e/kubetest2-kops/do/zones.go
+++ b/tests/e2e/kubetest2-kops/do/zones.go
@@ -26,12 +26,10 @@ var allZones = []string{
 	"nyc1",
 	"nyc3",
 	"sfo3",
-	"sfo2",
 	"tor1",
 	"lon1",
 	"sgp1",
 	"blr1",
-	"sfo2",
 	"sfo3",
 }
 


### PR DESCRIPTION
Saw e2e tests failing for SFO2 region - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-do-calico/1504078673064497152

Per discussion with @timoreimann this is expected and customers should use the new `SFO3` region going forward. We currently have `SFO3` already in the list of supported regions.