### PR TITLE
Automated cherry pick of #13366: Allow taints with unique key,value,effect

### DIFF
--- a/pkg/apis/kops/validation/instancegroup.go
+++ b/pkg/apis/kops/validation/instancegroup.go
@@ -148,15 +148,14 @@ func ValidateInstanceGroup(g *kops.InstanceGroup, cloud fi.Cloud) field.ErrorLis
 	taintKeys := sets.NewString()
 	for i, taint := range g.Spec.Taints {
 		path := field.NewPath("spec", "taints").Index(i)
-		parts, err := util.ParseTaint(taint)
+		_, err := util.ParseTaint(taint)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(path, taint, "invalid taint value"))
 		}
-		key := parts["key"]
-		if taintKeys.Has(key) {
-			allErrs = append(allErrs, field.Forbidden(path, fmt.Sprintf("cannot add multiple taints with key %q", key)))
+		if taintKeys.Has(taint) {
+			allErrs = append(allErrs, field.Duplicate(path, taint))
 		} else {
-			taintKeys.Insert(key)
+			taintKeys.Insert(taint)
 		}
 	}
 

--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -347,9 +347,15 @@ func TestValidTaints(t *testing.T) {
 		{
 			taints: []string{
 				"nvidia.com/gpu:NoSchedule",
-				"nvidia.com/gpu=1:NoSchedule",
+				"nvidia.com/gpu:NoExecute",
 			},
-			expected: []string{"Forbidden::spec.taints[1]"},
+		},
+		{
+			taints: []string{
+				"nvidia.com/gpu:NoSchedule",
+				"nvidia.com/gpu:NoSchedule",
+			},
+			expected: []string{"Duplicate value::spec.taints[1]"},
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #13366 on release-1.23.

#13366: Allow taints with unique key,value,effect

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```