### PR TITLE
Automated cherry pick of #13514: Revert to using 1.23.0-alpha.0 for AWS CCM

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -98,7 +98,7 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		case 22:
 			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.22.0"
 		case 23:
-			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0"
+			eccm.Image = "k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0"
 		default:
 			eccm.Image = "gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest"
 		}

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterCIDR: 172.20.0.0/16
     clusterName: minimal.example.com
     configureCloudRoutes: false
-    image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0
+    image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -38,7 +38,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-cloud-controller-manager.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0
+        image: k8s.gcr.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -133,7 +133,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 2f7a411982be984d3f9ecaab6d504277287e998c4abe487031ed9f94f6e63c1a
+    manifestHash: 13acfb69bcca8fa54cc39066a8763ba9b0df23790822d5bae20e5fad02d9ccd4
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #13514 on release-1.23.

#13514: Revert to using 1.23.0-alpha.0 for AWS CCM

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```