### PR TITLE
doc(mfa): add another workaround using aws-vault

### DIFF
--- a/docs/mfa.md
+++ b/docs/mfa.md
@@ -66,3 +66,13 @@ Use [awsudo](https://github.com/makethunder/awsudo) to generate temp credentials
 pip install awsudo
 env $(awsudo ${AWS_PROFILE} | grep AWS | xargs) kops ...
 ```
+
+## The Workaround #3
+
+Use [aws-vault](https://github.com/99designs/aws-vault) to generate temp session credentials. After setting up `aws-vault`, use alias for `kops` command. This way terminal will ask for MFA each time the credential session is expired. Commands would be:
+
+```bash
+AWS_PROFILE=sandbox
+aws-vault add $AWS_PROFILE
+alias kops="aws-vault exec ${AWS_PROFILE} -- kops"
+```


### PR DESCRIPTION
Add doc to use [aws-vault](https://github.com/99designs/aws-vault) as it's a common tool for MFA.