### PR TITLE
WIP: Use Ubuntu 22.04 as the default image for Kubernetes 1.24+

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -61,11 +61,19 @@ spec:
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404
       providerID: aws
       architectureID: amd64
-      kubernetesVersion: ">=1.18.0"
+      kubernetesVersion: ">=1.18.0 <1.24.0"
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220404
       providerID: aws
       architectureID: arm64
-      kubernetesVersion: ">=1.20.0"
+      kubernetesVersion: ">=1.20.0 <1.24.0"
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220420
+      providerID: aws
+      architectureID: amd64
+      kubernetesVersion: ">=1.24.0"
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220420
+      providerID: aws
+      architectureID: arm64
+      kubernetesVersion: ">=1.24.0"
     - name: cos-cloud/cos-stable-65-10323-99-0
       providerID: gce
       architectureID: amd64

--- a/channels/stable
+++ b/channels/stable
@@ -61,11 +61,19 @@ spec:
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404
       providerID: aws
       architectureID: amd64
-      kubernetesVersion: ">=1.18.0"
+      kubernetesVersion: ">=1.18.0 <1.24.0"
     - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220404
       providerID: aws
       architectureID: arm64
-      kubernetesVersion: ">=1.20.0"
+      kubernetesVersion: ">=1.20.0 <1.24.0"
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220420
+      providerID: aws
+      architectureID: amd64
+      kubernetesVersion: ">=1.24.0"
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-20220420
+      providerID: aws
+      architectureID: arm64
+      kubernetesVersion: ">=1.24.0"
     - name: cos-cloud/cos-stable-65-10323-99-0
       providerID: gce
       architectureID: amd64

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -52,6 +52,7 @@ func TestCreateClusterMinimal(t *testing.T) {
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal-1.21", "v1alpha2")
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal-1.22", "v1alpha2")
 	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal-1.23", "v1alpha2")
+	runCreateClusterIntegrationTest(t, "../../tests/integration/create_cluster/minimal-1.24", "v1alpha2")
 }
 
 // TestCreateClusterOverride tests the override flag

--- a/docs/releases/1.24-NOTES.md
+++ b/docs/releases/1.24-NOTES.md
@@ -6,6 +6,8 @@ This is a document to gather the release notes prior to the release.
 
 # Significant changes
 
+* **The default image has been updated to Ubuntu 22.04 (Jammy)**.
+
 ## Karpenter support
 
 By enabling the `Karpenter` feature flag, users can now create InstanceGroups managed by (https://karpenter.sh)[Karpenter]:

--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -366,6 +366,7 @@ func RecommendedKubernetesVersion(c *Channel, kopsVersionString string) *semver.
 func (c *Channel) HasUpstreamImagePrefix(image string) bool {
 	return strings.HasPrefix(image, "kope.io/k8s-") ||
 		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-") ||
+		strings.HasPrefix(image, "099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-") ||
 		strings.HasPrefix(image, "cos-cloud/cos-stable-") ||
 		strings.HasPrefix(image, "ubuntu-os-cloud/ubuntu-2004-focal-") ||
 		strings.HasPrefix(image, "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:")

--- a/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
@@ -64,7 +64,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: master-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220420
   instanceMetadata:
     httpPutResponseHopLimit: 3
     httpTokens: required
@@ -88,7 +88,7 @@ metadata:
     kops.k8s.io/cluster: minimal.example.com
   name: nodes-us-test-1a
 spec:
-  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220420
   instanceMetadata:
     httpPutResponseHopLimit: 1
     httpTokens: required

--- a/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
@@ -1,0 +1,103 @@
+apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  name: minimal.example.com
+spec:
+  api:
+    dns: {}
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudProvider: aws
+  configBase: memfs://tests/minimal.example.com
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+    - encryptedVolume: true
+      instanceGroup: master-us-test-1a
+      name: a
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+    - encryptedVolume: true
+      instanceGroup: master-us-test-1a
+      name: a
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  - ::/0
+  kubernetesVersion: v1.24.0
+  masterPublicName: api.minimal.example.com
+  networkCIDR: 172.20.0.0/16
+  networking:
+    cni: {}
+  nonMasqueradeCIDR: 100.64.0.0/10
+  sshAccess:
+  - 0.0.0.0/0
+  - ::/0
+  subnets:
+  - cidr: 172.20.32.0/19
+    name: us-test-1a
+    type: Public
+    zone: us-test-1a
+  topology:
+    dns:
+      type: Public
+    masters: public
+    nodes: public
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+  name: master-us-test-1a
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404
+  instanceMetadata:
+    httpPutResponseHopLimit: 3
+    httpTokens: required
+  machineType: m3.medium
+  manager: CloudGroup
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: master-us-test-1a
+  role: Master
+  subnets:
+  - us-test-1a
+
+---
+
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: "2017-01-01T00:00:00Z"
+  labels:
+    kops.k8s.io/cluster: minimal.example.com
+  name: nodes-us-test-1a
+spec:
+  image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404
+  instanceMetadata:
+    httpPutResponseHopLimit: 1
+    httpTokens: required
+  machineType: t2.medium
+  manager: CloudGroup
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    kops.k8s.io/instancegroup: nodes-us-test-1a
+  role: Node
+  subnets:
+  - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.24/options.yaml
+++ b/tests/integration/create_cluster/minimal-1.24/options.yaml
@@ -1,0 +1,6 @@
+ClusterName: minimal.example.com
+Zones:
+- us-test-1a
+CloudProvider: aws
+Networking: cni
+KubernetesVersion: v1.24.0


### PR DESCRIPTION
As agreed during the 22.04.2022 kOps office hours.