### PR TITLE
Automated cherry pick of #13501: Use etcd 3.5.3 instead of 3.5.1

### DIFF
--- a/pkg/model/components/etcd.go
+++ b/pkg/model/components/etcd.go
@@ -36,7 +36,7 @@ var _ loader.OptionsBuilder = &EtcdOptionsBuilder{}
 const (
 	DefaultEtcd3Version_1_17 = "3.4.3"
 	DefaultEtcd3Version_1_19 = "3.4.13"
-	DefaultEtcd3Version_1_22 = "3.5.1"
+	DefaultEtcd3Version_1_22 = "3.5.3"
 )
 
 // BuildOptions is responsible for filling in the defaults for the etcd cluster model

--- a/pkg/model/components/etcdmanager/options.go
+++ b/pkg/model/components/etcdmanager/options.go
@@ -66,7 +66,7 @@ func (b *EtcdManagerOptionsBuilder) BuildOptions(o interface{}) error {
 	return nil
 }
 
-var supportedEtcdVersions = []string{"3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3", "3.4.13", "3.5.0", "3.5.1"}
+var supportedEtcdVersions = []string{"3.1.12", "3.2.18", "3.2.24", "3.3.10", "3.3.13", "3.3.17", "3.4.3", "3.4.13", "3.5.0", "3.5.1", "3.5.3"}
 
 func etcdVersionIsSupported(version string) bool {
 	version = strings.TrimPrefix(version, "v")

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
@@ -137,9 +137,9 @@ docker:
 encryptionConfig: null
 etcdClusters:
   events:
-    version: 3.5.1
+    version: 3.5.3
   main:
-    version: 3.5.1
+    version: 3.5.3
 kubeAPIServer:
   allowPrivileged: true
   anonymousAuth: false

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -37,7 +37,7 @@ spec:
       name: us-test-1a
     name: main
     provider: Manager
-    version: 3.5.1
+    version: 3.5.3
   - backups:
       backupStore: memfs://clusters.example.com/privatecanal.example.com/backups/etcd/events
     enableEtcdTLS: true
@@ -47,7 +47,7 @@ spec:
       name: us-test-1a
     name: events
     provider: Manager
-    version: 3.5.1
+    version: 3.5.3
   externalDns:
     provider: dns-controller
   iam:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_etcd-cluster-spec-events_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_etcd-cluster-spec-events_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.1"
+  "etcdVersion": "3.5.3"
 }

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_etcd-cluster-spec-main_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_etcd-cluster-spec-main_content
@@ -1,4 +1,4 @@
 {
   "memberCount": 1,
-  "etcdVersion": "3.5.1"
+  "etcdVersion": "3.5.3"
 }


### PR DESCRIPTION
Cherry pick of #13501 on release-1.22.

#13501: Use etcd 3.5.3 instead of 3.5.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```