### PR TITLE
Allow cluster autoscaler to read EC2 instance types to build catalog dynamically

### DIFF
--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -427,7 +427,12 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		if b.Cluster.Spec.AWSLoadBalancerController != nil && fi.BoolValue(b.Cluster.Spec.AWSLoadBalancerController.Enabled) {
 			AddAWSLoadbalancerControllerPermissions(p)
 		}
-		AddClusterAutoscalerPermissions(p)
+
+		var useStaticInstanceList bool
+		if ca := b.Cluster.Spec.ClusterAutoscaler; ca != nil && fi.BoolValue(ca.AWSUseStaticInstanceList) {
+			useStaticInstanceList = true
+		}
+		AddClusterAutoscalerPermissions(p, useStaticInstanceList)
 
 		nth := b.Cluster.Spec.NodeTerminationHandler
 		if nth != nil && fi.BoolValue(nth.Enabled) && fi.BoolValue(nth.EnableSQSTerminationDraining) {
@@ -1013,7 +1018,7 @@ func AddAWSLoadbalancerControllerPermissions(p *Policy) {
 	)
 }
 
-func AddClusterAutoscalerPermissions(p *Policy) {
+func AddClusterAutoscalerPermissions(p *Policy, useStaticInstanceList bool) {
 	p.clusterTaggedAction.Insert(
 		"autoscaling:SetDesiredCapacity",
 		"autoscaling:TerminateInstanceInAutoScalingGroup",
@@ -1024,6 +1029,11 @@ func AddClusterAutoscalerPermissions(p *Policy) {
 		"autoscaling:DescribeLaunchConfigurations",
 		"ec2:DescribeLaunchTemplateVersions",
 	)
+	if !useStaticInstanceList {
+		p.unconditionalAction.Insert(
+			"ec2:DescribeInstanceTypes",
+		)
+	}
 }
 
 // AddAWSEBSCSIDriverPermissions appens policy statements that the AWS EBS CSI Driver needs to operate.

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_cluster-autoscaler.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_iam_role_policy_cluster-autoscaler.kube-system.sa.minimal.example.com_policy
@@ -5,6 +5,7 @@
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeLaunchTemplateVersions"
       ],
       "Effect": "Allow",

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_iam_role_policy_cluster-autoscaler.kube-system.sa.minimal.example.com_policy
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_iam_role_policy_cluster-autoscaler.kube-system.sa.minimal.example.com_policy
@@ -5,6 +5,7 @@
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeLaunchTemplateVersions"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
When the cluster autoscaler builds its EC2 instance type catalog dynamically instead of using only its statically defined set, grant it the additional IAM permissions—as prescribed in [the cluster autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#full-cluster-autoscaler-features-policy-recommended)—required to fetch the instance types from the AWS API.

Fixes #13520.