### PR TITLE
Fix unexpected type for object metadata when using gossip DNS

### DIFF
--- a/pkg/kubemanifest/yaml.go
+++ b/pkg/kubemanifest/yaml.go
@@ -51,7 +51,7 @@ func KubeObjectToApplyYAML(data runtime.Object) (string, error) {
 	// Remove metadata.creationTimestamp (can't be applied, shouldn't be specified)
 	metadataObj, found := jsonObj["metadata"]
 	if found {
-		if metadata, ok := metadataObj.(map[interface{}]interface{}); ok {
+		if metadata, ok := metadataObj.(map[string]interface{}); ok {
 			delete(metadata, "creationTimestamp")
 		} else {
 			klog.Warningf("unexpected type for object metadata: %T", metadataObj)


### PR DESCRIPTION
Before:
```
yaml.go:53] MetadataObj: map[creationTimestamp:<nil> labels:map[discovery.kops.k8s.io/internal-name:api.internal.test1.k8s.local] name:api-internal namespace:kube-system]:
yaml.go:58] unexpected type for object metadata: map[string]interface {}
yaml.go:63] MetadataObj: map[creationTimestamp:<nil> labels:map[discovery.kops.k8s.io/internal-name:api.internal.test1.k8s.local] name:api-internal namespace:kube-system]:
yaml.go:53] MetadataObj: map[creationTimestamp:<nil> labels:map[discovery.kops.k8s.io/internal-name:kops-controller.internal.test1.k8s.local] name:kops-controller-internal namespace:kube-system]:
yaml.go:58] unexpected type for object metadata: map[string]interface {}
yaml.go:63] MetadataObj: map[creationTimestamp:<nil> labels:map[discovery.kops.k8s.io/internal-name:kops-controller.internal.test1.k8s.local] name:kops-controller-internal namespace:kube-system]:
```
After:
```
yaml.go:53] MetadataObj: map[creationTimestamp:<nil> labels:map[discovery.kops.k8s.io/internal-name:api.internal.test1.k8s.local] name:api-internal namespace:kube-system]:
yaml.go:63] MetadataObj: map[labels:map[discovery.kops.k8s.io/internal-name:api.internal.test1.k8s.local] name:api-internal namespace:kube-system]:
yaml.go:53] MetadataObj: map[creationTimestamp:<nil> labels:map[discovery.kops.k8s.io/internal-name:kops-controller.internal.test1.k8s.local] name:kops-controller-internal namespace:kube-system]:
yaml.go:63] MetadataObj: map[labels:map[discovery.kops.k8s.io/internal-name:kops-controller.internal.test1.k8s.local] name:kops-controller-internal namespace:kube-system]:
```