### PR TITLE
Add relnote about breaking change with custom DHCP opts

### DIFF
--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -12,6 +12,32 @@ managed subnets will be configured to launch instances with Resource Based Names
 
 # Breaking changes
 
+## Custom domain names on AWS
+
+If your EC2 instances runs in a VPC that has custom domain name set in its DHCP options or custom resolve configuarion, instances will not be able to join the cluster. The reason for this is that the AWS
+cloud provider requires that instances use the default regional domain names. Before kOps 1.23, kOps would fetch the expected node name from the AWS EC2 API, but this
+caused scaling issues on large clusters and kOps now rely on the DNS configuration instead.
+
+As of Kubernetes 1.22, one can enable the [external cloud provider](https://cloud-provider-aws.sigs.k8s.io/), which supports Resource Based Naming.
+When the external cloud provider is used, kOps will automatically use instance IDs as node names instead of IP address based naming. These node
+names do not contain the domain, and therefore will work also with custom DHCP domain names.
+
+In order to enable the external cloud provider, add this to the cluster spec:
+
+```
+spec:
+  cloudControllerManager:
+    cloudProvider: aws
+  cloudConfig:
+    awsEBSCSIDriver:
+    enabled: true
+  kubernetesVersion: v1.23.1 #Must be 1.22.0 or higher
+```
+
+When using the external cloud provider, make sure that none of the Kubernetes components have the `cloudProvider` field set in the Cluster spec.
+
+## Other breaking changes
+
 * Support for Kubernetes version 1.17 has been removed.
 
 * Support for the Lyft CNI has been removed.


### PR DESCRIPTION
Been quite a few reports on this: #13540 #13492 and #13358

Alternative would be to revert, but I think we are too far out into the 1.23 lifecycle to do this. It will also fix itself on kops/k8s 1.24.