### PR TITLE
Automated cherry pick of #13515: Update aws-sdk-go to v1.43.41

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1059
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/amazon-ec2-instance-selector/v2 v2.0.2
-	github.com/aws/aws-sdk-go v1.43.11
+	github.com/aws/aws-sdk-go v1.43.41
 	github.com/blang/semver/v4 v4.0.0
 	github.com/denverdino/aliyungo v0.0.0-20210425065611-55bee4942cba
 	github.com/digitalocean/godo v1.65.0

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU
 github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.40.21/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/aws/aws-sdk-go v1.43.11 h1:NebCNJ2QvsFCnsKT1ei98bfwTPEoO2qwtWT42tJ3N3Q=
-github.com/aws/aws-sdk-go v1.43.11/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.43.41 h1:HaazVplP8/t6SOfybQlNUmjAxLWDKdLdX8BSEHFlJdY=
+github.com/aws/aws-sdk-go v1.43.41/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.13.0 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
-	github.com/aws/aws-sdk-go v1.43.11 // indirect
+	github.com/aws/aws-sdk-go v1.43.41 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
 	github.com/containers/image/v5 v5.9.0 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -269,8 +269,8 @@ github.com/aws/aws-sdk-go v1.31.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.40.21/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/aws/aws-sdk-go v1.43.11 h1:NebCNJ2QvsFCnsKT1ei98bfwTPEoO2qwtWT42tJ3N3Q=
-github.com/aws/aws-sdk-go v1.43.11/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.43.41 h1:HaazVplP8/t6SOfybQlNUmjAxLWDKdLdX8BSEHFlJdY=
+github.com/aws/aws-sdk-go v1.43.41/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/bazelbuild/buildtools v0.0.0-20190917191645-69366ca98f89/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/bazelbuild/rules_go v0.22.1/go.mod h1:MC23Dc/wkXEyk3Wpq6lCqz0ZAYOZDw2DR5y3N1q2i7M=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=

--- a/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/endpoints/defaults.go
@@ -2375,6 +2375,9 @@ var awsPartition = partition{
 					Region: "ap-southeast-2",
 				}: endpoint{},
 				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
 					Region: "eu-central-1",
 				}: endpoint{},
 				endpointKey{
@@ -2874,6 +2877,9 @@ var awsPartition = partition{
 					Region: "ap-southeast-2",
 				}: endpoint{},
 				endpointKey{
+					Region: "ap-southeast-3",
+				}: endpoint{},
+				endpointKey{
 					Region: "ca-central-1",
 				}: endpoint{},
 				endpointKey{
@@ -3046,6 +3052,20 @@ var awsPartition = partition{
 					Variant: fipsVariant,
 				}: endpoint{
 					Hostname: "fips.batch.us-west-2.amazonaws.com",
+				},
+			},
+		},
+		"billingconductor": service{
+			PartitionEndpoint: "aws-global",
+			IsRegionalized:    boxedFalse,
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "aws-global",
+				}: endpoint{
+					Hostname: "billingconductor.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
 				},
 			},
 		},
@@ -3634,6 +3654,9 @@ var awsPartition = partition{
 					Region: "ap-northeast-2",
 				}: endpoint{},
 				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
 					Region: "ap-south-1",
 				}: endpoint{},
 				endpointKey{
@@ -3641,6 +3664,9 @@ var awsPartition = partition{
 				}: endpoint{},
 				endpointKey{
 					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-3",
 				}: endpoint{},
 				endpointKey{
 					Region: "ca-central-1",
@@ -5199,6 +5225,147 @@ var awsPartition = partition{
 				}: endpoint{},
 			},
 		},
+		"data-ats.iot": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "ca-central-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.iot-fips.ca-central-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-3",
+				}: endpoint{},
+				endpointKey{
+					Region: "fips-ca-central-1",
+				}: endpoint{
+					Hostname: "data.iot-fips.ca-central-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "data.iot-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-east-2",
+				}: endpoint{
+					Hostname: "data.iot-fips.us-east-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-1",
+				}: endpoint{
+					Hostname: "data.iot-fips.us-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "data.iot-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "me-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "sa-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.iot-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-east-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-east-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.iot-fips.us-east-2.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.iot-fips.us-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.iot-fips.us-west-2.amazonaws.com",
+				},
+			},
+		},
 		"data.jobs.iot": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
@@ -6457,6 +6624,9 @@ var awsPartition = partition{
 				}: endpoint{},
 				endpointKey{
 					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-3",
 				}: endpoint{},
 				endpointKey{
 					Region: "ca-central-1",
@@ -9540,6 +9710,13 @@ var awsPartition = partition{
 				}: endpoint{},
 			},
 		},
+		"gamesparks": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+			},
+		},
 		"glacier": service{
 			Defaults: endpointDefaults{
 				defaultKey{}: endpoint{
@@ -10984,11 +11161,41 @@ var awsPartition = partition{
 					Region: "eu-west-1",
 				}: endpoint{},
 				endpointKey{
+					Region: "fips-us-east-1",
+				}: endpoint{
+					Hostname: "iotsitewise-fips.us-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-west-2",
+				}: endpoint{
+					Hostname: "iotsitewise-fips.us-west-2.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-west-2",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
 					Region: "us-east-1",
 				}: endpoint{},
 				endpointKey{
+					Region:  "us-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iotsitewise-fips.us-east-1.amazonaws.com",
+				},
+				endpointKey{
 					Region: "us-west-2",
 				}: endpoint{},
+				endpointKey{
+					Region:  "us-west-2",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iotsitewise-fips.us-west-2.amazonaws.com",
+				},
 			},
 		},
 		"iotthingsgraph": service{
@@ -11066,6 +11273,18 @@ var awsPartition = partition{
 		},
 		"ivs": service{
 			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
 				endpointKey{
 					Region: "eu-west-1",
 				}: endpoint{},
@@ -15078,7 +15297,13 @@ var awsPartition = partition{
 		"profile": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
+					Region: "af-south-1",
+				}: endpoint{},
+				endpointKey{
 					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-northeast-2",
 				}: endpoint{},
 				endpointKey{
 					Region: "ap-southeast-1",
@@ -15281,6 +15506,9 @@ var awsPartition = partition{
 				}: endpoint{},
 				endpointKey{
 					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-3",
 				}: endpoint{},
 				endpointKey{
 					Region: "ca-central-1",
@@ -18324,6 +18552,9 @@ var awsPartition = partition{
 					Region: "ap-northeast-2",
 				}: endpoint{},
 				endpointKey{
+					Region: "ap-northeast-3",
+				}: endpoint{},
+				endpointKey{
 					Region: "ap-south-1",
 				}: endpoint{},
 				endpointKey{
@@ -18331,6 +18562,9 @@ var awsPartition = partition{
 				}: endpoint{},
 				endpointKey{
 					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-3",
 				}: endpoint{},
 				endpointKey{
 					Region: "ca-central-1",
@@ -18646,6 +18880,9 @@ var awsPartition = partition{
 					Region: "ap-southeast-2",
 				}: endpoint{},
 				endpointKey{
+					Region: "ap-southeast-3",
+				}: endpoint{},
+				endpointKey{
 					Region: "ca-central-1",
 				}: endpoint{},
 				endpointKey{
@@ -18928,6 +19165,40 @@ var awsPartition = partition{
 				}: endpoint{
 					Hostname: "sms-fips.us-west-2.amazonaws.com",
 				},
+			},
+		},
+		"sms-voice": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "ap-northeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-south-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "ap-southeast-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "ca-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-central-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "eu-west-2",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "us-west-2",
+				}: endpoint{},
 			},
 		},
 		"snowball": service{
@@ -21988,6 +22259,9 @@ var awsPartition = partition{
 					Region: "ap-southeast-2",
 				}: endpoint{},
 				endpointKey{
+					Region: "ap-southeast-3",
+				}: endpoint{},
+				endpointKey{
 					Region: "ca-central-1",
 				}: endpoint{},
 				endpointKey{
@@ -22373,6 +22647,16 @@ var awscnPartition = partition{
 				},
 			},
 		},
+		"cloudcontrolapi": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
 		"cloudformation": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
@@ -22487,6 +22771,24 @@ var awscnPartition = partition{
 		},
 		"cur": service{
 			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-northwest-1",
+				}: endpoint{},
+			},
+		},
+		"data-ats.iot": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "cn-north-1",
+				}: endpoint{},
 				endpointKey{
 					Region: "cn-northwest-1",
 				}: endpoint{},
@@ -24217,6 +24519,14 @@ var awsusgovPartition = partition{
 			},
 		},
 		"autoscaling": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{},
+				defaultKey{
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "autoscaling.{region}.{dnsSuffix}",
+				},
+			},
 			Endpoints: serviceEndpoints{
 				endpointKey{
 					Region: "us-gov-east-1",
@@ -24401,20 +24711,40 @@ var awsusgovPartition = partition{
 		"cloudtrail": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
-					Region: "us-gov-east-1",
+					Region: "fips-us-gov-east-1",
 				}: endpoint{
 					Hostname: "cloudtrail.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
 				endpointKey{
-					Region: "us-gov-west-1",
+					Region: "fips-us-gov-west-1",
 				}: endpoint{
 					Hostname: "cloudtrail.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudtrail.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "cloudtrail.us-gov-west-1.amazonaws.com",
 				},
 			},
 		},
@@ -24715,6 +25045,54 @@ var awsusgovPartition = partition{
 				endpointKey{
 					Region: "us-gov-west-1",
 				}: endpoint{},
+			},
+		},
+		"data-ats.iot": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"https"},
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "fips-us-gov-east-1",
+				}: endpoint{
+					Hostname: "data.iot-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "data.iot-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Service: "iotdata",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.iot-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "data.iot-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"data.jobs.iot": service{
@@ -25406,20 +25784,40 @@ var awsusgovPartition = partition{
 		"events": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
-					Region: "us-gov-east-1",
+					Region: "fips-us-gov-east-1",
 				}: endpoint{
 					Hostname: "events.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
 				endpointKey{
-					Region: "us-gov-west-1",
+					Region: "fips-us-gov-west-1",
 				}: endpoint{
 					Hostname: "events.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "events.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "events.us-gov-west-1.amazonaws.com",
 				},
 			},
 		},
@@ -26070,8 +26468,23 @@ var awsusgovPartition = partition{
 		"iotsitewise": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "iotsitewise-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
 					Region: "us-gov-west-1",
 				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "iotsitewise-fips.us-gov-west-1.amazonaws.com",
+				},
 			},
 		},
 		"kafka": service{
@@ -26290,20 +26703,40 @@ var awsusgovPartition = partition{
 		"logs": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
-					Region: "us-gov-east-1",
+					Region: "fips-us-gov-east-1",
 				}: endpoint{
 					Hostname: "logs.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
 				},
 				endpointKey{
-					Region: "us-gov-west-1",
+					Region: "fips-us-gov-west-1",
 				}: endpoint{
 					Hostname: "logs.us-gov-west-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "logs.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "logs.us-gov-west-1.amazonaws.com",
 				},
 			},
 		},
@@ -26316,6 +26749,46 @@ var awsusgovPartition = partition{
 					CredentialScope: credentialScope{
 						Region: "us-gov-west-1",
 					},
+				},
+			},
+		},
+		"meetings-chime": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "meetings-chime-fips.us-gov-east-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-east-1-fips",
+				}: endpoint{
+					Hostname: "meetings-chime-fips.us-gov-east-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-east-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "meetings-chime-fips.us-gov-west-1.amazonaws.com",
+				},
+				endpointKey{
+					Region: "us-gov-west-1-fips",
+				}: endpoint{
+					Hostname: "meetings-chime-fips.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
 				},
 			},
 		},
@@ -27596,6 +28069,13 @@ var awsusgovPartition = partition{
 				},
 			},
 		},
+		"sms-voice": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-gov-west-1",
+				}: endpoint{},
+			},
+		},
 		"snowball": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
