### PR TITLE
Pin AWS CCM image tag for k8s 1.25

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -99,6 +99,8 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0"
 		case 24:
 			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0"
+		case 25:
+			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0"
 		default:
 			eccm.Image = "gcr.io/k8s-staging-provider-aws/cloud-controller-manager:latest"
 		}


### PR DESCRIPTION
With the k8s 1.24 rc.0 published, our prow jobs that use k8s CI builds are now on k8s 1.25.
To avoid https://github.com/kubernetes/cloud-provider-aws/issues/339 in the latest AWS CCM tag we have to pin 1.25 to the same tag as k8s 1.23 and 1.24

Should fix https://testgrid.k8s.io/kops-misc#kops-aws-misc-arm64-ci

you can see `latest` is being used in the daemonset here: https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-misc-arm64-ci/1517088467119509504/artifacts/cluster-info/kube-system/daemonsets.yaml

and the panic is occurring: https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-misc-arm64-ci/1517088467119509504/artifacts/cluster-info/kube-system/aws-cloud-controller-manager-kw82b/logs.txt