### PR TITLE
Automated cherry pick of #13570: Include sysctls in toolbox dump

### DIFF
--- a/pkg/dump/dumper.go
+++ b/pkg/dump/dumper.go
@@ -290,6 +290,9 @@ func (n *logDumperNode) dump(ctx context.Context) []error {
 	if err := n.shellToFile(ctx, "cat /etc/hosts", filepath.Join(n.dir, "etchosts")); err != nil {
 		errors = append(errors, err)
 	}
+	if err := n.shellToFile(ctx, "sysctl -a", filepath.Join(n.dir, "sysctls")); err != nil {
+		errors = append(errors, err)
+	}
 
 	return errors
 }


### PR DESCRIPTION
Cherry pick of #13570 on release-1.23.

#13570: Include sysctls in toolbox dump

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```