### PR TITLE
Update remaining addon manifests for the control-plane node role

### DIFF
--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: external-dns.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: d2f842ffe2ec25a9f130707a7aad6f64846fbd6ce017cc5eb5d394efe6beeb6c
+    manifestHash: 6a6fe058fff5a4ff1dc5b71c396b603e38165b3d8807643b936b97389d1548cc
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
@@ -24,6 +24,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v0.10.1
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --provider=aws
@@ -77,13 +87,13 @@ spec:
           runAsUser: 65534
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 65534
       serviceAccountName: external-dns
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: external-dns.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: aebb3498c2d7cf79e5a5f5e28a477cea5b1a7cb575d456e674040a2a24aa69a3
+    manifestHash: d8e7bfe4a3b070a3db5e424f1a07afe85cfd501dc7ba82d6fc16754209b8fe09
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
@@ -24,6 +24,16 @@ spec:
         kops.k8s.io/managed-by: kops
         version: v0.10.1
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - --provider=aws
@@ -85,13 +95,13 @@ spec:
           readOnly: true
       dnsPolicy: Default
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 65534
       serviceAccountName: external-dns
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: karpenter.sh/k8s-1.19.yaml
-    manifestHash: 764ff7009b5715ac53aa0966cc788be816f74b6823b630dbc59b47a11eed0cf2
+    manifestHash: d20d4eda23c530caceacaddc88f3ef89bb2228edbdf0e9a8854950282c64c648
     name: karpenter.sh
     selector:
       k8s-addon: karpenter.sh

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-karpenter.sh-k8s-1.19_content
@@ -661,14 +661,14 @@ spec:
           name: token-amazonaws-com
           readOnly: true
       dnsPolicy: Default
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
       serviceAccountName: karpenter
       tolerations:
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       topologySpreadConstraints:
       - labelSelector:
@@ -730,6 +730,17 @@ spec:
                 - linux
               - key: karpenter.sh/provisioner-name
                 operator: DoesNotExist
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: karpenter.sh/provisioner-name
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       containers:
       - args:
         - -port=8443
@@ -774,14 +785,14 @@ spec:
         - mountPath: /var/run/secrets/amazonaws.com/
           name: token-amazonaws-com
           readOnly: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       securityContext:
         fsGroup: 10001
       serviceAccountName: karpenter
       tolerations:
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       topologySpreadConstraints:
       - labelSelector:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.projectcalico.org/k8s-1.16.yaml
-    manifestHash: 24fea29838ef302183b890302ce09510a232d2c0d9c0a8330b3be96a49671e14
+    manifestHash: d58f4bf07be4093602410eeffd47a37125a74dfb2afd654a6d154c5017010e7a
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.16_content
@@ -4499,6 +4499,8 @@ spec:
         operator: Exists
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
 
 ---
 

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml
-    manifestHash: e5e6012f23d2dd5e64e139644569d002ec56d732bd6066f69e5ef67eb0bb7e72
+    manifestHash: 780687073d5ea4937d3e88351ba615f35805988907517009344e4a323086bf0b
     name: gcp-pd-csi-driver.addons.k8s.io
     selector:
       k8s-addon: gcp-pd-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-gcp-pd-csi-driver.addons.k8s.io-k8s-1.23_content
@@ -586,6 +586,24 @@ spec:
         app: gcp-compute-persistent-disk-csi-driver
         kops.k8s.io/managed-by: kops
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
       - args:
         - --v=5
@@ -704,9 +722,6 @@ spec:
         - mountPath: /csi
           name: socket-dir
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       priorityClassName: csi-gce-pd-controller
       serviceAccountName: csi-gce-pd-controller-sa
       tolerations:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.projectcalico.org/k8s-1.16.yaml
-    manifestHash: 5dd895a7f60f681439f5abc99e740eb27739d42e6a91c9aedd8e31a60ba476b9
+    manifestHash: 7cce9988276da48e2c85f1c79a7871cd59d0ffff07048e9bc0b2a41914aaebfe
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.16_content
@@ -4496,6 +4496,8 @@ spec:
         operator: Exists
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
 
 ---
 

--- a/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/authentication.aws/k8s-1.12.yaml.template
@@ -146,6 +146,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node-role.kubernetes.io/api-server
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists

--- a/upup/models/cloudup/resources/addons/authentication.kope.io/k8s-1.12.yaml
+++ b/upup/models/cloudup/resources/addons/authentication.kope.io/k8s-1.12.yaml
@@ -41,14 +41,24 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       serviceAccountName: auth-api
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - key: "CriticalAddonsOnly"
         operator: "Exists"
       containers:

--- a/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
+++ b/upup/models/cloudup/resources/addons/digitalocean-cloud-controller.addons.k8s.io/k8s-1.8.yaml.template
@@ -25,8 +25,16 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
       hostNetwork: true
