### PR TITLE
fix pod annotations in addon yamls

### DIFF
--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -27,6 +27,8 @@ spec:
     image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.21.2
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
+    podAnnotations:
+      testAnnotation: testAnnotation
     scaleDownDelayAfterAdd: 10m0s
     scaleDownUtilizationThreshold: "0.5"
     skipNodesWithLocalStorage: true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 7add7ef0ac062db6de829ad8b6c57d4a1a7e51d43848aa9eecdc9c5bdbb013f4
+    manifestHash: 7af7d35d7847cd9888e12f1c4fdbaac7137eb92b68bbc7e80fd7ca16d2def521
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -301,6 +301,7 @@ spec:
       annotations:
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
+        testAnnotation: testAnnotation
       creationTimestamp: null
       labels:
         app: cluster-autoscaler

--- a/tests/integration/update_cluster/many-addons/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/many-addons/in-v1alpha2.yaml
@@ -10,6 +10,8 @@ spec:
     enabled: true
   clusterAutoscaler:
     enabled: true
+    podAnnotations:
+      testAnnotation: testAnnotation
   kubernetesApiAccess:
   - 0.0.0.0/0
   channel: stable

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -274,8 +274,8 @@ spec:
       annotations:
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
-        {{- with .PodAnnotations }}
-        {{- . | nindent 8 }}
+        {{- range $key, $value := .PodAnnotations }}
+        {{ $key }}: "{{ $value }}"
         {{- end }}
       labels:
         app: cluster-autoscaler

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -128,9 +128,9 @@ spec:
       annotations:
         prometheus.io/port: "9253"
         prometheus.io/scrape: "true"
-{{- with KubeDNS.NodeLocalDNS.PodAnnotations }}
-        {{- . | nindent 8 }}
-{{- end }}
+        {{- range $key, $value := KubeDNS.NodeLocalDNS.PodAnnotations }}
+        {{ $key }}: "{{ $value }}"
+        {{- end }}
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: node-local-dns


### PR DESCRIPTION
PodAnnotations in both cluster autoscaler and node-local-dns are failing.

Changing the yaml definitions to correctly unmarshal `map[string][string]` to valid annotations.

Testing:
```
❯ ~/go/bin/kops update cluster
...
  ManagedFile/bronson.cluster.doordash.cloud-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15
        Contents
                                ...
                                          prometheus.io/port: "8085"
                                          prometheus.io/scrape: "true"
                                +         test1: test
                                +         test2: "123"
                                        creationTimestamp: null
                                        labels:
                                ...


  ManagedFile/bronson.cluster.doordash.cloud-addons-nodelocaldns.addons.k8s.io-k8s-1.12
        Contents
                                ...
                                          prometheus.io/port: "9253"
                                          prometheus.io/scrape: "true"
                                +         test1: test
                                +         test2: "123"
                                        creationTimestamp: null
                                        labels:
                                ...

❯ kd po node-local-dns-2qvz5
Name:                 node-local-dns-2qvz5
Namespace:            kube-system
Priority:             2000001000
Priority Class Name:  system-node-critical
Node:                 ip-172-20-38-152.us-west-2.compute.internal/172.20.38.152
Start Time:           Wed, 20 Apr 2022 13:53:15 -0700
Labels:               controller-revision-hash=7f58bd4969
                      k8s-app=node-local-dns
                      kops.k8s.io/managed-by=kops
                      pod-template-generation=4
Annotations:          prometheus.io/port: 9253
                      prometheus.io/scrape: true
                      test1: test
                      test2: 123

❯ kd po cluster-autoscaler-8495fb4f76-k25s2
Name:                 cluster-autoscaler-8495fb4f76-k25s2
Namespace:            kube-system
Priority:             2000000000
Priority Class Name:  system-cluster-critical
Node:                 ip-172-20-63-214.us-west-2.compute.internal/172.20.63.214
Start Time:           Wed, 20 Apr 2022 13:53:05 -0700
Labels:               app=cluster-autoscaler
                      app.kubernetes.io/name=cluster-autoscaler
                      k8s-addon=cluster-autoscaler.addons.k8s.io
                      k8s-app=cluster-autoscaler
                      kops.k8s.io/managed-by=kops
                      pod-template-hash=8495fb4f76
Annotations:          prometheus.io/port: 8085
                      prometheus.io/scrape: true
                      test1: test
                      test2: 123
```

Previously:
```
❯ ~/go/bin/kops update cluster
I0420 13:33:38.572420   95333 featureflag.go:162] FeatureFlag "ExperimentalClusterDNS"=true
I0420 13:33:38.572558   95333 featureflag.go:162] FeatureFlag "APIServerNodes"=true

*********************************************************************************

A new kubernetes version is available: 1.22.8
Upgrading is recommended (try kops upgrade cluster)

More information: https://github.com/kubernetes/kops/blob/master/permalinks/upgrade_k8s.md#1.22.8

*********************************************************************************

Error: error building tasks: error reading manifest addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml: error opening resource: error executing resource template "addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml": error executing template "addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml": template: addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml:132:24: executing "addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml" at <8>: wrong type for value; expected string; got map[string]string
```

/cc @hakman @olemarkus 