### PR TITLE
Add a nameservers parameter for cert-manager.

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -92,6 +92,22 @@ spec:
     managed: false
 ```
 
+##### DNS nameserver configuration for cert-manager pod
+{{ kops_feature_table(kops_added_default='1.23.3', k8s_min='1.16') }}
+
+Optional list of DNS nameserver IP addresses for the cert-manager pod to use.
+This is useful if you have a public and private DNS zone for the same domain to ensure that cert-manager can access ingress, or DNS01 challenge TXT records at all times.
+
+You can set pod DNS nameserver configuration for cert-manager like so:
+```yaml
+spec:
+  certManager:
+    enabled: true
+    nameservers:
+      - 1.1.1.1
+      - 8.8.8.8
+```
+
 
 Read more about cert-manager in the [official documentation](https://cert-manager.io/docs/)
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -289,6 +289,12 @@ spec:
                       by kOps. The deployment of cert-manager is skipped if this is
                       set to false.
                     type: boolean
+                  nameservers:
+                    description: 'nameservers is a list of nameserver IP addresses
+                      to use instead of the pod defaults. Default: none'
+                    items:
+                      type: string
+                    type: array
                 type: object
               channel:
                 description: The Channel we are following

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -1050,6 +1050,10 @@ type CertManagerConfig struct {
 	// defaultIssuer sets a default clusterIssuer
 	// Default: none
 	DefaultIssuer *string `json:"defaultIssuer,omitempty"`
+
+	// nameservers is a list of nameserver IP addresses to use instead of the pod defaults.
+	// Default: none
+	Nameservers []string `json:"nameservers,omitempty"`
 }
 
 // AWSLoadBalancerControllerConfig determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -1076,6 +1076,10 @@ type CertManagerConfig struct {
 	// defaultIssuer sets a default clusterIssuer
 	// Default: none
 	DefaultIssuer *string `json:"defaultIssuer,omitempty"`
+
+	// nameservers is a list of nameserver IP addresses to use instead of the pod defaults.
+	// Default: none
+	Nameservers []string `json:"nameservers,omitempty"`
 }
 
 // AWSLoadBalancerControllerConfig determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1882,6 +1882,7 @@ func autoConvert_v1alpha2_CertManagerConfig_To_kops_CertManagerConfig(in *CertMa
 	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
+	out.Nameservers = in.Nameservers
 	return nil
 }
 
@@ -1895,6 +1896,7 @@ func autoConvert_kops_CertManagerConfig_To_v1alpha2_CertManagerConfig(in *kops.C
 	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
+	out.Nameservers = in.Nameservers
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -519,6 +519,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Nameservers != nil {
+		in, out := &in.Nameservers, &out.Nameservers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -1047,6 +1047,10 @@ type CertManagerConfig struct {
 	// defaultIssuer sets a default clusterIssuer
 	// Default: none
 	DefaultIssuer *string `json:"defaultIssuer,omitempty"`
+
+	// nameservers is a list of nameserver IP addresses to use instead of the pod defaults.
+	// Default: none
+	Nameservers []string `json:"nameservers,omitempty"`
 }
 
 // AWSLoadBalancerControllerConfig determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1908,6 +1908,7 @@ func autoConvert_v1alpha3_CertManagerConfig_To_kops_CertManagerConfig(in *CertMa
 	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
+	out.Nameservers = in.Nameservers
 	return nil
 }
 
@@ -1921,6 +1922,7 @@ func autoConvert_kops_CertManagerConfig_To_v1alpha3_CertManagerConfig(in *kops.C
 	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
+	out.Nameservers = in.Nameservers
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -536,6 +536,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Nameservers != nil {
+		in, out := &in.Nameservers, &out.Nameservers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -535,6 +535,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Nameservers != nil {
+		in, out := &in.Nameservers, &out.Nameservers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -5215,6 +5215,14 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/master
                 operator: Exists
+      {{ if .CertManager.Nameservers }}
+      dnsConfig:
+        nameservers:
+        {{ range $nameserver := .CertManager.Nameservers }}
+        - "{{ $nameserver }}"
+        {{ end }}
+      dnsPolicy: None
+      {{ end }}
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager
       securityContext:


### PR DESCRIPTION
Provide a way to override the pod's list of DNS nameservers to use so
that split-view DNS zones still work for things like DNS01 challenges.
Without this the DNS TXT records are searched for in the private DNS
zone instead of the public one and the challenge will never succeed.