### PR TITLE
Always set cluster-id flag for Protokube

### DIFF
--- a/nodeup/pkg/model/protokube.go
+++ b/nodeup/pkg/model/protokube.go
@@ -156,6 +156,7 @@ func (t *ProtokubeBuilder) buildSystemdService() (*nodetasks.Service, error) {
 
 // ProtokubeFlags are the flags for protokube
 type ProtokubeFlags struct {
+	ClusterID         *string  `json:"clusterID,omitempty" flag:"cluster-id"`
 	Channels          []string `json:"channels,omitempty" flag:"channels"`
 	Cloud             *string  `json:"cloud,omitempty" flag:"cloud"`
 	Containerized     *bool    `json:"containerized,omitempty" flag:"containerized"`
@@ -194,6 +195,8 @@ func (t *ProtokubeBuilder) ProtokubeFlags(k8sVersion semver.Version) (*Protokube
 		LogLevel:      fi.Int32(4),
 		Master:        b(t.IsMaster),
 	}
+
+	f.ClusterID = fi.String(t.Cluster.ObjectMeta.Name)
 
 	zone := t.Cluster.Spec.DNSZone
 	if zone != "" {

--- a/nodeup/pkg/model/tests/protokube/tasks-protokube.yaml
+++ b/nodeup/pkg/model/tests/protokube/tasks-protokube.yaml
@@ -106,7 +106,7 @@ definition: |
   Documentation=https://kops.sigs.k8s.io
 
   [Service]
-  ExecStart=/opt/kops/bin/protokube --bootstrap-master-node-labels=true --cloud=aws --containerized=false --dns-internal-suffix=.internal.minimal.example.com --dns=aws-route53 --master=true --node-name=master.hostname.invalid --remove-dns-names=etcd-master-us-test-1a.internal.minimal.example.com,etcd-events-master-us-test-1a.internal.minimal.example.com --v=4 --zone=*/Z1AFAKE1ZON3YO
+  ExecStart=/opt/kops/bin/protokube --bootstrap-master-node-labels=true --cloud=aws --cluster-id=minimal.example.com --containerized=false --dns-internal-suffix=.internal.minimal.example.com --dns=aws-route53 --master=true --node-name=master.hostname.invalid --remove-dns-names=etcd-master-us-test-1a.internal.minimal.example.com,etcd-events-master-us-test-1a.internal.minimal.example.com --v=4 --zone=*/Z1AFAKE1ZON3YO
   EnvironmentFile=/etc/sysconfig/protokube
   Restart=always
   RestartSec=3s

--- a/protokube/pkg/protokube/aws_volume.go
+++ b/protokube/pkg/protokube/aws_volume.go
@@ -100,10 +100,6 @@ func NewAWSVolumes() (*AWSVolumes, error) {
 	return a, nil
 }
 
-func (a *AWSVolumes) ClusterID() string {
-	return a.clusterTag
-}
-
 func (a *AWSVolumes) InternalIP() net.IP {
 	return a.internalIP
 }

--- a/protokube/pkg/protokube/azure_volume.go
+++ b/protokube/pkg/protokube/azure_volume.go
@@ -80,11 +80,6 @@ func NewAzureVolumes() (*AzureVolumes, error) {
 	}, nil
 }
 
-// ClusterID implements Volumes ClusterID.
-func (a *AzureVolumes) ClusterID() string {
-	return a.clusterTag
-}
-
 // InstanceID implements Volumes InstanceID.
 func (a *AzureVolumes) InstanceID() string {
 	return a.instanceID

--- a/protokube/pkg/protokube/gce_volume.go
+++ b/protokube/pkg/protokube/gce_volume.go
@@ -67,11 +67,6 @@ func NewGCEVolumes() (*GCEVolumes, error) {
 	return a, nil
 }
 
-// ClusterID implements Volumes ClusterID
-func (a *GCEVolumes) ClusterID() string {
-	return a.clusterName
-}
-
 // Project returns the current GCE project
 func (a *GCEVolumes) Project() string {
 	return a.project

--- a/protokube/pkg/protokube/openstack_volume.go
+++ b/protokube/pkg/protokube/openstack_volume.go
@@ -117,11 +117,6 @@ func NewOpenstackVolumes() (*OpenstackVolumes, error) {
 	return a, nil
 }
 
-// ClusterID implements Volumes ClusterID
-func (a *OpenstackVolumes) ClusterID() string {
-	return a.meta.UserMeta.ClusterName
-}
-
 // Project returns the current GCE project
 func (a *OpenstackVolumes) Project() string {
 	return a.meta.ProjectID


### PR DESCRIPTION
Getting the cluster ID from the cloud provider is just not needed.
NodeUp knows the cluster ID and can set it when configuring Protokube.