### PR TITLE
Trim GCE firewall rule names to their max length

### DIFF
--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -100,7 +100,11 @@ func (c *GCEModelContext) NameForHealthcheck(id string) string {
 }
 
 func (c *GCEModelContext) NameForFirewallRule(id string) string {
-	return c.SafeObjectName(id)
+	name, err := gce.ClusterSuffixedName(id, c.Cluster.ObjectMeta.Name, 63)
+	if err != nil {
+		klog.Fatalf("failed to construct firewallrule name: %w", err)
+	}
+	return name
 }
 
 func (c *GCEModelContext) NetworkingIsIPAlias() bool {

--- a/pkg/model/gcemodel/firewall.go
+++ b/pkg/model/gcemodel/firewall.go
@@ -48,7 +48,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	// Allow all traffic from nodes -> nodes
 	{
 		t := &gcetasks.FirewallRule{
-			Name:       s(b.SafeObjectName("node-to-node")),
+			Name:       s(b.NameForFirewallRule("node-to-node")),
 			Lifecycle:  b.Lifecycle,
 			Network:    b.LinkToNetwork(),
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
@@ -61,7 +61,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	// Allow full traffic from master -> master
 	{
 		t := &gcetasks.FirewallRule{
-			Name:       s(b.SafeObjectName("master-to-master")),
+			Name:       s(b.NameForFirewallRule("master-to-master")),
 			Lifecycle:  b.Lifecycle,
 			Network:    b.LinkToNetwork(),
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
@@ -74,7 +74,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	// Allow full traffic from master -> node
 	{
 		t := &gcetasks.FirewallRule{
-			Name:       s(b.SafeObjectName("master-to-node")),
+			Name:       s(b.NameForFirewallRule("master-to-node")),
 			Lifecycle:  b.Lifecycle,
 			Network:    b.LinkToNetwork(),
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleMaster)},
@@ -87,7 +87,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 	// Allow limited traffic from nodes -> masters
 	{
 		t := &gcetasks.FirewallRule{
-			Name:       s(b.SafeObjectName("node-to-master")),
+			Name:       s(b.NameForFirewallRule("node-to-master")),
 			Lifecycle:  b.Lifecycle,
 			Network:    b.LinkToNetwork(),
 			SourceTags: []string{b.GCETagForRole(kops.InstanceGroupRoleNode)},
@@ -118,7 +118,7 @@ func (b *FirewallModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		}
 
 		c.AddTask(&gcetasks.FirewallRule{
-			Name:         s(b.SafeObjectName("pod-cidrs-to-node")),
+			Name:         s(b.NameForFirewallRule("pod-cidrs-to-node")),
 			Lifecycle:    b.Lifecycle,
 			Network:      b.LinkToNetwork(),
 			SourceRanges: []string{b.Cluster.Spec.PodCIDR},


### PR DESCRIPTION
fixes https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-grid-gce-u2004-k22-docker/1515837173192986624

`W0417 23:40:26.970906    5906 executor.go:139] error running task "FirewallRule/ssh-external-to-master-ipv6-e2e-e2e-kops-grid-gce-u2004-k22-docker-k8s-local" (9m59s remaining to succeed): error listing FirewallRules: googleapi: Error 400: Invalid value for field 'firewall': 'ssh-external-to-master-ipv6-e2e-e2e-kops-grid-gce-u2004-k22-docker-k8s-local'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}', invalid`

https://cloud.google.com/compute/docs/naming-resources#resource-name-format

This should be safe for existing clusters given that the integration test terraform files aren't changing as a result of this, it only allows the creation of clusters with longer names than what our integration tests currently have.