### PR TITLE
Use expected pointer type in type assertion when iterating over GS ACLs

### DIFF
--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -428,7 +428,7 @@ func (p *GSPath) RenderTerraform(w *terraformWriter.TerraformWriter, name string
 		RoleEntity: make([]string, 0),
 		Provider:   terraformWriter.LiteralTokens("google", "files"),
 	}
-	for _, re := range acl.(GSAcl).Acl {
+	for _, re := range acl.(*GSAcl).Acl {
 		// https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_object_acl#role_entity
 		tfACL.RoleEntity = append(tfACL.RoleEntity, fmt.Sprintf("%v:%v", re.Role, re.Entity))
 	}

--- a/util/pkg/vfs/tests/gsfs_test.go
+++ b/util/pkg/vfs/tests/gsfs_test.go
@@ -90,7 +90,7 @@ func TestGSRenderTerraform(t *testing.T) {
 			}
 			target := terraform.NewTerraformTarget(cloud, "", vfsProvider, "/dev/null", nil)
 
-			acl := vfs.GSAcl{
+			acl := &vfs.GSAcl{
 				Acl: []*storage.ObjectAccessControl{
 					{
 						Entity: fmt.Sprintf("user-%v", tc.serviceAcct),


### PR DESCRIPTION
When creating a new cluster for GCP and using the Terraform target, fix kops panic by using expected pointer type in a type assertion in `util/pkg/vfs/gsfs.go` instead of interface type.

Fixes #13533