### PR TITLE
Automated cherry pick of #13497: Update Calico to v3.21.5

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.projectcalico.org/k8s-1.16.yaml
-    manifestHash: bea659b33d14546c548c4d00b994d707cb8119bfbf49f4e21c36b1896bc979dd
+    manifestHash: 24fea29838ef302183b890302ce09510a232d2c0d9c0a8330b3be96a49671e14
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.16_content
@@ -4248,7 +4248,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.21.4
+        image: docker.io/calico/node:v3.21.5
         lifecycle:
           preStop:
             exec:
@@ -4320,7 +4320,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.21.4
+        image: docker.io/calico/cni:v3.21.5
         name: upgrade-ipam
         securityContext:
           privileged: true
@@ -4354,7 +4354,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.21.4
+        image: docker.io/calico/cni:v3.21.5
         name: install-cni
         securityContext:
           privileged: true
@@ -4363,7 +4363,7 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
-      - image: docker.io/calico/pod2daemon-flexvol:v3.21.4
+      - image: docker.io/calico/pod2daemon-flexvol:v3.21.5
         name: flexvol-driver
         securityContext:
           privileged: true
@@ -4473,7 +4473,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.21.4
+        image: docker.io/calico/kube-controllers:v3.21.5
         livenessProbe:
           exec:
             command:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.projectcalico.org/k8s-1.16.yaml
-    manifestHash: 4f7354074631e04e5805ea1e62fc9c2c130b1bf77b6c4646432c4689b55158f7
+    manifestHash: 5dd895a7f60f681439f5abc99e740eb27739d42e6a91c9aedd8e31a60ba476b9
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.16_content
@@ -4243,7 +4243,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.21.4
+        image: docker.io/calico/node:v3.21.5
         lifecycle:
           preStop:
             exec:
@@ -4317,7 +4317,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.21.4
+        image: docker.io/calico/cni:v3.21.5
         name: upgrade-ipam
         securityContext:
           privileged: true
@@ -4351,7 +4351,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.21.4
+        image: docker.io/calico/cni:v3.21.5
         name: install-cni
         securityContext:
           privileged: true
@@ -4360,7 +4360,7 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
-      - image: docker.io/calico/pod2daemon-flexvol:v3.21.4
+      - image: docker.io/calico/pod2daemon-flexvol:v3.21.5
         name: flexvol-driver
         securityContext:
           privileged: true
@@ -4470,7 +4470,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.21.4
+        image: docker.io/calico/kube-controllers:v3.21.5
         livenessProbe:
           exec:
             command:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: networking.projectcalico.org.canal/k8s-1.22.yaml
-    manifestHash: 5d80e8c0c838ee026344174d7fce56bc7f0082e86c0261f7cd797443abbce89b
+    manifestHash: a5c1eb2388d1a84fe25f5c37e2982abd43b28c99d4cf8e1d01add04818ad3ad1
     name: networking.projectcalico.org.canal
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
@@ -4239,7 +4239,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.21.4
+        image: docker.io/calico/node:v3.21.5
         lifecycle:
           preStop:
             exec:
@@ -4352,7 +4352,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.21.4
+        image: docker.io/calico/cni:v3.21.5
         name: install-cni
         securityContext:
           privileged: true
@@ -4361,7 +4361,7 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
-      - image: docker.io/calico/pod2daemon-flexvol:v3.21.4
+      - image: docker.io/calico/pod2daemon-flexvol:v3.21.5
         name: flexvol-driver
         securityContext:
           privileged: true
@@ -4471,7 +4471,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.21.4
+        image: docker.io/calico/kube-controllers:v3.21.5
         livenessProbe:
           exec:
             command:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
@@ -4136,7 +4136,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.21.4
+      - image: calico/typha:v3.21.5
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -4244,7 +4244,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.21.4
+          image: docker.io/calico/cni:v3.21.5
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4285,7 +4285,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.21.4
+          image: docker.io/calico/pod2daemon-flexvol:v3.21.5
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -4296,7 +4296,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.21.4
+          image: docker.io/calico/node:v3.21.5
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4563,7 +4563,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.21.4
+          image: docker.io/calico/kube-controllers:v3.21.5
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4137,7 +4137,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.21.4" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.21.5" }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -4258,7 +4258,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.21.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.21.5" }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -4285,7 +4285,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.21.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.21.5" }}
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4326,7 +4326,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.21.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.21.5" }}
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -4337,7 +4337,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.21.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.21.5" }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4435,6 +4435,7 @@ spec:
             # Set Felix endpoint to host default action to ACCEPT.
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
               value: "ACCEPT"
+            # Set IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
               value: "{{ IsIPv6Only }}"
             - name: FELIX_HEALTHENABLED
@@ -4652,7 +4653,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.21.4" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.21.5" }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
Cherry pick of #13497 on release-1.23.

#13497: Update Calico to v3.21.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```