### PR TITLE
Automated cherry pick of #13536: fix pod annotations in addon yamls

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -301,6 +301,7 @@ spec:
       annotations:
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
+        testAnnotation: testAnnotation
       creationTimestamp: null
       labels:
         app: cluster-autoscaler

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -27,6 +27,8 @@ spec:
     image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2
     maxNodeProvisionTime: 15m0s
     newPodScaleUpDelay: 0s
+    podAnnotations:
+      testAnnotation: testAnnotation
     scaleDownDelayAfterAdd: 10m0s
     scaleDownUtilizationThreshold: "0.5"
     skipNodesWithLocalStorage: true

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 8ab348ad7c6d4ce0b621fa33ad6154d17a72746f10e3670b33a7967e9b566020
+    manifestHash: 7af7d35d7847cd9888e12f1c4fdbaac7137eb92b68bbc7e80fd7ca16d2def521
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/many-addons/in-v1alpha2.yaml
@@ -10,6 +10,8 @@ spec:
     enabled: true
   clusterAutoscaler:
     enabled: true
+    podAnnotations:
+      testAnnotation: testAnnotation
   kubernetesApiAccess:
   - 0.0.0.0/0
   channel: stable

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -274,8 +274,8 @@ spec:
       annotations:
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
-        {{- with .PodAnnotations }}
-        {{- . | nindent 8 }}
+        {{- range $key, $value := .PodAnnotations }}
+        {{ $key }}: "{{ $value }}"
         {{- end }}
       labels:
         app: cluster-autoscaler

--- a/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/nodelocaldns.addons.k8s.io/k8s-1.12.yaml.template
@@ -128,6 +128,9 @@ spec:
       annotations:
         prometheus.io/port: "9253"
         prometheus.io/scrape: "true"
+        {{- range $key, $value := KubeDNS.NodeLocalDNS.PodAnnotations }}
+        {{ $key }}: "{{ $value }}"
+        {{- end }}
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: node-local-dns


### PR DESCRIPTION
Cherry pick of #13536 on release-1.23.

#13536: fix pod annotations in addon yamls

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```