### PR TITLE
Add support for fetching files from private GCS bucket.

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -203,6 +203,10 @@ func (b *BootstrapScript) buildEnvironmentVariables(cluster *kops.Cluster) (map[
 		}
 	}
 
+	if cluster.Spec.GetCloudProvider() == kops.CloudProviderGCE {
+		env["GCE_ACCESS_TOKEN_URL"] = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+	}
+
 	return env, nil
 }
 

--- a/pkg/model/resources/nodeup.go
+++ b/pkg/model/resources/nodeup.go
@@ -60,6 +60,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -76,29 +92,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -46,6 +46,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -62,29 +78,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -46,6 +46,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -62,29 +78,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -46,6 +46,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -62,29 +78,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -46,6 +46,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -62,29 +78,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -46,6 +46,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -62,29 +78,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -46,6 +46,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -62,29 +78,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
@@ -1,631 +1,230 @@
-Resources.AWSEC2LaunchTemplateapiserverapiserversminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: true
-      version: v1.5.0
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.22.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    protectKernelDefaults: true
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: apiserver
-  InstanceGroupRole: APIServer
-  NodeupConfigHash: 2g+iSy2UdZf6vXOvy/mYF/UNQbrzjq/Ma6pz6lzfdto=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: true
-      version: v1.5.0
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      manager:
-        env:
-        - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-          value: "true"
-      version: 3.5.1
-    main:
-      manager:
-        env:
-        - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-          value: "true"
-      version: 3.5.1
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-apiserver:v1.22.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: minimal.example.com
-    configureCloudRoutes: false
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-controller-manager:v1.22.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.22.0
-    logLevel: 2
-  kubeScheduler:
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-scheduler:v1.22.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    protectKernelDefaults: true
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    protectKernelDefaults: true
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: EOWNs8/wjh0FZPfcfA8xxlrhlhvjK5V82X1FeFzZqM0=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: true
-      version: v1.5.0
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.22.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    protectKernelDefaults: true
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: Ojz14cKdbBtjB//C+lmMWpLMbdnjnurwMGsb56e2dt0=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplateapiserverapiserversminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: true\n    version: v1.5.0\n  manageStorageClasses:
+  true\ncontainerRuntime: containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n
+  \ skipInstall: true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n
+  \ image: registry.k8s.io/kube-proxy:v1.22.0\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ protectKernelDefaults: true\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  apiserver\nInstanceGroupRole: APIServer\nNodeupConfigHash: 2g+iSy2UdZf6vXOvy/mYF/UNQbrzjq/Ma6pz6lzfdto=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: true\n    version: v1.5.0\n  manageStorageClasses:
+  true\ncontainerRuntime: containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n
+  \ skipInstall: true\nencryptionConfig: null\netcdClusters:\n  events:\n    manager:\n
+  \     env:\n      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK\n        value:
+  \"true\"\n    version: 3.5.1\n  main:\n    manager:\n      env:\n      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK\n
+  \       value: \"true\"\n    version: 3.5.1\nkubeAPIServer:\n  allowPrivileged:
+  true\n  anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount:
+  1\n  authorizationMode: AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n
+  \ enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n
+  \ - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ image: registry.k8s.io/kube-apiserver:v1.22.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.minimal.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.minimal.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n  allocateNodeCIDRs:
+  true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider: aws\n  clusterCIDR:
+  100.96.0.0/11\n  clusterName: minimal.example.com\n  configureCloudRoutes: false\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ image: registry.k8s.io/kube-controller-manager:v1.22.0\n  leaderElection:\n    leaderElect:
+  true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n  clusterCIDR:
+  100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.22.0\n
+  \ logLevel: 2\nkubeScheduler:\n  featureGates:\n    CSIMigrationAWS: \"true\"\n
+  \   InTreePluginAWSUnregister: \"true\"\n  image: registry.k8s.io/kube-scheduler:v1.22.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ protectKernelDefaults: true\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\nmasterKubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ protectKernelDefaults: true\n  registerSchedulable: false\n  shutdownGracePeriod:
+  30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml
+  << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: EOWNs8/wjh0FZPfcfA8xxlrhlhvjK5V82X1FeFzZqM0=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: true\n    version: v1.5.0\n  manageStorageClasses:
+  true\ncontainerRuntime: containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n
+  \ skipInstall: true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n
+  \ image: registry.k8s.io/kube-proxy:v1.22.0\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ protectKernelDefaults: true\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: Ojz14cKdbBtjB//C+lmMWpLMbdnjnurwMGsb56e2dt0=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
@@ -39,6 +39,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -55,29 +71,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -1,470 +1,165 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.LaunchTemplateData.UserData: |
-  Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
-  MIME-Version: 1.0
-
-  --MIMEBOUNDARY
-  Content-Disposition: attachment; filename="nodeup.sh"
-  Content-Transfer-Encoding: 7bit
-  Content-Type: text/x-shellscript
-  Mime-Version: 1.0
-
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    auditWebhookBatchThrottleQps: 3140m
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    cpuLimit: 500m
-    cpuRequest: 200m
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    memoryLimit: 1000Mi
-    memoryRequest: 800Mi
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.complex.example.com
-    serviceAccountJWKSURI: https://api.internal.complex.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    serviceNodePortRange: 28000-32767
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: complex.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/complex.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: Ypv+njGEdlkLhpNhz74waSxVXbRcABgT9LlNuw+mmr8=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-
-  --MIMEBOUNDARY
-  Content-Disposition: attachment; filename="myscript.sh"
-  Content-Transfer-Encoding: 7bit
-  Content-Type: text/x-shellscript
-  Mime-Version: 1.0
-
-  #!/bin/sh
-  echo "nodes: The time is now $(date -R)!" | tee /root/output.txt
-
-  --MIMEBOUNDARY--
-Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateData.UserData: |
-  Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
-  MIME-Version: 1.0
-
-  --MIMEBOUNDARY
-  Content-Disposition: attachment; filename="nodeup.sh"
-  Content-Transfer-Encoding: 7bit
-  Content-Type: text/x-shellscript
-  Mime-Version: 1.0
-
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/complex.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: yPkFbMcpagKgWbeaLBm+VzZA6j7pzymiEUToAgoi/jQ=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-
-  --MIMEBOUNDARY
-  Content-Disposition: attachment; filename="myscript.sh"
-  Content-Transfer-Encoding: 7bit
-  Content-Type: text/x-shellscript
-  Mime-Version: 1.0
-
-  #!/bin/sh
-  echo "nodes: The time is now $(date -R)!" | tee /root/output.txt
-
-  --MIMEBOUNDARY--
+Resources.AWSEC2LaunchTemplatemasterustest1amasterscomplexexamplecom.Properties.LaunchTemplateData.UserData: "Content-Type:
+  multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\n\n--MIMEBOUNDARY\nContent-Disposition:
+  attachment; filename=\"nodeup.sh\"\nContent-Transfer-Encoding: 7bit\nContent-Type:
+  text/x-shellscript\nMime-Version: 1.0\n\n#!/bin/bash\nset -o errexit\nset -o nounset\nset
+  -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  auditWebhookBatchThrottleQps:
+  3140m\n  authorizationMode: AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider:
+  aws\n  cpuLimit: 500m\n  cpuRequest: 200m\n  enableAdmissionPlugins:\n  - NamespaceLifecycle\n
+  \ - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n  - DefaultTolerationSeconds\n
+  \ - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n  - NodeRestriction\n
+  \ - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n  etcdServersOverrides:\n
+  \ - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  memoryLimit: 1000Mi\n  memoryRequest: 800Mi\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.complex.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.complex.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  100.64.0.0/13\n  serviceNodePortRange: 28000-32767\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: complex.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/complex.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: Ypv+njGEdlkLhpNhz74waSxVXbRcABgT9LlNuw+mmr8=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n\n--MIMEBOUNDARY\nContent-Disposition: attachment;
+  filename=\"myscript.sh\"\nContent-Transfer-Encoding: 7bit\nContent-Type: text/x-shellscript\nMime-Version:
+  1.0\n\n#!/bin/sh\necho \"nodes: The time is now $(date -R)!\" | tee /root/output.txt\n\n--MIMEBOUNDARY--\n"
+Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateData.UserData: "Content-Type:
+  multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\n\n--MIMEBOUNDARY\nContent-Disposition:
+  attachment; filename=\"nodeup.sh\"\nContent-Transfer-Encoding: 7bit\nContent-Type:
+  text/x-shellscript\nMime-Version: 1.0\n\n#!/bin/bash\nset -o errexit\nset -o nounset\nset
+  -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/complex.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: yPkFbMcpagKgWbeaLBm+VzZA6j7pzymiEUToAgoi/jQ=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n\n--MIMEBOUNDARY\nContent-Disposition: attachment;
+  filename=\"myscript.sh\"\nContent-Transfer-Encoding: 7bit\nContent-Type: text/x-shellscript\nMime-Version:
+  1.0\n\n#!/bin/sh\necho \"nodes: The time is now $(date -R)!\" | tee /root/output.txt\n\n--MIMEBOUNDARY--\n"

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
@@ -39,6 +39,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -55,29 +71,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
@@ -39,6 +39,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -55,29 +71,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/compress/data/aws_launch_template_master-us-test-1a.masters.compress.example.com_user_data
+++ b/tests/integration/update_cluster/compress/data/aws_launch_template_master-us-test-1a.masters.compress.example.com_user_data
@@ -39,6 +39,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -55,29 +71,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/compress/data/aws_launch_template_nodes.compress.example.com_user_data
+++ b/tests/integration/update_cluster/compress/data/aws_launch_template_nodes.compress.example.com_user_data
@@ -39,6 +39,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -55,29 +71,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/containerd-custom/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd-custom/cloudformation.json.extracted.yaml
@@ -1,440 +1,159 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    packages:
-      hashAmd64: "0000000000000000000000000000000000000000000000000000000000000000"
-      urlAmd64: https://github.com/containerd/containerd/releases/download/v1.3.9/cri-containerd-cni-1.3.9-linux-amd64.tar.gz
-    registryMirrors:
-      '*':
-      - http://HostIP2:Port2
-      docker.io:
-      - https://registry-1.docker.io
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.containerd.example.com
-    serviceAccountJWKSURI: https://api.internal.containerd.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: containerd.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/containerd.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: wQ2/Cohq6Dm9TzD4TLO1RUcBk0PsSOZIGOS/GrHXV1U=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    packages:
-      hashAmd64: "0000000000000000000000000000000000000000000000000000000000000000"
-      urlAmd64: https://github.com/containerd/containerd/releases/download/v1.3.9/cri-containerd-cni-1.3.9-linux-amd64.tar.gz
-    registryMirrors:
-      '*':
-      - http://HostIP2:Port2
-      docker.io:
-      - https://registry-1.docker.io
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/containerd.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: BncMb9tV+Hz8u7qGuBStsC/px0PFz7aJZxnS3Ft0idg=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  packages:\n    hashAmd64: \"0000000000000000000000000000000000000000000000000000000000000000\"\n
+  \   urlAmd64: https://github.com/containerd/containerd/releases/download/v1.3.9/cri-containerd-cni-1.3.9-linux-amd64.tar.gz\n
+  \ registryMirrors:\n    '*':\n    - http://HostIP2:Port2\n    docker.io:\n    -
+  https://registry-1.docker.io\n  version: 1.4.12\ndocker:\n  skipInstall: true\nencryptionConfig:
+  null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n    version: 3.4.13\nkubeAPIServer:\n
+  \ allowPrivileged: true\n  anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n
+  \ apiServerCount: 1\n  authorizationMode: AlwaysAllow\n  bindAddress: 0.0.0.0\n
+  \ cloudProvider: aws\n  enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n
+  \ - ServiceAccount\n  - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ image: registry.k8s.io/kube-apiserver:v1.21.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.containerd.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.containerd.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n  allocateNodeCIDRs:
+  true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider: aws\n  clusterCIDR:
+  100.96.0.0/11\n  clusterName: containerd.example.com\n  configureCloudRoutes: false\n
+  \ image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n    leaderElect:
+  true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n  clusterCIDR:
+  100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/containerd.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: wQ2/Cohq6Dm9TzD4TLO1RUcBk0PsSOZIGOS/GrHXV1U=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  packages:\n    hashAmd64: \"0000000000000000000000000000000000000000000000000000000000000000\"\n
+  \   urlAmd64: https://github.com/containerd/containerd/releases/download/v1.3.9/cri-containerd-cni-1.3.9-linux-amd64.tar.gz\n
+  \ registryMirrors:\n    '*':\n    - http://HostIP2:Port2\n    docker.io:\n    -
+  https://registry-1.docker.io\n  version: 1.4.12\ndocker:\n  skipInstall: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/containerd.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: BncMb9tV+Hz8u7qGuBStsC/px0PFz7aJZxnS3Ft0idg=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/containerd/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/containerd/cloudformation.json.extracted.yaml
@@ -1,424 +1,153 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.containerd.example.com
-    serviceAccountJWKSURI: https://api.internal.containerd.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: containerd.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/containerd.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: m3ZO9vHu+QdaI0zIncdCupxVrTgPyStQ9Z+uEYo1p3Q=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/containerd.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: uaOAxuWIsA47R70iX7vzqkuFGXdz3nps2c/jH3jgj2Y=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amasterscontainerdexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.containerd.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.containerd.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: containerd.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/containerd.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: m3ZO9vHu+QdaI0zIncdCupxVrTgPyStQ9Z+uEYo1p3Q=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodescontainerdexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/containerd.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: uaOAxuWIsA47R70iX7vzqkuFGXdz3nps2c/jH3jgj2Y=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
+++ b/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data
+++ b/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/docker-custom/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/docker-custom/cloudformation.json.extracted.yaml
@@ -1,456 +1,167 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersdockerexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: docker
-  containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: info
-  docker:
-    execOpt:
-    - native.cgroupdriver=systemd
-    ipMasq: false
-    ipTables: false
-    logDriver: json-file
-    logLevel: info
-    logOpt:
-    - max-size=10m
-    - max-file=5
-    packages:
-      hashAmd64: 000000000000000000000000000000000000000000000000000000000000000a
-      hashArm64: 000000000000000000000000000000000000000000000000000000000000000b
-      urlAmd64: https://download.docker.com/linux/static/stable/x86_64/docker-20.10.1.tgz
-      urlArm64: https://download.docker.com/linux/static/stable/aarch64/docker-20.10.1.tgz
-    storage: overlay2,overlay,aufs
-    version: 20.10.9
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.docker.example.com
-    serviceAccountJWKSURI: https://api.internal.docker.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: docker.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/docker.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: X63Erwp16OybmfuTwCiDMDCIVoJXKa9cdUobNbuE77E=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesdockerexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: docker
-  containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: info
-  docker:
-    execOpt:
-    - native.cgroupdriver=systemd
-    ipMasq: false
-    ipTables: false
-    logDriver: json-file
-    logLevel: info
-    logOpt:
-    - max-size=10m
-    - max-file=5
-    packages:
-      hashAmd64: 000000000000000000000000000000000000000000000000000000000000000a
-      hashArm64: 000000000000000000000000000000000000000000000000000000000000000b
-      urlAmd64: https://download.docker.com/linux/static/stable/x86_64/docker-20.10.1.tgz
-      urlArm64: https://download.docker.com/linux/static/stable/aarch64/docker-20.10.1.tgz
-    storage: overlay2,overlay,aufs
-    version: 20.10.9
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/docker.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: hQbYSisfjTmEKl0BZRts+YZao5uRXpgDQR3jJT1AzHQ=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersdockerexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  docker\ncontainerd:\n  configOverride: |\n    disabled_plugins = [\"cri\"]\n  logLevel:
+  info\ndocker:\n  execOpt:\n  - native.cgroupdriver=systemd\n  ipMasq: false\n  ipTables:
+  false\n  logDriver: json-file\n  logLevel: info\n  logOpt:\n  - max-size=10m\n  -
+  max-file=5\n  packages:\n    hashAmd64: 000000000000000000000000000000000000000000000000000000000000000a\n
+  \   hashArm64: 000000000000000000000000000000000000000000000000000000000000000b\n
+  \   urlAmd64: https://download.docker.com/linux/static/stable/x86_64/docker-20.10.1.tgz\n
+  \   urlArm64: https://download.docker.com/linux/static/stable/aarch64/docker-20.10.1.tgz\n
+  \ storage: overlay2,overlay,aufs\n  version: 20.10.9\nencryptionConfig: null\netcdClusters:\n
+  \ events:\n    version: 3.4.13\n  main:\n    version: 3.4.13\nkubeAPIServer:\n  allowPrivileged:
+  true\n  anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount:
+  1\n  authorizationMode: AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n
+  \ enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n
+  \ - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ image: registry.k8s.io/kube-apiserver:v1.21.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.docker.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.docker.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n  allocateNodeCIDRs:
+  true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider: aws\n  clusterCIDR:
+  100.96.0.0/11\n  clusterName: docker.example.com\n  configureCloudRoutes: false\n
+  \ image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n    leaderElect:
+  true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n  clusterCIDR:
+  100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/docker.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: X63Erwp16OybmfuTwCiDMDCIVoJXKa9cdUobNbuE77E=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesdockerexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  docker\ncontainerd:\n  configOverride: |\n    disabled_plugins = [\"cri\"]\n  logLevel:
+  info\ndocker:\n  execOpt:\n  - native.cgroupdriver=systemd\n  ipMasq: false\n  ipTables:
+  false\n  logDriver: json-file\n  logLevel: info\n  logOpt:\n  - max-size=10m\n  -
+  max-file=5\n  packages:\n    hashAmd64: 000000000000000000000000000000000000000000000000000000000000000a\n
+  \   hashArm64: 000000000000000000000000000000000000000000000000000000000000000b\n
+  \   urlAmd64: https://download.docker.com/linux/static/stable/x86_64/docker-20.10.1.tgz\n
+  \   urlArm64: https://download.docker.com/linux/static/stable/aarch64/docker-20.10.1.tgz\n
+  \ storage: overlay2,overlay,aufs\n  version: 20.10.9\nkubeProxy:\n  clusterCIDR:
+  100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/docker.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: hQbYSisfjTmEKl0BZRts+YZao5uRXpgDQR3jJT1AzHQ=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
+++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/existing_iam_cloudformation/cloudformation.json.extracted.yaml
@@ -1,424 +1,153 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: minimal.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: Px1gig3Ry7G3Xd3wHCOTUd9GyaD+Fb12x0dfIsxD0tk=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: BtCvWcFpkTpa7L1SoiolwpQ1Xm3zfW3zgx9/UisJ1AA=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.minimal.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: minimal.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: Px1gig3Ry7G3Xd3wHCOTUd9GyaD+Fb12x0dfIsxD0tk=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: BtCvWcFpkTpa7L1SoiolwpQ1Xm3zfW3zgx9/UisJ1AA=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
+++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/external_dns/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/external_dns/cloudformation.json.extracted.yaml
@@ -1,424 +1,153 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: minimal.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: Px1gig3Ry7G3Xd3wHCOTUd9GyaD+Fb12x0dfIsxD0tk=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: BtCvWcFpkTpa7L1SoiolwpQ1Xm3zfW3zgx9/UisJ1AA=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.minimal.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: minimal.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: Px1gig3Ry7G3Xd3wHCOTUd9GyaD+Fb12x0dfIsxD0tk=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: BtCvWcFpkTpa7L1SoiolwpQ1Xm3zfW3zgx9/UisJ1AA=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/external_dns/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/external_dns/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/externallb/cloudformation.json.extracted.yaml
@@ -1,424 +1,153 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersexternallbexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.externallb.example.com
-    serviceAccountJWKSURI: https://api.internal.externallb.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: externallb.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/externallb.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: amqjK20v02J1e/z4uchpj3NncpY6Efq252rkHVb4iXk=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesexternallbexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/externallb.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: Q7GGucTTp5m0T0WGXcMy9wbxPn3DFnun7/71t18NKQI=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersexternallbexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.externallb.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.externallb.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: externallb.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/externallb.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: amqjK20v02J1e/z4uchpj3NncpY6Efq252rkHVb4iXk=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesexternallbexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/externallb.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: Q7GGucTTp5m0T0WGXcMy9wbxPn3DFnun7/71t18NKQI=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
+++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
+++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
+++ b/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_startup-script
@@ -8,6 +8,7 @@ NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c9
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
 
+export GCE_ACCESS_TOKEN_URL=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
 
 
 
@@ -29,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -45,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_startup-script
@@ -8,6 +8,7 @@ NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c9
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
 
+export GCE_ACCESS_TOKEN_URL=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
 
 
 
@@ -29,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -45,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_startup-script
@@ -8,6 +8,7 @@ NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c9
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
 
+export GCE_ACCESS_TOKEN_URL=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
 
 
 
@@ -29,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -45,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_startup-script
@@ -8,6 +8,7 @@ NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c9
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
 
+export GCE_ACCESS_TOKEN_URL=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
 
 
 
@@ -29,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -45,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/irsa119/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa119/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/irsa119/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/irsa119/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-default.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-default.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-single-machinetype.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_karpenter-nodes-single-machinetype.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-etcd/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-etcd/cloudformation.json.extracted.yaml
@@ -1,440 +1,159 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimaletcdexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      etcdMembers:
-      - name: us-test-1a
-        volumeSize: 20
-      manager:
-        env:
-        - name: ETCD_MANAGER_HOURLY_BACKUPS_RETENTION
-          value: 1d
-        - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION
-          value: 30d
-        image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc
-      version: 3.4.13
-    main:
-      etcdMembers:
-      - name: us-test-1a
-        volumeSize: 20
-      manager:
-        image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc
-        logLevel: 10
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal-etcd.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal-etcd.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: minimal-etcd.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal-etcd.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: rU8eky9R3dEeLu2MgXrXTVCfaU3ZGdH8xtTPCVnB+AY=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimaletcdexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal-etcd.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: UFye0jAPqOv5CcCI40SyH1QNZIBC4aqAEr/pkW+a0XI=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimaletcdexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    etcdMembers:\n    -
+  name: us-test-1a\n      volumeSize: 20\n    manager:\n      env:\n      - name:
+  ETCD_MANAGER_HOURLY_BACKUPS_RETENTION\n        value: 1d\n      - name: ETCD_MANAGER_DAILY_BACKUPS_RETENTION\n
+  \       value: 30d\n      image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc\n
+  \   version: 3.4.13\n  main:\n    etcdMembers:\n    - name: us-test-1a\n      volumeSize:
+  20\n    manager:\n      image: gcr.io/k8s-staging-etcdadm/etcd:v20210430-v0.1.3-739-g7da12acc\n
+  \     logLevel: 10\n    version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n
+  \ anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount:
+  1\n  authorizationMode: AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n
+  \ enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n
+  \ - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ image: registry.k8s.io/kube-apiserver:v1.21.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.minimal-etcd.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.minimal-etcd.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n  allocateNodeCIDRs:
+  true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider: aws\n  clusterCIDR:
+  100.96.0.0/11\n  clusterName: minimal-etcd.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal-etcd.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: rU8eky9R3dEeLu2MgXrXTVCfaU3ZGdH8xtTPCVnB+AY=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimaletcdexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal-etcd.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: UFye0jAPqOv5CcCI40SyH1QNZIBC4aqAEr/pkW+a0XI=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/minimal-gp3/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-gp3/cloudformation.json.extracted.yaml
@@ -1,430 +1,155 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      etcdMembers:
-      - name: us-test-1a
-        volumeSize: 20
-      version: 3.4.13
-    main:
-      etcdMembers:
-      - name: us-test-1a
-        volumeSize: 50
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: minimal.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: Px1gig3Ry7G3Xd3wHCOTUd9GyaD+Fb12x0dfIsxD0tk=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: BtCvWcFpkTpa7L1SoiolwpQ1Xm3zfW3zgx9/UisJ1AA=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    etcdMembers:\n    -
+  name: us-test-1a\n      volumeSize: 20\n    version: 3.4.13\n  main:\n    etcdMembers:\n
+  \   - name: us-test-1a\n      volumeSize: 50\n    version: 3.4.13\nkubeAPIServer:\n
+  \ allowPrivileged: true\n  anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n
+  \ apiServerCount: 1\n  authorizationMode: AlwaysAllow\n  bindAddress: 0.0.0.0\n
+  \ cloudProvider: aws\n  enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n
+  \ - ServiceAccount\n  - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ image: registry.k8s.io/kube-apiserver:v1.21.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.minimal.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.minimal.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n  allocateNodeCIDRs:
+  true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider: aws\n  clusterCIDR:
+  100.96.0.0/11\n  clusterName: minimal.example.com\n  configureCloudRoutes: false\n
+  \ image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n    leaderElect:
+  true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n  clusterCIDR:
+  100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: Px1gig3Ry7G3Xd3wHCOTUd9GyaD+Fb12x0dfIsxD0tk=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: BtCvWcFpkTpa7L1SoiolwpQ1Xm3zfW3zgx9/UisJ1AA=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json.extracted.yaml
@@ -1,450 +1,160 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: true
-      version: v1.5.0
-    manageStorageClasses: true
-    nodeIPFamilies:
-    - ipv6
-    - ipv4
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: '::'
-    cloudProvider: external
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal-ipv6.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal-ipv6.example.com/openid/v1/jwks
-    serviceClusterIPRange: fd00:5e4f:ce::/108
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: false
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: external
-    clusterName: minimal-ipv6.example.com
-    configureCloudRoutes: false
-    controllers:
-    - '*'
-    - -nodeipam
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: external
-    clusterDNS: fd00:5e4f:ce::a
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: external
-    clusterDNS: fd00:5e4f:ce::a
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: MK0ADjiimAJft3zga357N1BVO5pDNmYLFsWDE8ejK2Q=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: true
-      version: v1.5.0
-    manageStorageClasses: true
-    nodeIPFamilies:
-    - ipv6
-    - ipv4
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: external
-    clusterDNS: fd00:5e4f:ce::a
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: jycf2UcZw5xd4lE+V/y/LowQ7qd9dg7399iHXUaYxF0=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: true\n    version: v1.5.0\n  manageStorageClasses:
+  true\n  nodeIPFamilies:\n  - ipv6\n  - ipv4\ncontainerRuntime: containerd\ncontainerd:\n
+  \ logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall: true\nencryptionConfig:
+  null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n    version: 3.4.13\nkubeAPIServer:\n
+  \ allowPrivileged: true\n  anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n
+  \ apiServerCount: 1\n  authorizationMode: AlwaysAllow\n  bindAddress: '::'\n  cloudProvider:
+  external\n  enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n  -
+  ServiceAccount\n  - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ image: registry.k8s.io/kube-apiserver:v1.21.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.minimal-ipv6.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.minimal-ipv6.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  fd00:5e4f:ce::/108\n  storageBackend: etcd3\nkubeControllerManager:\n  allocateNodeCIDRs:
+  false\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider: external\n  clusterName:
+  minimal-ipv6.example.com\n  configureCloudRoutes: false\n  controllers:\n  - '*'\n
+  \ - -nodeipam\n  featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister:
+  \"true\"\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n  logLevel: 2\nkubeScheduler:\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ image: registry.k8s.io/kube-scheduler:v1.21.0\n  leaderElection:\n    leaderElect:
+  true\n  logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n
+  \ cgroupRoot: /\n  cloudProvider: external\n  clusterDNS: fd00:5e4f:ce::a\n  clusterDomain:
+  cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  external\n  clusterDNS: fd00:5e4f:ce::a\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: MK0ADjiimAJft3zga357N1BVO5pDNmYLFsWDE8ejK2Q=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: true\n    version: v1.5.0\n  manageStorageClasses:
+  true\n  nodeIPFamilies:\n  - ipv6\n  - ipv4\ncontainerRuntime: containerd\ncontainerd:\n
+  \ logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall: true\nkubeProxy:\n
+  \ cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n  logLevel: 2\nkubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  external\n  clusterDNS: fd00:5e4f:ce::a\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: jycf2UcZw5xd4lE+V/y/LowQ7qd9dg7399iHXUaYxF0=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json.extracted.yaml
@@ -1,450 +1,160 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: true
-      version: v1.5.0
-    manageStorageClasses: true
-    nodeIPFamilies:
-    - ipv6
-    - ipv4
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: '::'
-    cloudProvider: external
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal-ipv6.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal-ipv6.example.com/openid/v1/jwks
-    serviceClusterIPRange: fd00:5e4f:ce::/108
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: false
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: external
-    clusterName: minimal-ipv6.example.com
-    configureCloudRoutes: false
-    controllers:
-    - '*'
-    - -nodeipam
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: external
-    clusterDNS: fd00:5e4f:ce::a
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: external
-    clusterDNS: fd00:5e4f:ce::a
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: MK0ADjiimAJft3zga357N1BVO5pDNmYLFsWDE8ejK2Q=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: true
-      version: v1.5.0
-    manageStorageClasses: true
-    nodeIPFamilies:
-    - ipv6
-    - ipv4
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: external
-    clusterDNS: fd00:5e4f:ce::a
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: jycf2UcZw5xd4lE+V/y/LowQ7qd9dg7399iHXUaYxF0=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: true\n    version: v1.5.0\n  manageStorageClasses:
+  true\n  nodeIPFamilies:\n  - ipv6\n  - ipv4\ncontainerRuntime: containerd\ncontainerd:\n
+  \ logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall: true\nencryptionConfig:
+  null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n    version: 3.4.13\nkubeAPIServer:\n
+  \ allowPrivileged: true\n  anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n
+  \ apiServerCount: 1\n  authorizationMode: AlwaysAllow\n  bindAddress: '::'\n  cloudProvider:
+  external\n  enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n  -
+  ServiceAccount\n  - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ image: registry.k8s.io/kube-apiserver:v1.21.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.minimal-ipv6.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.minimal-ipv6.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  fd00:5e4f:ce::/108\n  storageBackend: etcd3\nkubeControllerManager:\n  allocateNodeCIDRs:
+  false\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider: external\n  clusterName:
+  minimal-ipv6.example.com\n  configureCloudRoutes: false\n  controllers:\n  - '*'\n
+  \ - -nodeipam\n  featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister:
+  \"true\"\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n  logLevel: 2\nkubeScheduler:\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ image: registry.k8s.io/kube-scheduler:v1.21.0\n  leaderElection:\n    leaderElect:
+  true\n  logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n
+  \ cgroupRoot: /\n  cloudProvider: external\n  clusterDNS: fd00:5e4f:ce::a\n  clusterDomain:
+  cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  external\n  clusterDNS: fd00:5e4f:ce::a\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: MK0ADjiimAJft3zga357N1BVO5pDNmYLFsWDE8ejK2Q=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: true\n    version: v1.5.0\n  manageStorageClasses:
+  true\n  nodeIPFamilies:\n  - ipv6\n  - ipv4\ncontainerRuntime: containerd\ncontainerd:\n
+  \ logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall: true\nkubeProxy:\n
+  \ cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n  logLevel: 2\nkubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  external\n  clusterDNS: fd00:5e4f:ce::a\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: jycf2UcZw5xd4lE+V/y/LowQ7qd9dg7399iHXUaYxF0=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-ipv6/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-ipv6/cloudformation.json.extracted.yaml
@@ -1,450 +1,160 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: true
-      version: v1.5.0
-    manageStorageClasses: true
-    nodeIPFamilies:
-    - ipv6
-    - ipv4
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: '::'
-    cloudProvider: external
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal-ipv6.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal-ipv6.example.com/openid/v1/jwks
-    serviceClusterIPRange: fd00:5e4f:ce::/108
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: false
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: external
-    clusterName: minimal-ipv6.example.com
-    configureCloudRoutes: false
-    controllers:
-    - '*'
-    - -nodeipam
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: external
-    clusterDNS: fd00:5e4f:ce::a
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: external
-    clusterDNS: fd00:5e4f:ce::a
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: MK0ADjiimAJft3zga357N1BVO5pDNmYLFsWDE8ejK2Q=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: true
-      version: v1.5.0
-    manageStorageClasses: true
-    nodeIPFamilies:
-    - ipv6
-    - ipv4
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: external
-    clusterDNS: fd00:5e4f:ce::a
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    featureGates:
-      CSIMigrationAWS: "true"
-      InTreePluginAWSUnregister: "true"
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: jycf2UcZw5xd4lE+V/y/LowQ7qd9dg7399iHXUaYxF0=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: true\n    version: v1.5.0\n  manageStorageClasses:
+  true\n  nodeIPFamilies:\n  - ipv6\n  - ipv4\ncontainerRuntime: containerd\ncontainerd:\n
+  \ logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall: true\nencryptionConfig:
+  null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n    version: 3.4.13\nkubeAPIServer:\n
+  \ allowPrivileged: true\n  anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n
+  \ apiServerCount: 1\n  authorizationMode: AlwaysAllow\n  bindAddress: '::'\n  cloudProvider:
+  external\n  enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n  -
+  ServiceAccount\n  - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ image: registry.k8s.io/kube-apiserver:v1.21.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.minimal-ipv6.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.minimal-ipv6.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  fd00:5e4f:ce::/108\n  storageBackend: etcd3\nkubeControllerManager:\n  allocateNodeCIDRs:
+  false\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider: external\n  clusterName:
+  minimal-ipv6.example.com\n  configureCloudRoutes: false\n  controllers:\n  - '*'\n
+  \ - -nodeipam\n  featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister:
+  \"true\"\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n  logLevel: 2\nkubeScheduler:\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ image: registry.k8s.io/kube-scheduler:v1.21.0\n  leaderElection:\n    leaderElect:
+  true\n  logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n
+  \ cgroupRoot: /\n  cloudProvider: external\n  clusterDNS: fd00:5e4f:ce::a\n  clusterDomain:
+  cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  external\n  clusterDNS: fd00:5e4f:ce::a\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: MK0ADjiimAJft3zga357N1BVO5pDNmYLFsWDE8ejK2Q=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: true\n    version: v1.5.0\n  manageStorageClasses:
+  true\n  nodeIPFamilies:\n  - ipv6\n  - ipv4\ncontainerRuntime: containerd\ncontainerd:\n
+  \ logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall: true\nkubeProxy:\n
+  \ cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n  logLevel: 2\nkubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  external\n  clusterDNS: fd00:5e4f:ce::a\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ featureGates:\n    CSIMigrationAWS: \"true\"\n    InTreePluginAWSUnregister: \"true\"\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: jycf2UcZw5xd4lE+V/y/LowQ7qd9dg7399iHXUaYxF0=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-longclustername/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-longclustername/cloudformation.json.extracted.yaml
@@ -1,423 +1,152 @@
 ? Resources.AWSEC2LaunchTemplatemasterustest1amastersthisistrulyareallyreallylongclusternameminimalexamplecom.Properties.LaunchTemplateData.UserData
-: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.this.is.truly.a.really.really.long.cluster-name.minimal.example.com
-    serviceAccountJWKSURI: https://api.internal.this.is.truly.a.really.really.long.cluster-name.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: this.is.truly.a.really.really.long.cluster-name.minimal.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: urLp/r2nq7WqKItlcXIPY4DX+4Au4RmsvS2PF4FJQgw=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+: "#!/bin/bash\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.this.is.truly.a.really.really.long.cluster-name.minimal.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.this.is.truly.a.really.really.long.cluster-name.minimal.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: this.is.truly.a.really.really.long.cluster-name.minimal.example.com\n
+  \ configureCloudRoutes: false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  cgroupDriver:
+  systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain:
+  cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n
+  \ clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: urLp/r2nq7WqKItlcXIPY4DX+4Au4RmsvS2PF4FJQgw=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
 ? Resources.AWSEC2LaunchTemplatenodesthisistrulyareallyreallylongclusternameminimalexamplecom.Properties.LaunchTemplateData.UserData
-: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: yfDv+pqge28jGHwqpMqOc1aATLoceUPU+ktGCJQrU4s=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+: "#!/bin/bash\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: yfDv+pqge28jGHwqpMqOc1aATLoceUPU+ktGCJQrU4s=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_nodes.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_nodes.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal/cloudformation.json.extracted.yaml
@@ -1,421 +1,152 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: minimal.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: C8qAUpqZBMluWjUGWsSBFeNhbWVZEBa2LeAhLCfq6EI=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: nt2U9XS+exP3kAEZtdZuAN+2aqdHBpI2bFjWB6WRnE8=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.minimal.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: minimal.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  cgroupDriver:
+  systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain:
+  cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n
+  \ clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: C8qAUpqZBMluWjUGWsSBFeNhbWVZEBa2LeAhLCfq6EI=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: nt2U9XS+exP3kAEZtdZuAN+2aqdHBpI2bFjWB6WRnE8=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -8,6 +8,7 @@ NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c9
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
 
+export GCE_ACCESS_TOKEN_URL=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
 
 
 
@@ -29,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -45,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_startup-script
@@ -8,6 +8,7 @@ NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c9
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
 
+export GCE_ACCESS_TOKEN_URL=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
 
 
 
@@ -29,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -45,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_startup-script
@@ -8,6 +8,7 @@ NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c9
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
 
+export GCE_ACCESS_TOKEN_URL=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
 
 
 
@@ -29,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -45,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_startup-script
@@ -8,6 +8,7 @@ NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c9
 NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
 NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
 
+export GCE_ACCESS_TOKEN_URL=http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
 
 
 
@@ -29,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -45,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json.extracted.yaml
@@ -1,930 +1,333 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 3
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.mixedinstances.example.com
-    serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: mixedinstances.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatemasterustest1bmastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 3
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.mixedinstances.example.com
-    serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: mixedinstances.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
-  InstanceGroupName: master-us-test-1b
-  InstanceGroupRole: Master
-  NodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatemasterustest1cmastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 3
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.mixedinstances.example.com
-    serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: mixedinstances.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
-  InstanceGroupName: master-us-test-1c
-  InstanceGroupRole: Master
-  NodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: CELDbDSK0M8SJg2YoK5K1c6oh+Dw0+IlPEYRaBgP3uc=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 3\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.mixedinstances.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: mixedinstances.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/mixedinstances.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatemasterustest1bmastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 3\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.mixedinstances.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: mixedinstances.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/mixedinstances.example.com\nInstanceGroupName:
+  master-us-test-1b\nInstanceGroupRole: Master\nNodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatemasterustest1cmastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 3\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.mixedinstances.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: mixedinstances.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/mixedinstances.example.com\nInstanceGroupName:
+  master-us-test-1c\nInstanceGroupRole: Master\nNodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/mixedinstances.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: CELDbDSK0M8SJg2YoK5K1c6oh+Dw0+IlPEYRaBgP3uc=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/mixed_instances_spot/cloudformation.json.extracted.yaml
@@ -1,930 +1,333 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 3
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.mixedinstances.example.com
-    serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: mixedinstances.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatemasterustest1bmastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 3
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.mixedinstances.example.com
-    serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: mixedinstances.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
-  InstanceGroupName: master-us-test-1b
-  InstanceGroupRole: Master
-  NodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatemasterustest1cmastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 3
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.mixedinstances.example.com
-    serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: mixedinstances.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
-  InstanceGroupName: master-us-test-1c
-  InstanceGroupRole: Master
-  NodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: CELDbDSK0M8SJg2YoK5K1c6oh+Dw0+IlPEYRaBgP3uc=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 3\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.mixedinstances.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: mixedinstances.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/mixedinstances.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatemasterustest1bmastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 3\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.mixedinstances.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: mixedinstances.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/mixedinstances.example.com\nInstanceGroupName:
+  master-us-test-1b\nInstanceGroupRole: Master\nNodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatemasterustest1cmastersmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 3\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.mixedinstances.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.mixedinstances.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: mixedinstances.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/mixedinstances.example.com\nInstanceGroupName:
+  master-us-test-1c\nInstanceGroupRole: Master\nNodeupConfigHash: SWtB8lOMBx/+Ry8EFHyYRYnpo52cvT37/IwwsMUUdyM=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesmixedinstancesexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/mixedinstances.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: CELDbDSK0M8SJg2YoK5K1c6oh+Dw0+IlPEYRaBgP3uc=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/nth_sqs_resources/cloudformation.json.extracted.yaml
@@ -1,419 +1,150 @@
 ? Resources.AWSEC2LaunchTemplatemasterustest1amastersnthsqsresourceslongclusternameexamplecom.Properties.LaunchTemplateData.UserData
-: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.20.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.nthsqsresources.longclustername.example.com
-    serviceAccountJWKSURI: https://api.internal.nthsqsresources.longclustername.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: nthsqsresources.longclustername.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.20.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.20.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.20.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: IsRqrb7dMKBFiJFudQJc6Mo0JVApIrD5B2dewuutYf8=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesnthsqsresourceslongclusternameexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.20.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: hq+JAH/l0SsE9rH7Q8POHxFMrXDRXcmmf042WElqcUM=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+: "#!/bin/bash\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.20.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.nthsqsresources.longclustername.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.nthsqsresources.longclustername.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: nthsqsresources.longclustername.example.com\n
+  \ configureCloudRoutes: false\n  image: registry.k8s.io/kube-controller-manager:v1.20.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.20.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.20.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml <<
+  '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: IsRqrb7dMKBFiJFudQJc6Mo0JVApIrD5B2dewuutYf8=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesnthsqsresourceslongclusternameexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.20.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/nthsqsresources.longclustername.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: hq+JAH/l0SsE9rH7Q8POHxFMrXDRXcmmf042WElqcUM=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_master-us-test-1a.masters.nthsqsresources.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_master-us-test-1a.masters.nthsqsresources.longclustername.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.longclustername.example.com_user_data
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_launch_template_nodes.nthsqsresources.longclustername.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/nvidia/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/nvidia/cloudformation.json.extracted.yaml
@@ -1,430 +1,155 @@
-Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    nvidiaGPU:
-      enabled: true
-      package: nvidia-headless-460-server
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.minimal.example.com
-    serviceAccountJWKSURI: https://api.internal.minimal.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: minimal.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: XfW6vDRNRfTHJPOGeKVjmi0X8oyJNK2bnzKsVZy00K8=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    nvidiaGPU:
-      enabled: true
-      package: nvidia-headless-460-server
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/minimal.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: rXMJNOQF0/HDGwb7T9kem3+Ydeau/+I6oiA8ankZdEM=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  nvidiaGPU:\n    enabled: true\n    package:
+  nvidia-headless-460-server\n  version: 1.4.12\ndocker:\n  skipInstall: true\nencryptionConfig:
+  null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n    version: 3.4.13\nkubeAPIServer:\n
+  \ allowPrivileged: true\n  anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n
+  \ apiServerCount: 1\n  authorizationMode: AlwaysAllow\n  bindAddress: 0.0.0.0\n
+  \ cloudProvider: aws\n  enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n
+  \ - ServiceAccount\n  - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ image: registry.k8s.io/kube-apiserver:v1.21.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.minimal.example.com\n  serviceAccountJWKSURI:
+  https://api.internal.minimal.example.com/openid/v1/jwks\n  serviceClusterIPRange:
+  100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n  allocateNodeCIDRs:
+  true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider: aws\n  clusterCIDR:
+  100.96.0.0/11\n  clusterName: minimal.example.com\n  configureCloudRoutes: false\n
+  \ image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n    leaderElect:
+  true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n  clusterCIDR:
+  100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: XfW6vDRNRfTHJPOGeKVjmi0X8oyJNK2bnzKsVZy00K8=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  nvidiaGPU:\n    enabled: true\n    package:
+  nvidia-headless-460-server\n  version: 1.4.12\ndocker:\n  skipInstall: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/minimal.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: rXMJNOQF0/HDGwb7T9kem3+Ydeau/+I6oiA8ankZdEM=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/nvidia/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/nvidia/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/private-shared-ip/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/private-shared-ip/cloudformation.json.extracted.yaml
@@ -1,425 +1,154 @@
 Resources.AWSEC2LaunchTemplatebastionprivatesharedipexamplecom.Properties.LaunchTemplateData.UserData: ""
-Resources.AWSEC2LaunchTemplatemasterustest1amastersprivatesharedipexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.private-shared-ip.example.com
-    serviceAccountJWKSURI: https://api.internal.private-shared-ip.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: private-shared-ip.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/private-shared-ip.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: mv5b3GrW9IZysAArvrR1mGpHevz4S/70Q6enwo9v9Dg=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesprivatesharedipexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/private-shared-ip.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: rQu9vXX9D1epy/YeWxLLw3zjFuflZZ+IL6ORxwCV19s=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersprivatesharedipexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.private-shared-ip.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.private-shared-ip.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: private-shared-ip.example.com\n
+  \ configureCloudRoutes: false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/private-shared-ip.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: mv5b3GrW9IZysAArvrR1mGpHevz4S/70Q6enwo9v9Dg=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesprivatesharedipexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/private-shared-ip.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: rQu9vXX9D1epy/YeWxLLw3zjFuflZZ+IL6ORxwCV19s=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -1,425 +1,154 @@
 Resources.AWSEC2LaunchTemplatebastionprivatecalicoexamplecom.Properties.LaunchTemplateData.UserData: ""
-Resources.AWSEC2LaunchTemplatemasterustest1amastersprivatecalicoexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.privatecalico.example.com
-    serviceAccountJWKSURI: https://api.internal.privatecalico.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: privatecalico.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/privatecalico.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: XVQkcpAPIklkF28kVTF5iSiWwXvVDL1f6TBnOshBGa0=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesprivatecalicoexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/privatecalico.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: 1e6MWmZgviRMbJ/23fi0wWhbA6N8CRg2muOIaP6AxkI=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersprivatecalicoexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.privatecalico.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.privatecalico.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: privatecalico.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/privatecalico.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: XVQkcpAPIklkF28kVTF5iSiWwXvVDL1f6TBnOshBGa0=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesprivatecalicoexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/privatecalico.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: 1e6MWmZgviRMbJ/23fi0wWhbA6N8CRg2muOIaP6AxkI=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium/cloudformation.json.extracted.yaml
@@ -1,425 +1,154 @@
 Resources.AWSEC2LaunchTemplatebastionprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: ""
-Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.privatecilium.example.com
-    serviceAccountJWKSURI: https://api.internal.privatecilium.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: privatecilium.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/privatecilium.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: yocWJIDDYiXU+WwG9xiLFR01h7myuagKr9oy7clyiV8=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/privatecilium.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: QtbVjzk4Fkdi6uChHr52JLSzs5azZSiE208JZ6MWBHs=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  events:\n    version: 3.4.13\n  main:\n
+  \   version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n  anonymousAuth: false\n
+  \ apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount: 1\n  authorizationMode:
+  AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n
+  \ - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n
+  \ - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n
+  \ - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n
+  \ etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.21.0\n
+  \ kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n  - ExternalIP\n
+  \ logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceAccountIssuer: https://api.internal.privatecilium.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.privatecilium.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: privatecilium.example.com\n  configureCloudRoutes:
+  false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n  leaderElection:\n
+  \   leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials: true\nkubeProxy:\n
+  \ clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/privatecilium.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: yocWJIDDYiXU+WwG9xiLFR01h7myuagKr9oy7clyiV8=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.21.0\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/privatecilium.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: QtbVjzk4Fkdi6uChHr52JLSzs5azZSiE208JZ6MWBHs=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecilium2/cloudformation.json.extracted.yaml
@@ -1,431 +1,152 @@
 Resources.AWSEC2LaunchTemplatebastionprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: ""
-Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: docker
-  containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: info
-  docker:
-    ipMasq: false
-    ipTables: false
-    logDriver: json-file
-    logLevel: info
-    logOpt:
-    - max-size=10m
-    - max-file=5
-    storage: overlay2,overlay,aufs
-    version: 19.03.15
-  encryptionConfig: null
-  etcdClusters:
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.19.0
-    insecurePort: 0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: privatecilium.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.19.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.19.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.19.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-  masterKubelet:
-    anonymousAuth: false
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/privatecilium.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: lQl5vPS8cn5z6ZqlLfEpYOp5FJd5Rvo3/U5dA3VWZ88=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: docker
-  containerd:
-    configOverride: |
-      disabled_plugins = ["cri"]
-    logLevel: info
-  docker:
-    ipMasq: false
-    ipTables: false
-    logDriver: json-file
-    logLevel: info
-    logOpt:
-    - max-size=10m
-    - max-file=5
-    storage: overlay2,overlay,aufs
-    version: 19.03.15
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    image: registry.k8s.io/kube-proxy:v1.19.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/privatecilium.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: mONybsIQLRIuQ/k4BkPRuh6YET6I5XQVGqkv/UC114k=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  docker\ncontainerd:\n  configOverride: |\n    disabled_plugins = [\"cri\"]\n  logLevel:
+  info\ndocker:\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel:
+  info\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay2,overlay,aufs\n
+  \ version: 19.03.15\nencryptionConfig: null\netcdClusters:\n  events:\n    version:
+  3.4.13\n  main:\n    version: 3.4.13\nkubeAPIServer:\n  allowPrivileged: true\n
+  \ anonymousAuth: false\n  apiServerCount: 1\n  authorizationMode: AlwaysAllow\n
+  \ bindAddress: 0.0.0.0\n  cloudProvider: aws\n  enableAdmissionPlugins:\n  - NamespaceLifecycle\n
+  \ - LimitRanger\n  - ServiceAccount\n  - DefaultStorageClass\n  - DefaultTolerationSeconds\n
+  \ - MutatingAdmissionWebhook\n  - ValidatingAdmissionWebhook\n  - NodeRestriction\n
+  \ - ResourceQuota\n  etcdServers:\n  - https://127.0.0.1:4001\n  etcdServersOverrides:\n
+  \ - /events#https://127.0.0.1:4002\n  image: registry.k8s.io/kube-apiserver:v1.19.0\n
+  \ insecurePort: 0\n  kubeletPreferredAddressTypes:\n  - InternalIP\n  - Hostname\n
+  \ - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n  - aggregator\n  requestheaderExtraHeaderPrefixes:\n
+  \ - X-Remote-Extra-\n  requestheaderGroupHeaders:\n  - X-Remote-Group\n  requestheaderUsernameHeaders:\n
+  \ - X-Remote-User\n  securePort: 443\n  serviceClusterIPRange: 100.64.0.0/13\n  storageBackend:
+  etcd3\nkubeControllerManager:\n  allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod:
+  1m0s\n  cloudProvider: aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: privatecilium.example.com\n
+  \ configureCloudRoutes: false\n  image: registry.k8s.io/kube-controller-manager:v1.19.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: registry.k8s.io/kube-proxy:v1.19.0\n
+  \ logLevel: 2\nkubeScheduler:\n  image: registry.k8s.io/kube-scheduler:v1.19.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain:
+  cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n
+  \ clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml <<
+  '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/privatecilium.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: lQl5vPS8cn5z6ZqlLfEpYOp5FJd5Rvo3/U5dA3VWZ88=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesprivateciliumexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  docker\ncontainerd:\n  configOverride: |\n    disabled_plugins = [\"cri\"]\n  logLevel:
+  info\ndocker:\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel:
+  info\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay2,overlay,aufs\n
+  \ version: 19.03.15\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n
+  \ image: registry.k8s.io/kube-proxy:v1.19.0\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain:
+  cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/privatecilium.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: mONybsIQLRIuQ/k4BkPRuh6YET6I5XQVGqkv/UC114k=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privateciliumadvanced/cloudformation.json.extracted.yaml
@@ -1,429 +1,156 @@
 Resources.AWSEC2LaunchTemplatebastionprivateciliumadvancedexamplecom.Properties.LaunchTemplateData.UserData: ""
-Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumadvancedexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  encryptionConfig: null
-  etcdClusters:
-    cilium:
-      version: 3.4.13
-    events:
-      version: 3.4.13
-    main:
-      version: 3.4.13
-  kubeAPIServer:
-    allowPrivileged: true
-    anonymousAuth: false
-    apiAudiences:
-    - kubernetes.svc.default
-    apiServerCount: 1
-    authorizationMode: AlwaysAllow
-    bindAddress: 0.0.0.0
-    cloudProvider: aws
-    enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - NodeRestriction
-    - ResourceQuota
-    etcdServers:
-    - https://127.0.0.1:4001
-    etcdServersOverrides:
-    - /events#https://127.0.0.1:4002
-    image: registry.k8s.io/kube-apiserver:v1.21.0
-    kubeletPreferredAddressTypes:
-    - InternalIP
-    - Hostname
-    - ExternalIP
-    logLevel: 2
-    requestheaderAllowedNames:
-    - aggregator
-    requestheaderExtraHeaderPrefixes:
-    - X-Remote-Extra-
-    requestheaderGroupHeaders:
-    - X-Remote-Group
-    requestheaderUsernameHeaders:
-    - X-Remote-User
-    securePort: 443
-    serviceAccountIssuer: https://api.internal.privateciliumadvanced.example.com
-    serviceAccountJWKSURI: https://api.internal.privateciliumadvanced.example.com/openid/v1/jwks
-    serviceClusterIPRange: 100.64.0.0/13
-    storageBackend: etcd3
-  kubeControllerManager:
-    allocateNodeCIDRs: true
-    attachDetachReconcileSyncPeriod: 1m0s
-    cloudProvider: aws
-    clusterCIDR: 100.96.0.0/11
-    clusterName: privateciliumadvanced.example.com
-    configureCloudRoutes: false
-    image: registry.k8s.io/kube-controller-manager:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-    useServiceAccountCredentials: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    enabled: false
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubeScheduler:
-    image: registry.k8s.io/kube-scheduler:v1.21.0
-    leaderElection:
-      leaderElect: true
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-  masterKubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    registerSchedulable: false
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
-  InstanceGroupName: master-us-test-1a
-  InstanceGroupRole: Master
-  NodeupConfigHash: Wa/atZKOLRqMfSfWURRpFtDR02PSO7Ao0khqzcac6fA=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
-Resources.AWSEC2LaunchTemplatenodesprivateciliumadvancedexamplecom.Properties.LaunchTemplateData.UserData: |
-  #!/bin/bash
-  set -o errexit
-  set -o nounset
-  set -o pipefail
-
-  NODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64
-  NODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924
-  NODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64
-  NODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865
-
-  export AWS_REGION=us-test-1
-
-
-
-
-  sysctl -w net.core.rmem_max=16777216 || true
-  sysctl -w net.core.wmem_max=16777216 || true
-  sysctl -w net.ipv4.tcp_rmem='4096 87380 16777216' || true
-  sysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true
-
-
-  function ensure-install-dir() {
-    INSTALL_DIR="/opt/kops"
-    # On ContainerOS, we install under /var/lib/toolbox; /opt is ro and noexec
-    if [[ -d /var/lib/toolbox ]]; then
-      INSTALL_DIR="/var/lib/toolbox/kops"
-    fi
-    mkdir -p ${INSTALL_DIR}/bin
-    mkdir -p ${INSTALL_DIR}/conf
-    cd ${INSTALL_DIR}
-  }
-
-  # Retry a download until we get it. args: name, sha, urls
-  download-or-bust() {
-    local -r file="$1"
-    local -r hash="$2"
-    local -r urls=( $(split-commas "$3") )
-
-    if [[ -f "${file}" ]]; then
-      if ! validate-hash "${file}" "${hash}"; then
-        rm -f "${file}"
-      else
-        return 0
-      fi
-    fi
-
-    while true; do
-      for url in "${urls[@]}"; do
-        commands=(
-          "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-          "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-          "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        )
-        for cmd in "${commands[@]}"; do
-          echo "Attempting download with: ${cmd} {url}"
-          if ! (${cmd} "${url}"); then
-            echo "== Download failed with ${cmd} =="
-            continue
-          fi
-          if ! validate-hash "${file}" "${hash}"; then
-            echo "== Hash validation of ${url} failed. Retrying. =="
-            rm -f "${file}"
-          else
-            echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-            return 0
-          fi
-        done
-      done
-
-      echo "All downloads failed; sleeping before retrying"
-      sleep 60
-    done
-  }
-
-  validate-hash() {
-    local -r file="$1"
-    local -r expected="$2"
-    local actual
-
-    actual=$(sha256sum ${file} | awk '{ print $1 }') || true
-    if [[ "${actual}" != "${expected}" ]]; then
-      echo "== ${file} corrupted, hash ${actual} doesn't match expected ${expected} =="
-      return 1
-    fi
-  }
-
-  function split-commas() {
-    echo $1 | tr "," "\n"
-  }
-
-  function download-release() {
-    case "$(uname -m)" in
-    x86_64*|i?86_64*|amd64*)
-      NODEUP_URL="${NODEUP_URL_AMD64}"
-      NODEUP_HASH="${NODEUP_HASH_AMD64}"
-      ;;
-    aarch64*|arm64*)
-      NODEUP_URL="${NODEUP_URL_ARM64}"
-      NODEUP_HASH="${NODEUP_HASH_ARM64}"
-      ;;
-    *)
-      echo "Unsupported host arch: $(uname -m)" >&2
-      exit 1
-      ;;
-    esac
-
-    cd ${INSTALL_DIR}/bin
-    download-or-bust nodeup "${NODEUP_HASH}" "${NODEUP_URL}"
-
-    chmod +x nodeup
-
-    echo "Running nodeup"
-    # We can't run in the foreground because of https://github.com/docker/docker/issues/23793
-    ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml --v=8  )
-  }
-
-  ####################################################################################
-
-  /bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"
-
-  echo "== nodeup node config starting =="
-  ensure-install-dir
-
-  cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
-  cloudConfig:
-    awsEBSCSIDriver:
-      enabled: false
-    manageStorageClasses: true
-  containerRuntime: containerd
-  containerd:
-    logLevel: info
-    version: 1.4.12
-  docker:
-    skipInstall: true
-  kubeProxy:
-    clusterCIDR: 100.96.0.0/11
-    cpuRequest: 100m
-    enabled: false
-    image: registry.k8s.io/kube-proxy:v1.21.0
-    logLevel: 2
-  kubelet:
-    anonymousAuth: false
-    cgroupDriver: systemd
-    cgroupRoot: /
-    cloudProvider: aws
-    clusterDNS: 100.64.0.10
-    clusterDomain: cluster.local
-    enableDebuggingHandlers: true
-    evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
-    kubeconfigPath: /var/lib/kubelet/kubeconfig
-    logLevel: 2
-    networkPluginName: cni
-    podInfraContainerImage: registry.k8s.io/pause:3.6
-    podManifestPath: /etc/kubernetes/manifests
-    shutdownGracePeriod: 30s
-    shutdownGracePeriodCriticalPods: 10s
-
-  __EOF_CLUSTER_SPEC
-
-  cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
-  CloudProvider: aws
-  ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
-  InstanceGroupName: nodes
-  InstanceGroupRole: Node
-  NodeupConfigHash: wdndJ/CG9YopEHzQj23D9PUmiQPvq0bCiSH3Tdq81SE=
-
-  __EOF_KUBE_ENV
-
-  download-release
-  echo "== nodeup node config done =="
+Resources.AWSEC2LaunchTemplatemasterustest1amastersprivateciliumadvancedexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nencryptionConfig: null\netcdClusters:\n  cilium:\n    version: 3.4.13\n  events:\n
+  \   version: 3.4.13\n  main:\n    version: 3.4.13\nkubeAPIServer:\n  allowPrivileged:
+  true\n  anonymousAuth: false\n  apiAudiences:\n  - kubernetes.svc.default\n  apiServerCount:
+  1\n  authorizationMode: AlwaysAllow\n  bindAddress: 0.0.0.0\n  cloudProvider: aws\n
+  \ enableAdmissionPlugins:\n  - NamespaceLifecycle\n  - LimitRanger\n  - ServiceAccount\n
+  \ - DefaultStorageClass\n  - DefaultTolerationSeconds\n  - MutatingAdmissionWebhook\n
+  \ - ValidatingAdmissionWebhook\n  - NodeRestriction\n  - ResourceQuota\n  etcdServers:\n
+  \ - https://127.0.0.1:4001\n  etcdServersOverrides:\n  - /events#https://127.0.0.1:4002\n
+  \ image: registry.k8s.io/kube-apiserver:v1.21.0\n  kubeletPreferredAddressTypes:\n
+  \ - InternalIP\n  - Hostname\n  - ExternalIP\n  logLevel: 2\n  requestheaderAllowedNames:\n
+  \ - aggregator\n  requestheaderExtraHeaderPrefixes:\n  - X-Remote-Extra-\n  requestheaderGroupHeaders:\n
+  \ - X-Remote-Group\n  requestheaderUsernameHeaders:\n  - X-Remote-User\n  securePort:
+  443\n  serviceAccountIssuer: https://api.internal.privateciliumadvanced.example.com\n
+  \ serviceAccountJWKSURI: https://api.internal.privateciliumadvanced.example.com/openid/v1/jwks\n
+  \ serviceClusterIPRange: 100.64.0.0/13\n  storageBackend: etcd3\nkubeControllerManager:\n
+  \ allocateNodeCIDRs: true\n  attachDetachReconcileSyncPeriod: 1m0s\n  cloudProvider:
+  aws\n  clusterCIDR: 100.96.0.0/11\n  clusterName: privateciliumadvanced.example.com\n
+  \ configureCloudRoutes: false\n  image: registry.k8s.io/kube-controller-manager:v1.21.0\n
+  \ leaderElection:\n    leaderElect: true\n  logLevel: 2\n  useServiceAccountCredentials:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  enabled: false\n
+  \ image: registry.k8s.io/kube-proxy:v1.21.0\n  logLevel: 2\nkubeScheduler:\n  image:
+  registry.k8s.io/kube-scheduler:v1.21.0\n  leaderElection:\n    leaderElect: true\n
+  \ logLevel: 2\nkubelet:\n  anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot:
+  /\n  cloudProvider: aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n
+  \ enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\nmasterKubelet:\n
+  \ anonymousAuth: false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider:
+  aws\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers:
+  true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ registerSchedulable: false\n  shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods:
+  10s\n\n__EOF_CLUSTER_SPEC\n\ncat > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider:
+  aws\nConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com\nInstanceGroupName:
+  master-us-test-1a\nInstanceGroupRole: Master\nNodeupConfigHash: Wa/atZKOLRqMfSfWURRpFtDR02PSO7Ao0khqzcac6fA=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"
+Resources.AWSEC2LaunchTemplatenodesprivateciliumadvancedexamplecom.Properties.LaunchTemplateData.UserData: "#!/bin/bash\nset
+  -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL_AMD64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/amd64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-amd64\nNODEUP_HASH_AMD64=585fbda0f0a43184656b4bfc0cc5f0c0b85612faf43b8816acca1f99d422c924\nNODEUP_URL_ARM64=https://artifacts.k8s.io/binaries/kops/1.21.0-alpha.1/linux/arm64/nodeup,https://github.com/kubernetes/kops/releases/download/v1.21.0-alpha.1/nodeup-linux-arm64\nNODEUP_HASH_ARM64=7603675379699105a9b9915ff97718ea99b1bbb01a4c184e2f827c8a96e8e865\n\nexport
+  AWS_REGION=us-test-1\n\n\n\n\nsysctl -w net.core.rmem_max=16777216 || true\nsysctl
+  -w net.core.wmem_max=16777216 || true\nsysctl -w net.ipv4.tcp_rmem='4096 87380 16777216'
+  || true\nsysctl -w net.ipv4.tcp_wmem='4096 87380 16777216' || true\n\n\nfunction
+  ensure-install-dir() {\n  INSTALL_DIR=\"/opt/kops\"\n  # On ContainerOS, we install
+  under /var/lib/toolbox; /opt is ro and noexec\n  if [[ -d /var/lib/toolbox ]]; then\n
+  \   INSTALL_DIR=\"/var/lib/toolbox/kops\"\n  fi\n  mkdir -p ${INSTALL_DIR}/bin\n
+  \ mkdir -p ${INSTALL_DIR}/conf\n  cd ${INSTALL_DIR}\n}\n\ntry-download-file() {\n
+  \ local -r url=\"$1\"\n  local -r file=\"$2\"\n  local -r auth=\"$3\"\n  if [[ \"$auth\"
+  == \"\" ]]; then\n        if curl -f --compressed -Lo \"${file}\" --connect-timeout
+  20 --retry 6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if wget --compression=auto
+  -O \"${file}\" --connect-timeout=20 --tries=6 --wait=10 \"${url}\"; then return
+  0; fi\n        if curl -f -Lo \"${file}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n        if wget -O \"${file}\" --connect-timeout=20
+  --tries=6 --wait=10 \"${url}\"; then return 0; fi\n  else\n        if curl -f --compressed
+  -Lo \"${file}\" -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry
+  6 --retry-delay 10 \"${url}\"; then return 0; fi\n        if curl -f -Lo \"${file}\"
+  -v -H \"Authorization: Bearer ${auth}\" --connect-timeout 20 --retry 6 --retry-delay
+  10 \"${url}\"; then return 0; fi\n  fi\n  return 1\n}\n\n# Retry a download until
+  we get it. args: name, sha, urls\ndownload-or-bust() {\n  local -r file=\"$1\"\n
+  \ local -r hash=\"$2\"\n  local -r urls=( $(split-commas \"$3\") )\n\n  if [[ -f
+  \"${file}\" ]]; then\n    if ! validate-hash \"${file}\" \"${hash}\"; then\n      rm
+  -f \"${file}\"\n    else\n      return 0\n    fi\n  fi\n\n  while true; do\n    for
+  url in \"${urls[@]}\"; do\n      local access_token=\"\"\n      if [[ \"${GCE_ACCESS_TOKEN_URL:-}\"
+  != \"\" ]]; then\n        # The token always begins with 'ya29' and continues until
+  the next double-quote.\n        # We would normally use jq to be more tolerant of
+  format changes, \n        # but it's not available in flatcar during startup (depends
+  on docker, which isn't up yet.)\n        access_token=$(curl \"$GCE_ACCESS_TOKEN_URL\"
+  -H \"Metadata-Flavor: Google\" | grep -Eo 'ya29\\.[^\\\"]*')\n      fi\n\n      echo
+  \"Attempting download of ${url}\"\n      if ! try-download-file \"${url}\" \"${file}\"
+  \"${access_token}\" ; then\n        continue\n      fi\n      if ! validate-hash
+  \"${file}\" \"${hash}\"; then\n        echo \"== Hash validation of ${url} failed.
+  Retrying. ==\"\n        rm -f \"${file}\"\n      else\n        echo \"== Downloaded
+  ${url} (SHA256 = ${hash}) ==\"\n        return\n      fi\n    done\n\n    echo \"Download
+  failed with all plausible commands; sleeping before retrying\"\n    sleep 60\n  done\n}\n\nvalidate-hash()
+  {\n  local -r file=\"$1\"\n  local -r expected=\"$2\"\n  local actual\n\n  actual=$(sha256sum
+  ${file} | awk '{ print $1 }') || true\n  if [[ \"${actual}\" != \"${expected}\"
+  ]]; then\n    echo \"== ${file} corrupted, hash ${actual} doesn't match expected
+  ${expected} ==\"\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1
+  | tr \",\" \"\\n\"\n}\n\nfunction download-release() {\n  case \"$(uname -m)\" in\n
+  \ x86_64*|i?86_64*|amd64*)\n    NODEUP_URL=\"${NODEUP_URL_AMD64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_AMD64}\"\n
+  \   ;;\n  aarch64*|arm64*)\n    NODEUP_URL=\"${NODEUP_URL_ARM64}\"\n    NODEUP_HASH=\"${NODEUP_HASH_ARM64}\"\n
+  \   ;;\n  *)\n    echo \"Unsupported host arch: $(uname -m)\" >&2\n    exit 1\n
+  \   ;;\n  esac\n\n  cd ${INSTALL_DIR}/bin\n  download-or-bust nodeup \"${NODEUP_HASH}\"
+  \"${NODEUP_URL}\"\n\n  chmod +x nodeup\n\n  echo \"Running nodeup\"\n  # We can't
+  run in the foreground because of https://github.com/docker/docker/issues/23793\n
+  \ ( cd ${INSTALL_DIR}/bin; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/conf/kube_env.yaml
+  --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup
+  || echo \"failed to set up ensure machine-id configured\"\n\necho \"== nodeup node
+  config starting ==\"\nensure-install-dir\n\ncat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'\ncloudConfig:\n
+  \ awsEBSCSIDriver:\n    enabled: false\n  manageStorageClasses: true\ncontainerRuntime:
+  containerd\ncontainerd:\n  logLevel: info\n  version: 1.4.12\ndocker:\n  skipInstall:
+  true\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  enabled: false\n
+  \ image: registry.k8s.io/kube-proxy:v1.21.0\n  logLevel: 2\nkubelet:\n  anonymousAuth:
+  false\n  cgroupDriver: systemd\n  cgroupRoot: /\n  cloudProvider: aws\n  clusterDNS:
+  100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard:
+  memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n
+  \ kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginName:
+  cni\n  podInfraContainerImage: registry.k8s.io/pause:3.6\n  podManifestPath: /etc/kubernetes/manifests\n
+  \ shutdownGracePeriod: 30s\n  shutdownGracePeriodCriticalPods: 10s\n\n__EOF_CLUSTER_SPEC\n\ncat
+  > conf/kube_env.yaml << '__EOF_KUBE_ENV'\nCloudProvider: aws\nConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com\nInstanceGroupName:
+  nodes\nInstanceGroupRole: Node\nNodeupConfigHash: wdndJ/CG9YopEHzQj23D9PUmiQPvq0bCiSH3Tdq81SE=\n\n__EOF_KUBE_ENV\n\ndownload-release\necho
+  \"== nodeup node config done ==\"\n"

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
+++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
+++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privateweave/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data
+++ b/tests/integration/update_cluster/privateweave/data/aws_launch_template_master-us-test-1a.masters.privateweave.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/privateweave/data/aws_launch_template_nodes.privateweave.example.com_user_data
+++ b/tests/integration/update_cluster/privateweave/data/aws_launch_template_nodes.privateweave.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
+++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
+++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }

