### PR TITLE
Skip upstream e2e log dump

### DIFF
--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -435,6 +435,8 @@ func (t *Tester) execute() error {
 	}
 	t.addNonBlockingTaintsFlag()
 
+	t.TestArgs += " --disable-log-dump"
+
 	return t.Test()
 }
 


### PR DESCRIPTION
E2E has its own log dump script that e2e consistently fail to execute because of a path issue. 
```
Mar 29 17:20:38.405: INFO: Error running cluster/log-dump/log-dump.sh: fork/exec ../../cluster/log-dump/log-dump.sh: no such file or directory
```

This script wouldn't work with kOps anyway, and we have our own dumper. So best to just explicitly skip it.