### PR TITLE
Pick the right OS server group when creating cloud groups

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -630,7 +630,7 @@ func getCloudGroups(c OpenstackCloud, cluster *kops.Cluster, instancegroups []*k
 			}
 			continue
 		}
-		groups[instancegroup.ObjectMeta.Name], err = osBuildCloudInstanceGroup(c, cluster, instancegroup, &grp, nodeMap)
+		groups[instancegroup.ObjectMeta.Name], err = osBuildCloudInstanceGroup(c, cluster, instancegroup, grp, nodeMap)
 		if err != nil {
 			return nil, fmt.Errorf("error getting cloud instance group %q: %v", instancegroup.ObjectMeta.Name, err)
 		}

--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -109,7 +109,7 @@ func matchInstanceGroup(name string, clusterName string, instancegroups []*kops.
 	return instancegroup, nil
 }
 
-func osBuildCloudInstanceGroup(c OpenstackCloud, cluster *kops.Cluster, ig *kops.InstanceGroup, g *servergroups.ServerGroup, nodeMap map[string]*v1.Node) (*cloudinstances.CloudInstanceGroup, error) {
+func osBuildCloudInstanceGroup(c OpenstackCloud, cluster *kops.Cluster, ig *kops.InstanceGroup, g servergroups.ServerGroup, nodeMap map[string]*v1.Node) (*cloudinstances.CloudInstanceGroup, error) {
 	newLaunchConfigName := g.Name
 	cg := &cloudinstances.CloudInstanceGroup{
 		HumanName:     newLaunchConfigName,
@@ -117,7 +117,7 @@ func osBuildCloudInstanceGroup(c OpenstackCloud, cluster *kops.Cluster, ig *kops
 		MinSize:       int(fi.Int32Value(ig.Spec.MinSize)),
 		TargetSize:    int(fi.Int32Value(ig.Spec.MinSize)), // TODO: Retrieve the target size from OpenStack?
 		MaxSize:       int(fi.Int32Value(ig.Spec.MaxSize)),
-		Raw:           g,
+		Raw:           &g,
 	}
 	for _, i := range g.Members {
 		instanceId := i


### PR DESCRIPTION
This fixes an issue where kops picks the last server group found on OpenStack instead of the right one when getting the cloud groups.

For example, lets assume that kops created those server groups and they are returned in the order as shown here by the OpenStack API:

```
cluster-name-bastion
cluster-name-cp-0
cluster-name-worker
````

Now kops looks for nodes associated with the IG "bastion" and the expected behavior would be that it ends up using "cluster-name-bastion". However, it will actually end up  associating the cloud group with the last server group, which is in this case "cluster-name-worker" due to the reference switching to the last item when the loop is done.

In the worst case this could lead to kops deleting the wrong instances when deleting an IG.

Not using the server group as a "by reference" argument when building the cloud group fixes this behavior.

PS: I wanted to do tests for this, but TBH i do not know how. I'd appreciate help in that regard or just ignore it and merge it ;). Thx