### PR TITLE
Promote alpha to stable

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -88,13 +88,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.23.0"
-    recommendedVersion: 1.23.4
+    recommendedVersion: 1.23.5
     requiredVersion: 1.23.0
   - range: ">=1.22.0"
-    recommendedVersion: 1.22.7
+    recommendedVersion: 1.22.8
     requiredVersion: 1.22.0
   - range: ">=1.21.0"
-    recommendedVersion: 1.21.10
+    recommendedVersion: 1.21.11
     requiredVersion: 1.21.0
   - range: ">=1.20.0"
     recommendedVersion: 1.20.15
@@ -133,15 +133,15 @@ spec:
   - range: ">=1.23.0-alpha.1"
     recommendedVersion: "1.23.0"
     #requiredVersion: 1.22.0
-    kubernetesVersion: 1.23.4
+    kubernetesVersion: 1.23.5
   - range: ">=1.22.0-alpha.1"
     recommendedVersion: "1.23.0"
     #requiredVersion: 1.22.0
-    kubernetesVersion: 1.22.7
+    kubernetesVersion: 1.22.8
   - range: ">=1.21.0-alpha.1"
     recommendedVersion: "1.23.0"
     #requiredVersion: 1.21.0
-    kubernetesVersion: 1.21.10
+    kubernetesVersion: 1.21.11
   - range: ">=1.20.0-alpha.1"
     recommendedVersion: "1.23.0"
     #requiredVersion: 1.20.0


### PR DESCRIPTION
It's been 8 days since #13379 was merged, so we should be good with promoting the latest k8s versions to `stable` at this point.
/cc @hakman @olemarkus 