### PR TITLE
Skip topology hints tests in k8s 1.23

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -97,6 +97,11 @@ func (t *Tester) setSkipRegexFlag() error {
 		skipRegex += "|should.not.disrupt.a.cloud.load-balancer.s.connectivity.during.rollout"
 	}
 
+	if strings.Contains(cluster.Spec.KubernetesVersion, "v1.23.") {
+		// beta feature not enabled by default
+		skipRegex += "|Topology.Hints"
+	}
+
 	// Ensure it is valid regex
 	if _, err := regexp.Compile(skipRegex); err != nil {
 		return err


### PR DESCRIPTION
fixes one test in https://testgrid.k8s.io/kops-misc#kops-aws-misc-ha-euwest1

It is enabled by default in 1.24 so we only ever need to skip it in 1.23: https://github.com/kubernetes/kubernetes/commit/1183f270cb5aefbe8ae2d4ff6624adf4a65eb96c