### PR TITLE
Update kubetest2

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/klog/v2 v2.30.0
 	k8s.io/kops v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc
-	sigs.k8s.io/kubetest2 v0.0.0-20220224035534-5e5d3e9eebc6
+	sigs.k8s.io/kubetest2 v0.0.0-20220411203323-036d47c48813
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -2773,8 +2773,8 @@ sigs.k8s.io/controller-tools v0.6.2/go.mod h1:oaeGpjXn6+ZSEIQkUe/+3I40PNiDYp9aea
 sigs.k8s.io/controller-tools v0.7.0/go.mod h1:bpBAo0VcSDDLuWt47evLhMLPxRPxMDInTEH/YbdeMK0=
 sigs.k8s.io/gateway-api v0.4.1/go.mod h1:r3eiNP+0el+NTLwaTfOrCNXy8TukC+dIM3ggc+fbNWk=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
-sigs.k8s.io/kubetest2 v0.0.0-20220224035534-5e5d3e9eebc6 h1:OlOThE5LCL799Dr5TTV76XA+dIbdr4WTi5pnVsOf/+c=
-sigs.k8s.io/kubetest2 v0.0.0-20220224035534-5e5d3e9eebc6/go.mod h1:99HO7HbhRZ1kJ7j9Ell5bdsYISpkYvyllTK9Y58ysdM=
+sigs.k8s.io/kubetest2 v0.0.0-20220411203323-036d47c48813 h1:RKcl4omAGujM+pzdT2mcDSNOGh6zCOzYXeTU9Hb2E7g=
+sigs.k8s.io/kubetest2 v0.0.0-20220411203323-036d47c48813/go.mod h1:99HO7HbhRZ1kJ7j9Ell5bdsYISpkYvyllTK9Y58ysdM=
 sigs.k8s.io/kustomize/api v0.8.11/go.mod h1:a77Ls36JdfCWojpUqR6m60pdGY1AYFix4AH83nJtY1g=
 sigs.k8s.io/kustomize/api v0.10.1/go.mod h1:2FigT1QN6xKdcnGS2Ppp1uIWrtWN28Ms8A3OZUZhwr8=
 sigs.k8s.io/kustomize/cmd/config v0.9.13/go.mod h1:7547FLF8W/lTaDf0BDqFTbZxM9zqwEJqCKN9sSR0xSs=

--- a/tests/e2e/kubetest2-kops/deployer/up.go
+++ b/tests/e2e/kubetest2-kops/deployer/up.go
@@ -97,7 +97,6 @@ func (d *deployer) Up() error {
 	}
 	isUp, err := d.IsUp()
 	if err != nil {
-		d.Down()
 		return err
 	} else if isUp {
 		klog.V(1).Infof("cluster reported as up")


### PR DESCRIPTION
With this version, kubetest2 should always call down again.