### PR TITLE
Update Calico and Canal to v3.20.5 for kOps 1.22

### DIFF
--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.projectcalico.org/k8s-1.16.yaml
-    manifestHash: 43fa22184ec44003b4293b0b9739b7e0c97e43bb3085fe7948195cce8f57aa18
+    manifestHash: 19cc895fba22ce9fb26b23b6c3c60cc28eb2a91ee0a52f660bcbb0ff5d4c674b
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.16_content
@@ -3897,7 +3897,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.20.3
+        image: docker.io/calico/node:v3.20.5
         lifecycle:
           preStop:
             exec:
@@ -3971,7 +3971,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.20.3
+        image: docker.io/calico/cni:v3.20.5
         name: upgrade-ipam
         securityContext:
           privileged: true
@@ -4005,7 +4005,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.20.3
+        image: docker.io/calico/cni:v3.20.5
         name: install-cni
         securityContext:
           privileged: true
@@ -4014,7 +4014,7 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
-      - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+      - image: docker.io/calico/pod2daemon-flexvol:v3.20.5
         name: flexvol-driver
         securityContext:
           privileged: true
@@ -4122,7 +4122,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.20.3
+        image: docker.io/calico/kube-controllers:v3.20.5
         livenessProbe:
           exec:
             command:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: networking.projectcalico.org.canal/k8s-1.22.yaml
-    manifestHash: 55e99ac918787db6ea49149ac9b31d757237575f30abc9355bb6e82321b50f1f
+    manifestHash: 353ebc7e4f51cd9b9758a8b58f956020ab3160dacbc87837158b572143b8ee74
     name: networking.projectcalico.org.canal
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
@@ -3883,7 +3883,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/node:v3.20.3
+        image: docker.io/calico/node:v3.20.5
         lifecycle:
           preStop:
             exec:
@@ -3996,7 +3996,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: docker.io/calico/cni:v3.20.3
+        image: docker.io/calico/cni:v3.20.5
         name: install-cni
         securityContext:
           privileged: true
@@ -4005,7 +4005,7 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
-      - image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+      - image: docker.io/calico/pod2daemon-flexvol:v3.20.5
         name: flexvol-driver
         securityContext:
           privileged: true
@@ -4113,7 +4113,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: docker.io/calico/kube-controllers:v3.20.3
+        image: docker.io/calico/kube-controllers:v3.20.5
         livenessProbe:
           exec:
             command:

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
@@ -3796,7 +3796,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: calico/typha:v3.20.3
+      - image: calico/typha:v3.20.5
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -3904,7 +3904,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.20.3
+          image: docker.io/calico/cni:v3.20.5
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3945,7 +3945,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.20.3
+          image: docker.io/calico/pod2daemon-flexvol:v3.20.5
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3956,7 +3956,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.20.3
+          image: docker.io/calico/node:v3.20.5
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4223,7 +4223,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: docker.io/calico/kube-controllers:v3.20.3
+          image: docker.io/calico/kube-controllers:v3.20.5
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -3797,7 +3797,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.20.3" }}
+      - image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/typha:{{ or .Networking.Calico.Version "v3.20.5" }}
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -3918,7 +3918,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.20.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.20.5" }}
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -3945,7 +3945,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.20.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/cni:{{ or .Networking.Calico.Version "v3.20.5" }}
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3986,7 +3986,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.20.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/pod2daemon-flexvol:{{ or .Networking.Calico.Version "v3.20.5" }}
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3997,7 +3997,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.20.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/node:{{ or .Networking.Calico.Version "v3.20.5" }}
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4300,7 +4300,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.20.3" }}
+          image: {{ or .Networking.Calico.Registry "docker.io" }}/calico/kube-controllers:{{ or .Networking.Calico.Version "v3.20.5" }}
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS


### PR DESCRIPTION
Ref: https://projectcalico.docs.tigera.io/archive/v3.20/release-notes/#v3205