### PR TITLE
Update Canal's Flannel to v0.15.1

### DIFF
--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: networking.projectcalico.org.canal/k8s-1.22.yaml
-    manifestHash: 3ba7d989e4267b133b6d469eed4833ab790a2d9809e788b11853c86361e767d7
+    manifestHash: b71e423aaac74d5fdb3e3a254759150d32f523df77ad6bb0def85cc088b0ff87
     name: networking.projectcalico.org.canal
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
@@ -4315,7 +4315,7 @@ spec:
             configMapKeyRef:
               key: masquerade
               name: canal-config
-        image: quay.io/coreos/flannel:v0.14.0
+        image: quay.io/coreos/flannel:v0.15.1
         name: kube-flannel
         securityContext:
           privileged: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
@@ -4443,7 +4443,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.14.0
+          image: quay.io/coreos/flannel:v0.15.1
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true


### PR DESCRIPTION
Ref: https://github.com/flannel-io/flannel/releases/tag/v0.15.1

This brings Flannel's [MAC address allocation bugfix](https://github.com/flannel-io/flannel/commit/0198d5dd0f9d2e83a6ce03ff29b9a160fb69e71b) for OSes using systemd 242+ (such as Debian 11) in.