### PR TITLE
allow ecr pull-through-cache

### DIFF
--- a/docs/iam_roles.md
+++ b/docs/iam_roles.md
@@ -28,6 +28,7 @@ The additional permissions are:
   "Action": [
     "ecr:BatchCheckLayerAvailability",
     "ecr:BatchGetImage",
+    "ecr:BatchImportUpstreamImage",
     "ecr:DescribeRepositories",
     "ecr:GetAuthorizationToken",
     "ecr:GetDownloadUrlForLayer",

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -806,6 +806,7 @@ func addECRPermissions(p *Policy) {
 		"ecr:DescribeRepositories",
 		"ecr:ListImages",
 		"ecr:BatchGetImage",
+		"ecr:BatchImportUpstreamImage",
 	)
 }
 

--- a/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_master_strict_ecr.json
@@ -131,6 +131,7 @@
         "ec2:ModifyVolume",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
+        "ecr:BatchImportUpstreamImage",
         "ecr:DescribeRepositories",
         "ecr:GetAuthorizationToken",
         "ecr:GetDownloadUrlForLayer",

--- a/pkg/model/iam/tests/iam_builder_node_legacy.json
+++ b/pkg/model/iam/tests/iam_builder_node_legacy.json
@@ -54,7 +54,8 @@
         "ecr:GetRepositoryPolicy",
         "ecr:DescribeRepositories",
         "ecr:ListImages",
-        "ecr:BatchGetImage"
+        "ecr:BatchGetImage",
+        "ecr:BatchImportUpstreamImage"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
+++ b/pkg/model/iam/tests/iam_builder_node_strict_ecr.json
@@ -34,6 +34,7 @@
         "ec2:DescribeRegions",
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
+        "ecr:BatchImportUpstreamImage",
         "ecr:DescribeRepositories",
         "ecr:GetAuthorizationToken",
         "ecr:GetDownloadUrlForLayer",


### PR DESCRIPTION
- Adds `ecr:BatchImportUpstreamImage` to the nodes IAM. fixes #13456 