### PR TITLE
Adopt control-plane taint and remove master role labels

### DIFF
--- a/docs/releases/1.24-NOTES.md
+++ b/docs/releases/1.24-NOTES.md
@@ -25,6 +25,38 @@ kOps will directly manage the Karpenter Provisioner resources. Read more about h
 
 # Breaking changes
 
+## Control plane taints and labels
+
+As of Kubernetes version 1.24, the control plane (formerly master) nodes no longer have the deprecated `node-role.kubernetes.io/master` label.
+The deprecated `node-role.kubernetes.io/master` taint has been replaced by `node-role.kubernetes.io/control-plane`. If you run your own workload on the control plane, you have to adjust your Pod spec to accommodate for this change.
+
+The following shows a node affinity/node label selector and tolerations that works with both new and old control plane nodes:
+
+```yaml
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+        - matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: Exists
+  tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+```
+
+## Removing the `kubernetes.io/role` label
+
+The deprecated `kubernetes.io/role` label has been removed for all roles as of Kubernetes version 1.24. Use `node-role.kubernetes.io/<role>` label instead.
+
+## Other breaking changes
+
 * Support for Kubernetes version 1.18 has been removed.
 
 * Support for Aliyun/Alibaba Cloud has been removed.
@@ -42,8 +74,6 @@ kOps will directly manage the Karpenter Provisioner resources. Read more about h
 * Support for Kubernetes version 1.20 is deprecated and will be removed in kOps 1.26.
 
 * All legacy addons are deprecated in favor of managed addons, including the [metrics server addon](https://github.com/kubernetes/kops/tree/master/addons/metrics-server) and the [autoscaler addon](https://github.com/kubernetes/kops/tree/master/addons/cluster-autoscaler).
-
-* The `node-role.kubernetes.io/master` and `kubernetes.io/role` labels are deprecated and might be removed from control plane nodes in future versions of kOps.
 
 * Due to lack of maintainers, the CloudFormation support has been deprecated. The current implementation will be left as-is until the implementation needs updates or otherwise becomes incompatible. At that point, it will be removed. We very much welcome anyone willing to contribute to this target.
 

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -588,7 +588,11 @@ func (b *KubeletBuilder) buildKubeletConfigSpec() (*kops.KubeletConfigSpec, erro
 	{
 		if len(c.Taints) == 0 && isMaster {
 			// (Even though the value is empty, we still expect <Key>=<Value>:<Effect>)
-			c.Taints = append(c.Taints, nodelabels.RoleLabelMaster16+"=:"+string(v1.TaintEffectNoSchedule))
+			if b.IsKubernetesLT("1.24") {
+				c.Taints = append(c.Taints, nodelabels.RoleLabelMaster16+"=:"+string(v1.TaintEffectNoSchedule))
+			} else {
+				c.Taints = append(c.Taints, nodelabels.RoleLabelControlPlane20+"=:"+string(v1.TaintEffectNoSchedule))
+			}
 		}
 		if len(c.Taints) == 0 && isAPIServer {
 			// (Even though the value is empty, we still expect <Key>=<Value>:<Effect>)

--- a/pkg/model/openstackmodel/servergroup_test.go
+++ b/pkg/model/openstackmodel/servergroup_test.go
@@ -60,6 +60,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",
@@ -117,6 +118,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",
@@ -202,6 +204,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet-a",
@@ -327,6 +330,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 					Topology: &kops.TopologySpec{
 						Masters: kops.TopologyPrivate,
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet-a",
@@ -448,6 +452,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet-a",
@@ -569,6 +574,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet-a",
@@ -650,6 +656,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",
@@ -709,6 +716,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",
@@ -791,6 +799,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",
@@ -834,6 +843,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",
@@ -879,6 +889,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",
@@ -922,6 +933,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",
@@ -965,6 +977,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",
@@ -1008,6 +1021,7 @@ func getServerGroupModelBuilderTestInput() []serverGroupModelBuilderTestInput {
 							},
 						},
 					},
+					KubernetesVersion: "1.24.0",
 					Subnets: []kops.ClusterSubnetSpec{
 						{
 							Name:   "subnet",

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -19,7 +19,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -19,7 +19,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -19,7 +19,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
@@ -19,7 +19,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -71,9 +71,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
@@ -158,9 +156,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
@@ -245,9 +241,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
@@ -331,7 +325,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
@@ -409,7 +402,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node
@@ -487,7 +479,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -76,9 +76,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
@@ -151,9 +149,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
@@ -226,9 +222,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
@@ -306,7 +300,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
@@ -384,7 +377,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
@@ -462,7 +454,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -83,9 +83,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
@@ -170,9 +168,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
@@ -257,9 +253,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
@@ -343,7 +337,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
@@ -421,7 +414,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
@@ -499,7 +491,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -35,9 +35,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-a
@@ -116,9 +114,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-b
@@ -197,9 +193,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master-c
@@ -277,7 +271,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-a
@@ -349,7 +342,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-b
@@ -421,7 +413,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node-c

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -24,7 +24,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_bastion: "1"
   kops.k8s.io_instancegroup: bastion
@@ -97,9 +96,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
@@ -177,7 +174,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -44,7 +44,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_bastion: "1"
   kops.k8s.io_instancegroup: bastion
@@ -123,9 +122,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
@@ -203,7 +200,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -23,9 +23,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
@@ -103,7 +101,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -43,9 +43,7 @@ Metadata:
   ig_generation: "0"
   k8s: cluster
   k8s.io_cluster-autoscaler_node-template_label_kops.k8s.io_kops-controller-pki: ""
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: master
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_control-plane: ""
-  k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_master: ""
   k8s.io_cluster-autoscaler_node-template_label_node.kubernetes.io_exclude-from-external-load-balancers: ""
   k8s.io_role_master: "1"
   kops.k8s.io_instancegroup: master
@@ -129,7 +127,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -19,7 +19,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -19,7 +19,6 @@ Metadata:
   cluster_generation: "0"
   ig_generation: "0"
   k8s: cluster
-  k8s.io_cluster-autoscaler_node-template_label_kubernetes.io_role: node
   k8s.io_cluster-autoscaler_node-template_label_node-role.kubernetes.io_node: ""
   k8s.io_role_node: "1"
   kops.k8s.io_instancegroup: node

--- a/pkg/nodelabels/builder.go
+++ b/pkg/nodelabels/builder.go
@@ -67,13 +67,17 @@ func BuildNodeLabels(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) m
 		if isAPIServer || featureflag.APIServerNodes.Enabled() {
 			nodeLabels[RoleLabelAPIServer16] = ""
 		}
-		nodeLabels[RoleLabelName15] = RoleAPIServerLabelValue15
+		if cluster.IsKubernetesLT("1.24") {
+			nodeLabels[RoleLabelName15] = RoleAPIServerLabelValue15
+		}
 	} else {
 		if nodeLabels == nil {
 			nodeLabels = make(map[string]string)
 		}
 		nodeLabels[RoleLabelNode16] = ""
-		nodeLabels[RoleLabelName15] = RoleNodeLabelValue15
+		if cluster.IsKubernetesLT("1.24") {
+			nodeLabels[RoleLabelName15] = RoleNodeLabelValue15
+		}
 	}
 
 	if isControlPlane {
@@ -82,6 +86,10 @@ func BuildNodeLabels(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) m
 		}
 		for label, value := range BuildMandatoryControlPlaneLabels() {
 			nodeLabels[label] = value
+		}
+		if cluster.IsKubernetesLT("1.24") {
+			nodeLabels[RoleLabelMaster16] = ""
+			nodeLabels[RoleLabelName15] = RoleMasterLabelValue15
 		}
 	}
 
@@ -102,9 +110,7 @@ func BuildNodeLabels(cluster *kops.Cluster, instanceGroup *kops.InstanceGroup) m
 // BuildMandatoryControlPlaneLabels returns the list of labels all CP nodes must have
 func BuildMandatoryControlPlaneLabels() map[string]string {
 	nodeLabels := make(map[string]string)
-	nodeLabels[RoleLabelMaster16] = ""
 	nodeLabels[RoleLabelControlPlane20] = ""
-	nodeLabels[RoleLabelName15] = RoleMasterLabelValue15
 	nodeLabels["kops.k8s.io/kops-controller-pki"] = ""
 	nodeLabels["node.kubernetes.io/exclude-from-external-load-balancers"] = ""
 	return nodeLabels

--- a/pkg/validation/validate_cluster.go
+++ b/pkg/validation/validate_cluster.go
@@ -182,13 +182,14 @@ var masterStaticPods = []string{
 }
 
 func (v *ValidationCluster) collectPodFailures(ctx context.Context, client kubernetes.Interface, nodes []v1.Node,
-	nodeInstanceGroupMapping map[string]*kops.InstanceGroup) error {
+	nodeInstanceGroupMapping map[string]*kops.InstanceGroup,
+) error {
 	masterWithoutPod := map[string]map[string]bool{}
 	nodeByAddress := map[string]string{}
 
 	for _, node := range nodes {
 		labels := node.GetLabels()
-		if labels != nil && labels["kubernetes.io/role"] == "master" {
+		if _, found := labels["node-role.kubernetes.io/control-plane"]; found {
 			masterWithoutPod[node.Name] = map[string]bool{}
 			for _, pod := range masterStaticPods {
 				masterWithoutPod[node.Name][pod] = true

--- a/pkg/validation/validate_cluster_test.go
+++ b/pkg/validation/validate_cluster_test.go
@@ -461,7 +461,7 @@ func Test_ValidateMasterStaticPods(t *testing.T) {
 				Node: &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "master-1a",
-						Labels: map[string]string{"kubernetes.io/role": "master"},
+						Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
 					},
 					Status: v1.NodeStatus{
 						Addresses: []v1.NodeAddress{
@@ -482,7 +482,7 @@ func Test_ValidateMasterStaticPods(t *testing.T) {
 				Node: &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "master-1b",
-						Labels: map[string]string{"kubernetes.io/role": "master"},
+						Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
 					},
 					Status: v1.NodeStatus{
 						Conditions: []v1.NodeCondition{
@@ -501,7 +501,7 @@ func Test_ValidateMasterStaticPods(t *testing.T) {
 				Node: &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   "master-1c",
-						Labels: map[string]string{"kubernetes.io/role": "master"},
+						Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
 					},
 					Status: v1.NodeStatus{
 						Conditions: []v1.NodeCondition{

--- a/tests/e2e/pkg/tester/tester.go
+++ b/tests/e2e/pkg/tester/tester.go
@@ -372,7 +372,9 @@ func (t *Tester) addNonBlockingTaintsFlag() {
 	if hasFlag(t.TestArgs, "non-blocking-taints") {
 		return
 	}
-	nbt := "node-role.kubernetes.io/master,node-role.kubernetes.io/api-server"
+	nbt := "node-role.kubernetes.io/master,"
+	nbt += "node-role.kubernetes.io/api-server,"
+	nbt += "node-role.kubernetes.io/control-plane"
 	klog.Infof("Setting --non-blocking-taints=%s", nbt)
 	t.TestArgs += fmt.Sprintf(" --non-blocking-taints=%v", nbt)
 }

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -600,6 +600,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -692,9 +710,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 78f1d287865750eb0ab71fd8dab5138dea58e2c8bba94ea680585a7e49f80c97
+    manifestHash: 176e0b3d01d0a622dea466500084b0541339ccf12e6ddaa17915aed4a371f0cf
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a373b6ece25fc4c051b80be14fd55216a635f63672f9bf6b21a01948bd6e37d5
+    manifestHash: 86a296b67597631d4cfadf5eec72f7705e87dc23335e16c5d29f4556f0cd7e1f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,14 +40,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c12dafcfd2cabbd4670cd7e5afd40e9082ba656ce996889b7175308c32990eca
+    manifestHash: 1644cbb8f01e4e3e936feff9a89f22a0e438250f6d6cf69ef9a9f6aff53c5b43
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: e38cd2b41a4513b8a2f6ef81090d7b4c19af9dadd2e1958d1942e300afaca69d
+    manifestHash: 3e332f4bcde151e5513f704e468b03135aee2057346f7589edb78263370d407a
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9376,6 +9376,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9390,13 +9400,13 @@ spec:
         name: cert-manager
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-cainjector
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9438,6 +9448,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9459,13 +9479,13 @@ spec:
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9503,6 +9523,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9544,13 +9574,13 @@ spec:
           timeoutSeconds: 1
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-webhook
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -57,8 +67,6 @@ spec:
           readOnly: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
@@ -67,6 +75,8 @@ spec:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 50c6c8d8a08b66a00d3bedaf45f580ac6c5711c8b2b32d02c19ddd554f082cec
+    manifestHash: edabe640f3392adfdccda27178a9de8aecd02b5bf02de1827e8d3732a4bddcf3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 72a1528d90d8133e41c942f72b1f569ad2b9328c2ebe93c8b6661edda3b35988
+    manifestHash: aa9d2a8278d198de23e9762fe7256955d6577295d87425d925d95c38ead0abcc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7e2a8ab7ea2947690f44d3d419adba9670c277a41af140ec318952f530118eee
+    manifestHash: a8c0181e8064fa90766bae80a8efd42b0253abba172867ea9941358f02b1870f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7818b332306c831cfbece06884a96a518592fbc660fefcade40d2b4da78f0b11
+    manifestHash: 5c4b5c7f0aab41d1c1d06660a6d00d25a08aae31beebba712027d80c57b44971
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3780ac97fb0265bb74e08e6acd22ad1d5db74f64df3634694bd22a2048bac4b8
+    manifestHash: 5d4f17e49c243f0ec017301b1fc38d0aef3942ebc2f3041e12b3807bb4aaf94d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 710b251a79c05c2dd2d15d5aec7d2440b84160e1104e7bb68b1792cb00a41868
+    manifestHash: 8f272c4485e671fe9719b3db467a85a62169cd5282e57585a2001339b7a75488
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4782efaccebe0c03e9b80ca6ab559848f93c1674f86c0418bba1fd1785c55436
+    manifestHash: be8d0ea1940777477892162f45bccec2c7c9594941c97553ecb1aa8154954c2b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fad2bb842a627caaf8af35cb0298e12b2534093767c9c1c215976476d17c86ca
+    manifestHash: 8f05aa7096919c1e642f8890bd6bddd194e1b63e6491b9dd3d522ddd4e845e30
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5af6dc3f474a791a2388cabff5484e7f4ea322a68e2e6a4f68c1f2fcd9127014
+    manifestHash: af0576eda6e8379e8b97d6ed120685ef65aa20292f046f9475e624f5f1629da6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a0ee8d47d374a9249c12712d38902d745b69a9819a83d0cf9933770e77cfb474
+    manifestHash: e8c7a22dab271a2a861f51257d04f4fca507c1db85308c9839f9411437136159
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c9760e4c04465334c50050614877c97f7ff56b53631321b1dd76733d6010b943
+    manifestHash: 539a79ee7a1d627e74d4c503d5724619037a3d12912458e4f687bb5b82586a80
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -39,6 +39,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -62,9 +76,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -73,6 +84,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,14 +40,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: e38cd2b41a4513b8a2f6ef81090d7b4c19af9dadd2e1958d1942e300afaca69d
+    manifestHash: 3e332f4bcde151e5513f704e468b03135aee2057346f7589edb78263370d407a
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9376,6 +9376,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9390,13 +9400,13 @@ spec:
         name: cert-manager
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-cainjector
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9438,6 +9448,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9459,13 +9479,13 @@ spec:
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9503,6 +9523,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9544,13 +9574,13 @@ spec:
           timeoutSeconds: 1
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-webhook
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c12dafcfd2cabbd4670cd7e5afd40e9082ba656ce996889b7175308c32990eca
+    manifestHash: 1644cbb8f01e4e3e936feff9a89f22a0e438250f6d6cf69ef9a9f6aff53c5b43
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -57,8 +67,6 @@ spec:
           readOnly: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
@@ -67,6 +75,8 @@ spec:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,6 +20,16 @@ spec:
         k8s-app: aws-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true
@@ -52,8 +62,6 @@ spec:
           name: token-amazonaws-com
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
@@ -64,6 +72,8 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -600,6 +600,20 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -752,8 +766,6 @@ spec:
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
           readOnly: true
-      nodeSelector:
-        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c12dafcfd2cabbd4670cd7e5afd40e9082ba656ce996889b7175308c32990eca
+    manifestHash: 1644cbb8f01e4e3e936feff9a89f22a0e438250f6d6cf69ef9a9f6aff53c5b43
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: e38cd2b41a4513b8a2f6ef81090d7b4c19af9dadd2e1958d1942e300afaca69d
+    manifestHash: 3e332f4bcde151e5513f704e468b03135aee2057346f7589edb78263370d407a
     name: certmanager.io
     selector: null
     version: 9.99.0
@@ -126,14 +126,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 30f36f21a91740b5a6a41ca588659ac9f78b15080fb36c1d368ef659db3f34b4
+    manifestHash: 68b06d3d8c32968ccbb4fce151ad898fbb5869e338cc405ec39d3bd6fb906d1b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3228ca0a3c17449a6aeb2d875b538684acc8883b83f0d53fd9cf8cad89520f14
+    manifestHash: 0d53c5c245f8e5766a0e67fefda0768510ccda47202c251752f750edfeca9f48
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9376,6 +9376,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9390,13 +9400,13 @@ spec:
         name: cert-manager
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-cainjector
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9438,6 +9448,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9459,13 +9479,13 @@ spec:
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9503,6 +9523,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9544,13 +9574,13 @@ spec:
           timeoutSeconds: 1
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-webhook
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -57,8 +67,6 @@ spec:
           readOnly: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
@@ -67,6 +75,8 @@ spec:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,6 +20,16 @@ spec:
         k8s-app: aws-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true
@@ -52,8 +62,6 @@ spec:
           name: token-amazonaws-com
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
@@ -64,6 +72,8 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -600,6 +600,20 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -752,8 +766,6 @@ spec:
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
           readOnly: true
-      nodeSelector:
-        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c6d967f138e890b0346ab859cb029b1f248b80b367050e0ec0050e2fb24d0ef5
+    manifestHash: 49c23555b1b04f5b00a030e1ce4ba6c44e045b7f8b3ae86d755750a48718ccb3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c12dafcfd2cabbd4670cd7e5afd40e9082ba656ce996889b7175308c32990eca
+    manifestHash: 1644cbb8f01e4e3e936feff9a89f22a0e438250f6d6cf69ef9a9f6aff53c5b43
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: e38cd2b41a4513b8a2f6ef81090d7b4c19af9dadd2e1958d1942e300afaca69d
+    manifestHash: 3e332f4bcde151e5513f704e468b03135aee2057346f7589edb78263370d407a
     name: certmanager.io
     selector: null
     version: 9.99.0
@@ -133,14 +133,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: f59ed4baa6061c0251e0db04a8dbad9ac866d0faa9e510d37c7b966e9043bfd7
+    manifestHash: 4a92b788c49b97165fd55056e876729b5142cf87f3017467e75e3aaeb657e69b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 3228ca0a3c17449a6aeb2d875b538684acc8883b83f0d53fd9cf8cad89520f14
+    manifestHash: 0d53c5c245f8e5766a0e67fefda0768510ccda47202c251752f750edfeca9f48
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9376,6 +9376,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9390,13 +9400,13 @@ spec:
         name: cert-manager
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-cainjector
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9438,6 +9448,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9459,13 +9479,13 @@ spec:
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9503,6 +9523,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9544,13 +9574,13 @@ spec:
           timeoutSeconds: 1
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-webhook
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -57,8 +67,6 @@ spec:
           readOnly: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
@@ -67,6 +75,8 @@ spec:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,6 +20,16 @@ spec:
         k8s-app: aws-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true
@@ -45,8 +55,6 @@ spec:
           name: cloudconfig
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
@@ -55,6 +63,8 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -600,6 +600,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -703,9 +721,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,21 +40,21 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 1b6871ddbce414f8a21cb24946d9f101f9711b4a442d19216cf0027c6f2ea5fa
+    manifestHash: 7add7ef0ac062db6de829ad8b6c57d4a1a7e51d43848aa9eecdc9c5bdbb013f4
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: e38cd2b41a4513b8a2f6ef81090d7b4c19af9dadd2e1958d1942e300afaca69d
+    manifestHash: 3e332f4bcde151e5513f704e468b03135aee2057346f7589edb78263370d407a
     name: certmanager.io
     selector: null
     version: 9.99.0
@@ -126,14 +126,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: fac0a051139fa7fc9d3136dea8c20abf7246caf13c41ba10d8ce61ac29582aec
+    manifestHash: 58375f21e39f9da94beb1e7d8d5163068d1a757391310c6fc7e446252c58f3e2
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 01f3af72affcf655f3a7fb6a7427deb716cb638c05b09879daeb176792e3a49e
+    manifestHash: 9ca0be6963372f135fa5a1efeacf68cb1470d6e673a0dda93556039820d9fb02
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9376,6 +9376,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9390,13 +9400,13 @@ spec:
         name: cert-manager
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-cainjector
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9438,6 +9448,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9459,13 +9479,13 @@ spec:
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9503,6 +9523,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9544,13 +9574,13 @@ spec:
           timeoutSeconds: 1
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-webhook
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -309,6 +309,16 @@ spec:
         k8s-app: cluster-autoscaler
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - command:
         - ./cluster-autoscaler
@@ -350,11 +360,11 @@ spec:
             cpu: 100m
             memory: 300Mi
       dnsPolicy: ClusterFirst
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: cluster-autoscaler
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
       topologySpreadConstraints:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -600,6 +600,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -703,9 +721,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,21 +40,21 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 1b6871ddbce414f8a21cb24946d9f101f9711b4a442d19216cf0027c6f2ea5fa
+    manifestHash: 7add7ef0ac062db6de829ad8b6c57d4a1a7e51d43848aa9eecdc9c5bdbb013f4
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: e38cd2b41a4513b8a2f6ef81090d7b4c19af9dadd2e1958d1942e300afaca69d
+    manifestHash: 3e332f4bcde151e5513f704e468b03135aee2057346f7589edb78263370d407a
     name: certmanager.io
     selector: null
     version: 9.99.0
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 01f3af72affcf655f3a7fb6a7427deb716cb638c05b09879daeb176792e3a49e
+    manifestHash: 9ca0be6963372f135fa5a1efeacf68cb1470d6e673a0dda93556039820d9fb02
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -9376,6 +9376,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9390,13 +9400,13 @@ spec:
         name: cert-manager
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-cainjector
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9438,6 +9448,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9459,13 +9479,13 @@ spec:
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 
@@ -9503,6 +9523,16 @@ spec:
         app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -9544,13 +9574,13 @@ spec:
           timeoutSeconds: 1
         securityContext:
           allowPrivilegeEscalation: false
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-webhook
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
 

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -309,6 +309,16 @@ spec:
         k8s-app: cluster-autoscaler
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - command:
         - ./cluster-autoscaler
@@ -350,11 +360,11 @@ spec:
             cpu: 100m
             memory: 300Mi
       dnsPolicy: ClusterFirst
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: cluster-autoscaler
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
       topologySpreadConstraints:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -600,6 +600,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -692,9 +710,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0b21c5df7bb8e8c10c5385f58e2aa626d94f78adc0a6f1a8577dcee36c067d6d
+    manifestHash: 99cb23c19ad2e1178d3a0eb38cabb69c78579186bc8257bebe64d8ca7c0d6edb
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a373b6ece25fc4c051b80be14fd55216a635f63672f9bf6b21a01948bd6e37d5
+    manifestHash: 86a296b67597631d4cfadf5eec72f7705e87dc23335e16c5d29f4556f0cd7e1f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -264,7 +264,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: master-us-test-1a
 InstanceGroupRole: Master
-NodeupConfigHash: f0LcV+QA1S5UcTKOho1tKdpP4FXx5UCurYnxjJNYXOI=
+NodeupConfigHash: fAcOKkJe54UWH+yDgoCGChWTvhJcmtpV2GoKqv54t4E=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://tests/minimal.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: DwWv/si1DvEwrKWUpf1ujt9KqF3cDLIoXmpT4vIZN5I=
+NodeupConfigHash: 6UbJPRQ3InqrcZkd+lbZDaq6BW+9+vaafDW44vmnHNM=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,6 +20,16 @@ spec:
         k8s-app: aws-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true
@@ -46,8 +56,6 @@ spec:
           name: cloudconfig
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
@@ -56,6 +64,8 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -600,6 +600,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -692,9 +710,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fdbfb97f62ef2c93600dc730f7fd2dce933045defa4b14bce6364c07520cae48
+    manifestHash: ccd1b113101a51672d18e0747bd9afa1325acabd13c1b699932dc709596cdb46
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -61,14 +61,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 3d1758e93f951407207dbead23bb40309b86acda59dc79241403465ddfbc2fc6
+    manifestHash: 543da97ed6297cb17d110a5053e393b7ac8ebfb4998c153bf27afcbd8cd77706
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a373b6ece25fc4c051b80be14fd55216a635f63672f9bf6b21a01948bd6e37d5
+    manifestHash: 86a296b67597631d4cfadf5eec72f7705e87dc23335e16c5d29f4556f0cd7e1f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
@@ -252,9 +252,7 @@ KubeletConfig:
   nodeLabels:
     kops.k8s.io/instancegroup: master-us-test-1a
     kops.k8s.io/kops-controller-pki: ""
-    kubernetes.io/role: master
     node-role.kubernetes.io/control-plane: ""
-    node-role.kubernetes.io/master: ""
     node.kubernetes.io/exclude-from-external-load-balancers: ""
   podInfraContainerImage: registry.k8s.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_nodeupconfig-nodes_content
@@ -55,7 +55,6 @@ KubeletConfig:
   logLevel: 2
   nodeLabels:
     kops.k8s.io/instancegroup: nodes-us-test-1a
-    kubernetes.io/role: node
     node-role.kubernetes.io/node: ""
   podInfraContainerImage: registry.k8s.io/pause:3.6
   podManifestPath: /etc/kubernetes/manifests

--- a/tests/integration/update_cluster/minimal-1.24/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal-1.24/kubernetes.tf
@@ -117,17 +117,7 @@ resource "aws_autoscaling_group" "master-us-test-1a-masters-minimal-example-com"
     value               = ""
   }
   tag {
-    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
-    propagate_at_launch = true
-    value               = "master"
-  }
-  tag {
     key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"
-    propagate_at_launch = true
-    value               = ""
-  }
-  tag {
-    key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"
     propagate_at_launch = true
     value               = ""
   }
@@ -179,11 +169,6 @@ resource "aws_autoscaling_group" "nodes-minimal-example-com" {
     key                 = "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"
     propagate_at_launch = true
     value               = "nodes-us-test-1a"
-  }
-  tag {
-    key                 = "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"
-    propagate_at_launch = true
-    value               = "node"
   }
   tag {
     key                 = "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node"
@@ -359,9 +344,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
-      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"                                      = "master"
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
-      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"                          = ""
       "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
       "k8s.io/role/master"                                                                                    = "1"
       "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
@@ -375,9 +358,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
       "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
-      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"                                      = "master"
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
-      "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"                          = ""
       "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
       "k8s.io/role/master"                                                                                    = "1"
       "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
@@ -389,9 +370,7 @@ resource "aws_launch_template" "master-us-test-1a-masters-minimal-example-com" {
     "Name"                                                                                                  = "master-us-test-1a.masters.minimal.example.com"
     "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"                               = "master-us-test-1a"
     "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/kops-controller-pki"                         = ""
-    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"                                      = "master"
     "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/control-plane"                   = ""
-    "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/master"                          = ""
     "k8s.io/cluster-autoscaler/node-template/label/node.kubernetes.io/exclude-from-external-load-balancers" = ""
     "k8s.io/role/master"                                                                                    = "1"
     "kops.k8s.io/instancegroup"                                                                             = "master-us-test-1a"
@@ -443,7 +422,6 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
-      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
       "k8s.io/role/node"                                                           = "1"
       "kops.k8s.io/instancegroup"                                                  = "nodes"
@@ -456,7 +434,6 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
       "KubernetesCluster"                                                          = "minimal.example.com"
       "Name"                                                                       = "nodes.minimal.example.com"
       "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
-      "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
       "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
       "k8s.io/role/node"                                                           = "1"
       "kops.k8s.io/instancegroup"                                                  = "nodes"
@@ -467,7 +444,6 @@ resource "aws_launch_template" "nodes-minimal-example-com" {
     "KubernetesCluster"                                                          = "minimal.example.com"
     "Name"                                                                       = "nodes.minimal.example.com"
     "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup"    = "nodes-us-test-1a"
-    "k8s.io/cluster-autoscaler/node-template/label/kubernetes.io/role"           = "node"
     "k8s.io/cluster-autoscaler/node-template/label/node-role.kubernetes.io/node" = ""
     "k8s.io/role/node"                                                           = "1"
     "kops.k8s.io/instancegroup"                                                  = "nodes"

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,6 +20,16 @@ spec:
         k8s-app: aws-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true
@@ -45,8 +55,6 @@ spec:
           name: cloudconfig
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
@@ -55,6 +63,8 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -602,6 +602,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -696,9 +714,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c449e2ff880a3bddb35f79798b48d22e25ffe98f65ac0e7c9ef5e6aefab5c6df
+    manifestHash: 534fbc9d2ba1651efd805c5dabc43a444b592859091bf9d454b7992e76548976
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8089150cc0526976a9290b830ce432928f355948eaa4c81ce82311f14900dbdd
+    manifestHash: 6d59fd21371d2a08bc94f9fa08bef4dd60abe660c25023d06e78ae4f4c3eaa73
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -61,14 +61,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 15db171bad59d1f9db967d2dd96f491f63df1bca03e451c669257e411b82db7c
+    manifestHash: 1d43b0341a8ac38fd43cb5e575307c7e933e33f60cac6febd7e82b5ef17f315b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e27aee8dfd630a57c046d0b900b127d59ee1b8ff2bb99bfa7e1480de1e0b2fbe
+    manifestHash: 84eed146051a94438019bc41bdce5ef5797c0d2dc126b9e87560264ac6c6a6bd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,6 +20,16 @@ spec:
         k8s-app: aws-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true
@@ -45,8 +55,6 @@ spec:
           name: cloudconfig
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
@@ -55,6 +63,8 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -602,6 +602,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -696,9 +714,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c449e2ff880a3bddb35f79798b48d22e25ffe98f65ac0e7c9ef5e6aefab5c6df
+    manifestHash: 534fbc9d2ba1651efd805c5dabc43a444b592859091bf9d454b7992e76548976
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8089150cc0526976a9290b830ce432928f355948eaa4c81ce82311f14900dbdd
+    manifestHash: 6d59fd21371d2a08bc94f9fa08bef4dd60abe660c25023d06e78ae4f4c3eaa73
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 64138b0aac5ef30c51ff1a2529121ead307934682991c22ba70c777302416ae7
+    manifestHash: c1dc3698a0ab221e6f1cc7ec1817d3b3ea9fc92d7b80ef1fd0adf4732e276558
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:
@@ -62,14 +62,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 15db171bad59d1f9db967d2dd96f491f63df1bca03e451c669257e411b82db7c
+    manifestHash: 1d43b0341a8ac38fd43cb5e575307c7e933e33f60cac6febd7e82b5ef17f315b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e27aee8dfd630a57c046d0b900b127d59ee1b8ff2bb99bfa7e1480de1e0b2fbe
+    manifestHash: 84eed146051a94438019bc41bdce5ef5797c0d2dc126b9e87560264ac6c6a6bd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -573,6 +573,16 @@ spec:
         kops.k8s.io/managed-by: kops
         name: cilium-operator
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -622,8 +632,6 @@ spec:
           name: cilium-config-path
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       serviceAccount: cilium-operator

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,6 +20,16 @@ spec:
         k8s-app: aws-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true
@@ -45,8 +55,6 @@ spec:
           name: cloudconfig
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
@@ -55,6 +63,8 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -602,6 +602,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -696,9 +714,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1d44de8c0ed5191dbacbfcd33732db1eed05fcdadacd5f86e9f2cdb6b96d40c6
+    manifestHash: f9f810419172566344ca18d1547fb82ba2dbe50f0bb835b9d0af758d73df9d90
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8089150cc0526976a9290b830ce432928f355948eaa4c81ce82311f14900dbdd
+    manifestHash: 6d59fd21371d2a08bc94f9fa08bef4dd60abe660c25023d06e78ae4f4c3eaa73
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -61,14 +61,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: e15435df00134be9b35478dc4de8c767361700174a38b44002db6087a0ca0f11
+    manifestHash: f5e000fac5cba7d0d7c0a8f443ab2c796588eb262f902b892486f5cca47d662d
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e27aee8dfd630a57c046d0b900b127d59ee1b8ff2bb99bfa7e1480de1e0b2fbe
+    manifestHash: 84eed146051a94438019bc41bdce5ef5797c0d2dc126b9e87560264ac6c6a6bd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -20,6 +20,16 @@ spec:
         k8s-app: aws-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true
@@ -45,8 +55,6 @@ spec:
           name: cloudconfig
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
@@ -55,6 +63,8 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -602,6 +602,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -696,9 +714,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c449e2ff880a3bddb35f79798b48d22e25ffe98f65ac0e7c9ef5e6aefab5c6df
+    manifestHash: 534fbc9d2ba1651efd805c5dabc43a444b592859091bf9d454b7992e76548976
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8089150cc0526976a9290b830ce432928f355948eaa4c81ce82311f14900dbdd
+    manifestHash: 6d59fd21371d2a08bc94f9fa08bef4dd60abe660c25023d06e78ae4f4c3eaa73
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,14 +54,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 15db171bad59d1f9db967d2dd96f491f63df1bca03e451c669257e411b82db7c
+    manifestHash: 1d43b0341a8ac38fd43cb5e575307c7e933e33f60cac6febd7e82b5ef17f315b
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: e27aee8dfd630a57c046d0b900b127d59ee1b8ff2bb99bfa7e1480de1e0b2fbe
+    manifestHash: 84eed146051a94438019bc41bdce5ef5797c0d2dc126b9e87560264ac6c6a6bd
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8bf5118815f6ab3744134c8846baeb38117303cdcbd3645037382978f9d6fdfa
+    manifestHash: f73ce88dc5837cf47763a4f5aae28969769497c87d30027783935eefd811163b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -600,6 +600,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -692,9 +710,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f9d65eb1b9a99380c1d2185b4a4648f5ddbbb731a963f74ef0688103a5f8703d
+    manifestHash: 952f40e147aa2d19cdd814e2871b5dec2af6cd47a7346edc0b5aac735494e0c3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: f43416748aa0e0328d0dc5f30d55c07a2c201924375d144e576f76f00be76125
+    manifestHash: cb8f10bcb5ceb7796b11cf34c8e5b1770ed3d8188733fae799292618cf433001
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 9b2dc0e934d4c49b068f5a9762f3345a53d0009d96d0fb3714b0a1f78314dc37
+    manifestHash: 2a46a7a3d56f0c1fcebaaad1219405d284e7d6ca66c1c5a88733cecc0948118d
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -573,6 +573,16 @@ spec:
         kops.k8s.io/managed-by: kops
         name: cilium-operator
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -622,8 +632,6 @@ spec:
           name: cilium-config-path
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       serviceAccount: cilium-operator

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8c31a6e0f6bc41edac03026c287c7ddcee41cbd16a526d8e24fb13b7f293590f
+    manifestHash: 284834f5fe5d95229a073e45ced0fcbce281e63adec810a9d99a05ce7577f059
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c9760e4c04465334c50050614877c97f7ff56b53631321b1dd76733d6010b943
+    manifestHash: 539a79ee7a1d627e74d4c503d5724619037a3d12912458e4f687bb5b82586a80
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6226865b5b2c46556edd6aeaa51a270fa10f1b148e61cc1326a36548245dc5a4
+    manifestHash: 6fde09a3a3e41b392626fa0128adc1206ba1e142435a3393eada70849b73c60a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c9760e4c04465334c50050614877c97f7ff56b53631321b1dd76733d6010b943
+    manifestHash: 539a79ee7a1d627e74d4c503d5724619037a3d12912458e4f687bb5b82586a80
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -39,6 +39,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -62,9 +76,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -73,6 +84,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7612651835953042f9fc7e5302dfc21c844bd55b2795c2f6db2280888d46ef64
+    manifestHash: b2558654074143733cbcac7e41b63681e372ac08be92b3f61790dd5964be2ab7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: bfaee9089029ee6b46e6dbb073f5ba0de85be9a569c47792ab06c03d7cec9852
+    manifestHash: 7cee53f3ab1091acb1af5f0830cc4882fe4d60640cc656fa52ff59bd8cd79a99
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -52,14 +62,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7612651835953042f9fc7e5302dfc21c844bd55b2795c2f6db2280888d46ef64
+    manifestHash: b2558654074143733cbcac7e41b63681e372ac08be92b3f61790dd5964be2ab7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 1b84fb86518c2adf7dba246e30e92f306e11c62ea65fb3b55b7fdbb51d9821b5
+    manifestHash: 02e79e68e888fc01c4e562e09b099fb66543b4e8483f055f9a3d75ac6383ff0b
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -60,8 +70,6 @@ spec:
           readOnly: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
@@ -70,6 +78,8 @@ spec:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6c462e6b33dc51270f0d88d0411480f148376718630dc2142438efe11cf0a652
+    manifestHash: 42b3acc60af8cb9a23f46e7aa0554e3ffdcae00124d56f6850f6d014e36bb159
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6c462e6b33dc51270f0d88d0411480f148376718630dc2142438efe11cf0a652
+    manifestHash: 42b3acc60af8cb9a23f46e7aa0554e3ffdcae00124d56f6850f6d014e36bb159
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1b4a695f299f7a7bc5c9482f0b2ea5465c1f98ca1ef0d657f4d172b3491d8d04
+    manifestHash: 39f4720cded49c5507adbc037c5c22733da82e52e924682281f290312c961d81
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,14 +40,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: cf741c78a61335c7f8129bb8ecdf11e8936309e59f15885a8117c8c893eb2d9a
+    manifestHash: 8970868807f879c5d33906616d1c260ace78ccb2dd07a75b22e16985fd4a4800
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -132,6 +132,16 @@ spec:
         kops.k8s.io/managed-by: kops
         kubernetes.io/os: linux
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - env:
         - name: NODE_NAME
@@ -221,8 +231,6 @@ spec:
           runAsGroup: 1000
           runAsNonRoot: true
           runAsUser: 1000
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 1000

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 077905ac173082b3a2e57211fb8058440ebe8b0cfa347545478a02d59c068500
+    manifestHash: fc6c8e4d8865536b5f05f2c6d3d175f9c305c803b1c5e0acf9fd2da011cb3799
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1dfe0d6ffc77686a7fdd571cfe5b6fe0b0aae7f0ff6bd9e8ed3db16971fff654
+    manifestHash: 7dee0182ee0702314fb674312a8d4a67b0fcad0fd0fb3fb23e2873fb6bc97596
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 09a9843341397c1db6197db76af51b45cf3f68b1a51e49d0cf48b5020c82f48b
+    manifestHash: 84b5de10eab2dd9d846021b2868b1e731d7f4c95688d7a9d3b3ae1120434b422
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -600,6 +600,24 @@ spec:
         app.kubernetes.io/version: v1.5.0
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - controller
@@ -692,9 +710,6 @@ spec:
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: ebs-csi-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3fd1848a52ab507500f9aed8813ab8eb75e7a3d882af8df24c85cb33dce43221
+    manifestHash: a6e32fe0b782004e320de3d8f339e5422930a8dd360d1dcd20db68f8e925948f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,14 +54,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: networking.projectcalico.org.canal/k8s-1.22.yaml
-    manifestHash: a5c1eb2388d1a84fe25f5c37e2982abd43b28c99d4cf8e1d01add04818ad3ad1
+    manifestHash: 3ba7d989e4267b133b6d469eed4833ab790a2d9809e788b11853c86361e767d7
     name: networking.projectcalico.org.canal
     selector:
       role.kubernetes.io/networking: "1"
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: cf163f874afbe2ea7b546ffa3fcceb1cb60327e4608e2c1de5a7bf511d6a3ebe
+    manifestHash: d1a0efd5daebf67febf556fc8a9849e8ce23c4ce8a11c9bfcbca4d27d95b4481
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
@@ -4465,6 +4465,24 @@ spec:
       name: calico-kube-controllers
       namespace: kube-system
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - env:
         - name: ENABLED_CONTROLLERS
@@ -4488,8 +4506,6 @@ spec:
             - /usr/bin/check-status
             - -r
           periodSeconds: 10
-      nodeSelector:
-        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: calico-kube-controllers
       tolerations:
@@ -4497,6 +4513,8 @@ spec:
         operator: Exists
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
 
 ---
 

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8e0c99ba2354842f566843a3f0a0ab92dc376c58471bcaff130a2c41775b27b8
+    manifestHash: 32302c2dcafd93a5fe092e32b78b7355404e4a1fb0a7fd53c9f384ee92f5209f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: e4766b5a28d1337f1d6b8d147e8fb69e5b72493b5f38d123d15962cd2d75a83e
+    manifestHash: 66adfbc851a124cc4942ce88eda484c5ed9d859d4bc6ca340fcf6937ac13a017
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -573,6 +573,16 @@ spec:
         kops.k8s.io/managed-by: kops
         name: cilium-operator
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -622,8 +632,6 @@ spec:
           name: cilium-config-path
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       serviceAccount: cilium-operator

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8e0c99ba2354842f566843a3f0a0ab92dc376c58471bcaff130a2c41775b27b8
+    manifestHash: 32302c2dcafd93a5fe092e32b78b7355404e4a1fb0a7fd53c9f384ee92f5209f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c99841f5df0801222ba599c996156745b1c00fcfc83e28a09973c6ead55779fb
+    manifestHash: 1c3e0cb1af70fab5d381772c8dcfc37d0085c55d7da6d3d4a4d623c27e48cb4a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: d143167ad3ea5617dfa254b8d8a69ba9fedb04278136c917c3dd572bb46cabbe
+    manifestHash: d296e9b18f9797aa01bf41af2e794f4289487ccc1ec4d3aa3ae89bd1020b4992
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -604,6 +604,16 @@ spec:
         kops.k8s.io/managed-by: kops
         name: cilium-operator
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -659,8 +669,6 @@ spec:
           name: etcd-secrets
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       restartPolicy: Always
       serviceAccount: cilium-operator

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3473bc89bad47bf6bf903aa22a8ef97e7ac7f1498a1304052694badcb6d790c0
+    manifestHash: 6ccdafddae5483d78c959acf8e3fe72e736608c22336f6b2de7abf57edfd0549
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: a6f089c28b0cc7c84c6b8be07f57aec69e446882898a9d2c36d60355c6d18eb8
+    manifestHash: d0b15c4b51e6167361831cca7b07c24b07d480a3728d0cb6c2d3fb2bd31dd2e3
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2295362e18cab8750fdff7920246305e658ada3ddc6a02d22aa0616665a0b712
+    manifestHash: 7671f280721272ab5d6843909683b2cdd15435e7c954cbfedf193575e3fd8182
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6264d42d1c2af88e5d20c5dc9345798d1a5dbe4775d139ed2742c1f0f4f01c89
+    manifestHash: 5523689fd6b5d7406f14ff2bb7d67e67ced12d44938564a5f5c95a880e6f9e6f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ca2186fa37fb92f0e1065c6813b7e573da91877c4fa6d2f2107233d84a090d33
+    manifestHash: f4c14a330aaccc1ba36d7a21686381f67109369a752f8bb8daaf4b1def04937c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 580351d9b9da556c8d6802f6fb3f90296d3851fdf06dfa14b9352bbd2ba7476f
+    manifestHash: 20f517933e160c4757f730c4f6be25983f056b6d155c62abbee8d2c709c6163b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d2d235804f4f68f7bff96811a5338e3475e2cf9800775b241efd9428f6dac3f1
+    manifestHash: 43f2ccd274943684af29dd710f61cdb977cfe0b73b9f342359b2b449dcf2b7c4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c12dafcfd2cabbd4670cd7e5afd40e9082ba656ce996889b7175308c32990eca
+    manifestHash: 1644cbb8f01e4e3e936feff9a89f22a0e438250f6d6cf69ef9a9f6aff53c5b43
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -57,8 +67,6 @@ spec:
           readOnly: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
@@ -67,6 +75,8 @@ spec:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 78aa6167212c3b8ba2fdd3265b18cb85f661ef5c26999e859d9034f22ae322e4
+    manifestHash: 0d53dad2608c92d6a98878490ad785d9fa51c54269fb6f79aa883fa640ad943e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 55aca51abd97869880c41a6424e290a425a9116f9a962e062c5458b9ca132e65
+    manifestHash: ef244fa9a22d449e9e64c1c1abd76239cca3f4c20a9c6a12efcc7059a36b8f40
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1d3cd6c3d347e83d4b863b3f13a312ebed4d7f194914ef6bb5f4147e6ba920a5
+    manifestHash: 5dc5c6557b3808c5242f42d34aaad58c787114e993dd50b140cacbf150572759
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1519b2f7b0ff090b907f3d66cf66dbc90f9b34f06d632b7fbf6acb2185b9983b
+    manifestHash: 34ecac720406637161b7d7527cf74d49a96cbad562f63b1a1308de54612fac6e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -49,14 +59,14 @@ spec:
           runAsNonRoot: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: dns-controller
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml.template
@@ -17,13 +17,23 @@ spec:
       labels:
         k8s-app: aws-cloud-controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
         effect: NoSchedule
       - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -396,6 +396,28 @@ spec:
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/version: {{ .Version }}
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              {{ if not UseServiceAccountExternalPermissions }}
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              {{ end }}
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              {{ if not UseServiceAccountExternalPermissions }}
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              {{ end }}
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: "topology.kubernetes.io/zone"
@@ -413,11 +435,6 @@ spec:
             app: ebs-csi-controller
             app.kubernetes.io/name: aws-ebs-csi-driver
             app.kubernetes.io/instance: aws-ebs-csi-driver
-      nodeSelector:
-        kubernetes.io/os: linux
-        {{ if not UseServiceAccountExternalPermissions }}
-        node-role.kubernetes.io/master: ""
-        {{ end }}
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
       {{ if not UseServiceAccountExternalPermissions }}

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.9.yaml.template
@@ -736,6 +736,16 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: aws-load-balancer-controller
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --cluster-name={{ ClusterName }}
@@ -772,8 +782,6 @@ spec:
           name: cert
           readOnly: true
       priorityClassName: system-cluster-critical
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       securityContext:
         fsGroup: 1337
       serviceAccountName: aws-load-balancer-controller

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -5139,13 +5139,23 @@ spec:
         app.kubernetes.io/component: "cainjector"
         app.kubernetes.io/version: "v1.8.0"
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-cainjector
       securityContext:
         runAsNonRoot: true
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
       containers:
@@ -5195,13 +5205,23 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9402'
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager
       securityContext:
         runAsNonRoot: true
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
       containers:
@@ -5260,13 +5280,23 @@ spec:
         app.kubernetes.io/component: "webhook"
         app.kubernetes.io/version: "v1.8.0"
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager-webhook
       securityContext:
         runAsNonRoot: true
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
       containers:

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -280,6 +280,18 @@ spec:
         k8s-app: cluster-autoscaler
         app.kubernetes.io/name: "cluster-autoscaler"
     spec:
+      {{ if not UseServiceAccountExternalPermissions }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      {{ end }}
       priorityClassName: "system-cluster-critical"
       dnsPolicy: "ClusterFirst"
       containers:
@@ -328,13 +340,11 @@ spec:
             requests:
               cpu: {{ or .CPURequest "100m"}}
               memory: {{ or .MemoryRequest "300Mi"}}
-      {{ if not UseServiceAccountExternalPermissions }}
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-      {{ end }}
       serviceAccountName: cluster-autoscaler
       {{ if not UseServiceAccountExternalPermissions }}
       tolerations:
+      - operator: "Exists"
+        key: node-role.kubernetes.io/control-plane
       - operator: "Exists"
         key: node-role.kubernetes.io/master
       {{ end }}

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -24,15 +24,25 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       priorityClassName: system-cluster-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
         operator: Exists
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
       hostNetwork: true
       serviceAccount: dns-controller

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -37,6 +37,20 @@ spec:
         dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
 {{ end }}
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       priorityClassName: system-cluster-critical
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
@@ -45,9 +59,8 @@ spec:
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
-        kops.k8s.io/kops-controller-pki: ""
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
       hostNetwork: true
       serviceAccount: kops-controller

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -915,6 +915,16 @@ spec:
         io.cilium/app: operator
         name: cilium-operator
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - "--config-dir=/tmp/cilium/config-map"
@@ -1020,8 +1030,6 @@ spec:
           path: /etc/kubernetes/pki/cilium
           type: Directory
 {{- end }}
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
 {{ if WithDefaultBool .Hubble.Enabled false }}
 ---
 # Source: cilium/charts/hubble-relay/templates/deployment.yaml

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
@@ -4128,6 +4128,8 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: canal
@@ -4551,13 +4553,31 @@ spec:
       labels:
         k8s-app: calico-kube-controllers
     spec:
-      nodeSelector:
-        kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values: 
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values: 
+                - linux
       tolerations:
         # Mark the pod as a critical add-on for rescheduling.
         - key: CriticalAddonsOnly
           operator: Exists
         - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -116,6 +116,20 @@ spec:
         k8s-app: aws-node-termination-handler
         kubernetes.io/os: linux
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              {{ if not UseServiceAccountExternalPermissions }}
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              {{ end }}
+            - matchExpressions:
+              {{ if not UseServiceAccountExternalPermissions }}
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              {{ end }}
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-node-termination-handler
       securityContext:
@@ -210,8 +224,6 @@ spec:
             cpu: {{ .CPURequest }}
             memory: {{ .MemoryRequest }}
       {{ if not UseServiceAccountExternalPermissions }}
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       tolerations:
       - operator: Exists
       {{ end }}

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -20,6 +20,16 @@ spec:
         k8s-app: aws-cloud-controller-manager
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --allocate-node-cidrs=true
@@ -45,8 +55,6 @@ spec:
           name: cloudconfig
           readOnly: true
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-cloud-controller-manager
       tolerations:
@@ -55,6 +63,8 @@ spec:
         value: "true"
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       volumes:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,14 +54,14 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 5eff7fae6bb01bc014fdeb79f2e9f24d5c5697de266485fcc73f339b8a7d4478
+    manifestHash: 5304564ed6418e6fc5c4ad2cd4a8dc4c43c80c8d16485c9408cbfa0df882aa07
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a373b6ece25fc4c051b80be14fd55216a635f63672f9bf6b21a01948bd6e37d5
+    manifestHash: 86a296b67597631d4cfadf5eec72f7705e87dc23335e16c5d29f4556f0cd7e1f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 1941d76744ad39833023164cf78f9b9be50e5d8dcdafabf72468da5f7517c912
+    manifestHash: acc243bc69201fe5473732afaeafac80703f4afd32625e482d286e81dae88f50
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: a373b6ece25fc4c051b80be14fd55216a635f63672f9bf6b21a01948bd6e37d5
+    manifestHash: 86a296b67597631d4cfadf5eec72f7705e87dc23335e16c5d29f4556f0cd7e1f
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 1941d76744ad39833023164cf78f9b9be50e5d8dcdafabf72468da5f7517c912
+    manifestHash: acc243bc69201fe5473732afaeafac80703f4afd32625e482d286e81dae88f50
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: e38cd2b41a4513b8a2f6ef81090d7b4c19af9dadd2e1958d1942e300afaca69d
+    manifestHash: 3e332f4bcde151e5513f704e468b03135aee2057346f7589edb78263370d407a
     name: certmanager.io
     selector: null
     version: 9.99.0
@@ -68,7 +68,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 1941d76744ad39833023164cf78f9b9be50e5d8dcdafabf72468da5f7517c912
+    manifestHash: acc243bc69201fe5473732afaeafac80703f4afd32625e482d286e81dae88f50
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -28,6 +28,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --watch-ingress=false
@@ -57,8 +67,6 @@ spec:
           readOnly: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
@@ -67,6 +75,8 @@ spec:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists
       - key: node.kubernetes.io/not-ready
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c12dafcfd2cabbd4670cd7e5afd40e9082ba656ce996889b7175308c32990eca
+    manifestHash: 1644cbb8f01e4e3e936feff9a89f22a0e438250f6d6cf69ef9a9f6aff53c5b43
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -41,6 +41,20 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v1.24.0-alpha.3
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kops.k8s.io/kops-controller-pki
+                operator: Exists
       containers:
       - args:
         - --v=2
@@ -64,9 +78,6 @@ spec:
           name: kops-controller-pki
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        kops.k8s.io/kops-controller-pki: ""
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccount: kops-controller
       tolerations:
@@ -75,6 +86,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a9627af1bdaf0e074a5f1ecfba894d386179b983006a4823515557b8adc10c94
+    manifestHash: 1b5ba88aca09ac0cfece7c4c72cee2bacce56739be50c9822ea9a0d1f6a993fa
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c34841b1b517c289dfb14d059e262cc73b5799a01a18597084069f6cc69cd318
+    manifestHash: 1c9b07eceb3bc9cd657268edfa3e893152b0597a5fd561fc53b97b4cdff022e4
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io


### PR DESCRIPTION
Following kubeadm, we can move to the next stage of master label/taints removal.
The master labels are removed.
While kubeadm only adds the control plane taint, removing the master taint in 1.25, we swap the master taint with the control-plane taint in one go.