@@ -38,6 +46,8 @@ spec:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
         - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+        - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
         - effect: NoExecute
           key: node.kubernetes.io/not-ready

--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
@@ -19,17 +19,27 @@ spec:
         k8s-app: external-dns
         version: v0.10.1
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       priorityClassName: system-cluster-critical
       serviceAccountName: external-dns
       securityContext:
         fsGroup: 65534
       tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       - key: "node-role.kubernetes.io/master"
         effect: NoSchedule
       - key: "node.kubernetes.io/not-ready"
         effect: NoSchedule
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       dnsPolicy: Default  # Don't use cluster DNS (we are likely running before kube-dns)
       hostNetwork: true
       containers:

--- a/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-cloud-controller.addons.k8s.io/k8s-1.23.yaml.template
@@ -18,8 +18,16 @@ spec:
         tier: control-plane
         component: cloud-controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
       - key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
@@ -27,6 +35,8 @@ spec:
       - key: node.kubernetes.io/not-ready
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       serviceAccountName: cloud-controller-manager
       containers:

--- a/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template
@@ -336,6 +336,24 @@ spec:
       labels:
         app: gcp-compute-persistent-disk-csi-driver
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       # Host network must be used for interaction with Workload Identity in GKE
       # since it replaces GCE Metadata Server with GKE Metadata Server. Remove
       # this requirement when issue is resolved and before any exposure of
@@ -347,9 +365,6 @@ spec:
         operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/master: ""
       serviceAccountName: csi-gce-pd-controller-sa
       priorityClassName: csi-gce-pd-controller
       containers:

--- a/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/karpenter.sh/k8s-1.19.yaml.template
@@ -437,6 +437,16 @@ spec:
       labels:
         karpenter: controller
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       priorityClassName: system-cluster-critical
       serviceAccountName: karpenter
       dnsPolicy: Default
@@ -497,6 +507,8 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
       topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: "topology.kubernetes.io/zone"
@@ -510,8 +522,6 @@ spec:
         labelSelector:
           matchLabels:
             karpenter: webhook
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
 
 ---
 # Source: karpenter/templates/webhook/deployment.yaml
@@ -581,8 +591,21 @@ spec:
                 - linux
               - key: karpenter.sh/provisioner-name
                 operator: DoesNotExist
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: karpenter.sh/provisioner-name
+                operator: DoesNotExist
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
       - key: node-role.kubernetes.io/master
+        operator: Exists
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
       topologySpreadConstraints:
       - maxSkew: 1
@@ -597,8 +620,6 @@ spec:
         labelSelector:
           matchLabels:
             karpenter: webhook
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
 ---
 # Source: karpenter/templates/webhook/webhooks.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4129,6 +4129,8 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       serviceAccountName: calico-node
@@ -4648,6 +4650,8 @@ spec:
         - key: CriticalAddonsOnly
           operator: Exists
         - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       serviceAccountName: calico-kube-controllers
       priorityClassName: system-cluster-critical

--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
@@ -181,11 +181,20 @@ spec:
       labels:
         name: openstack-cloud-provider
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+
       # run on the host network (don't depend on CNI)
       hostNetwork: true
       # run on each master node
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: system-node-critical
       securityContext:
         runAsUser: 1001

--- a/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
+++ b/upup/models/cloudup/resources/addons/spotinst-kubernetes-cluster-controller.addons.k8s.io/v1.14.0.yaml.template
@@ -294,3 +294,5 @@ spec:
         tolerationSeconds: 150
       - key: node-role.kubernetes.io/master
         operator: Exists
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/authentication.aws-k8s-1.12.yaml
@@ -206,6 +206,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node-role.kubernetes.io/api-server
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: ed004e8c71d751324c97b3015c97f1e81178a5423587184fa26579b2e84a6f92
+    manifestHash: 93c9176865015c0ae01ea61470cba42f0a7277d805bac87760a91cd13ef8ecdd
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/authentication.aws-k8s-1.12.yaml
@@ -203,6 +203,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node-role.kubernetes.io/api-server
       - key: node.cloudprovider.kubernetes.io/uninitialized
         operator: Exists

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: authentication.aws/k8s-1.12.yaml
-    manifestHash: b23a547c9b8cce314129b07f4b7ec2f2e926732dde89938d12977d80004b309b
+    manifestHash: 6fdac02f93971ee2021a300b74daf80e27ee1128f1bfa8b93005e8d3d3021800
     name: authentication.aws
     selector:
       role.kubernetes.io/authentication: "1"


### PR DESCRIPTION
followup to https://github.com/kubernetes/kops/pull/13452


fixes failing jobs like this: https://testgrid.k8s.io/kops-misc#kops-aws-external-dns