### PR TITLE
Automated cherry pick of #13495: Revert "Enable etcd corruption check"

### DIFF
--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -49,9 +49,7 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 			etcdCluster.Backups.BackupStore = urls.Join(base, "backups", "etcd", etcdCluster.Name)
 		}
 
-		version := strings.TrimPrefix(etcdCluster.Version, "v")
-
-		if !etcdVersionIsSupported(version) {
+		if !etcdVersionIsSupported(etcdCluster.Version) {
 			if featureflag.SkipEtcdVersionCheck.Enabled() {
 				klog.Warningf("etcd version %q is not known to be supported, but ignoring because of SkipEtcdVersionCheck feature flag", etcdCluster.Version)
 			} else {
@@ -59,40 +57,19 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 				return fmt.Errorf("etcd version %q is not supported with etcd-manager, please specify a supported version or remove the value to use the default version.  Supported versions: %s", etcdCluster.Version, strings.Join(supportedEtcdVersions, ", "))
 			}
 		}
-		for _, s := range []string{"3.5.0", "3.5.1"} {
-			if s == version {
-				appendCorruptionCheckFlag(etcdCluster)
-			}
-		}
-
 	}
+
 	return nil
 }
 
 var supportedEtcdVersions = []string{"3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3", "3.4.13", "3.5.0", "3.5.1"}
 
 func etcdVersionIsSupported(version string) bool {
+	version = strings.TrimPrefix(version, "v")
 	for _, v := range supportedEtcdVersions {
 		if v == version {
 			return true
 		}
 	}
 	return false
-}
-
-func appendCorruptionCheckFlag(etcdCluster *kops.EtcdClusterSpec) {
-	varName := "ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK"
-	if etcdCluster.Manager == nil {
-		etcdCluster.Manager = &kops.EtcdManagerSpec{}
-	}
-	for _, env := range etcdCluster.Manager.Env {
-		if env.Name == varName {
-			return
-		}
-	}
-	etcdCluster.Manager.Env = append(etcdCluster.Manager.Env,
-		kops.EnvVar{
-			Name:  varName,
-			Value: "true",
-		})
 }

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
@@ -315,16 +315,8 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
   encryptionConfig: null
   etcdClusters:
     events:
-      manager:
-        env:
-        - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-          value: "true"
       version: 3.5.1
     main:
-      manager:
-        env:
-        - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-          value: "true"
       version: 3.5.1
   kubeAPIServer:
     allowPrivileged: true

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -137,16 +137,8 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     version: 3.5.1
   main:
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     version: 3.5.1
 kubeAPIServer:
   allowPrivileged: true

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -31,10 +31,6 @@ spec:
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     name: main
     version: 3.5.1
   - backups:
@@ -42,10 +38,6 @@ spec:
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     name: events
     version: 3.5.1
   externalDns:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,9 +21,6 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,9 +21,6 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -137,16 +137,8 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     version: 3.5.1
   main:
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     version: 3.5.1
 kubeAPIServer:
   allowPrivileged: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -56,10 +56,6 @@ spec:
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     name: main
     version: 3.5.1
   - backups:
@@ -67,10 +63,6 @@ spec:
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     name: events
     version: 3.5.1
   externalDns:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -18,9 +18,6 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -18,9 +18,6 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -138,18 +138,10 @@ encryptionConfig: null
 etcdClusters:
   events:
     cpuRequest: 100m
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     memoryRequest: 100Mi
     version: 3.5.1
   main:
     cpuRequest: 200m
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     memoryRequest: 100Mi
     version: 3.5.1
 kubeAPIServer:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,10 +33,6 @@ spec:
     - encryptedVolume: true
       instanceGroup: master-us-test-1a
       name: a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     memoryRequest: 100Mi
     name: main
     version: 3.5.1
@@ -47,10 +43,6 @@ spec:
     - encryptedVolume: true
       instanceGroup: master-us-test-1a
       name: a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     memoryRequest: 100Mi
     name: events
     version: 3.5.1

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -18,9 +18,6 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -18,9 +18,6 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
       > /tmp/pipe 2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -138,18 +138,10 @@ encryptionConfig: null
 etcdClusters:
   events:
     cpuRequest: 100m
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     memoryRequest: 100Mi
     version: 3.5.1
   main:
     cpuRequest: 200m
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     memoryRequest: 100Mi
     version: 3.5.1
 kubeAPIServer:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -42,10 +42,6 @@ spec:
     - encryptedVolume: true
       instanceGroup: master-us-test-1a
       name: a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     memoryRequest: 100Mi
     name: main
     version: 3.5.1
@@ -56,10 +52,6 @@ spec:
     - encryptedVolume: true
       instanceGroup: master-us-test-1a
       name: a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     memoryRequest: 100Mi
     name: events
     version: 3.5.1

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -32,10 +32,6 @@ spec:
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     name: main
     version: 3.5.1
   - backups:
@@ -43,10 +39,6 @@ spec:
     etcdMembers:
     - instanceGroup: master-us-test1-a
       name: "1"
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     name: events
     version: 3.5.1
   externalDns:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -18,9 +18,6 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -18,9 +18,6 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:

--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
+++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_startup-script
@@ -138,16 +138,8 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     version: 3.5.1
   main:
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     version: 3.5.1
 kubeAPIServer:
   allowPrivileged: true

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
@@ -137,16 +137,8 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     version: 3.5.1
   main:
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     version: 3.5.1
 kubeAPIServer:
   allowPrivileged: true

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -33,10 +33,6 @@ spec:
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     name: main
     version: 3.5.1
   - backups:
@@ -44,10 +40,6 @@ spec:
     etcdMembers:
     - instanceGroup: master-us-test-1a
       name: us-test-1a
-    manager:
-      env:
-      - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-        value: "true"
     name: events
     version: 3.5.1
   externalDns:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -19,9 +19,6 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecanal.example.com=owned > /tmp/pipe
       2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -19,9 +19,6 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecanal.example.com=owned > /tmp/pipe
       2>&1
-    env:
-    - name: ETCD_EXPERIMENTAL_INITIAL_CORRUPT_CHECK
-      value: "true"
     image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
     name: etcd-manager
     resources:


### PR DESCRIPTION
Cherry pick of #13495 on release-1.23.

#13495: Revert "Enable etcd corruption check as mitigatio of 3.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```