### PR TITLE
Creaate kubeconfig for the root user on Ubuntu

### DIFF
--- a/nodeup/pkg/model/kubectl_test.go
+++ b/nodeup/pkg/model/kubectl_test.go
@@ -20,12 +20,16 @@ import (
 	"testing"
 
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/util/pkg/distributions"
 )
 
 func TestKubectlBuilder(t *testing.T) {
 	RunGoldenTest(t, "tests/golden/minimal", "kubectl", func(nodeupModelContext *NodeupModelContext, target *fi.ModelBuilderContext) error {
 		nodeupModelContext.Assets = fi.NewAssetStore("")
 		nodeupModelContext.Assets.AddForTest("kubectl", "/path/to/kubectl/asset", "testing kubectl content")
+		// NodeUp looks for the default user and group on the machine running the tests.
+		// Flatcar is unlikely to be used for such task, so tests results should be consistent.
+		nodeupModelContext.Distribution = distributions.DistributionFlatcar
 		builder := KubectlBuilder{NodeupModelContext: nodeupModelContext}
 		return builder.Build(target)
 	})

--- a/nodeup/pkg/model/tests/golden/minimal/tasks-kubectl.yaml
+++ b/nodeup/pkg/model/tests/golden/minimal/tasks-kubectl.yaml
@@ -3,7 +3,7 @@ contents:
     AssetPath: /path/to/kubectl/asset
     Key: kubectl
 mode: "0755"
-path: /usr/local/bin/kubectl
+path: /opt/kops/bin/kubectl
 type: file
 ---
 contents:

--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -76,7 +76,7 @@ func (d *Distribution) DefaultUsers() ([]string, error) {
 	case "debian":
 		return []string{"admin", "root"}, nil
 	case "ubuntu":
-		return []string{"ubuntu"}, nil
+		return []string{"ubuntu", "root"}, nil
 	case "centos":
 		return []string{"centos"}, nil
 	case "rhel", "amazonlinux2":


### PR DESCRIPTION
Some Ubuntu images use the `root` user as the initial SSH user.