### PR TITLE
Automated cherry pick of #13534: Use a pointer type in type assertion

### DIFF
--- a/util/pkg/vfs/gsfs.go
+++ b/util/pkg/vfs/gsfs.go
@@ -428,7 +428,7 @@ func (p *GSPath) RenderTerraform(w *terraformWriter.TerraformWriter, name string
 		RoleEntity: make([]string, 0),
 		Provider:   terraformWriter.LiteralTokens("google", "files"),
 	}
-	for _, re := range acl.(GSAcl).Acl {
+	for _, re := range acl.(*GSAcl).Acl {
 		// https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_object_acl#role_entity
 		tfACL.RoleEntity = append(tfACL.RoleEntity, fmt.Sprintf("%v:%v", re.Role, re.Entity))
 	}

--- a/util/pkg/vfs/tests/gsfs_test.go
+++ b/util/pkg/vfs/tests/gsfs_test.go
@@ -90,7 +90,7 @@ func TestGSRenderTerraform(t *testing.T) {
 			}
 			target := terraform.NewTerraformTarget(cloud, "", vfsProvider, "/dev/null", nil)
 
-			acl := vfs.GSAcl{
+			acl := &vfs.GSAcl{
 				Acl: []*storage.ObjectAccessControl{
 					{
 						Entity: fmt.Sprintf("user-%v", tc.serviceAcct),


### PR DESCRIPTION
Cherry pick of #13534 on release-1.23.

#13534: Use a pointer type in type assertion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```