### PR TITLE
WIP: Support channels over OCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,3 +749,21 @@ cloudbuild-artifacts:
 	# cd ${KOPS_ROOT}/${BAZEL_BIN}/; find . -name '*.digest' -type f | sort | xargs grep . > ${KOPS_ROOT}/cloudbuild/image-digests
 	# ${BUILDER_OUTPUT}/output is a special cloudbuild target; the first 4KB is captured securely
 	cd ${KOPS_ROOT}/cloudbuild/; find -type f | sort | xargs sha256sum > ${BUILDER_OUTPUT}/output
+
+
+#------------------------------------------------------
+# Channel images
+#
+# We create some images for channels.
+
+.PHONY: ko-channel-images-push-alpha ko-channel-images-push-stable
+ko-channel-images-push-alpha ko-channel-images-push-stable: ko-channel-images-push-%:
+	mkdir -p ${IMAGES}/channels/$*/
+	cp -fp channels/$* ${IMAGES}/channels/$*/channel.yaml
+	mkdir -p ${UPLOAD}/kops/${VERSION}/images/
+	rm -f ${UPLOAD}/kops/${VERSION}/images/channels-$*.tar.gz
+	cd ${IMAGES}/channels/$*/; tar cvf ${UPLOAD}/kops/${VERSION}/images/channels-$*.tar.gz .
+	crane append -f ${UPLOAD}/kops/${VERSION}/images/channels-$*.tar.gz -t justinsb/kops-channels-v1.24-$*:latest
+
+.PHONY: ko-channel-images-push
+ko-channel-images-push: ko-channel-images-push-alpha ko-channel-images-push-stable

--- a/cmd/kops/toolbox_template.go
+++ b/cmd/kops/toolbox_template.go
@@ -36,6 +36,7 @@ import (
 
 	"k8s.io/kops/cmd/kops/util"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/channel"
 	"k8s.io/kops/pkg/try"
 	"k8s.io/kops/pkg/util/templater"
 	"k8s.io/kops/upup/pkg/fi/utils"
@@ -174,7 +175,7 @@ func RunToolBoxTemplate(f *util.Factory, out io.Writer, options *ToolboxTemplate
 		}
 	}
 
-	channel, err := kopsapi.LoadChannel(options.channel)
+	channel, err := channel.LoadChannel(options.channel)
 	if err != nil {
 		return fmt.Errorf("error loading channel %q: %v", options.channel, err)
 	}

--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kops"
 	"k8s.io/kops/cmd/kops/util"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/channel"
 	kopsutil "k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/commands"
 	"k8s.io/kops/pkg/commands/commandutils"
@@ -138,7 +139,7 @@ func RunUpgradeCluster(ctx context.Context, f *util.Factory, out io.Writer, opti
 		})
 	}
 
-	channel, err := kopsapi.LoadChannel(channelLocation)
+	channel, err := channel.LoadChannel(channelLocation)
 	if err != nil {
 		return fmt.Errorf("error loading channel %q: %v", channelLocation, err)
 	}

--- a/pkg/apis/kops/channel/load.go
+++ b/pkg/apis/kops/channel/load.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channel
+
+import (
+	"fmt"
+
+	"k8s.io/klog/v2"
+	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/util/pkg/vfs"
+)
+
+// ParseChannel parses a Channel object
+func ParseChannel(channelBytes []byte) (*api.Channel, error) {
+	channel := &api.Channel{}
+	err := api.ParseRawYaml(channelBytes, channel)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing channel %v", err)
+	}
+
+	return channel, nil
+}
+
+// LoadChannel loads a Channel object from the specified VFS location
+func LoadChannel(location string) (*api.Channel, error) {
+	resolvedURL, err := ResolveChannel(location)
+	if err != nil {
+		return nil, err
+	}
+
+	if resolvedURL == nil {
+		return &api.Channel{}, nil
+	}
+
+	if isOCI(resolvedURL) {
+		return LoadChannelFromOCI(resolvedURL)
+	}
+
+	resolved := resolvedURL.String()
+
+	klog.V(2).Infof("Loading channel from %q", resolved)
+	channelBytes, err := vfs.Context.ReadFile(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("error reading channel %q: %v", resolved, err)
+	}
+	channel, err := ParseChannel(channelBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing channel %q: %v", resolved, err)
+	}
+	klog.V(4).Infof("Channel contents: %s", string(channelBytes))
+
+	return channel, nil
+}

