### PR TITLE
Upgrade flannel to 0.17.0

### DIFF
--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: networking.flannel/k8s-1.12.yaml
-    manifestHash: e6ecee9b4e64b0ee838bcf999a33f572b19c00fcb3769b55437e30ac8509bb14
+    manifestHash: 9a1dce09e6c31f0da54c1a7f593f3bb111cd9b50453f6f31a382215290794571
     name: networking.flannel
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-networking.flannel-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-networking.flannel-k8s-1.12_content
@@ -217,7 +217,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/coreos/flannel:v0.15.1
+        image: rancher/mirrored-flannelcni-flannel:v0.17.0
         name: kube-flannel
         resources:
           limits:
@@ -238,15 +238,28 @@ spec:
           name: dev-net
         - mountPath: /etc/kube-flannel/
           name: flannel-cfg
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       hostNetwork: true
       initContainers:
+      - args:
+        - -f
+        - /flannel
+        - /opt/cni/bin/flannel
+        command:
+        - cp
+        image: rancher/mirrored-flannelcni-flannel-cni-plugin:v1.0.1
+        name: install-cni-plugin
+        volumeMounts:
+        - mountPath: /opt/cni/bin
+          name: cni-plugin
       - args:
         - -f
         - /etc/kube-flannel/cni-conf.json
         - /etc/cni/net.d/10-flannel.conflist
         command:
         - cp
-        image: quay.io/coreos/flannel:v0.15.1
+        image: rancher/mirrored-flannelcni-flannel:v0.17.0
         name: install-cni
         volumeMounts:
         - mountPath: /etc/cni/net.d
@@ -265,8 +278,15 @@ spec:
           path: /dev/net
         name: dev-net
       - hostPath:
+          path: /opt/cni/bin
+        name: cni-plugin
+      - hostPath:
           path: /etc/cni/net.d
         name: cni
       - configMap:
           name: kube-flannel-cfg
         name: flannel-cfg
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock

--- a/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.flannel/k8s-1.12.yaml.template
@@ -1,4 +1,4 @@
-# Pulled and modified from: https://raw.githubusercontent.com/coreos/flannel/v0.15.1/Documentation/kube-flannel.yml
+# Pulled and modified from: https://raw.githubusercontent.com/coreos/flannel/v0.17.0/Documentation/kube-flannel.yml
 
 ---
 apiVersion: policy/v1beta1
@@ -170,8 +170,19 @@ spec:
       - operator: Exists
       serviceAccountName: flannel
       initContainers:
+      - name: install-cni-plugin
+        image: rancher/mirrored-flannelcni-flannel-cni-plugin:v1.0.1
+        command:
+        - cp
+        args:
+        - -f
+        - /flannel
+        - /opt/cni/bin/flannel
+        volumeMounts:
+        - name: cni-plugin
+          mountPath: /opt/cni/bin
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.15.1
+        image: rancher/mirrored-flannelcni-flannel:v0.17.0
         command:
         - cp
         args:
@@ -185,7 +196,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.15.1
+        image: rancher/mirrored-flannelcni-flannel:v0.17.0
         command:
         - /opt/bin/flanneld
         args:
@@ -218,6 +229,8 @@ spec:
           mountPath: /dev/net
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
       volumes:
       - name: run
         hostPath:
@@ -225,9 +238,16 @@ spec:
       - name: dev-net
         hostPath:
           path: /dev/net
+      - name: cni-plugin
+        hostPath:
+          path: /opt/cni/bin
       - name: cni
         hostPath:
           path: /etc/cni/net.d
       - name: flannel-cfg
         configMap:
           name: kube-flannel-cfg
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate


### PR DESCRIPTION
The images were moved from quay back to dockerhub in https://github.com/flannel-io/flannel/pull/1516. I checked and 0.17.0 is not published to the quay image, so we may not have a choice there