@@ -27639,21 +28119,43 @@ var awsusgovPartition = partition{
 		"sns": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
-					Region: "us-gov-east-1",
+					Region: "fips-us-gov-east-1",
 				}: endpoint{
 					Hostname: "sns.us-gov-east-1.amazonaws.com",
 					CredentialScope: credentialScope{
 						Region: "us-gov-east-1",
 					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "fips-us-gov-west-1",
+				}: endpoint{
+					Hostname: "sns.us-gov-west-1.amazonaws.com",
+					CredentialScope: credentialScope{
+						Region: "us-gov-west-1",
+					},
+					Deprecated: boxedTrue,
+				},
+				endpointKey{
+					Region: "us-gov-east-1",
+				}: endpoint{},
+				endpointKey{
+					Region:  "us-gov-east-1",
+					Variant: fipsVariant,
+				}: endpoint{
+					Hostname: "sns.us-gov-east-1.amazonaws.com",
 				},
 				endpointKey{
 					Region: "us-gov-west-1",
 				}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+				endpointKey{
+					Region:  "us-gov-west-1",
+					Variant: fipsVariant,
+				}: endpoint{
 					Hostname:  "sns.us-gov-west-1.amazonaws.com",
 					Protocols: []string{"http", "https"},
-					CredentialScope: credentialScope{
-						Region: "us-gov-west-1",
-					},
 				},
 			},
 		},
@@ -28576,6 +29078,18 @@ var awsisoPartition = partition{
 				}: endpoint{},
 			},
 		},
