### PR TITLE
Correctly detect GovCloud regions

### DIFF
--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -36,11 +36,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// matches all regional naming conventions of S3:
-// https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+// matches regional naming conventions of S3:
+// https://docs.aws.amazon.com/general/latest/gr/s3.html
+// TODO: match fips and S3 access point naming conventions
 // TODO: perhaps make region regex more specific, i.e. (us|eu|ap|cn|ca|sa), to prevent matching bucket names that match region format?
 //       but that will mean updating this list when AWS introduces new regions
-var s3UrlRegexp = regexp.MustCompile(`(s3([-.](?P<region>\w{2}-\w+-\d{1})|[-.](?P<bucket>[\w.\-\_]+)|)?|(?P<bucket>[\w.\-\_]+)[.]s3([.](?P<region>\w{2}-\w+-\d{1}))?)[.]amazonaws[.]com([.]cn)?(?P<path>.*)?`)
+var s3UrlRegexp = regexp.MustCompile(`(s3([-.](?P<region>\w{2}(-gov)?-\w+-\d{1})|[-.](?P<bucket>[\w.\-\_]+)|)?|(?P<bucket>[\w.\-\_]+)[.]s3([.-](?P<region>\w{2}(-gov)?-\w+-\d{1}))?)[.]amazonaws[.]com([.]cn)?(?P<path>.*)?`)
 
 type S3BucketDetails struct {
 	// context is the S3Context we are associated with

--- a/util/pkg/vfs/s3context_test.go
+++ b/util/pkg/vfs/s3context_test.go
@@ -85,6 +85,16 @@ func Test_VFSPath(t *testing.T) {
 			ExpectError:    false,
 		},
 		{
+			Input:          "https://s3.us-gov-west-1.amazonaws.com/bucket",
+			ExpectedResult: "s3://bucket",
+			ExpectError:    false,
+		},
+		{
+			Input:          "https://s3.us-gov-west-1.amazonaws.com/bucket/path",
+			ExpectedResult: "s3://bucket/path",
+			ExpectError:    false,
+		},
+		{
 			Input:          "https://s3.amazonaws.com/bucket",
 			ExpectedResult: "s3://bucket",
 			ExpectError:    false,
@@ -121,6 +131,16 @@ func Test_VFSPath(t *testing.T) {
 		},
 		{
 			Input:          "https://bucket-name.s3.amazonaws.com/path",
+			ExpectedResult: "s3://bucket-name/path",
+			ExpectError:    false,
+		},
+		{
+			Input:          "https://bucket-name.s3-us-gov-west-1.amazonaws.com",
+			ExpectedResult: "s3://bucket-name",
+			ExpectError:    false,
+		},
+		{
+			Input:          "https://bucket-name.s3-us-gov-west-1.amazonaws.com/path",
 			ExpectedResult: "s3://bucket-name/path",
 			ExpectError:    false,
 		},


### PR DESCRIPTION
This PR correctly detects S3 HTTP URLs in GovCloud regions for `spec.assets.fileRepository`.

e.g.  this is the S3 object URL format for GovCloud
```
spec:
  assets:
    fileRepository: https://bucket-name.s3-us-gov-west-1.amazonaws.com/bucket-path
```

Prior to this PR, the bucket name is captured incorrectly in the example above as `s3-us-gov-west-1`.