### PR TITLE
Remove GOPATH dependency for apimachinery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,37 +501,54 @@ apimachinery: apimachinery-codegen goimports
 apimachinery-codegen: apimachinery-codegen-conversion apimachinery-codegen-deepcopy apimachinery-codegen-defaulter apimachinery-codegen-client
 
 .PHONY: apimachinery-codegen-conversion
+apimachinery-codegen-conversion: export GOPATH=
 apimachinery-codegen-conversion:
-	go run k8s.io/code-generator/cmd/conversion-gen@${CODEGEN_VERSION} ${API_OPTIONS} --skip-unsafe=true --input-dirs ./pkg/apis/kops/v1alpha2 --v=0  --output-file-base=zz_generated.conversion \
+	go run k8s.io/code-generator/cmd/conversion-gen@${CODEGEN_VERSION} --skip-unsafe=true --v=0 --input-dirs ./pkg/apis/kops/v1alpha2 \
+		 --output-base=./ --output-file-base=zz_generated.conversion \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
 	grep 'requires manual conversion' ${KOPS_ROOT}/pkg/apis/kops/v1alpha2/zz_generated.conversion.go ; [ $$? -eq 1 ]
-	go run k8s.io/code-generator/cmd/conversion-gen@${CODEGEN_VERSION} ${API_OPTIONS} --skip-unsafe=true --input-dirs ./pkg/apis/kops/v1alpha3 --v=0  --output-file-base=zz_generated.conversion \
+	go run k8s.io/code-generator/cmd/conversion-gen@${CODEGEN_VERSION} --skip-unsafe=true --v=0 --input-dirs ./pkg/apis/kops/v1alpha3 \
+		 --output-base=./ --output-file-base=zz_generated.conversion \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
 	grep 'requires manual conversion' ${KOPS_ROOT}/pkg/apis/kops/v1alpha3/zz_generated.conversion.go ; [ $$? -eq 1 ]
 
 .PHONY: apimachinery-codegen-deepcopy
+apimachinery-codegen-deepcopy: export GOPATH=
 apimachinery-codegen-deepcopy:
-	go run k8s.io/code-generator/cmd/deepcopy-gen@${CODEGEN_VERSION} ${API_OPTIONS} --input-dirs ./pkg/apis/kops --v=0  --output-file-base=zz_generated.deepcopy \
+	go run k8s.io/code-generator/cmd/deepcopy-gen@${CODEGEN_VERSION} --v=0 --input-dirs ./pkg/apis/kops \
+		 --output-base=./ --output-file-base=zz_generated.deepcopy \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
-	go run k8s.io/code-generator/cmd/deepcopy-gen@${CODEGEN_VERSION} ${API_OPTIONS} --input-dirs ./pkg/apis/kops/v1alpha2 --v=0  --output-file-base=zz_generated.deepcopy \
+	go run k8s.io/code-generator/cmd/deepcopy-gen@${CODEGEN_VERSION} --v=0 --input-dirs ./pkg/apis/kops/v1alpha2 \
+		 --output-base=./ --output-file-base=zz_generated.deepcopy \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
-	go run k8s.io/code-generator/cmd/deepcopy-gen@${CODEGEN_VERSION} ${API_OPTIONS} --input-dirs ./pkg/apis/kops/v1alpha3 --v=0  --output-file-base=zz_generated.deepcopy \
+	go run k8s.io/code-generator/cmd/deepcopy-gen@${CODEGEN_VERSION} --v=0 --input-dirs ./pkg/apis/kops/v1alpha3 \
+		 --output-base=./ --output-file-base=zz_generated.deepcopy \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
 
 .PHONY: apimachinery-codegen-defaulter
+apimachinery-codegen-defaulter: export GOPATH=
 apimachinery-codegen-defaulter:
