### PR TITLE
Automated cherry pick of #13592: Fix unexpected type for object metadata when using gossip DNS

### DIFF
--- a/pkg/kubemanifest/yaml.go
+++ b/pkg/kubemanifest/yaml.go
@@ -51,7 +51,7 @@ func KubeObjectToApplyYAML(data runtime.Object) (string, error) {
 	// Remove metadata.creationTimestamp (can't be applied, shouldn't be specified)
 	metadataObj, found := jsonObj["metadata"]
 	if found {
-		if metadata, ok := metadataObj.(map[interface{}]interface{}); ok {
+		if metadata, ok := metadataObj.(map[string]interface{}); ok {
 			delete(metadata, "creationTimestamp")
 		} else {
 			klog.Warningf("unexpected type for object metadata: %T", metadataObj)


### PR DESCRIPTION
Cherry pick of #13592 on release-1.23.

#13592: Fix unexpected type for object metadata when using gossip DNS

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```