--- a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -30,6 +30,22 @@ function ensure-install-dir() {
   cd ${INSTALL_DIR}
 }
 
+try-download-file() {
+  local -r url="$1"
+  local -r file="$2"
+  local -r auth="$3"
+  if [[ "$auth" == "" ]]; then
+        if curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then return 0; fi
+  else
+        if curl -f --compressed -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+        if curl -f -Lo "${file}" -v -H "Authorization: Bearer ${auth}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then return 0; fi
+  fi
+  return 1
+}
+
 # Retry a download until we get it. args: name, sha, urls
 download-or-bust() {
   local -r file="$1"
@@ -46,29 +62,28 @@ download-or-bust() {
 
   while true; do
     for url in "${urls[@]}"; do
-      commands=(
-        "curl -f --compressed -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget --compression=auto -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-        "curl -f -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10"
-        "wget -O "${file}" --connect-timeout=20 --tries=6 --wait=10"
-      )
-      for cmd in "${commands[@]}"; do
-        echo "Attempting download with: ${cmd} {url}"
-        if ! (${cmd} "${url}"); then
-          echo "== Download failed with ${cmd} =="
-          continue
-        fi
-        if ! validate-hash "${file}" "${hash}"; then
-          echo "== Hash validation of ${url} failed. Retrying. =="
-          rm -f "${file}"
-        else
-          echo "== Downloaded ${url} (SHA256 = ${hash}) =="
-          return 0
-        fi
-      done
+      local access_token=""
+      if [[ "${GCE_ACCESS_TOKEN_URL:-}" != "" ]]; then
+        # The token always begins with 'ya29' and continues until the next double-quote.
+        # We would normally use jq to be more tolerant of format changes, 
+        # but it's not available in flatcar during startup (depends on docker, which isn't up yet.)
+        access_token=$(curl "$GCE_ACCESS_TOKEN_URL" -H "Metadata-Flavor: Google" | grep -Eo 'ya29\.[^\"]*')
+      fi
+
+      echo "Attempting download of ${url}"
+      if ! try-download-file "${url}" "${file}" "${access_token}" ; then
+        continue
+      fi
+      if ! validate-hash "${file}" "${hash}"; then
+        echo "== Hash validation of ${url} failed. Retrying. =="
+        rm -f "${file}"
+      else
+        echo "== Downloaded ${url} (SHA256 = ${hash}) =="
+        return
+      fi
     done
 
-    echo "All downloads failed; sleeping before retrying"
+    echo "Download failed with all plausible commands; sleeping before retrying"
     sleep 60
   done
 }


### PR DESCRIPTION
* Service account authentication is available when running on GCE.
    * If we are accessing a google cloud storage bucket, we now fetch
      an auth token and apply it to any requests made.
    * This includes the initial request to download nodeup,
      subsequent requests made by nodeup to download additional files.
    * It also rewrites requests made as part of preflight checking
      (e.g. checking the existence of the nodeup binary) if those
      requests are GCS requests.

Room for improvement:
    * We could support rewrites in the other direction as well - allow
      the user to specify the gs:// scheme url and rewrite it
      to storage.googleapis.com when fetching nodeup.
    * This would be useful generically, and could be extended to include
      authenticated requests to S3 buckets.