### PR TITLE
Add protocol explicitly to services

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -844,6 +844,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    protocol: TCP
     targetPort: 9443
   selector:
     app.kubernetes.io/component: controller

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -53,7 +53,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 031bee52f2675f7061880afd3291fc78cb613401ad4c0b75718890388b259a16
+    manifestHash: b6ed9a1c67a7120d5b37ca4512547c1f7ce8171ce1fbe2a9934d2bc23cc513cb
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -53,7 +53,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 441d923fd8f8c63000b7e9ee520b461e558200f865092624c40d3055db6ab1bd
+    manifestHash: 3cb2a206a51d01886014383dca7a94d99e941a7eb6eec663c607bb14a28fb907
     name: eks-pod-identity-webhook.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
@@ -254,6 +254,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    protocol: TCP
     targetPort: 443
   selector:
     app: pod-identity-webhook

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -844,6 +844,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    protocol: TCP
     targetPort: 9443
   selector:
     app.kubernetes.io/component: controller

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -103,7 +103,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 031bee52f2675f7061880afd3291fc78cb613401ad4c0b75718890388b259a16
+    manifestHash: b6ed9a1c67a7120d5b37ca4512547c1f7ce8171ce1fbe2a9934d2bc23cc513cb
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -844,6 +844,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    protocol: TCP
     targetPort: 9443
   selector:
     app.kubernetes.io/component: controller

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -110,7 +110,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 031bee52f2675f7061880afd3291fc78cb613401ad4c0b75718890388b259a16
+    manifestHash: b6ed9a1c67a7120d5b37ca4512547c1f7ce8171ce1fbe2a9934d2bc23cc513cb
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -844,6 +844,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    protocol: TCP
     targetPort: 9443
   selector:
     app.kubernetes.io/component: controller

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -103,7 +103,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: ab863a89548a526a9717d90d4e7815f452e8f5e10a89884eef8937cdecf50cde
+    manifestHash: d42e618c15f4c6fce08b13f0a3fb56695c140e20858c15c7a602adf55ed84e31
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-aws-load-balancer-controller.addons.k8s.io-k8s-1.19_content
@@ -844,6 +844,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    protocol: TCP
     targetPort: 9443
   selector:
     app.kubernetes.io/component: controller

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -103,7 +103,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: ab863a89548a526a9717d90d4e7815f452e8f5e10a89884eef8937cdecf50cde
+    manifestHash: d42e618c15f4c6fce08b13f0a3fb56695c140e20858c15c7a602adf55ed84e31
     name: aws-load-balancer-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
@@ -711,6 +711,7 @@ spec:
   ports:
   - port: 443
     targetPort: 9443
+    protocol: TCP
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: aws-load-balancer-controller

--- a/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
@@ -190,6 +190,7 @@ spec:
   ports:
   - port: 443
     targetPort: 443
+    protocol: TCP
   selector:
     app: pod-identity-webhook
 ---


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/92332
Basically, server-side apply fails if protocol is not set on k8s 1.20 and older.