### PR TITLE
Automated cherry pick of #13562: Update Canal's Flannel to v0.15.1

### DIFF
--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: networking.projectcalico.org.canal/k8s-1.22.yaml
-    manifestHash: a5c1eb2388d1a84fe25f5c37e2982abd43b28c99d4cf8e1d01add04818ad3ad1
+    manifestHash: c92f6983b271f38e10d7773cfabf7454d6e8567c117040138ac1afb0033017ac
     name: networking.projectcalico.org.canal
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
@@ -4315,7 +4315,7 @@ spec:
             configMapKeyRef:
               key: masquerade
               name: canal-config
-        image: quay.io/coreos/flannel:v0.14.0
+        image: quay.io/coreos/flannel:v0.15.1
         name: kube-flannel
         securityContext:
           privileged: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
@@ -4441,7 +4441,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.14.0
+          image: quay.io/coreos/flannel:v0.15.1
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true


### PR DESCRIPTION
Cherry pick of #13562 on release-1.23.

#13562: Update Canal's Flannel to v0.15.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```