### PR TITLE
Automated cherry pick of #13373: If kubetest2 fails cluster validation, we run down before

### DIFF
--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -96,6 +96,7 @@ func (d *deployer) Up() error {
 	}
 	isUp, err := d.IsUp()
 	if err != nil {
+		d.Down()
 		return err
 	} else if isUp {
 		klog.V(1).Infof("cluster reported as up")


### PR DESCRIPTION
Cherry pick of #13373 on release-1.23.

#13373: If kubetest2 fails cluster validation, we run down before

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```