--- a/pkg/apis/kops/channel/oci.go
+++ b/pkg/apis/kops/channel/oci.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channel
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"k8s.io/klog/v2"
+	api "k8s.io/kops/pkg/apis/kops"
+)
+
+// isOCI returns true if the URL refers to an OCI image (container image)
+func isOCI(u *url.URL) bool {
+	return u.Scheme == "oci"
+}
+
+func resolveOCIChannel(u *url.URL) (*url.URL, error) {
+	imageSpec, err := parseOCIImageSpec(u)
+	if err != nil {
+		return nil, err
+	}
+
+	if imageSpec.Tag != "" {
+		// We already have a tag
+		return u, nil
+	}
+
+	// Find the newest tag
+	var options []crane.Option
+	tags, err := crane.ListTags(imageSpec.Name, options...)
+	if err != nil {
+		return nil, fmt.Errorf("error listing tags for %s: %w", imageSpec.Name, err)
+	}
+
+	var latestTag string
+	var latestVersion semver.Version
+	for _, tag := range tags {
+		version, err := semver.ParseTolerant(tag)
+		if err != nil {
+			klog.Warningf("ignoring unparseable tag %q", tag)
+		}
+		if latestTag == "" || version.Compare(latestVersion) >= 0 {
+			latestTag = tag
+			latestVersion = version
+		}
+	}
+
+	if latestTag == "" {
+		return nil, fmt.Errorf("could not find any tags for %s", u.String())
+	}
+
+	klog.Warningf("found latest tag %q for %v", latestTag, u.String())
+	withVersion := &url.URL{}
+	*withVersion = *u
+	withVersion.Path += "@" + latestTag
+	return withVersion, nil
+}
+
+type ociImageEntry struct {
+	Path     string
+	Header   tar.Header
+	Contents []byte
+}
+
+type ociImage struct {
+	Entries map[string]*ociImageEntry
+}
+
+type ociImageSpec struct {
+	Name string
+	Tag  string
+}
+
+func parseOCIImageSpec(u *url.URL) (*ociImageSpec, error) {
+	if !isOCI(u) {
+		return nil, fmt.Errorf("expected scheme to be oci in %q", u.String())
+	}
+
+	spec := &ociImageSpec{}
+
+	pathTokens := strings.Split(u.Path, "@")
+	if len(pathTokens) == 1 {
+		// No tag
+	} else if len(pathTokens) == 2 {
+		spec.Tag = pathTokens[1]
+	} else {
+		return nil, fmt.Errorf("found multiple @ versions in %q", u.String())
+	}
+
+	path := pathTokens[0]
+	path = strings.Trim(path, "/")
+
+	spec.Name = u.Host + "/" + path
+
+	return spec, nil
+}
+
+func loadOCIImage(resolvedURL *url.URL) (*ociImage, error) {
+	resolved := resolvedURL.String()
+
+	imageSpec, err := parseOCIImageSpec(resolvedURL)
+	if err != nil {
+		return nil, err
+	}
+	klog.V(2).Infof("Loading channel from %q", resolved)
+
+	if imageSpec.Tag == "" {
+		return nil, fmt.Errorf("expected @ version in %q", resolved)
+	}
+
+	srcImage := imageSpec.Name + ":" + imageSpec.Tag
+	var pullOptions []crane.Option
+	img, err := crane.Pull(srcImage, pullOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("error pulling %s: %w", srcImage, err)
+	}
+
+	// We don't expect these to be very large, so we expand them entirely in-memory
+	// (without e.g. implementing streaming)
+	var b bytes.Buffer
+	if err := crane.Export(img, &b); err != nil {
+		return nil, fmt.Errorf("error exporting %s: %w", srcImage, err)
+	}
+
+	tarFile := &ociImage{
+		Entries: make(map[string]*ociImageEntry),
+	}
+	tr := tar.NewReader(&b)
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("error reading tar header: %w", err)
+		}
+
+		b, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("error reading tar contents for %q: %w", header.Name, err)
+		}
+		tarFile.Entries[header.Name] = &ociImageEntry{
+			Path:     header.Name,
+			Header:   *header,
+			Contents: b,
+		}
+	}
+
+	return tarFile, nil
+}
+
+func LoadChannelFromOCI(resolvedURL *url.URL) (*api.Channel, error) {
+	image, err := loadOCIImage(resolvedURL)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := image.Entries["channel.yaml"]
+	if entry == nil {
+		return nil, fmt.Errorf("channel.yaml entry not found in %s", resolvedURL.String())
+	}
+
+	channel, err := ParseChannel(entry.Contents)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing channel %q: %v", resolvedURL.String(), err)
+	}
+	klog.V(4).Infof("Channel contents: %s", string(entry.Contents))
+
+	return channel, nil
+}

