### PR TITLE
Add hashes for containerd and Docker in order to fix CVE-2022-23648

### DIFF
--- a/upup/pkg/fi/cloudup/containerd.go
+++ b/upup/pkg/fi/cloudup/containerd.go
@@ -199,6 +199,7 @@ func findAllContainerdHashesAmd64() map[string]string {
 		"1.4.10": "5b256b372a02fd37c84939c87a6a81cae06058a7881a60d682525c11f6dea7d1",
 		"1.4.11": "a4a4af4776316833cad5996c66d59f8b4a2af4da716b7902b7a2d5f5ac362dcc",
 		"1.4.12": "f6120552408175ca332fd3b5d31c5edd115d8426d6731664e4ea3951c5eee3b4",
+		"1.4.13": "29ef1e8635795c2a49a20a56e778f45ff163c5400a5428ca33999ed53d44e3d8",
 		"1.5.0":  "aee7b553ab88842fdafe43955757abe746b8e9995b2be55c603f0a236186ff9b",
 		"1.5.1":  "2fd97916b24396c13849cfcd89805170e1ef0265a2f7fce8e74ae044a6a6a169",
 		"1.5.2":  "e7adbb6c6f6e67639460579a8aa991e9ce4de2062ed36d3261e6e4865574d947",
@@ -241,6 +242,7 @@ func findAllContainerdDockerMappings() map[string]string {
 		"1.4.9":  "20.10.8",
 		"1.4.11": "20.10.9",
 		"1.4.12": "20.10.11",
+		"1.4.13": "20.10.13",
 	}
 
 	return versions

--- a/upup/pkg/fi/cloudup/docker.go
+++ b/upup/pkg/fi/cloudup/docker.go
@@ -203,6 +203,8 @@ func findAllDockerHashesAmd64() map[string]string {
 		"20.10.9":  "caf74e54b58c0b38bb4d96c8f87665f29b684371c9a325562a3904b8c389995e",
 		"20.10.10": "1719446f99cd56e87d0c67019996af4ea859f11891bfd89de2252d6c916ccaaa",
 		"20.10.11": "dd6ff72df1edfd61ae55feaa4aadb88634161f0aa06dbaaf291d1be594099ff3",
+		"20.10.12": "ee9b5be14e54bf92f48c82c2e6a83fbdd1c5329e8f247525a9ed2fe90d9f89a5",
+		"20.10.13": "39edf7c8d773939ff5e4d318ae565691a9c7e754ed768e172757e58898fb7079",
 	}
 
 	return hashes
@@ -258,6 +260,8 @@ func findAllDockerHashesArm64() map[string]string {
 		"20.10.9":  "0259f8b6572f02cf0dafd7388ca0e4adfdbbfaba81cfb1b7443e89fccbed22c7",
 		"20.10.10": "8db47cdcd7ac6e082c9ce83347d8fb99eaa01e04b0c8d94851e8d58f350a3633",
 		"20.10.11": "87a4219c54552797ffd38790b72832372a90eceb7c8e451c36a682093d57dae6",
+		"20.10.12": "e1f964e9a7a824bbe2164560c0eb335fab9cc7ee9eb90da36c250c073459cf17",
+		"20.10.13": "debed306ed9a4e70dcbcb228a0b3898f9730099e324f34bb0e76abbaddf7a6a7",
 	}
 
 	return hashes


### PR DESCRIPTION
According to [this](https://www.crowdstrike.com/blog/understanding-cve-2022-23648-kubernetes-vulnerability/) article from crowdstrike, containerd version 1.4.13 is the recommended version to fully PATH CVE-2022-23648.

This PR adds 1.4.13 hash to kops binary.

Suggestion: cherrypick this to 1.23 and 1.22