### PR TITLE
Trim GCE Subnet and Disk names

### DIFF
--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -54,7 +54,11 @@ func (c *GCEModelContext) NameForIPAliasRange(key string) string {
 func (c *GCEModelContext) LinkToSubnet(subnet *kops.ClusterSubnetSpec) *gcetasks.Subnet {
 	name := subnet.ProviderID
 	if name == "" {
-		name = c.SafeObjectName(subnet.Name)
+		var err error
+		name, err = gce.ClusterSuffixedName(subnet.Name, c.Cluster.ObjectMeta.Name, 63)
+		if err != nil {
+			klog.Fatalf("failed to construct subnet name: %w", err)
+		}
 	}
 
 	return &gcetasks.Subnet{Name: s(name)}


### PR DESCRIPTION
GCE jobs are still failing due to cluster names being too long:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-grid-gce-u2004-k22-containerd/1516912053338509312

`W0420 23:01:47.344909    5875 executor.go:139] error running task "Disk/a-etcd-main-e2e-e2e-kops-grid-gce-u2004-k22-containerd-k8s-local" (6s remaining to succeed): error listing Disks: googleapi: Error 400: Invalid value for field 'disk': 'a-etcd-main-e2e-e2e-kops-grid-gce-u2004-k22-containerd-k8s-local'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}', invalid`

`W0420 23:01:47.344921    5875 executor.go:139] error running task "Subnet/us-central1-e2e-e2e-kops-grid-gce-u2004-k22-containerd-k8s-local" (6s remaining to succeed): error listing Subnets: googleapi: Error 400: Invalid value for field 'subnetwork': 'us-central1-e2e-e2e-kops-grid-gce-u2004-k22-containerd-k8s-local'. Must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}', invalid`