+		"eks": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+			},
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+			},
+		},
 		"elasticache": service{
 			Endpoints: serviceEndpoints{
 				endpointKey{
@@ -28988,6 +29502,13 @@ var awsisoPartition = partition{
 				}: endpoint{},
 			},
 		},
+		"tagging": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-iso-east-1",
+				}: endpoint{},
+			},
+		},
 		"transcribe": service{
 			Defaults: endpointDefaults{
 				defaultKey{}: endpoint{
@@ -29232,6 +29753,18 @@ var awsisobPartition = partition{
 			},
 		},
 		"ecs": service{
+			Endpoints: serviceEndpoints{
+				endpointKey{
+					Region: "us-isob-east-1",
+				}: endpoint{},
+			},
+		},
+		"eks": service{
+			Defaults: endpointDefaults{
+				defaultKey{}: endpoint{
+					Protocols: []string{"http", "https"},
+				},
+			},
 			Endpoints: serviceEndpoints{
 				endpointKey{
 					Region: "us-isob-east-1",

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
@@ -15,8 +15,8 @@ import (
 // and determine if a request API error should be retried.
 //
 // client.DefaultRetryer is the SDK's default implementation of the Retryer. It
-// uses the which uses the Request.IsErrorRetryable and Request.IsErrorThrottle
-// methods to determine if the request is retried.
+// uses the Request.IsErrorRetryable and Request.IsErrorThrottle methods to
+// determine if the request is retried.
 type Retryer interface {
 	// RetryRules return the retry delay that should be used by the SDK before
 	// making another request attempt for the failed request.

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.43.11"
+const SDKVersion = "1.43.41"

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/transport.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi/transport.go
@@ -5,6 +5,6 @@ package eventstreamapi
 
 import "github.com/aws/aws-sdk-go/aws/request"
 
-// This is a no-op for Go 1.18 and above.
+// ApplyHTTPTransportFixes is a no-op for Go 1.18 and above.
 func ApplyHTTPTransportFixes(r *request.Request) {
 }

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/build.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/build.go
@@ -276,6 +276,25 @@ func convertType(v reflect.Value, tag reflect.StructTag) (str string, err error)
 			value = base64.StdEncoding.EncodeToString([]byte(value))
 		}
 		str = value
+	case []*string:
+		if tag.Get("location") != "header" || tag.Get("enum") == "" {
+			return "", fmt.Errorf("%T is only supported with location header and enum shapes", value)
+		}
+		buff := &bytes.Buffer{}
+		for i, sv := range value {
+			if sv == nil || len(*sv) == 0 {
+				continue
+			}
+			if i != 0 {
+				buff.WriteRune(',')
+			}
+			item := *sv
+			if strings.Index(item, `,`) != -1 || strings.Index(item, `"`) != -1 {
+				item = strconv.Quote(item)
+			}
+			buff.WriteString(item)
+		}
+		str = string(buff.Bytes())
 	case []byte:
 		str = base64.StdEncoding.EncodeToString(value)
 	case bool:

--- a/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
@@ -13446,7 +13446,7 @@ type InstanceRequirements struct {
 	//    * For instance types with Xilinx devices, specify xilinx.
 	//
 	// Default: Any manufacturer
-	AcceleratorManufacturers []*string `type:"list"`
+	AcceleratorManufacturers []*string `type:"list" enum:"AcceleratorManufacturer"`
 
 	// Lists the accelerators that must be on an instance type.
 	//
@@ -13465,7 +13465,7 @@ type InstanceRequirements struct {
 	//    * For instance types with Xilinx VU9P FPGAs, specify vu9p.
 	//
 	// Default: Any accelerator
-	AcceleratorNames []*string `type:"list"`
+	AcceleratorNames []*string `type:"list" enum:"AcceleratorName"`
 
 	// The minimum and maximum total memory size for the accelerators on an instance
 	// type, in MiB.
@@ -13482,7 +13482,7 @@ type InstanceRequirements struct {
 	//    * For instance types with inference accelerators, specify inference.
 	//
 	// Default: Any accelerator type
-	AcceleratorTypes []*string `type:"list"`
+	AcceleratorTypes []*string `type:"list" enum:"AcceleratorType"`
 
 	// Indicates whether bare metal instance types are included, excluded, or required.
 	//
@@ -13516,7 +13516,7 @@ type InstanceRequirements struct {
 	// Amazon Machine Image (AMI) that you specify in your launch template.
 	//
 	// Default: Any manufacturer
-	CpuManufacturers []*string `type:"list"`
+	CpuManufacturers []*string `type:"list" enum:"CpuManufacturer"`
 
 	// Lists which instance types to exclude. You can use strings with one or more
 	// wild cards, represented by an asterisk (*). The following are examples: c5*,
@@ -13540,7 +13540,7 @@ type InstanceRequirements struct {
 	//    * For previous generation instance types, specify previous.
 	//
 	// Default: Any current or previous generation
-	InstanceGenerations []*string `type:"list"`
+	InstanceGenerations []*string `type:"list" enum:"InstanceGeneration"`
 
 	// Indicates whether instance types with instance store volumes are included,
 	// excluded, or required. For more information, see Amazon EC2 instance store
@@ -13557,7 +13557,7 @@ type InstanceRequirements struct {
 	//    * For instance types with solid state drive (SSD) storage, specify sdd.
 	//
 	// Default: Any local storage type
-	LocalStorageTypes []*string `type:"list"`
+	LocalStorageTypes []*string `type:"list" enum:"LocalStorageType"`
 
 	// The minimum and maximum amount of memory per vCPU for an instance type, in
 	// GiB.

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudformation/api.go
@@ -7959,7 +7959,7 @@ type CreateChangeSetInput struct {
 	//    action, and specifying this capability. For more information on macros,
 	//    see Using CloudFormation macros to perform custom processing on templates
 	//    (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// The name of the change set. The name must be unique among all change sets
 	// that are associated with the specified stack.
@@ -8343,7 +8343,7 @@ type CreateStackInput struct {
 	//    Be aware that the Lambda function owner can update the function operation
 	//    without CloudFormation being notified. For more information, see Using
 	//    CloudFormation macros to perform custom processing on templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// A unique identifier for this CreateStack request. Specify this token if you
 	// plan to retry requests so that CloudFormation knows that you're not attempting
@@ -8972,7 +8972,7 @@ type CreateStackSetInput struct {
 	//    transforms, which are macros hosted by CloudFormation.) Even if you specify
 	//    this capability for a stack set with service-managed permissions, if you
 	//    reference a macro in your template the stack set operation will fail.
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// A unique identifier for this CreateStackSet request. Specify this token if
 	// you plan to retry requests so that CloudFormation knows that you're not attempting
@@ -10346,7 +10346,7 @@ type DescribeChangeSetOutput struct {
 
 	// If you execute the change set, the list of capabilities that were explicitly
 	// acknowledged when the change set was created.
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// The Amazon Resource Name (ARN) of the change set.
 	ChangeSetId *string `min:"1" type:"string"`
@@ -11100,7 +11100,7 @@ type DescribeStackResourceDriftsInput struct {
 	//    configuration.
 	//
 	//    * NOT_CHECKED: CloudFormation doesn't currently return this value.
-	StackResourceDriftStatusFilters []*string `min:"1" type:"list"`
+	StackResourceDriftStatusFilters []*string `min:"1" type:"list" enum:"StackResourceDriftStatus"`
 }
 
 // String returns the string representation.
@@ -13147,7 +13147,7 @@ type GetTemplateOutput struct {
 	// and Processed templates are always available. For change sets, the Original
 	// template is always available. After CloudFormation finishes creating the
 	// change set, the Processed template becomes available.
-	StagesAvailable []*string `type:"list"`
+	StagesAvailable []*string `type:"list" enum:"TemplateStage"`
 
 	// Structure containing the template body. (For more information, go to Template
 	// Anatomy (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html)
@@ -13322,7 +13322,7 @@ type GetTemplateSummaryOutput struct {
 	//
 	// For more information, see Acknowledging IAM Resources in CloudFormation Templates
 	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// The list of resources that generated the values in the Capabilities response
 	// element.
@@ -14626,7 +14626,7 @@ type ListStacksInput struct {
 	// Stack status to use as a filter. Specify one or more stack status codes to
 	// list only stacks with the specified status codes. For a complete list of
 	// stack status codes, see the StackStatus parameter of the Stack data type.
-	StackStatusFilter []*string `type:"list"`
+	StackStatusFilter []*string `type:"list" enum:"StackStatus"`
 }
 
 // String returns the string representation.
@@ -16463,7 +16463,7 @@ type ResourceChange struct {
 	// For the Modify action, indicates which resource attribute is triggering this
 	// update, such as a change in the resource attribute's Metadata, Properties,
 	// or Tags.
-	Scope []*string `type:"list"`
+	Scope []*string `type:"list" enum:"ResourceAttribute"`
 }
 
 // String returns the string representation.
@@ -17598,7 +17598,7 @@ type Stack struct {
 	_ struct{} `type:"structure"`
 
 	// The capabilities allowed in the stack.
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// The unique ID of the change set.
 	ChangeSetId *string `min:"1" type:"string"`
@@ -19290,7 +19290,7 @@ type StackSet struct {
 	// account—for example, by creating new Identity and Access Management (IAM)
 	// users. For more information, see Acknowledging IAM Resources in CloudFormation
 	// Templates. (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities)
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// A description of the stack set that you specify when the stack set is created
 	// or updated.
@@ -21423,7 +21423,7 @@ type UpdateStackInput struct {
 	//    Be aware that the Lambda function owner can update the function operation
 	//    without CloudFormation being notified. For more information, see Using
 	//    CloudFormation Macros to Perform Custom Processing on Templates (http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html).
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// A unique identifier for this UpdateStack request. Specify this token if you
 	// plan to retry requests so that CloudFormation knows that you're not attempting
@@ -22083,7 +22083,7 @@ type UpdateStackSetInput struct {
 	//    transforms, which are macros hosted by CloudFormation.) Even if you specify
 	//    this capability for a stack set with service-managed permissions, if you
 	//    reference a macro in your template the stack set operation will fail.
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// [Service-managed permissions] The Organizations accounts in which to update
 	// associated stack instances.
@@ -22620,7 +22620,7 @@ type ValidateTemplateOutput struct {
 	//
 	// For more information, see Acknowledging IAM Resources in CloudFormation Templates
 	// (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#capabilities).
-	Capabilities []*string `type:"list"`
+	Capabilities []*string `type:"list" enum:"Capability"`
 
 	// The list of resources that generated the values in the Capabilities response
 	// element.

--- a/vendor/github.com/aws/aws-sdk-go/service/ec2/ec2iface/interface.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ec2/ec2iface/interface.go
@@ -2088,6 +2088,10 @@ type EC2API interface {
 	ModifyInstanceEventWindowWithContext(aws.Context, *ec2.ModifyInstanceEventWindowInput, ...request.Option) (*ec2.ModifyInstanceEventWindowOutput, error)
 	ModifyInstanceEventWindowRequest(*ec2.ModifyInstanceEventWindowInput) (*request.Request, *ec2.ModifyInstanceEventWindowOutput)
 
+	ModifyInstanceMaintenanceOptions(*ec2.ModifyInstanceMaintenanceOptionsInput) (*ec2.ModifyInstanceMaintenanceOptionsOutput, error)
+	ModifyInstanceMaintenanceOptionsWithContext(aws.Context, *ec2.ModifyInstanceMaintenanceOptionsInput, ...request.Option) (*ec2.ModifyInstanceMaintenanceOptionsOutput, error)
+	ModifyInstanceMaintenanceOptionsRequest(*ec2.ModifyInstanceMaintenanceOptionsInput) (*request.Request, *ec2.ModifyInstanceMaintenanceOptionsOutput)
+
 	ModifyInstanceMetadataOptions(*ec2.ModifyInstanceMetadataOptionsInput) (*ec2.ModifyInstanceMetadataOptionsOutput, error)
 	ModifyInstanceMetadataOptionsWithContext(aws.Context, *ec2.ModifyInstanceMetadataOptionsInput, ...request.Option) (*ec2.ModifyInstanceMetadataOptionsOutput, error)
 	ModifyInstanceMetadataOptionsRequest(*ec2.ModifyInstanceMetadataOptionsInput) (*request.Request, *ec2.ModifyInstanceMetadataOptionsOutput)

--- a/vendor/github.com/aws/aws-sdk-go/service/eventbridge/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/eventbridge/api.go
@@ -472,6 +472,97 @@ func (c *EventBridge) CreateConnectionWithContext(ctx aws.Context, input *Create
 	return out, req.Send()
 }
 
+const opCreateEndpoint = "CreateEndpoint"
+
+// CreateEndpointRequest generates a "aws/request.Request" representing the
+// client's request for the CreateEndpoint operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See CreateEndpoint for more information on using the CreateEndpoint
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the CreateEndpointRequest method.
+//    req, resp := client.CreateEndpointRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/CreateEndpoint
+func (c *EventBridge) CreateEndpointRequest(input *CreateEndpointInput) (req *request.Request, output *CreateEndpointOutput) {
+	op := &request.Operation{
+		Name:       opCreateEndpoint,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &CreateEndpointInput{}
+	}
+
+	output = &CreateEndpointOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// CreateEndpoint API operation for Amazon EventBridge.
+//
+// Creates a global endpoint. Global endpoints improve your application's availability
+// by making it regional-fault tolerant. To do this, you define a primary and
+// secondary Region with event buses in each Region. You also create a Amazon
+// Route 53 health check that will tell EventBridge to route events to the secondary
+// Region when an "unhealthy" state is encountered and events will be routed
+// back to the primary Region when the health check reports a "healthy" state.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EventBridge's
+// API operation CreateEndpoint for usage and error information.
+//
+// Returned Error Types:
+//   * ResourceAlreadyExistsException
+//   The resource you are trying to create already exists.
+//
+//   * LimitExceededException
+//   The request failed because it attempted to create resource beyond the allowed
+//   service quota.
+//
+//   * InternalException
+//   This exception occurs due to unexpected causes.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/CreateEndpoint
+func (c *EventBridge) CreateEndpoint(input *CreateEndpointInput) (*CreateEndpointOutput, error) {
+	req, out := c.CreateEndpointRequest(input)
+	return out, req.Send()
+}
+
+// CreateEndpointWithContext is the same as CreateEndpoint with the addition of
+// the ability to pass a context and additional request options.
+//
+// See CreateEndpoint for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EventBridge) CreateEndpointWithContext(ctx aws.Context, input *CreateEndpointInput, opts ...request.Option) (*CreateEndpointOutput, error) {
+	req, out := c.CreateEndpointRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opCreateEventBus = "CreateEventBus"
 
 // CreateEventBusRequest generates a "aws/request.Request" representing the
@@ -1133,6 +1224,95 @@ func (c *EventBridge) DeleteConnectionWithContext(ctx aws.Context, input *Delete
 	return out, req.Send()
 }
 
+const opDeleteEndpoint = "DeleteEndpoint"
+
+// DeleteEndpointRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteEndpoint operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DeleteEndpoint for more information on using the DeleteEndpoint
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DeleteEndpointRequest method.
+//    req, resp := client.DeleteEndpointRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/DeleteEndpoint
+func (c *EventBridge) DeleteEndpointRequest(input *DeleteEndpointInput) (req *request.Request, output *DeleteEndpointOutput) {
+	op := &request.Operation{
+		Name:       opDeleteEndpoint,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DeleteEndpointInput{}
+	}
+
+	output = &DeleteEndpointOutput{}
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Swap(jsonrpc.UnmarshalHandler.Name, protocol.UnmarshalDiscardBodyHandler)
+	return
+}
+
+// DeleteEndpoint API operation for Amazon EventBridge.
+//
+// Delete an existing global endpoint. For more information about global endpoints,
+// see Making applications Regional-fault tolerant with global endpoints and
+// event replication (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-global-endpoints.html)
+// in the Amazon EventBridge User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EventBridge's
+// API operation DeleteEndpoint for usage and error information.
+//
+// Returned Error Types:
+//   * ConcurrentModificationException
+//   There is concurrent modification on a rule, target, archive, or replay.
+//
+//   * ResourceNotFoundException
+//   An entity that you specified does not exist.
+//
+//   * InternalException
+//   This exception occurs due to unexpected causes.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/DeleteEndpoint
+func (c *EventBridge) DeleteEndpoint(input *DeleteEndpointInput) (*DeleteEndpointOutput, error) {
+	req, out := c.DeleteEndpointRequest(input)
+	return out, req.Send()
+}
+
+// DeleteEndpointWithContext is the same as DeleteEndpoint with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DeleteEndpoint for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EventBridge) DeleteEndpointWithContext(ctx aws.Context, input *DeleteEndpointInput, opts ...request.Option) (*DeleteEndpointOutput, error) {
+	req, out := c.DeleteEndpointRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDeleteEventBus = "DeleteEventBus"
 
 // DeleteEventBusRequest generates a "aws/request.Request" representing the
@@ -1662,6 +1842,91 @@ func (c *EventBridge) DescribeConnection(input *DescribeConnectionInput) (*Descr
 // for more information on using Contexts.
 func (c *EventBridge) DescribeConnectionWithContext(ctx aws.Context, input *DescribeConnectionInput, opts ...request.Option) (*DescribeConnectionOutput, error) {
 	req, out := c.DescribeConnectionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeEndpoint = "DescribeEndpoint"
+
+// DescribeEndpointRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeEndpoint operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See DescribeEndpoint for more information on using the DescribeEndpoint
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the DescribeEndpointRequest method.
+//    req, resp := client.DescribeEndpointRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/DescribeEndpoint
+func (c *EventBridge) DescribeEndpointRequest(input *DescribeEndpointInput) (req *request.Request, output *DescribeEndpointOutput) {
+	op := &request.Operation{
+		Name:       opDescribeEndpoint,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeEndpointInput{}
+	}
+
+	output = &DescribeEndpointOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeEndpoint API operation for Amazon EventBridge.
+//
+// Get the information about an existing global endpoint. For more information
+// about global endpoints, see Making applications Regional-fault tolerant with
+// global endpoints and event replication (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-global-endpoints.html)
+// in the Amazon EventBridge User Guide..
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EventBridge's
+// API operation DescribeEndpoint for usage and error information.
+//
+// Returned Error Types:
+//   * ResourceNotFoundException
+//   An entity that you specified does not exist.
+//
+//   * InternalException
+//   This exception occurs due to unexpected causes.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/DescribeEndpoint
+func (c *EventBridge) DescribeEndpoint(input *DescribeEndpointInput) (*DescribeEndpointOutput, error) {
+	req, out := c.DescribeEndpointRequest(input)
+	return out, req.Send()
+}
+
+// DescribeEndpointWithContext is the same as DescribeEndpoint with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeEndpoint for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EventBridge) DescribeEndpointWithContext(ctx aws.Context, input *DescribeEndpointInput, opts ...request.Option) (*DescribeEndpointOutput, error) {
+	req, out := c.DescribeEndpointRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -2545,6 +2810,88 @@ func (c *EventBridge) ListConnectionsWithContext(ctx aws.Context, input *ListCon
 	return out, req.Send()
 }
 
+const opListEndpoints = "ListEndpoints"
+
+// ListEndpointsRequest generates a "aws/request.Request" representing the
+// client's request for the ListEndpoints operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See ListEndpoints for more information on using the ListEndpoints
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the ListEndpointsRequest method.
+//    req, resp := client.ListEndpointsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/ListEndpoints
+func (c *EventBridge) ListEndpointsRequest(input *ListEndpointsInput) (req *request.Request, output *ListEndpointsOutput) {
+	op := &request.Operation{
+		Name:       opListEndpoints,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &ListEndpointsInput{}
+	}
+
+	output = &ListEndpointsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// ListEndpoints API operation for Amazon EventBridge.
+//
+// List the global endpoints associated with this account. For more information
+// about global endpoints, see Making applications Regional-fault tolerant with
+// global endpoints and event replication (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-global-endpoints.html)
+// in the Amazon EventBridge User Guide..
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EventBridge's
+// API operation ListEndpoints for usage and error information.
+//
+// Returned Error Types:
+//   * InternalException
+//   This exception occurs due to unexpected causes.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/ListEndpoints
+func (c *EventBridge) ListEndpoints(input *ListEndpointsInput) (*ListEndpointsOutput, error) {
+	req, out := c.ListEndpointsRequest(input)
+	return out, req.Send()
+}
+
+// ListEndpointsWithContext is the same as ListEndpoints with the addition of
+// the ability to pass a context and additional request options.
+//
+// See ListEndpoints for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EventBridge) ListEndpointsWithContext(ctx aws.Context, input *ListEndpointsInput, opts ...request.Option) (*ListEndpointsOutput, error) {
+	req, out := c.ListEndpointsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opListEventBuses = "ListEventBuses"
 
 // ListEventBusesRequest generates a "aws/request.Request" representing the
@@ -3341,6 +3688,10 @@ func (c *EventBridge) PutEventsRequest(input *PutEventsInput) (req *request.Requ
 // Sends custom events to Amazon EventBridge so that they can be matched to
 // rules.
 //
+// PutEvents will only process nested JSON up to 1100 levels deep.
+//
+// This AWS SDK does not support calling multi-region endpoints with SigV4a authentication.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -3779,55 +4130,59 @@ func (c *EventBridge) PutTargetsRequest(input *PutTargetsInput) (req *request.Re
 //
 //    * API destination (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html)
 //
-//    * Amazon API Gateway REST API endpoints
-//
-//    * API Gateway
+//    * API Gateway (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-gateway-target.html)
 //
 //    * Batch job queue
 //
-//    * CloudWatch Logs group
+//    * CloudWatch group
 //
 //    * CodeBuild project
 //
 //    * CodePipeline
 //
-//    * Amazon EC2 CreateSnapshot API call
+//    * EC2 CreateSnapshot API call
 //
 //    * EC2 Image Builder
 //
-//    * Amazon EC2 RebootInstances API call
+//    * EC2 RebootInstances API call
 //
-//    * Amazon EC2 StopInstances API call
+//    * EC2 StopInstances API call
 //
-//    * Amazon EC2 TerminateInstances API call
+//    * EC2 TerminateInstances API call
 //
-//    * Amazon ECS tasks
+//    * ECS task
 //
-//    * Event bus in a different Amazon Web Services account or Region. You
-//    can use an event bus in the US East (N. Virginia) us-east-1, US West (Oregon)
-//    us-west-2, or Europe (Ireland) eu-west-1 Regions as a target for a rule.
+//    * Event bus in a different account or Region (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cross-account.html)
 //
-//    * Firehose delivery stream (Kinesis Data Firehose)
+//    * Event bus in the same account and Region (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-bus-to-bus.html)
 //
-//    * Inspector assessment template (Amazon Inspector)
+//    * Firehose delivery stream
 //
-//    * Kinesis stream (Kinesis Data Stream)
+//    * Glue workflow
+//
+//    * Incident Manager response plan (https://docs.aws.amazon.com/incident-manager/latest/userguide/incident-creation.html#incident-tracking-auto-eventbridge)
+//
+//    * Inspector assessment template
+//
+//    * Kinesis stream
 //
 //    * Lambda function
 //
-//    * Redshift clusters (Data API statement execution)
+//    * Redshift cluster
 //
-//    * Amazon SNS topic
+//    * SageMaker Pipeline
 //
-//    * Amazon SQS queues (includes FIFO queues)
+//    * SNS topic
 //
-//    * SSM Automation
+//    * SQS queue
 //
-//    * SSM OpsItem
+//    * Step Functions state machine
 //
-//    * SSM Run Command
+//    * Systems Manager Automation
 //
-//    * Step Functions state machines
+//    * Systems Manager OpsItem
+//
+//    * Systems Manager Run Command
 //
 // Creating rules with built-in targets is supported only in the Amazon Web
 // Services Management Console. The built-in targets are EC2 CreateSnapshot
@@ -4810,6 +5165,94 @@ func (c *EventBridge) UpdateConnection(input *UpdateConnectionInput) (*UpdateCon
 // for more information on using Contexts.
 func (c *EventBridge) UpdateConnectionWithContext(ctx aws.Context, input *UpdateConnectionInput, opts ...request.Option) (*UpdateConnectionOutput, error) {
 	req, out := c.UpdateConnectionRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opUpdateEndpoint = "UpdateEndpoint"
+
+// UpdateEndpointRequest generates a "aws/request.Request" representing the
+// client's request for the UpdateEndpoint operation. The "output" return
+// value will be populated with the request's response once the request completes
+// successfully.
+//
+// Use "Send" method on the returned Request to send the API call to the service.
+// the "output" return value is not valid until after Send returns without error.
+//
+// See UpdateEndpoint for more information on using the UpdateEndpoint
+// API call, and error handling.
+//
+// This method is useful when you want to inject custom logic or configuration
+// into the SDK's request lifecycle. Such as custom headers, or retry logic.
+//
+//
+//    // Example sending a request using the UpdateEndpointRequest method.
+//    req, resp := client.UpdateEndpointRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/UpdateEndpoint
+func (c *EventBridge) UpdateEndpointRequest(input *UpdateEndpointInput) (req *request.Request, output *UpdateEndpointOutput) {
+	op := &request.Operation{
+		Name:       opUpdateEndpoint,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &UpdateEndpointInput{}
+	}
+
+	output = &UpdateEndpointOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// UpdateEndpoint API operation for Amazon EventBridge.
+//
+// Update an existing endpoint. For more information about global endpoints,
+// see Making applications Regional-fault tolerant with global endpoints and
+// event replication (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-global-endpoints.html)
+// in the Amazon EventBridge User Guide..
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon EventBridge's
+// API operation UpdateEndpoint for usage and error information.
+//
+// Returned Error Types:
+//   * ResourceNotFoundException
+//   An entity that you specified does not exist.
+//
+//   * ConcurrentModificationException
+//   There is concurrent modification on a rule, target, archive, or replay.
+//
+//   * InternalException
+//   This exception occurs due to unexpected causes.
+//
+// See also, https://docs.aws.amazon.com/goto/WebAPI/eventbridge-2015-10-07/UpdateEndpoint
+func (c *EventBridge) UpdateEndpoint(input *UpdateEndpointInput) (*UpdateEndpointOutput, error) {
+	req, out := c.UpdateEndpointRequest(input)
+	return out, req.Send()
+}
+
+// UpdateEndpointWithContext is the same as UpdateEndpoint with the addition of
+// the ability to pass a context and additional request options.
+//
+// See UpdateEndpoint for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *EventBridge) UpdateEndpointWithContext(ctx aws.Context, input *UpdateEndpointInput, opts ...request.Option) (*UpdateEndpointOutput, error) {
+	req, out := c.UpdateEndpointRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -7024,6 +7467,218 @@ func (s *CreateConnectionOutput) SetLastModifiedTime(v time.Time) *CreateConnect
 	return s
 }
 
+type CreateEndpointInput struct {
+	_ struct{} `type:"structure"`
+
+	// A description of the global endpoint.
+	Description *string `type:"string"`
+
+	// Define the event buses used.
+	//
+	// The names of the event buses must be identical in each Region.
+	//
+	// EventBuses is a required field
+	EventBuses []*EndpointEventBus `min:"2" type:"list" required:"true"`
+
+	// The name of the global endpoint. For example, "Name":"us-east-2-custom_bus_A-endpoint".
+	//
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`
+
+	// Enable or disable event replication.
+	ReplicationConfig *ReplicationConfig `type:"structure"`
+
+	// The ARN of the role used for replication.
+	RoleArn *string `min:"1" type:"string"`
+
+	// Configure the routing policy, including the health check and secondary Region..
+	//
+	// RoutingConfig is a required field
+	RoutingConfig *RoutingConfig `type:"structure" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s CreateEndpointInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s CreateEndpointInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *CreateEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "CreateEndpointInput"}
+	if s.EventBuses == nil {
+		invalidParams.Add(request.NewErrParamRequired("EventBuses"))
+	}
+	if s.EventBuses != nil && len(s.EventBuses) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("EventBuses", 2))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 1))
+	}
+	if s.RoutingConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("RoutingConfig"))
+	}
+	if s.EventBuses != nil {
+		for i, v := range s.EventBuses {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "EventBuses", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.RoutingConfig != nil {
+		if err := s.RoutingConfig.Validate(); err != nil {
+			invalidParams.AddNested("RoutingConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDescription sets the Description field's value.
+func (s *CreateEndpointInput) SetDescription(v string) *CreateEndpointInput {
+	s.Description = &v
+	return s
+}
+
+// SetEventBuses sets the EventBuses field's value.
+func (s *CreateEndpointInput) SetEventBuses(v []*EndpointEventBus) *CreateEndpointInput {
+	s.EventBuses = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateEndpointInput) SetName(v string) *CreateEndpointInput {
+	s.Name = &v
+	return s
+}
+
+// SetReplicationConfig sets the ReplicationConfig field's value.
+func (s *CreateEndpointInput) SetReplicationConfig(v *ReplicationConfig) *CreateEndpointInput {
+	s.ReplicationConfig = v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *CreateEndpointInput) SetRoleArn(v string) *CreateEndpointInput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRoutingConfig sets the RoutingConfig field's value.
+func (s *CreateEndpointInput) SetRoutingConfig(v *RoutingConfig) *CreateEndpointInput {
+	s.RoutingConfig = v
+	return s
+}
+
+type CreateEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the endpoint that was created by this request.
+	Arn *string `min:"1" type:"string"`
+
+	// The event buses used by this request.
+	EventBuses []*EndpointEventBus `min:"2" type:"list"`
+
+	// The name of the endpoint that was created by this request.
+	Name *string `min:"1" type:"string"`
+
+	// Whether event replication was enabled or disabled by this request.
+	ReplicationConfig *ReplicationConfig `type:"structure"`
+
+	// The ARN of the role used by event replication for this request.
+	RoleArn *string `min:"1" type:"string"`
+
+	// The routing configuration defined by this request.
+	RoutingConfig *RoutingConfig `type:"structure"`
+
+	// The state of the endpoint that was created by this request.
+	State *string `type:"string" enum:"EndpointState"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s CreateEndpointOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s CreateEndpointOutput) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *CreateEndpointOutput) SetArn(v string) *CreateEndpointOutput {
+	s.Arn = &v
+	return s
+}
+
+// SetEventBuses sets the EventBuses field's value.
+func (s *CreateEndpointOutput) SetEventBuses(v []*EndpointEventBus) *CreateEndpointOutput {
+	s.EventBuses = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *CreateEndpointOutput) SetName(v string) *CreateEndpointOutput {
+	s.Name = &v
+	return s
+}
+
+// SetReplicationConfig sets the ReplicationConfig field's value.
+func (s *CreateEndpointOutput) SetReplicationConfig(v *ReplicationConfig) *CreateEndpointOutput {
+	s.ReplicationConfig = v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *CreateEndpointOutput) SetRoleArn(v string) *CreateEndpointOutput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRoutingConfig sets the RoutingConfig field's value.
+func (s *CreateEndpointOutput) SetRoutingConfig(v *RoutingConfig) *CreateEndpointOutput {
+	s.RoutingConfig = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *CreateEndpointOutput) SetState(v string) *CreateEndpointOutput {
+	s.State = &v
+	return s
+}
+
 type CreateEventBusInput struct {
 	_ struct{} `type:"structure"`
 
@@ -7735,6 +8390,77 @@ func (s *DeleteConnectionOutput) SetLastAuthorizedTime(v time.Time) *DeleteConne
 func (s *DeleteConnectionOutput) SetLastModifiedTime(v time.Time) *DeleteConnectionOutput {
 	s.LastModifiedTime = &v
 	return s
+}
+
+type DeleteEndpointInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the endpoint you want to delete. For example, "Name":"us-east-2-custom_bus_A-endpoint"..
+	//
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DeleteEndpointInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DeleteEndpointInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteEndpointInput"}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetName sets the Name field's value.
+func (s *DeleteEndpointInput) SetName(v string) *DeleteEndpointInput {
+	s.Name = &v
+	return s
+}
+
+type DeleteEndpointOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DeleteEndpointOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DeleteEndpointOutput) GoString() string {
+	return s.String()
 }
 
 type DeleteEventBusInput struct {
@@ -8498,6 +9224,210 @@ func (s *DescribeConnectionOutput) SetSecretArn(v string) *DescribeConnectionOut
 
 // SetStateReason sets the StateReason field's value.
 func (s *DescribeConnectionOutput) SetStateReason(v string) *DescribeConnectionOutput {
+	s.StateReason = &v
+	return s
+}
+
+type DescribeEndpointInput struct {
+	_ struct{} `type:"structure"`
+
+	// The primary Region of the endpoint you want to get information about. For
+	// example "HomeRegion": "us-east-1".
+	HomeRegion *string `min:"9" type:"string"`
+
+	// The name of the endpoint you want to get information about. For example,
+	// "Name":"us-east-2-custom_bus_A-endpoint".
+	//
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DescribeEndpointInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DescribeEndpointInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeEndpointInput"}
+	if s.HomeRegion != nil && len(*s.HomeRegion) < 9 {
+		invalidParams.Add(request.NewErrParamMinLen("HomeRegion", 9))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetHomeRegion sets the HomeRegion field's value.
+func (s *DescribeEndpointInput) SetHomeRegion(v string) *DescribeEndpointInput {
+	s.HomeRegion = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DescribeEndpointInput) SetName(v string) *DescribeEndpointInput {
+	s.Name = &v
+	return s
+}
+
+type DescribeEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the endpoint you asked for information about.
+	Arn *string `min:"1" type:"string"`
+
+	// The time the endpoint you asked for information about was created.
+	CreationTime *time.Time `type:"timestamp"`
+
+	// The description of the endpoint you asked for information about.
+	Description *string `type:"string"`
+
+	// The ID of the endpoint you asked for information about.
+	EndpointId *string `min:"1" type:"string"`
+
+	// The URL of the endpoint you asked for information about.
+	EndpointUrl *string `min:"1" type:"string"`
+
+	// The event buses being used by the endpoint you asked for information about.
+	EventBuses []*EndpointEventBus `min:"2" type:"list"`
+
+	// The last time the endpoint you asked for information about was modified.
+	LastModifiedTime *time.Time `type:"timestamp"`
+
+	// The name of the endpoint you asked for information about.
+	Name *string `min:"1" type:"string"`
+
+	// Whether replication is enabled or disabled for the endpoint you asked for
+	// information about.
+	ReplicationConfig *ReplicationConfig `type:"structure"`
+
+	// The ARN of the role used by the endpoint you asked for information about.
+	RoleArn *string `min:"1" type:"string"`
+
+	// The routing configuration of the endpoint you asked for information about.
+	RoutingConfig *RoutingConfig `type:"structure"`
+
+	// The current state of the endpoint you asked for information about.
+	State *string `type:"string" enum:"EndpointState"`
+
+	// The reason the endpoint you asked for information about is in its current
+	// state.
+	StateReason *string `min:"1" type:"string"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DescribeEndpointOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s DescribeEndpointOutput) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *DescribeEndpointOutput) SetArn(v string) *DescribeEndpointOutput {
+	s.Arn = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *DescribeEndpointOutput) SetCreationTime(v time.Time) *DescribeEndpointOutput {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *DescribeEndpointOutput) SetDescription(v string) *DescribeEndpointOutput {
+	s.Description = &v
+	return s
+}
+
+// SetEndpointId sets the EndpointId field's value.
+func (s *DescribeEndpointOutput) SetEndpointId(v string) *DescribeEndpointOutput {
+	s.EndpointId = &v
+	return s
+}
+
+// SetEndpointUrl sets the EndpointUrl field's value.
+func (s *DescribeEndpointOutput) SetEndpointUrl(v string) *DescribeEndpointOutput {
+	s.EndpointUrl = &v
+	return s
+}
+
+// SetEventBuses sets the EventBuses field's value.
+func (s *DescribeEndpointOutput) SetEventBuses(v []*EndpointEventBus) *DescribeEndpointOutput {
+	s.EventBuses = v
+	return s
+}
+
+// SetLastModifiedTime sets the LastModifiedTime field's value.
+func (s *DescribeEndpointOutput) SetLastModifiedTime(v time.Time) *DescribeEndpointOutput {
+	s.LastModifiedTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *DescribeEndpointOutput) SetName(v string) *DescribeEndpointOutput {
+	s.Name = &v
+	return s
+}
+
+// SetReplicationConfig sets the ReplicationConfig field's value.
+func (s *DescribeEndpointOutput) SetReplicationConfig(v *ReplicationConfig) *DescribeEndpointOutput {
+	s.ReplicationConfig = v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *DescribeEndpointOutput) SetRoleArn(v string) *DescribeEndpointOutput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRoutingConfig sets the RoutingConfig field's value.
+func (s *DescribeEndpointOutput) SetRoutingConfig(v *RoutingConfig) *DescribeEndpointOutput {
+	s.RoutingConfig = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *DescribeEndpointOutput) SetState(v string) *DescribeEndpointOutput {
+	s.State = &v
+	return s
+}
+
+// SetStateReason sets the StateReason field's value.
+func (s *DescribeEndpointOutput) SetStateReason(v string) *DescribeEndpointOutput {
 	s.StateReason = &v
 	return s
 }
@@ -9574,6 +10504,201 @@ func (s EnableRuleOutput) GoString() string {
 	return s.String()
 }
 
+// An global endpoint used to improve your application's availability by making
+// it regional-fault tolerant. For more information about global endpoints,
+// see Making applications Regional-fault tolerant with global endpoints and
+// event replication (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-global-endpoints.html)
+// in the Amazon EventBridge User Guide..
+type Endpoint struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the endpoint.
+	Arn *string `min:"1" type:"string"`
+
+	// The time the endpoint was created.
+	CreationTime *time.Time `type:"timestamp"`
+
+	// A description for the endpoint.
+	Description *string `type:"string"`
+
+	// The URL subdomain of the endpoint. For example, if the URL for Endpoint is
+	// abcde.veo.endpoints.event.amazonaws.com, then the EndpointId is abcde.veo.
+	EndpointId *string `min:"1" type:"string"`
+
+	// The URL of the endpoint.
+	EndpointUrl *string `min:"1" type:"string"`
+
+	// The event buses being used by the endpoint.
+	EventBuses []*EndpointEventBus `min:"2" type:"list"`
+
+	// The last time the endpoint was modified.
+	LastModifiedTime *time.Time `type:"timestamp"`
+
+	// The name of the endpoint.
+	Name *string `min:"1" type:"string"`
+
+	// Whether event replication was enabled or disabled for this endpoint.
+	ReplicationConfig *ReplicationConfig `type:"structure"`
+
+	// The ARN of the role used by event replication for the endpoint.
+	RoleArn *string `min:"1" type:"string"`
+
+	// The routing configuration of the endpoint.
+	RoutingConfig *RoutingConfig `type:"structure"`
+
+	// The current state of the endpoint.
+	State *string `type:"string" enum:"EndpointState"`
+
+	// The reason the endpoint is in its current state.
+	StateReason *string `min:"1" type:"string"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s Endpoint) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s Endpoint) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *Endpoint) SetArn(v string) *Endpoint {
+	s.Arn = &v
+	return s
+}
+
+// SetCreationTime sets the CreationTime field's value.
+func (s *Endpoint) SetCreationTime(v time.Time) *Endpoint {
+	s.CreationTime = &v
+	return s
+}
+
+// SetDescription sets the Description field's value.
+func (s *Endpoint) SetDescription(v string) *Endpoint {
+	s.Description = &v
+	return s
+}
+
+// SetEndpointId sets the EndpointId field's value.
+func (s *Endpoint) SetEndpointId(v string) *Endpoint {
+	s.EndpointId = &v
+	return s
+}
+
+// SetEndpointUrl sets the EndpointUrl field's value.
+func (s *Endpoint) SetEndpointUrl(v string) *Endpoint {
+	s.EndpointUrl = &v
+	return s
+}
+
+// SetEventBuses sets the EventBuses field's value.
+func (s *Endpoint) SetEventBuses(v []*EndpointEventBus) *Endpoint {
+	s.EventBuses = v
+	return s
+}
+
+// SetLastModifiedTime sets the LastModifiedTime field's value.
+func (s *Endpoint) SetLastModifiedTime(v time.Time) *Endpoint {
+	s.LastModifiedTime = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Endpoint) SetName(v string) *Endpoint {
+	s.Name = &v
+	return s
+}
+
+// SetReplicationConfig sets the ReplicationConfig field's value.
+func (s *Endpoint) SetReplicationConfig(v *ReplicationConfig) *Endpoint {
+	s.ReplicationConfig = v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *Endpoint) SetRoleArn(v string) *Endpoint {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRoutingConfig sets the RoutingConfig field's value.
+func (s *Endpoint) SetRoutingConfig(v *RoutingConfig) *Endpoint {
+	s.RoutingConfig = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *Endpoint) SetState(v string) *Endpoint {
+	s.State = &v
+	return s
+}
+
+// SetStateReason sets the StateReason field's value.
+func (s *Endpoint) SetStateReason(v string) *Endpoint {
+	s.StateReason = &v
+	return s
+}
+
+// The event buses the endpoint is associated with.
+type EndpointEventBus struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the event bus the endpoint is associated with.
+	//
+	// EventBusArn is a required field
+	EventBusArn *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s EndpointEventBus) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s EndpointEventBus) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *EndpointEventBus) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "EndpointEventBus"}
+	if s.EventBusArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("EventBusArn"))
+	}
+	if s.EventBusArn != nil && len(*s.EventBusArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EventBusArn", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetEventBusArn sets the EventBusArn field's value.
+func (s *EndpointEventBus) SetEventBusArn(v string) *EndpointEventBus {
+	s.EventBusArn = &v
+	return s
+}
+
 // An event bus receives events from a source and routes them to rules associated
 // with that event bus. Your account's default event bus receives events from
 // Amazon Web Services services. A custom event bus can receive events from
@@ -9711,6 +10836,79 @@ func (s *EventSource) SetName(v string) *EventSource {
 // SetState sets the State field's value.
 func (s *EventSource) SetState(v string) *EventSource {
 	s.State = &v
+	return s
+}
+
+// The failover configuration for an endpoint. This includes what triggers failover
+// and what happens when it's triggered.
+type FailoverConfig struct {
+	_ struct{} `type:"structure"`
+
+	// The main Region of the endpoint.
+	//
+	// Primary is a required field
+	Primary *Primary `type:"structure" required:"true"`
+
+	// The Region that events are routed to when failover is triggered or event
+	// replication is enabled.
+	//
+	// Secondary is a required field
+	Secondary *Secondary `type:"structure" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s FailoverConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s FailoverConfig) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *FailoverConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "FailoverConfig"}
+	if s.Primary == nil {
+		invalidParams.Add(request.NewErrParamRequired("Primary"))
+	}
+	if s.Secondary == nil {
+		invalidParams.Add(request.NewErrParamRequired("Secondary"))
+	}
+	if s.Primary != nil {
+		if err := s.Primary.Validate(); err != nil {
+			invalidParams.AddNested("Primary", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Secondary != nil {
+		if err := s.Secondary.Validate(); err != nil {
+			invalidParams.AddNested("Secondary", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPrimary sets the Primary field's value.
+func (s *FailoverConfig) SetPrimary(v *Primary) *FailoverConfig {
+	s.Primary = v
+	return s
+}
+
+// SetSecondary sets the Secondary field's value.
+func (s *FailoverConfig) SetSecondary(v *Secondary) *FailoverConfig {
+	s.Secondary = v
 	return s
 }
 
@@ -10625,6 +11823,137 @@ func (s *ListConnectionsOutput) SetConnections(v []*Connection) *ListConnections
 
 // SetNextToken sets the NextToken field's value.
 func (s *ListConnectionsOutput) SetNextToken(v string) *ListConnectionsOutput {
+	s.NextToken = &v
+	return s
+}
+
+type ListEndpointsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The primary Region of the endpoints associated with this account. For example
+	// "HomeRegion": "us-east-1".
+	HomeRegion *string `min:"9" type:"string"`
+
+	// The maximum number of results returned by the call.
+	MaxResults *int64 `min:"1" type:"integer"`
+
+	// A value that will return a subset of the endpoints associated with this account.
+	// For example, "NamePrefix": "ABC" will return all endpoints with "ABC" in
+	// the name.
+	NamePrefix *string `min:"1" type:"string"`
+
+	// If nextToken is returned, there are more results available. The value of
+	// nextToken is a unique pagination token for each page. Make the call again
+	// using the returned token to retrieve the next page. Keep all other arguments
+	// unchanged. Each pagination token expires after 24 hours. Using an expired
+	// pagination token will return an HTTP 400 InvalidToken error.
+	NextToken *string `min:"1" type:"string"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ListEndpointsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ListEndpointsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListEndpointsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListEndpointsInput"}
+	if s.HomeRegion != nil && len(*s.HomeRegion) < 9 {
+		invalidParams.Add(request.NewErrParamMinLen("HomeRegion", 9))
+	}
+	if s.MaxResults != nil && *s.MaxResults < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("MaxResults", 1))
+	}
+	if s.NamePrefix != nil && len(*s.NamePrefix) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NamePrefix", 1))
+	}
+	if s.NextToken != nil && len(*s.NextToken) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("NextToken", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetHomeRegion sets the HomeRegion field's value.
+func (s *ListEndpointsInput) SetHomeRegion(v string) *ListEndpointsInput {
+	s.HomeRegion = &v
+	return s
+}
+
+// SetMaxResults sets the MaxResults field's value.
+func (s *ListEndpointsInput) SetMaxResults(v int64) *ListEndpointsInput {
+	s.MaxResults = &v
+	return s
+}
+
+// SetNamePrefix sets the NamePrefix field's value.
+func (s *ListEndpointsInput) SetNamePrefix(v string) *ListEndpointsInput {
+	s.NamePrefix = &v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListEndpointsInput) SetNextToken(v string) *ListEndpointsInput {
+	s.NextToken = &v
+	return s
+}
+
+type ListEndpointsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The endpoints returned by the call.
+	Endpoints []*Endpoint `type:"list"`
+
+	// If nextToken is returned, there are more results available. The value of
+	// nextToken is a unique pagination token for each page. Make the call again
+	// using the returned token to retrieve the next page. Keep all other arguments
+	// unchanged. Each pagination token expires after 24 hours. Using an expired
+	// pagination token will return an HTTP 400 InvalidToken error.
+	NextToken *string `min:"1" type:"string"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ListEndpointsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ListEndpointsOutput) GoString() string {
+	return s.String()
+}
+
+// SetEndpoints sets the Endpoints field's value.
+func (s *ListEndpointsOutput) SetEndpoints(v []*Endpoint) *ListEndpointsOutput {
+	s.Endpoints = v
+	return s
+}
+
+// SetNextToken sets the NextToken field's value.
+func (s *ListEndpointsOutput) SetNextToken(v string) *ListEndpointsOutput {
 	s.NextToken = &v
 	return s
 }
@@ -12131,8 +13460,67 @@ func (s *PolicyLengthExceededException) RequestID() string {
 	return s.RespMetadata.RequestID
 }
 
+// The primary Region of the endpoint.
+type Primary struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the health check used by the endpoint to determine whether failover
+	// is triggered.
+	//
+	// HealthCheck is a required field
+	HealthCheck *string `min:"1" type:"string" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s Primary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s Primary) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Primary) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Primary"}
+	if s.HealthCheck == nil {
+		invalidParams.Add(request.NewErrParamRequired("HealthCheck"))
+	}
+	if s.HealthCheck != nil && len(*s.HealthCheck) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("HealthCheck", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetHealthCheck sets the HealthCheck field's value.
+func (s *Primary) SetHealthCheck(v string) *Primary {
+	s.HealthCheck = &v
+	return s
+}
+
 type PutEventsInput struct {
 	_ struct{} `type:"structure"`
+
+	// The URL subdomain of the endpoint. For example, if the URL for Endpoint is
+	// abcde.veo.endpoints.event.amazonaws.com, then the EndpointId is abcde.veo.
+	//
+	// When using Java, you must include auth-crt on the class path.
+	//
+	// This AWS SDK does not support calling multi-region endpoints with SigV4a authentication.
+	EndpointId *string `min:"1" type:"string"`
 
 	// The entry that defines an event in your system. You can specify several parameters
 	// for the entry such as the source and type of the event, resources associated
@@ -12163,6 +13551,9 @@ func (s PutEventsInput) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *PutEventsInput) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "PutEventsInput"}
+	if s.EndpointId != nil && len(*s.EndpointId) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("EndpointId", 1))
+	}
 	if s.Entries == nil {
 		invalidParams.Add(request.NewErrParamRequired("Entries"))
 	}
@@ -12184,6 +13575,12 @@ func (s *PutEventsInput) Validate() error {
 		return invalidParams
 	}
 	return nil
+}
+
+// SetEndpointId sets the EndpointId field's value.
+func (s *PutEventsInput) SetEndpointId(v string) *PutEventsInput {
+	s.EndpointId = &v
+	return s
 }
 
 // SetEntries sets the Entries field's value.
@@ -12238,7 +13635,7 @@ func (s *PutEventsOutput) SetFailedEntryCount(v int64) *PutEventsOutput {
 type PutEventsRequestEntry struct {
 	_ struct{} `type:"structure"`
 
-	// A valid JSON string. There is no other schema imposed. The JSON string may
+	// A valid JSON object. There is no other schema imposed. The JSON object may
 	// contain fields and nested subobjects.
 	Detail *string `type:"string"`
 
@@ -12248,6 +13645,11 @@ type PutEventsRequestEntry struct {
 	// The name or ARN of the event bus to receive the event. Only the rules that
 	// are associated with this event bus are used to match the event. If you omit
 	// this, the default event bus is used.
+	//
+	// If you're using a global endpoint with a custom bus, you must enter the name,
+	// not the ARN, of the event bus in either the primary or secondary Region here
+	// and the corresponding event bus in the other Region will be determined based
+	// on the endpoint referenced by the EndpointId.
 	EventBusName *string `min:"1" type:"string"`
 
 	// Amazon Web Services resources, identified by Amazon Resource Name (ARN),
@@ -12791,7 +14193,7 @@ type PutRuleInput struct {
 	// this, the default event bus is used.
 	EventBusName *string `min:"1" type:"string"`
 
-	// The event pattern. For more information, see Events and Event Patterns (https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
+	// The event pattern. For more information, see EventBridge event patterns (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html.html)
 	// in the Amazon EventBridge User Guide.
 	EventPattern *string `type:"string"`
 
@@ -13684,6 +15086,38 @@ func (s *ReplayDestination) SetFilterArns(v []*string) *ReplayDestination {
 	return s
 }
 
+// Endpoints can replicate all events to the secondary Region.
+type ReplicationConfig struct {
+	_ struct{} `type:"structure"`
+
+	// The state of event replication.
+	State *string `type:"string" enum:"ReplicationState"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ReplicationConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s ReplicationConfig) GoString() string {
+	return s.String()
+}
+
+// SetState sets the State field's value.
+func (s *ReplicationConfig) SetState(v string) *ReplicationConfig {
+	s.State = &v
+	return s
+}
+
 // The resource you are trying to create already exists.
 type ResourceAlreadyExistsException struct {
 	_            struct{}                  `type:"structure"`
@@ -13865,6 +15299,59 @@ func (s *RetryPolicy) SetMaximumEventAgeInSeconds(v int64) *RetryPolicy {
 // SetMaximumRetryAttempts sets the MaximumRetryAttempts field's value.
 func (s *RetryPolicy) SetMaximumRetryAttempts(v int64) *RetryPolicy {
 	s.MaximumRetryAttempts = &v
+	return s
+}
+
+// The routing configuration of the endpoint.
+type RoutingConfig struct {
+	_ struct{} `type:"structure"`
+
+	// The failover configuration for an endpoint. This includes what triggers failover
+	// and what happens when it's triggered.
+	//
+	// FailoverConfig is a required field
+	FailoverConfig *FailoverConfig `type:"structure" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s RoutingConfig) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s RoutingConfig) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *RoutingConfig) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "RoutingConfig"}
+	if s.FailoverConfig == nil {
+		invalidParams.Add(request.NewErrParamRequired("FailoverConfig"))
+	}
+	if s.FailoverConfig != nil {
+		if err := s.FailoverConfig.Validate(); err != nil {
+			invalidParams.AddNested("FailoverConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFailoverConfig sets the FailoverConfig field's value.
+func (s *RoutingConfig) SetFailoverConfig(v *FailoverConfig) *RoutingConfig {
+	s.FailoverConfig = v
 	return s
 }
 
@@ -14232,6 +15719,57 @@ func (s *SageMakerPipelineParameters) Validate() error {
 // SetPipelineParameterList sets the PipelineParameterList field's value.
 func (s *SageMakerPipelineParameters) SetPipelineParameterList(v []*SageMakerPipelineParameter) *SageMakerPipelineParameters {
 	s.PipelineParameterList = v
+	return s
+}
+
+// The secondary Region that processes events when failover is triggered or
+// replication is enabled.
+type Secondary struct {
+	_ struct{} `type:"structure"`
+
+	// Defines the secondary Region.
+	//
+	// Route is a required field
+	Route *string `min:"9" type:"string" required:"true"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s Secondary) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s Secondary) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *Secondary) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "Secondary"}
+	if s.Route == nil {
+		invalidParams.Add(request.NewErrParamRequired("Route"))
+	}
+	if s.Route != nil && len(*s.Route) < 9 {
+		invalidParams.Add(request.NewErrParamMinLen("Route", 9))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetRoute sets the Route field's value.
+func (s *Secondary) SetRoute(v string) *Secondary {
+	s.Route = &v
 	return s
 }
 
@@ -15877,6 +17415,227 @@ func (s *UpdateConnectionOutput) SetLastModifiedTime(v time.Time) *UpdateConnect
 	return s
 }
 
+type UpdateEndpointInput struct {
+	_ struct{} `type:"structure"`
+
+	// A description for the endpoint.
+	Description *string `type:"string"`
+
+	// Define event buses used for replication.
+	EventBuses []*EndpointEventBus `min:"2" type:"list"`
+
+	// The name of the endpoint you want to update.
+	//
+	// Name is a required field
+	Name *string `min:"1" type:"string" required:"true"`
+
+	// Whether event replication was enabled or disabled by this request.
+	ReplicationConfig *ReplicationConfig `type:"structure"`
+
+	// The ARN of the role used by event replication for this request.
+	RoleArn *string `min:"1" type:"string"`
+
+	// Configure the routing policy, including the health check and secondary Region..
+	RoutingConfig *RoutingConfig `type:"structure"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s UpdateEndpointInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s UpdateEndpointInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *UpdateEndpointInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "UpdateEndpointInput"}
+	if s.EventBuses != nil && len(s.EventBuses) < 2 {
+		invalidParams.Add(request.NewErrParamMinLen("EventBuses", 2))
+	}
+	if s.Name == nil {
+		invalidParams.Add(request.NewErrParamRequired("Name"))
+	}
+	if s.Name != nil && len(*s.Name) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Name", 1))
+	}
+	if s.RoleArn != nil && len(*s.RoleArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("RoleArn", 1))
+	}
+	if s.EventBuses != nil {
+		for i, v := range s.EventBuses {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "EventBuses", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+	if s.RoutingConfig != nil {
+		if err := s.RoutingConfig.Validate(); err != nil {
+			invalidParams.AddNested("RoutingConfig", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDescription sets the Description field's value.
+func (s *UpdateEndpointInput) SetDescription(v string) *UpdateEndpointInput {
+	s.Description = &v
+	return s
+}
+
+// SetEventBuses sets the EventBuses field's value.
+func (s *UpdateEndpointInput) SetEventBuses(v []*EndpointEventBus) *UpdateEndpointInput {
+	s.EventBuses = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateEndpointInput) SetName(v string) *UpdateEndpointInput {
+	s.Name = &v
+	return s
+}
+
+// SetReplicationConfig sets the ReplicationConfig field's value.
+func (s *UpdateEndpointInput) SetReplicationConfig(v *ReplicationConfig) *UpdateEndpointInput {
+	s.ReplicationConfig = v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *UpdateEndpointInput) SetRoleArn(v string) *UpdateEndpointInput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRoutingConfig sets the RoutingConfig field's value.
+func (s *UpdateEndpointInput) SetRoutingConfig(v *RoutingConfig) *UpdateEndpointInput {
+	s.RoutingConfig = v
+	return s
+}
+
+type UpdateEndpointOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN of the endpoint you updated in this request.
+	Arn *string `min:"1" type:"string"`
+
+	// The ID of the endpoint you updated in this request.
+	EndpointId *string `min:"1" type:"string"`
+
+	// The URL of the endpoint you updated in this request.
+	EndpointUrl *string `min:"1" type:"string"`
+
+	// The event buses used for replication for the endpoint you updated in this
+	// request.
+	EventBuses []*EndpointEventBus `min:"2" type:"list"`
+
+	// The name of the endpoint you updated in this request.
+	Name *string `min:"1" type:"string"`
+
+	// Whether event replication was enabled or disabled for the endpoint you updated
+	// in this request.
+	ReplicationConfig *ReplicationConfig `type:"structure"`
+
+	// The ARN of the role used by event replication for the endpoint you updated
+	// in this request.
+	RoleArn *string `min:"1" type:"string"`
+
+	// The routing configuration you updated in this request.
+	RoutingConfig *RoutingConfig `type:"structure"`
+
+	// The state of the endpoint you updated in this request.
+	State *string `type:"string" enum:"EndpointState"`
+}
+
+// String returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s UpdateEndpointOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation.
+//
+// API parameter values that are decorated as "sensitive" in the API will not
+// be included in the string output. The member name will be present, but the
+// value will be replaced with "sensitive".
+func (s UpdateEndpointOutput) GoString() string {
+	return s.String()
+}
+
+// SetArn sets the Arn field's value.
+func (s *UpdateEndpointOutput) SetArn(v string) *UpdateEndpointOutput {
+	s.Arn = &v
+	return s
+}
+
+// SetEndpointId sets the EndpointId field's value.
+func (s *UpdateEndpointOutput) SetEndpointId(v string) *UpdateEndpointOutput {
+	s.EndpointId = &v
+	return s
+}
+
+// SetEndpointUrl sets the EndpointUrl field's value.
+func (s *UpdateEndpointOutput) SetEndpointUrl(v string) *UpdateEndpointOutput {
+	s.EndpointUrl = &v
+	return s
+}
+
+// SetEventBuses sets the EventBuses field's value.
+func (s *UpdateEndpointOutput) SetEventBuses(v []*EndpointEventBus) *UpdateEndpointOutput {
+	s.EventBuses = v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *UpdateEndpointOutput) SetName(v string) *UpdateEndpointOutput {
+	s.Name = &v
+	return s
+}
+
+// SetReplicationConfig sets the ReplicationConfig field's value.
+func (s *UpdateEndpointOutput) SetReplicationConfig(v *ReplicationConfig) *UpdateEndpointOutput {
+	s.ReplicationConfig = v
+	return s
+}
+
+// SetRoleArn sets the RoleArn field's value.
+func (s *UpdateEndpointOutput) SetRoleArn(v string) *UpdateEndpointOutput {
+	s.RoleArn = &v
+	return s
+}
+
+// SetRoutingConfig sets the RoutingConfig field's value.
+func (s *UpdateEndpointOutput) SetRoutingConfig(v *RoutingConfig) *UpdateEndpointOutput {
+	s.RoutingConfig = v
+	return s
+}
+
+// SetState sets the State field's value.
+func (s *UpdateEndpointOutput) SetState(v string) *UpdateEndpointOutput {
+	s.State = &v
+	return s
+}
+
 const (
 	// ApiDestinationHttpMethodPost is a ApiDestinationHttpMethod enum value
 	ApiDestinationHttpMethodPost = "POST"
@@ -16054,6 +17813,42 @@ func ConnectionState_Values() []string {
 }
 
 const (
+	// EndpointStateActive is a EndpointState enum value
+	EndpointStateActive = "ACTIVE"
+
+	// EndpointStateCreating is a EndpointState enum value
+	EndpointStateCreating = "CREATING"
+
+	// EndpointStateUpdating is a EndpointState enum value
+	EndpointStateUpdating = "UPDATING"
+
+	// EndpointStateDeleting is a EndpointState enum value
+	EndpointStateDeleting = "DELETING"
+
+	// EndpointStateCreateFailed is a EndpointState enum value
+	EndpointStateCreateFailed = "CREATE_FAILED"
+
+	// EndpointStateUpdateFailed is a EndpointState enum value
+	EndpointStateUpdateFailed = "UPDATE_FAILED"
+
+	// EndpointStateDeleteFailed is a EndpointState enum value
+	EndpointStateDeleteFailed = "DELETE_FAILED"
+)
+
+// EndpointState_Values returns all elements of the EndpointState enum
+func EndpointState_Values() []string {
+	return []string{
+		EndpointStateActive,
+		EndpointStateCreating,
+		EndpointStateUpdating,
+		EndpointStateDeleting,
+		EndpointStateCreateFailed,
+		EndpointStateUpdateFailed,
+		EndpointStateDeleteFailed,
+	}
+}
+
+const (
 	// EventSourceStatePending is a EventSourceState enum value
 	EventSourceStatePending = "PENDING"
 
@@ -16170,6 +17965,22 @@ func ReplayState_Values() []string {
 		ReplayStateCompleted,
 		ReplayStateCancelled,
 		ReplayStateFailed,
+	}
+}
+
+const (
+	// ReplicationStateEnabled is a ReplicationState enum value
+	ReplicationStateEnabled = "ENABLED"
+
+	// ReplicationStateDisabled is a ReplicationState enum value
+	ReplicationStateDisabled = "DISABLED"
+)
+
+// ReplicationState_Values returns all elements of the ReplicationState enum
+func ReplicationState_Values() []string {
+	return []string{
+		ReplicationStateEnabled,
+		ReplicationStateDisabled,
 	}
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/eventbridge/eventbridgeiface/interface.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/eventbridge/eventbridgeiface/interface.go
@@ -80,6 +80,10 @@ type EventBridgeAPI interface {
 	CreateConnectionWithContext(aws.Context, *eventbridge.CreateConnectionInput, ...request.Option) (*eventbridge.CreateConnectionOutput, error)
 	CreateConnectionRequest(*eventbridge.CreateConnectionInput) (*request.Request, *eventbridge.CreateConnectionOutput)
 
+	CreateEndpoint(*eventbridge.CreateEndpointInput) (*eventbridge.CreateEndpointOutput, error)
+	CreateEndpointWithContext(aws.Context, *eventbridge.CreateEndpointInput, ...request.Option) (*eventbridge.CreateEndpointOutput, error)
+	CreateEndpointRequest(*eventbridge.CreateEndpointInput) (*request.Request, *eventbridge.CreateEndpointOutput)
+
 	CreateEventBus(*eventbridge.CreateEventBusInput) (*eventbridge.CreateEventBusOutput, error)
 	CreateEventBusWithContext(aws.Context, *eventbridge.CreateEventBusInput, ...request.Option) (*eventbridge.CreateEventBusOutput, error)
 	CreateEventBusRequest(*eventbridge.CreateEventBusInput) (*request.Request, *eventbridge.CreateEventBusOutput)
@@ -108,6 +112,10 @@ type EventBridgeAPI interface {
 	DeleteConnectionWithContext(aws.Context, *eventbridge.DeleteConnectionInput, ...request.Option) (*eventbridge.DeleteConnectionOutput, error)
 	DeleteConnectionRequest(*eventbridge.DeleteConnectionInput) (*request.Request, *eventbridge.DeleteConnectionOutput)
 
+	DeleteEndpoint(*eventbridge.DeleteEndpointInput) (*eventbridge.DeleteEndpointOutput, error)
+	DeleteEndpointWithContext(aws.Context, *eventbridge.DeleteEndpointInput, ...request.Option) (*eventbridge.DeleteEndpointOutput, error)
+	DeleteEndpointRequest(*eventbridge.DeleteEndpointInput) (*request.Request, *eventbridge.DeleteEndpointOutput)
+
 	DeleteEventBus(*eventbridge.DeleteEventBusInput) (*eventbridge.DeleteEventBusOutput, error)
 	DeleteEventBusWithContext(aws.Context, *eventbridge.DeleteEventBusInput, ...request.Option) (*eventbridge.DeleteEventBusOutput, error)
 	DeleteEventBusRequest(*eventbridge.DeleteEventBusInput) (*request.Request, *eventbridge.DeleteEventBusOutput)
@@ -131,6 +139,10 @@ type EventBridgeAPI interface {
 	DescribeConnection(*eventbridge.DescribeConnectionInput) (*eventbridge.DescribeConnectionOutput, error)
 	DescribeConnectionWithContext(aws.Context, *eventbridge.DescribeConnectionInput, ...request.Option) (*eventbridge.DescribeConnectionOutput, error)
 	DescribeConnectionRequest(*eventbridge.DescribeConnectionInput) (*request.Request, *eventbridge.DescribeConnectionOutput)
+
+	DescribeEndpoint(*eventbridge.DescribeEndpointInput) (*eventbridge.DescribeEndpointOutput, error)
+	DescribeEndpointWithContext(aws.Context, *eventbridge.DescribeEndpointInput, ...request.Option) (*eventbridge.DescribeEndpointOutput, error)
+	DescribeEndpointRequest(*eventbridge.DescribeEndpointInput) (*request.Request, *eventbridge.DescribeEndpointOutput)
 
 	DescribeEventBus(*eventbridge.DescribeEventBusInput) (*eventbridge.DescribeEventBusOutput, error)
 	DescribeEventBusWithContext(aws.Context, *eventbridge.DescribeEventBusInput, ...request.Option) (*eventbridge.DescribeEventBusOutput, error)
@@ -171,6 +183,10 @@ type EventBridgeAPI interface {
 	ListConnections(*eventbridge.ListConnectionsInput) (*eventbridge.ListConnectionsOutput, error)
 	ListConnectionsWithContext(aws.Context, *eventbridge.ListConnectionsInput, ...request.Option) (*eventbridge.ListConnectionsOutput, error)
 	ListConnectionsRequest(*eventbridge.ListConnectionsInput) (*request.Request, *eventbridge.ListConnectionsOutput)
+
+	ListEndpoints(*eventbridge.ListEndpointsInput) (*eventbridge.ListEndpointsOutput, error)
+	ListEndpointsWithContext(aws.Context, *eventbridge.ListEndpointsInput, ...request.Option) (*eventbridge.ListEndpointsOutput, error)
+	ListEndpointsRequest(*eventbridge.ListEndpointsInput) (*request.Request, *eventbridge.ListEndpointsOutput)
 
 	ListEventBuses(*eventbridge.ListEventBusesInput) (*eventbridge.ListEventBusesOutput, error)
 	ListEventBusesWithContext(aws.Context, *eventbridge.ListEventBusesInput, ...request.Option) (*eventbridge.ListEventBusesOutput, error)
@@ -263,6 +279,10 @@ type EventBridgeAPI interface {
 	UpdateConnection(*eventbridge.UpdateConnectionInput) (*eventbridge.UpdateConnectionOutput, error)
 	UpdateConnectionWithContext(aws.Context, *eventbridge.UpdateConnectionInput, ...request.Option) (*eventbridge.UpdateConnectionOutput, error)
 	UpdateConnectionRequest(*eventbridge.UpdateConnectionInput) (*request.Request, *eventbridge.UpdateConnectionOutput)
+
+	UpdateEndpoint(*eventbridge.UpdateEndpointInput) (*eventbridge.UpdateEndpointOutput, error)
+	UpdateEndpointWithContext(aws.Context, *eventbridge.UpdateEndpointInput, ...request.Option) (*eventbridge.UpdateEndpointOutput, error)
+	UpdateEndpointRequest(*eventbridge.UpdateEndpointInput) (*request.Request, *eventbridge.UpdateEndpointOutput)
 }
 
 var _ EventBridgeAPI = (*eventbridge.EventBridge)(nil)

--- a/vendor/github.com/aws/aws-sdk-go/service/iam/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/iam/api.go
@@ -23869,7 +23869,7 @@ type GetAccountAuthorizationDetailsInput struct {
 	// The format for this parameter is a comma-separated (if more than one) list
 	// of strings. Each string value in the list must be one of the valid values
 	// listed below.
-	Filter []*string `type:"list"`
+	Filter []*string `type:"list" enum:"EntityType"`
 
 	// Use this parameter only when paginating results and only after you receive
 	// a response indicating that the results are truncated. Set it to the value

--- a/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
@@ -8691,7 +8691,7 @@ type CreateGrantInput struct {
 	// in the Key Management Service Developer Guide.
 	//
 	// Operations is a required field
-	Operations []*string `type:"list" required:"true"`
+	Operations []*string `type:"list" required:"true" enum:"GrantOperation"`
 
 	// The principal that has permission to use the RetireGrant operation to retire
 	// the grant.
@@ -12407,7 +12407,7 @@ type GetPublicKeyOutput struct {
 	//
 	// This field appears in the response only when the KeyUsage of the public key
 	// is ENCRYPT_DECRYPT.
-	EncryptionAlgorithms []*string `type:"list"`
+	EncryptionAlgorithms []*string `type:"list" enum:"EncryptionAlgorithmSpec"`
 
 	// The Amazon Resource Name (key ARN (https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN))
 	// of the asymmetric KMS key from which the public key was downloaded.
@@ -12436,7 +12436,7 @@ type GetPublicKeyOutput struct {
 	//
 	// This field appears in the response only when the KeyUsage of the public key
 	// is SIGN_VERIFY.
-	SigningAlgorithms []*string `type:"list"`
+	SigningAlgorithms []*string `type:"list" enum:"SigningAlgorithmSpec"`
 }
 
 // String returns the string representation.
@@ -12603,7 +12603,7 @@ type GrantListEntry struct {
 	Name *string `min:"1" type:"string"`
 
 	// The list of operations permitted by the grant.
-	Operations []*string `type:"list"`
+	Operations []*string `type:"list" enum:"GrantOperation"`
 
 	// The principal that can retire the grant.
 	RetiringPrincipal *string `min:"1" type:"string"`
@@ -13863,7 +13863,7 @@ type KeyMetadata struct {
 	// key with other encryption algorithms within KMS.
 	//
 	// This value is present only when the KeyUsage of the KMS key is ENCRYPT_DECRYPT.
-	EncryptionAlgorithms []*string `type:"list"`
+	EncryptionAlgorithms []*string `type:"list" enum:"EncryptionAlgorithmSpec"`
 
 	// Specifies whether the KMS key's key material expires. This value is present
 	// only when Origin is EXTERNAL, otherwise this value is omitted.
@@ -13944,7 +13944,7 @@ type KeyMetadata struct {
 	// key with other signing algorithms within KMS.
 	//
 	// This field appears only when the KeyUsage of the KMS key is SIGN_VERIFY.
-	SigningAlgorithms []*string `type:"list"`
+	SigningAlgorithms []*string `type:"list" enum:"SigningAlgorithmSpec"`
 
 	// The time at which the imported key material expires. When the key material
 	// expires, KMS deletes the key material and the KMS key becomes unusable. This

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
@@ -12812,7 +12812,7 @@ type HealthCheckConfig struct {
 	// health checks, Route 53 will briefly continue to perform checks from that
 	// region to ensure that some health checkers are always checking the endpoint
 	// (for example, if you replace three regions with four different regions).
-	Regions []*string `locationNameList:"Region" min:"3" type:"list"`
+	Regions []*string `locationNameList:"Region" min:"3" type:"list" enum:"HealthCheckRegion"`
 
 	// The number of seconds between the time that Amazon Route 53 gets a response
 	// from your endpoint and the time that it sends the next health check request.
@@ -17919,7 +17919,7 @@ type UpdateHealthCheckInput struct {
 
 	// A complex type that contains one Region element for each region that you
 	// want Amazon Route 53 health checkers to check the specified endpoint from.
-	Regions []*string `locationNameList:"Region" min:"3" type:"list"`
+	Regions []*string `locationNameList:"Region" min:"3" type:"list" enum:"HealthCheckRegion"`
 
 	// A complex type that contains one ResettableElementName element for each element
 	// that you want to reset to the default value. Valid values for ResettableElementName
@@ -17936,7 +17936,7 @@ type UpdateHealthCheckInput struct {
 	//
 	//    * ResourcePath: Route 53 resets ResourcePath (https://docs.aws.amazon.com/Route53/latest/APIReference/API_HealthCheckConfig.html#Route53-Type-HealthCheckConfig-ResourcePath)
 	//    to null.
-	ResetElements []*string `locationNameList:"ResettableElementName" type:"list"`
+	ResetElements []*string `locationNameList:"ResettableElementName" type:"list" enum:"ResettableElementName"`
 
 	// The path that you want Amazon Route 53 to request when performing health
 	// checks. The path can be any value for which your endpoint will return an

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -12633,7 +12633,7 @@ type CloudFunctionConfiguration struct {
 	Event *string `deprecated:"true" type:"string" enum:"Event"`
 
 	// Bucket events for which to send notifications.
-	Events []*string `locationName:"Event" type:"list" flattened:"true"`
+	Events []*string `locationName:"Event" type:"list" flattened:"true" enum:"Event"`
 
 	// An optional unique identifier for configurations in a notification configuration.
 	// If you don't provide one, Amazon S3 will assign an ID.
@@ -21627,7 +21627,7 @@ type GetObjectAttributesInput struct {
 	// in the response. Fields that you do not specify are not returned.
 	//
 	// ObjectAttributes is a required field
-	ObjectAttributes []*string `location:"header" locationName:"x-amz-object-attributes" type:"list" required:"true"`
+	ObjectAttributes []*string `location:"header" locationName:"x-amz-object-attributes" type:"list" required:"true" enum:"ObjectAttributes"`
 
 	// Specifies the part after which listing should begin. Only parts with higher
 	// part numbers will be listed.
@@ -25167,7 +25167,7 @@ type InventoryConfiguration struct {
 	IsEnabled *bool `type:"boolean" required:"true"`
 
 	// Contains the optional fields that are included in the inventory results.
-	OptionalFields []*string `locationNameList:"Field" type:"list"`
+	OptionalFields []*string `locationNameList:"Field" type:"list" enum:"InventoryOptionalField"`
 
 	// Specifies the schedule for generating inventory results.
 	//
@@ -25694,7 +25694,7 @@ type LambdaFunctionConfiguration struct {
 	// in the Amazon S3 User Guide.
 	//
 	// Events is a required field
-	Events []*string `locationName:"Event" type:"list" flattened:"true" required:"true"`
+	Events []*string `locationName:"Event" type:"list" flattened:"true" required:"true" enum:"Event"`
 
 	// Specifies object key name filtering rules. For information about key name
 	// filtering, see Configuring Event Notifications (https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
@@ -29643,7 +29643,7 @@ type Object struct {
 	_ struct{} `type:"structure"`
 
 	// The algorithm that was used to create a checksum of the object.
-	ChecksumAlgorithm []*string `type:"list" flattened:"true"`
+	ChecksumAlgorithm []*string `type:"list" flattened:"true" enum:"ChecksumAlgorithm"`
 
 	// The entity tag is a hash of the object. The ETag reflects changes only to
 	// the contents of an object, not its metadata. The ETag may or may not be an
@@ -30060,7 +30060,7 @@ type ObjectVersion struct {
 	_ struct{} `type:"structure"`
 
 	// The algorithm that was used to create a checksum of the object.
-	ChecksumAlgorithm []*string `type:"list" flattened:"true"`
+	ChecksumAlgorithm []*string `type:"list" flattened:"true" enum:"ChecksumAlgorithm"`
 
 	// The entity tag is an MD5 hash of that version of the object.
 	ETag *string `type:"string"`
@@ -36025,7 +36025,7 @@ type QueueConfiguration struct {
 	// A collection of bucket events for which to send notifications
 	//
 	// Events is a required field
-	Events []*string `locationName:"Event" type:"list" flattened:"true" required:"true"`
+	Events []*string `locationName:"Event" type:"list" flattened:"true" required:"true" enum:"Event"`
 
 	// Specifies object key name filtering rules. For information about key name
 	// filtering, see Configuring Event Notifications (https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
@@ -36114,7 +36114,7 @@ type QueueConfigurationDeprecated struct {
 	Event *string `deprecated:"true" type:"string" enum:"Event"`
 
 	// A collection of bucket events for which to send notifications.
-	Events []*string `locationName:"Event" type:"list" flattened:"true"`
+	Events []*string `locationName:"Event" type:"list" flattened:"true" enum:"Event"`
 
 	// An optional unique identifier for configurations in a notification configuration.
 	// If you don't provide one, Amazon S3 will assign an ID.
@@ -39062,7 +39062,7 @@ type TopicConfiguration struct {
 	// in the Amazon S3 User Guide.
 	//
 	// Events is a required field
-	Events []*string `locationName:"Event" type:"list" flattened:"true" required:"true"`
+	Events []*string `locationName:"Event" type:"list" flattened:"true" required:"true" enum:"Event"`
 
 	// Specifies object key name filtering rules. For information about key name
 	// filtering, see Configuring Event Notifications (https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
@@ -39152,7 +39152,7 @@ type TopicConfigurationDeprecated struct {
 	Event *string `deprecated:"true" type:"string" enum:"Event"`
 
 	// A collection of events related to objects
-	Events []*string `locationName:"Event" type:"list" flattened:"true"`
+	Events []*string `locationName:"Event" type:"list" flattened:"true" enum:"Event"`
 
 	// An optional unique identifier for configurations in a notification configuration.
 	// If you don't provide one, Amazon S3 will assign an ID.

--- a/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sqs/api.go
@@ -3407,7 +3407,7 @@ type GetQueueAttributesInput struct {
 	//
 	// For information on throughput quotas, see Quotas related to messages (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html)
 	// in the Amazon SQS Developer Guide.
-	AttributeNames []*string `locationNameList:"AttributeName" type:"list" flattened:"true"`
+	AttributeNames []*string `locationNameList:"AttributeName" type:"list" flattened:"true" enum:"QueueAttributeName"`
 
 	// The URL of the Amazon SQS queue whose attribute information is retrieved.
 	//
@@ -4281,7 +4281,7 @@ type ReceiveMessageInput struct {
 	//    in sequence.
 	//
 	//    * SequenceNumber – Returns the value provided by Amazon SQS.
-	AttributeNames []*string `locationNameList:"AttributeName" type:"list" flattened:"true"`
+	AttributeNames []*string `locationNameList:"AttributeName" type:"list" flattened:"true" enum:"QueueAttributeName"`
 
 	// The maximum number of messages to return. Amazon SQS never returns more messages
 	// than this value (however, fewer messages might be returned). Valid values:

--- a/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/sts/api.go
@@ -507,8 +507,9 @@ func (c *STS) AssumeRoleWithWebIdentityRequest(input *AssumeRoleWithWebIdentityI
 //
 // Returns a set of temporary security credentials for users who have been authenticated
 // in a mobile or web application with a web identity provider. Example providers
-// include Amazon Cognito, Login with Amazon, Facebook, Google, or any OpenID
-// Connect-compatible identity provider.
+// include the OAuth 2.0 providers Login with Amazon and Facebook, or any OpenID
+// Connect-compatible identity provider such as Google or Amazon Cognito federated
+// identities (https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html).
 //
 // For mobile applications, we recommend that you use Amazon Cognito. You can
 // use Amazon Cognito with the Amazon Web Services SDK for iOS Developer Guide
@@ -1537,7 +1538,7 @@ type AssumeRoleInput struct {
 	// the new session inherits any transitive session tags from the calling session.
 	// If you pass a session tag with the same key as an inherited tag, the operation
 	// fails. To view the inherited tags for a session, see the CloudTrail logs.
-	// For more information, see Viewing Session Tags in CloudTrail (https://docs.aws.amazon.com/IAM/latest/UserGuide/session-tags.html#id_session-tags_ctlogs)
+	// For more information, see Viewing Session Tags in CloudTrail (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html#id_session-tags_ctlogs)
 	// in the IAM User Guide.
 	Tags []*Tag `type:"list"`
 
@@ -2220,11 +2221,12 @@ type AssumeRoleWithWebIdentityInput struct {
 	// in the IAM User Guide.
 	PolicyArns []*PolicyDescriptorType `type:"list"`
 
-	// The fully qualified host component of the domain name of the identity provider.
+	// The fully qualified host component of the domain name of the OAuth 2.0 identity
+	// provider. Do not specify this value for an OpenID Connect identity provider.
 	//
-	// Specify this value only for OAuth 2.0 access tokens. Currently www.amazon.com
-	// and graph.facebook.com are the only supported identity providers for OAuth
-	// 2.0 access tokens. Do not include URL schemes and port numbers.
+	// Currently www.amazon.com and graph.facebook.com are the only supported identity
+	// providers for OAuth 2.0 access tokens. Do not include URL schemes and port
+	// numbers.
 	//
 	// Do not specify this value for OpenID Connect ID tokens.
 	ProviderId *string `min:"4" type:"string"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,7 +107,7 @@ github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/cli
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector
 github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs
-# github.com/aws/aws-sdk-go v1.43.11
+# github.com/aws/aws-sdk-go v1.43.41
 ## explicit; go 1.11
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn


### PR DESCRIPTION
Cherry pick of #13515 on release-1.23.

#13515: Update aws-sdk-go to v1.43.41

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```