--- a/pkg/apis/kops/channel/resolve.go
+++ b/pkg/apis/kops/channel/resolve.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channel
+
+import (
+	"fmt"
+	"net/url"
+
+	"k8s.io/klog/v2"
+)
+
+const GithubChannelBase = "https://raw.githubusercontent.com/kubernetes/kops/master/channels/"
+
+// TestChannelBase can be set by tests to override the channel base.
+var TestChannelBase = ""
+
+func ChannelBase() string {
+	if TestChannelBase != "" {
+		return TestChannelBase
+	}
+	return GithubChannelBase
+}
+
+// ResolveChannel maps a channel to an absolute URL (possibly a VFS URL)
+// If the channel is the well-known "none" value, we return (nil, nil)
+func ResolveChannel(location string) (*url.URL, error) {
+	if location == "none" {
+		return nil, nil
+	}
+
+	u, err := url.Parse(location)
+	if err != nil {
+		return nil, fmt.Errorf("invalid channel location: %q", location)
+	}
+
+	if !u.IsAbs() {
+		channelBase := ChannelBase()
+		base, err := url.Parse(channelBase)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base channel location: %q", channelBase)
+		}
+		klog.V(4).Infof("resolving %q against default channel location %q", location, channelBase)
+		u = base.ResolveReference(u)
+	}
+
+	if isOCI(u) {
+		return resolveOCIChannel(u)
+	}
+
+	return u, nil
+}

