### PR TITLE
Automated cherry pick of #13557: Add back support for Ubuntu 18.04

### DIFF
--- a/docs/operations/images.md
+++ b/docs/operations/images.md
@@ -33,23 +33,24 @@ spec:
 
 The following table provides the support status for various distros with regards to kOps version: 
 
-| Distro | Experimental | Stable | Deprecated | Removed | 
-| ------------ | -----------: | -----: | ---------: | ------: |
-| [Amazon Linux 2](#amazon-linux-2) | 1.10 | 1.18 | - | - |
-| [CentOS 7](#centos-7) | - | 1.5 | 1.21 | - |
-| [CentOS 8](#centos-8) | 1.15 | - | 1.21 | - |
-| CoreOS | 1.6 | 1.9 | 1.17 | 1.18 |
-| Debian 8 | - | 1.5 | 1.17 | 1.18 |
-| [Debian 9](#debian-9-stretch) | 1.8 | 1.10 | 1.21 | - |
-| [Debian 10](#debian-10-buster) | 1.13 | 1.17 | - | - |
-| [Debian 11](#debian-11-bullseye) | 1.21.1 | - | - | - |
-| [Flatcar](#flatcar) | 1.15.1 | 1.17 | - | - |
-| [Kope.io](#kopeio) | - | - | 1.18 | - |
-| [RHEL 7](#rhel-7) | - | 1.5 | 1.21 | - |
-| [RHEL 8](#rhel-8) | 1.15 | 1.18 | - | - |
-| Ubuntu 16.04 | 1.5 | 1.10 | 1.17 | 1.20 |
-| [Ubuntu 18.04](#ubuntu-1804-bionic) | 1.10 | 1.16 | 1.21 | - |
-| [Ubuntu 20.04](#ubuntu-2004-focal) | 1.16.2 | 1.18 | - | - |
+| Distro                              | Experimental | Stable | Deprecated | Removed | 
+|-------------------------------------|-------------:|-------:|-----------:|--------:|
+| [Amazon Linux 2](#amazon-linux-2)   |         1.10 |   1.18 |          - |       - |
+| [CentOS 7](#centos-7)               |            - |    1.5 |       1.21 |       - |
+| [CentOS 8](#centos-8)               |         1.15 |      - |       1.21 |       - |
+| CoreOS                              |          1.6 |    1.9 |       1.17 |    1.18 |
+| Debian 8                            |            - |    1.5 |       1.17 |    1.18 |
+| [Debian 9](#debian-9-stretch)       |          1.8 |   1.10 |       1.21 |       - |
+| [Debian 10](#debian-10-buster)      |         1.13 |   1.17 |          - |       - |
+| [Debian 11](#debian-11-bullseye)    |       1.21.1 |      - |          - |       - |
+| [Flatcar](#flatcar)                 |       1.15.1 |   1.17 |          - |       - |
+| [Kope.io](#kopeio)                  |            - |      - |       1.18 |       - |
+| [RHEL 7](#rhel-7)                   |            - |    1.5 |       1.21 |       - |
+| [RHEL 8](#rhel-8)                   |         1.15 |   1.18 |          - |       - |
+| [RHEL 8](#rhel-8)                   |         1.15 |   1.18 |          - |       - |
+| Ubuntu 16.04                        |          1.5 |   1.10 |       1.17 |    1.20 |
+| [Ubuntu 18.04](#ubuntu-1804-bionic) |         1.10 |   1.16 |          - |       - |
+| [Ubuntu 20.04](#ubuntu-2004-focal)  |       1.16.2 |   1.18 |          - |       - |
 
 ## Supported Distros
 
@@ -134,6 +135,20 @@ aws ec2 describe-images --region us-east-1 --output table \
   --owners 309956199498 \
   --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
   --filters "Name=name,Values=RHEL-8.*x86_64*"
+```
+
+### Ubuntu 18.04 (Bionic)
+
+Ubuntu 18.04.5 is based on Kernel version **5.4** which fixes all the known major Kernel bugs.
+Earlier patch versions may still work, but are not recommended nor supported.
+
+Available images can be listed using:
+
+```bash
+aws ec2 describe-images --region us-east-1 --output table \
+  --owners 099720109477 \
+  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
+  --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-*"
 ```
 
 ### Ubuntu 20.04 (Focal)
@@ -222,22 +237,6 @@ aws ec2 describe-images --region us-east-1 --output table \
   --owners 309956199498 \
   --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
   --filters "Name=name,Values=RHEL-7.*x86_64*"
-```
-
-### Ubuntu 18.04 (Bionic)
-
-Ubuntu 18.04 is based on Kernel version **4.15** which has a number of known bugs that affect it and which may be noticed with larger clusters:
-
-* [kubernetes/kubernetes#56903](https://github.com/kubernetes/kubernetes/issues/56903)
-* [kubernetes/kubernetes#67577](https://github.com/kubernetes/kubernetes/issues/67577)
-
-Available images can be listed using:
-
-```bash
-aws ec2 describe-images --region us-east-1 --output table \
-  --owners 099720109477 \
-  --query "sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]" \
-  --filters "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-*"
 ```
 
 ## Owner aliases 

--- a/docs/releases/1.23-NOTES.md
+++ b/docs/releases/1.23-NOTES.md
@@ -31,8 +31,6 @@ being used, then Kubernetes Node resources will be named after their AWS instanc
 
 * Support for Ubuntu 16.04 (Xenial) has been removed.
 
-* Support for Ubuntu 18.04 (Bionic) has been removed.
-
 * Cilium now has `disable-cnp-status-updates: true` by default. Set this to false if you rely on the CiliumNetworkPolicy status fields.
 
 # Required actions

--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -39,6 +39,7 @@ type Distribution struct {
 var (
 	DistributionDebian10     = Distribution{packageFormat: "deb", project: "debian", id: "buster", version: 10}
 	DistributionDebian11     = Distribution{packageFormat: "deb", project: "debian", id: "bullseye", version: 11}
+	DistributionUbuntu1804   = Distribution{packageFormat: "deb", project: "ubuntu", id: "bionic", version: 18.04}
 	DistributionUbuntu2004   = Distribution{packageFormat: "deb", project: "ubuntu", id: "focal", version: 20.04}
 	DistributionUbuntu2010   = Distribution{packageFormat: "deb", project: "ubuntu", id: "groovy", version: 20.10}
 	DistributionUbuntu2104   = Distribution{packageFormat: "deb", project: "ubuntu", id: "hirsute", version: 21.04}

--- a/util/pkg/distributions/identify.go
+++ b/util/pkg/distributions/identify.go
@@ -54,6 +54,8 @@ func FindDistribution(rootfs string) (Distribution, error) {
 		return DistributionDebian10, nil
 	case "debian-11":
 		return DistributionDebian11, nil
+	case "ubuntu-18.04":
+		return DistributionUbuntu1804, nil
 	case "ubuntu-20.04":
 		return DistributionUbuntu2004, nil
 	case "ubuntu-20.10":

--- a/util/pkg/distributions/identify_test.go
+++ b/util/pkg/distributions/identify_test.go
@@ -96,8 +96,8 @@ func TestFindDistribution(t *testing.T) {
 		},
 		{
 			rootfs:   "ubuntu1804",
-			err:      fmt.Errorf("unsupported distro: ubuntu-18.04"),
-			expected: Distribution{},
+			err:      nil,
+			expected: DistributionUbuntu1804,
 		},
 		{
 			rootfs:   "ubuntu2004",


### PR DESCRIPTION
Cherry pick of #13557 on release-1.23.

#13557: Add back support for Ubuntu 18.04

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```