### PR TITLE
Automated cherry pick of #13511: add cluster autoscaler pod annotations

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -647,6 +647,12 @@ spec:
                       ignore unschedulable pods until they are a certain "age", regardless
                       of the scan-interval Default: 0s'
                     type: string
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: 'PodAnnotations are the annotations added to cluster
+                      autoscaler pod when they are created. Default: none'
+                    type: object
                   scaleDownDelayAfterAdd:
                     description: 'ScaleDownDelayAfterAdd determines the time after
                       scale up that scale down evaluation resumes Default: 10m0s'

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -1002,6 +1002,9 @@ type ClusterAutoscalerConfig struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// MaxNodeProvisionTime determines how long CAS will wait for a node to join the cluster.
 	MaxNodeProvisionTime string `json:"maxNodeProvisionTime,omitempty"`
+	// PodAnnotations are the annotations added to cluster autoscaler pods when they are created.
+	// Default: none
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // MetricsServerConfig determines the metrics server configuration.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -1022,6 +1022,9 @@ type ClusterAutoscalerConfig struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// MaxNodeProvisionTime determines how long CAS will wait for a node to join the cluster.
 	MaxNodeProvisionTime string `json:"maxNodeProvisionTime,omitempty"`
+	// PodAnnotations are the annotations added to cluster autoscaler pod when they are created.
+	// Default: none
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // MetricsServerConfig determines the metrics server configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -2258,6 +2258,7 @@ func autoConvert_v1alpha2_ClusterAutoscalerConfig_To_kops_ClusterAutoscalerConfi
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MaxNodeProvisionTime = in.MaxNodeProvisionTime
+	out.PodAnnotations = in.PodAnnotations
 	return nil
 }
 
@@ -2280,6 +2281,7 @@ func autoConvert_kops_ClusterAutoscalerConfig_To_v1alpha2_ClusterAutoscalerConfi
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MaxNodeProvisionTime = in.MaxNodeProvisionTime
+	out.PodAnnotations = in.PodAnnotations
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -905,6 +905,13 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -999,6 +999,9 @@ type ClusterAutoscalerConfig struct {
 	CPURequest *resource.Quantity `json:"cpuRequest,omitempty"`
 	// MaxNodeProvisionTime determines how long CAS will wait for a node to join the cluster.
 	MaxNodeProvisionTime string `json:"maxNodeProvisionTime,omitempty"`
+	// PodAnnotations are the annotations added to cluster autoscaler pods when they are created.
+	// Default: none
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // MetricsServerConfig determines the metrics server configuration.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -2149,6 +2149,7 @@ func autoConvert_v1alpha3_ClusterAutoscalerConfig_To_kops_ClusterAutoscalerConfi
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MaxNodeProvisionTime = in.MaxNodeProvisionTime
+	out.PodAnnotations = in.PodAnnotations
 	return nil
 }
 
@@ -2171,6 +2172,7 @@ func autoConvert_kops_ClusterAutoscalerConfig_To_v1alpha3_ClusterAutoscalerConfi
 	out.MemoryRequest = in.MemoryRequest
 	out.CPURequest = in.CPURequest
 	out.MaxNodeProvisionTime = in.MaxNodeProvisionTime
+	out.PodAnnotations = in.PodAnnotations
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -816,6 +816,13 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -908,6 +908,13 @@ func (in *ClusterAutoscalerConfig) DeepCopyInto(out *ClusterAutoscalerConfig) {
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -274,9 +274,9 @@ spec:
       annotations:
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
-        {{ range $key, $value := .PodAnnotations }}
-        $key: $value
-        {{ end }}
+        {{- with .PodAnnotations }}
+        {{- . | nindent 8 }}
+        {{- end }}
       labels:
         app: cluster-autoscaler
         k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -274,6 +274,9 @@ spec:
       annotations:
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
+        {{ range $key, $value := .PodAnnotations }}
+        $key: $value
+        {{ end }}
       labels:
         app: cluster-autoscaler
         k8s-addon: cluster-autoscaler.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #13511 on release-1.23.

#13511: add cluster autoscaler pod annotations

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```