### PR TITLE
Update control plane toleration for external-dns

### DIFF
--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: external-dns.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 6a6fe058fff5a4ff1dc5b71c396b603e38165b3d8807643b936b97389d1548cc
+    manifestHash: 5c3e41d606c2bb1a4ab539c15a0738780a74b7a3cefac13843130a3f947f8b98
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
@@ -92,8 +92,8 @@ spec:
         fsGroup: 65534
       serviceAccountName: external-dns
       tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: external-dns.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: d8e7bfe4a3b070a3db5e424f1a07afe85cfd501dc7ba82d6fc16754209b8fe09
+    manifestHash: 434828d368be94b39c53fc31ae835da06dac13475ee2b7261c65982e527da554
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
@@ -100,8 +100,8 @@ spec:
         fsGroup: 65534
       serviceAccountName: external-dns
       tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule

--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
@@ -35,7 +35,7 @@ spec:
         fsGroup: 65534
       tolerations:
       - key: node-role.kubernetes.io/control-plane
-        operator: Exists
+        effect: NoSchedule
       - key: "node-role.kubernetes.io/master"
         effect: NoSchedule
       - key: "node.kubernetes.io/not-ready"


### PR DESCRIPTION
clusters are failing to validate: https://testgrid.k8s.io/kops-misc#kops-aws-external-dns

[kube-scheduler logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-external-dns/1516181215399383040/artifacts/3.138.101.39/kube-scheduler.log) show:

`I0418 22:41:15.011259      10 scheduler.go:351] "Unable to schedule pod; no fit; waiting" pod="kube-system/external-dns-695c9468f9-dbl5q" err="0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector, 1 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling."`