### PR TITLE
Re-add net.bridge settings for flannel

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -134,6 +134,19 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
+	// Running Flannel on Amazon Linux 2 needs custom settings
+	if b.Cluster.Spec.Networking.Flannel != nil && b.Distribution == distributions.DistributionAmazonLinux2 {
+		proxyMode := b.Cluster.Spec.KubeProxy.ProxyMode
+		if proxyMode == "" || proxyMode == "iptables" {
+			sysctls = append(sysctls,
+				"# Flannel settings on Amazon Linux 2",
+				"# Issue https://github.com/coreos/flannel/issues/902",
+				"net.bridge.bridge-nf-call-ip6tables=1",
+				"net.bridge.bridge-nf-call-iptables=1",
+				"")
+		}
+	}
+
 	if b.Cluster.Spec.IsIPv6Only() {
 		if b.Distribution == distributions.DistributionDebian11 {
 			// Accepting Router Advertisements must be enabled for each existing network interface to take effect.


### PR DESCRIPTION
This was originally only set on Centos 7 / RHEL 7 but we're experiencing similar issues on Amazon Linux 2

backstory:

This PR's lengthy discussion to remove support for flannel/vxlan after the same issues were causing grid failures for Centos 7 / RHEL 7: https://github.com/kubernetes/kops/pull/8614
 
These sysctl settings were added for centos/rhel which supposedly fixed our grid jobs: https://github.com/kubernetes/kops/pull/8381

These settings were removed when we dropped support for those distros: https://github.com/kubernetes/kops/pull/12882/files#diff-5326919ae93590b94b210fb2373f8374d5567d146aadaf815ca6a1f7b68179dd


Hoping this fixes these grid jobs: https://testgrid.k8s.io/kops-grid#kops-grid-flannel-amzn2-k23-docker