--- a/pkg/testutils/integrationtestharness.go
+++ b/pkg/testutils/integrationtestharness.go
@@ -52,7 +52,7 @@ import (
 	"k8s.io/kops/cloudmock/openstack/mockimage"
 	"k8s.io/kops/cloudmock/openstack/mockloadbalancer"
 	"k8s.io/kops/cloudmock/openstack/mocknetworking"
-	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/channel"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/pki"
 	"k8s.io/kops/upup/pkg/fi"
@@ -65,8 +65,8 @@ type IntegrationTestHarness struct {
 	TempDir string
 	T       *testing.T
 
-	// The original kops DefaultChannelBase value, restored on Close
-	originalDefaultChannelBase string
+	// The original TestChannelBase value, restored on Close
+	originalTestChannelBase string
 
 	// originalKopsVersion is the original kops.Version value, restored on Close
 	originalKopsVersion string
@@ -97,10 +97,10 @@ func NewIntegrationTestHarness(t *testing.T) *IntegrationTestHarness {
 			t.Fatalf("error resolving stable channel path: %v", err)
 		}
 		channelPath += "/"
-		h.originalDefaultChannelBase = kops.DefaultChannelBase
+		h.originalTestChannelBase = channel.TestChannelBase
 
 		// Make sure any platform-specific separators that aren't /, are converted to / for use in a file: protocol URL
-		kops.DefaultChannelBase = "file://" + filepath.ToSlash(channelPath)
+		channel.TestChannelBase = "file://" + filepath.ToSlash(channelPath)
 	}
 
 	return h
@@ -122,9 +122,7 @@ func (h *IntegrationTestHarness) Close() {
 		kopsroot.Version = h.originalKopsVersion
 	}
 
-	if h.originalDefaultChannelBase != "" {
-		kops.DefaultChannelBase = h.originalDefaultChannelBase
-	}
+	channel.TestChannelBase = h.originalTestChannelBase
 
 	if h.originalPKIDefaultPrivateKeySize != 0 {
 		pki.DefaultPrivateKeySize = h.originalPKIDefaultPrivateKeySize

--- a/pkg/wellknownoperators/operators.go
+++ b/pkg/wellknownoperators/operators.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	channelsapi "k8s.io/kops/channels/pkg/api"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/channel"
 	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/pkg/kubemanifest"
 	"k8s.io/kops/upup/pkg/fi"
@@ -87,7 +88,7 @@ func (b *Builder) loadClusterPackage(u *unstructured.Unstructured) (*Package, er
 	id := operatorVersion
 
 	location := path.Join("packages", operatorKey, operatorVersion, "manifest.yaml")
-	channelURL, err := kops.ResolveChannel(b.Cluster.Spec.Channel)
+	channelURL, err := channel.ResolveChannel(b.Cluster.Spec.Channel)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving channel %q: %v", b.Cluster.Spec.Channel, err)
 	}

--- a/tests/integration/channel/integration_test.go
+++ b/tests/integration/channel/integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/channel"
 	"k8s.io/kops/tests/integration/channel/simple"
 	"k8s.io/kops/util/pkg/architectures"
 )
@@ -121,7 +122,7 @@ func TestKubernetesUpgrades(t *testing.T) {
 		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 	}
 
-	channel, err := kops.ParseChannel(sourceBytes)
+	channel, err := channel.ParseChannel(sourceBytes)
 	if err != nil {
 		t.Fatalf("failed to parse channel: %v", err)
 	}
@@ -215,7 +216,7 @@ func TestFindImage(t *testing.T) {
 		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 	}
 
-	channel, err := kops.ParseChannel(sourceBytes)
+	channel, err := channel.ParseChannel(sourceBytes)
 	if err != nil {
 		t.Fatalf("failed to parse channel: %v", err)
 	}
@@ -270,7 +271,7 @@ func TestRecommendedKubernetesVersion(t *testing.T) {
 		t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 	}
 
-	channel, err := kops.ParseChannel(sourceBytes)
+	channel, err := channel.ParseChannel(sourceBytes)
 	if err != nil {
 		t.Fatalf("failed to parse channel: %v", err)
 	}
@@ -364,7 +365,7 @@ func TestChannelsSelfConsistent(t *testing.T) {
 			t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 		}
 
-		channel, err := kops.ParseChannel(sourceBytes)
+		channel, err := channel.ParseChannel(sourceBytes)
 		if err != nil {
 			t.Fatalf("failed to parse channel %s: %v", g.Channel, err)
 		}
@@ -404,21 +405,21 @@ func semverString(sv *semver.Version) string {
 
 // All Images in channel should have a specified upstream image prefix
 func TestChannelImages(t *testing.T) {
-	for _, channel := range []string{"stable", "alpha"} {
-		t.Run(channel+"-channel", func(t *testing.T) {
-			sourcePath := "../../../channels/" + channel
+	for _, channelName := range []string{"stable", "alpha"} {
+		t.Run(channelName+"-channel", func(t *testing.T) {
+			sourcePath := "../../../channels/" + channelName
 			sourceBytes, err := os.ReadFile(sourcePath)
 			if err != nil {
 				t.Fatalf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 			}
 
-			channel, err := kops.ParseChannel(sourceBytes)
+			c, err := channel.ParseChannel(sourceBytes)
 			if err != nil {
 				t.Fatalf("failed to parse channel: %v", err)
 			}
 
-			for _, image := range channel.Spec.Images {
-				if !channel.HasUpstreamImagePrefix(image.Name) {
+			for _, image := range c.Spec.Images {
+				if !c.HasUpstreamImagePrefix(image.Name) {
 					t.Errorf("unknown image prefix: %q", image.Name)
 				}
 			}

--- a/tests/integration/channel/simple/mock_channel.go
+++ b/tests/integration/channel/simple/mock_channel.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/channel"
 )
 
 func NewMockChannel(sourcePath string) (*kops.Channel, error) {
@@ -29,7 +30,7 @@ func NewMockChannel(sourcePath string) (*kops.Channel, error) {
 		return nil, fmt.Errorf("unexpected error reading sourcePath %q: %v", sourcePath, err)
 	}
 
-	channel, err := kops.ParseChannel(sourceBytes)
+	channel, err := channel.ParseChannel(sourceBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse channel: %v", err)
 	}

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/klog/v2"
 	kopsbase "k8s.io/kops"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/channel"
 	apiModel "k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/pkg/apis/kops/registry"
 	"k8s.io/kops/pkg/apis/kops/util"
@@ -1087,7 +1088,7 @@ func ChannelForCluster(c *kops.Cluster) (*kops.Channel, error) {
 	if channelLocation == "" {
 		channelLocation = kops.DefaultChannel
 	}
-	return kops.LoadChannel(channelLocation)
+	return channel.LoadChannel(channelLocation)
 }
 
 // needsMounterAsset checks if we need the mounter program

--- a/upup/pkg/fi/cloudup/defaults.go
+++ b/upup/pkg/fi/cloudup/defaults.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/channel"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/azure"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
@@ -136,7 +137,7 @@ func PerformAssignments(c *kops.Cluster, cloud fi.Cloud) error {
 func ensureKubernetesVersion(c *kops.Cluster) error {
 	if c.Spec.KubernetesVersion == "" {
 		if c.Spec.Channel != "" {
-			channel, err := kops.LoadChannel(c.Spec.Channel)
+			channel, err := channel.LoadChannel(c.Spec.Channel)
 			if err != nil {
 				return err
 			}

--- a/upup/pkg/fi/cloudup/new_cluster.go
+++ b/upup/pkg/fi/cloudup/new_cluster.go
@@ -30,6 +30,7 @@ import (
 
 	"k8s.io/kops"
 	api "k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/apis/kops/channel"
 	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/pkg/client/simple"
 	"k8s.io/kops/pkg/dns"
@@ -183,7 +184,7 @@ func NewCluster(opt *NewClusterOptions, clientset simple.Clientset) (*NewCluster
 	if opt.Channel == "" {
 		opt.Channel = api.DefaultChannel
 	}
-	channel, err := api.LoadChannel(opt.Channel)
+	channel, err := channel.LoadChannel(opt.Channel)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We want to support richer mirroring for channels, into the official k8s distribution locations.

However, our channels currently update in place, and this doesn't seem
like a great match for the http-based distribution mechanisms (which
both expect artifacts to be immutable and don't support listing).

Instead, we support fetching the files via a container (OCI registry);
we still treat them as immutable but OCI makes it easy to list tags.
