### PR TITLE
Use Cluster Autoscaler 1.23 for k8s 1.24

### DIFF
--- a/pkg/model/components/clusterautoscaler.go
+++ b/pkg/model/components/clusterautoscaler.go
@@ -43,6 +43,8 @@ func (b *ClusterAutoscalerOptionsBuilder) BuildOptions(o interface{}) error {
 		v, err := util.ParseKubernetesVersion(clusterSpec.KubernetesVersion)
 		if err == nil {
 			switch v.Minor {
+			case 24:
+				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.0"
 			case 23:
 				image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.0"
 			case 22:


### PR DESCRIPTION
We made this explicitly fail before because there is a risk of us forgetting to bump. I think, however, history has shown this risk is not very real