### PR TITLE
Add support for installing additional packages

### DIFF
--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -834,6 +834,11 @@ spec:
                 description: NodeLabels indicates the kubernetes labels for nodes
                   in this instance group
                 type: object
+              packages:
+                description: Packages specifies additional packages to be installed.
+                items:
+                  type: string
+                type: array
               role:
                 description: 'Type determines the role of instances in this instance
                   group: masters or nodes'

--- a/nodeup/pkg/model/packages.go
+++ b/nodeup/pkg/model/packages.go
@@ -52,6 +52,10 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 		c.AddTask(&nodetasks.Package{Name: "pigz"})
 		c.AddTask(&nodetasks.Package{Name: "socat"})
 		c.AddTask(&nodetasks.Package{Name: "util-linux"})
+		// Additional packages
+		for _, additionalPackage := range b.NodeupConfig.Packages {
+			c.EnsureTask(&nodetasks.Package{Name: additionalPackage})
+		}
 	} else if b.Distribution.IsRHELFamily() {
 		c.AddTask(&nodetasks.Package{Name: "nfs-utils"})
 		// From containerd: https://github.com/containerd/cri/blob/master/contrib/ansible/tasks/bootstrap_centos.yaml
@@ -71,6 +75,10 @@ func (b *PackagesBuilder) Build(c *fi.ModelBuilderContext) error {
 		default:
 			c.AddTask(&nodetasks.Package{Name: "container-selinux"})
 			c.AddTask(&nodetasks.Package{Name: "pigz"})
+		}
+		// Additional packages
+		for _, additionalPackage := range b.NodeupConfig.Packages {
+			c.EnsureTask(&nodetasks.Package{Name: additionalPackage})
 		}
 	} else {
 		// Hopefully they are already installed

--- a/pkg/apis/kops/instancegroup.go
+++ b/pkg/apis/kops/instancegroup.go
@@ -192,6 +192,8 @@ type InstanceGroupSpec struct {
 	WarmPool *WarmPoolSpec `json:"warmPool,omitempty"`
 	// Containerd specifies override configuration for instance group
 	Containerd *ContainerdConfig `json:"containerd,omitempty"`
+	// Packages specifies additional packages to be installed.
+	Packages []string `json:"packages,omitempty"`
 }
 
 const (

--- a/pkg/apis/kops/v1alpha2/instancegroup.go
+++ b/pkg/apis/kops/v1alpha2/instancegroup.go
@@ -158,6 +158,8 @@ type InstanceGroupSpec struct {
 	WarmPool *WarmPoolSpec `json:"warmPool,omitempty"`
 	// Containerd specifies override configuration for instance group
 	Containerd *ContainerdConfig `json:"containerd,omitempty"`
+	// Packages specifies additional packages to be installed.
+	Packages []string `json:"packages,omitempty"`
 }
 
 // InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -4413,6 +4413,7 @@ func autoConvert_v1alpha2_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	} else {
 		out.Containerd = nil
 	}
+	out.Packages = in.Packages
 	return nil
 }
 
@@ -4584,6 +4585,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha2_InstanceGroupSpec(in *kops.I
 	} else {
 		out.Containerd = nil
 	}
+	out.Packages = in.Packages
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -2491,6 +2491,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(ContainerdConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Packages != nil {
+		in, out := &in.Packages, &out.Packages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/instancegroup.go
+++ b/pkg/apis/kops/v1alpha3/instancegroup.go
@@ -155,6 +155,8 @@ type InstanceGroupSpec struct {
 	WarmPool *WarmPoolSpec `json:"warmPool,omitempty"`
 	// Containerd specifies override configuration for instance group
 	Containerd *ContainerdConfig `json:"containerd,omitempty"`
+	// Packages specifies additional packages to be installed.
+	Packages []string `json:"packages,omitempty"`
 }
 
 // InstanceMetadataOptions defines the EC2 instance metadata service options (AWS Only)

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -4506,6 +4506,7 @@ func autoConvert_v1alpha3_InstanceGroupSpec_To_kops_InstanceGroupSpec(in *Instan
 	} else {
 		out.Containerd = nil
 	}
+	out.Packages = in.Packages
 	return nil
 }
 
@@ -4677,6 +4678,7 @@ func autoConvert_kops_InstanceGroupSpec_To_v1alpha3_InstanceGroupSpec(in *kops.I
 	} else {
 		out.Containerd = nil
 	}
+	out.Packages = in.Packages
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -2476,6 +2476,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(ContainerdConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Packages != nil {
+		in, out := &in.Packages, &out.Packages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -2639,6 +2639,11 @@ func (in *InstanceGroupSpec) DeepCopyInto(out *InstanceGroupSpec) {
 		*out = new(ContainerdConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Packages != nil {
+		in, out := &in.Packages, &out.Packages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/nodeup/config.go
+++ b/pkg/apis/nodeup/config.go
@@ -41,6 +41,8 @@ type Config struct {
 	ApiserverAdditionalIPs []string `json:",omitempty"`
 	// WarmPoolImages are the container images to pre-pull during instance pre-initialization
 	WarmPoolImages []string `json:"warmPoolImages,omitempty"`
+	// Packages specifies additional packages to be installed.
+	Packages []string `json:"packages,omitempty"`
 
 	// Manifests for running etcd
 	EtcdManifests []string `json:"etcdManifests,omitempty"`

--- a/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/complex/cloudformation.json.extracted.yaml
@@ -451,7 +451,7 @@ Resources.AWSEC2LaunchTemplatenodescomplexexamplecom.Properties.LaunchTemplateDa
   ConfigBase: memfs://clusters.example.com/complex.example.com
   InstanceGroupName: nodes
   InstanceGroupRole: Node
-  NodeupConfigHash: yPkFbMcpagKgWbeaLBm+VzZA6j7pzymiEUToAgoi/jQ=
+  NodeupConfigHash: B6m52ipzLUBjmF25OCRWFS53lSl8+f4IJsRxTiYiX+4=
 
   __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
@@ -171,7 +171,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/complex.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: yPkFbMcpagKgWbeaLBm+VzZA6j7pzymiEUToAgoi/jQ=
+NodeupConfigHash: B6m52ipzLUBjmF25OCRWFS53lSl8+f4IJsRxTiYiX+4=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
@@ -62,3 +62,5 @@ channels:
 containerdConfig:
   logLevel: info
   version: 1.4.12
+packages:
+- nfs-common

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -118,6 +118,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  packages:
+  - nfs-common
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -119,6 +119,8 @@ spec:
   machineType: t2.medium
   maxSize: 2
   minSize: 2
+  packages:
+  - nfs-common
   role: Node
   subnets:
   - us-test-1a

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1410,6 +1410,10 @@ func (n *nodeUpConfigBuilder) BuildConfig(ig *kops.InstanceGroup, apiserverAddit
 		config.WarmPoolImages = n.buildWarmPoolImages(ig)
 	}
 
+	if ig.Spec.Packages != nil {
+		config.Packages = ig.Spec.Packages
+	}
+
 	return config, bootConfig, nil
 }
 


### PR DESCRIPTION
Easy way to install additional packages. Should allow kOps to not install optional packages, like https://github.com/kubernetes/kops/pull/13577.

/cc @rifelpet @justinsb 