### PR TITLE
[Digital Ocean] Use available regions as per the latest DO documentation

### DIFF
--- a/pkg/zones/wellknown.go
+++ b/pkg/zones/wellknown.go
@@ -269,13 +269,10 @@ var gceZones = []string{
 
 var doZones = []string{
 	"nyc1",
-	"nyc2",
 	"nyc3",
 
-	"sfo1",
 	"sfo3",
 
-	"ams2",
 	"ams3",
 
 	"tor1",

--- a/tests/e2e/kubetest2-kops/do/zones.go
+++ b/tests/e2e/kubetest2-kops/do/zones.go
@@ -24,15 +24,12 @@ import (
 
 var allZones = []string{
 	"nyc1",
-	"nyc2",
 	"nyc3",
 	"tor1",
 	"lon1",
 	"sgp1",
 	"blr1",
-	"sfo1",
 	"sfo3",
-	"ams2",
 	"ams3",
 	"fra1",
 }


### PR DESCRIPTION
Per latest docs - the region availability matrix supports regions as mentioned [here](https://docs.digitalocean.com/products/platform/availability-matrix/).

Remove regions that doesn't match this list (ams2, nyc2, sfo1)