-	go run k8s.io/code-generator/cmd/defaulter-gen@${CODEGEN_VERSION} ${API_OPTIONS} --input-dirs ./pkg/apis/kops/v1alpha2 --v=0  --output-file-base=zz_generated.defaults \
+	go run k8s.io/code-generator/cmd/defaulter-gen@${CODEGEN_VERSION} --v=0 --input-dirs ./pkg/apis/kops/v1alpha2 \
+		 --output-base=./ --output-file-base=zz_generated.defaults \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
-	go run k8s.io/code-generator/cmd/defaulter-gen@${CODEGEN_VERSION} ${API_OPTIONS} --input-dirs ./pkg/apis/kops/v1alpha3 --v=0  --output-file-base=zz_generated.defaults \
+	go run k8s.io/code-generator/cmd/defaulter-gen@${CODEGEN_VERSION} --v=0 --input-dirs ./pkg/apis/kops/v1alpha3 \
+		 --output-base=./ --output-file-base=zz_generated.defaults \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
 
 .PHONY: apimachinery-codegen-client
+apimachinery-codegen-client: export GOPATH=
+apimachinery-codegen-client: TMPDIR := $(shell mktemp -d)
 apimachinery-codegen-client:
-	# Hack: doesn't seem to be a way to output to the current directory - wants to insert the full package path
-	go run k8s.io/code-generator/cmd/client-gen@${CODEGEN_VERSION} ${API_OPTIONS} --input-base=k8s.io/kops/pkg/apis --input-dirs=. --input="kops/,kops/v1alpha2,kops/v1alpha3" --output-package=k8s.io/kops/pkg/client/clientset_generated/ --output-base=../../ \
+	go run k8s.io/code-generator/cmd/client-gen@${CODEGEN_VERSION} --v=0 \
+		 --input-base=k8s.io/kops/pkg/apis --input-dirs=. --input="kops/,kops/v1alpha2,kops/v1alpha3" \
+		 --output-package=k8s.io/kops/pkg/client/clientset_generated/ --output-base=$(TMPDIR) \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
-	go run k8s.io/code-generator/cmd/client-gen@${CODEGEN_VERSION} ${API_OPTIONS} --clientset-name="clientset" --input-base=k8s.io/kops/pkg/apis --input-dirs=. --input="kops/,kops/v1alpha2,kops/v1alpha3" --output-package=k8s.io/kops/pkg/client/clientset_generated/  --output-base=../../ \
+	go run k8s.io/code-generator/cmd/client-gen@${CODEGEN_VERSION} --v=0 --clientset-name="clientset" \
+		 --input-base=k8s.io/kops/pkg/apis --input-dirs=. --input="kops/,kops/v1alpha2,kops/v1alpha3" \
+ 		 --output-package=k8s.io/kops/pkg/client/clientset_generated/  --output-base=$(TMPDIR) \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
+	cp -r $(TMPDIR)/k8s.io/kops/pkg .
+	rm -rf $(TMPDIR)
 
 .PHONY: verify-apimachinery
 verify-apimachinery:

--- a/hack/verify-apimachinery.sh
+++ b/hack/verify-apimachinery.sh
@@ -22,11 +22,14 @@ set -o pipefail
 
 cd "${KOPS_ROOT}"
 
-export API_OPTIONS="--verify-only"
-if make apimachinery-codegen; then
-	echo "apimachinery is up to date"
-else
-	echo -e "\n FAIL: - the verify-apimachinery.sh test failed, apimachinery is not up to date"
-	echo -e "\n FAIL: - please run the command 'make apimachinery'"
-	exit 1
+make apimachinery-codegen
+changed_files=$(git status --porcelain --untracked-files=no || true)
+if [ -n "${changed_files}" ]; then
+   echo "Detected that apimachinery is not up to date; run 'make apimachinery'"
+   echo "changed files:"
+   printf "%s\n" "${changed_files}"
+   echo "git diff:"
+   git --no-pager diff
+   echo "To fix: run 'make apimachinery'"
+   exit 1
 fi


### PR DESCRIPTION
Without setting `--output-base` flag to `./`, it defaults to `$GOPATH`:
```
  -o, --output-base string               Output base; defaults to $GOPATH/src/ or ./ if $GOPATH is not set. (default "./")
```

/cc @olemarkus 