### PR TITLE
Automated cherry pick of #13462: Add back hash for containerd v1.6.1

### DIFF
--- a/upup/pkg/fi/cloudup/containerd.go
+++ b/upup/pkg/fi/cloudup/containerd.go
@@ -220,6 +220,7 @@ func findAllContainerdHashesAmd64() map[string]string {
 func findAllContainerdHashesArm64() map[string]string {
 	hashes := map[string]string{
 		"1.6.0": "6eff3e16d44c89e1e8480a9ca078f79bab82af602818455cc162be344f64686a",
+		"1.6.1": "fbeec71f2d37e0e4ceaaac2bdf081295add940a7a5c7a6bcc125e5bbae067791",
 		"1.6.2": "a4b24b3c38a67852daa80f03ec2bc94e31a0f4393477cd7dc1c1a7c2d3eb2a95",
 	}
 


### PR DESCRIPTION
Cherry pick of #13462 on release-1.23.

#13462: Add back hash for containerd v1.6.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```