### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ env:
   GOPROXY: https://proxy.golang.org
   GOPATH: ${{ github.workspace }}/go
 
+permissions:
+  contents: read
+
 jobs:
   build-linux-amd64:
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2 https://api.github.com/repos/actions/setup-go/git/commits/bfdd3570ce990073878bf10f6b2d79082de49492
         with:
           go-version: 1.17.5
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2 https://api.github.com/repos/actions/checkout/git/tags/629c2de402a417ea7690ca6ce3f33229e27606a5
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
 
@@ -31,11 +31,11 @@ jobs:
     runs-on: macos-10.15
     steps:
     - name: Set up go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2 https://api.github.com/repos/actions/setup-go/git/commits/bfdd3570ce990073878bf10f6b2d79082de49492
       with:
         go-version: 1.17.5
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2 https://api.github.com/repos/actions/checkout/git/tags/629c2de402a417ea7690ca6ce3f33229e27606a5
       with:
         path: ${{ env.GOPATH }}/src/k8s.io/kops
 
@@ -48,11 +48,11 @@ jobs:
     runs-on: windows-2019
     steps:
     - name: Set up go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2 https://api.github.com/repos/actions/setup-go/git/commits/bfdd3570ce990073878bf10f6b2d79082de49492
       with:
         go-version: 1.17.5
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2 https://api.github.com/repos/actions/checkout/git/tags/629c2de402a417ea7690ca6ce3f33229e27606a5
       with:
         path: ${{ env.GOPATH }}/src/k8s.io/kops
 
@@ -65,11 +65,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2 https://api.github.com/repos/actions/setup-go/git/commits/bfdd3570ce990073878bf10f6b2d79082de49492
         with:
           go-version: 1.17.5
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2 https://api.github.com/repos/actions/checkout/git/tags/629c2de402a417ea7690ca6ce3f33229e27606a5
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2 https://api.github.com/repos/actions/checkout/git/tags/629c2de402a417ea7690ca6ce3f33229e27606a5
       - run: /usr/bin/git config --global user.email actions@github.com
       - run: /usr/bin/git config --global user.name 'GitHub Actions Release Tagger'
       - run: hack/tag-release.sh


### PR DESCRIPTION

**What this PR does / why we need it**:

- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
