### PR TITLE
Automated cherry pick of #13378: Do not return a '-1' exit if no keys found and json/yaml

### DIFF
--- a/cmd/kops/get_sshpublickeys.go
+++ b/cmd/kops/get_sshpublickeys.go
@@ -105,12 +105,12 @@ func RunGetSSHPublicKeys(ctx context.Context, f *util.Factory, out io.Writer, op
 		items = append(items, item)
 	}
 
-	if len(items) == 0 {
-		return fmt.Errorf("no SSH public key found")
-	}
 	switch options.Output {
 
 	case OutputTable:
+		if len(items) == 0 {
+			return fmt.Errorf("no SSH public key found")
+		}
 		t := &tables.Table{}
 		t.AddColumn("ID", func(i *SSHKeyItem) string {
 			return i.ID


### PR DESCRIPTION
Cherry pick of #13378 on release-1.23.

#13378: Do not return a '-1' exit if no keys found and json/yaml

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.