### PR TITLE
Add IRSA for kube-router

### DIFF
--- a/pkg/model/components/addonmanifests/kuberouter/iam.go
+++ b/pkg/model/components/addonmanifests/kuberouter/iam.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberouter
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/kops/pkg/model/iam"
+)
+
+// ServiceAccount represents the service-account used by kube-router when we're using IRSA
+// It implements iam.Subject to get AWS IAM permissions.
+type ServiceAccount struct{}
+
+var _ iam.Subject = &ServiceAccount{}
+
+// BuildAWSPolicy generates a custom policy for a ServiceAccount IAM role.
+func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, error) {
+	clusterName := b.Cluster.ObjectMeta.Name
+	p := iam.NewPolicy(clusterName, b.Partition)
+	iam.AddKubeRouterPermissions(b, p)
+	return p, nil
+}
+
+// ServiceAccount returns the kubernetes service account used.
+func (r *ServiceAccount) ServiceAccount() (types.NamespacedName, bool) {
+	return types.NamespacedName{
+		Namespace: "kube-system",
+		Name:      "kube-router",
+	}, true
+}

--- a/pkg/model/components/addonmanifests/remap.go
+++ b/pkg/model/components/addonmanifests/remap.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kops/pkg/model/components/addonmanifests/dnscontroller"
 	"k8s.io/kops/pkg/model/components/addonmanifests/externaldns"
 	"k8s.io/kops/pkg/model/components/addonmanifests/karpenter"
+	"k8s.io/kops/pkg/model/components/addonmanifests/kuberouter"
 	"k8s.io/kops/pkg/model/components/addonmanifests/nodeterminationhandler"
 	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/upup/pkg/fi"
@@ -129,6 +130,8 @@ func getWellknownServiceAccount(name string) iam.Subject {
 		return &externaldns.ServiceAccount{}
 	case "karpenter":
 		return &karpenter.ServiceAccount{}
+	case "kube-router":
+		return &kuberouter.ServiceAccount{}
 	default:
 		return nil
 	}

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -1115,6 +1115,14 @@ func AddDNSControllerPermissions(b *PolicyBuilder, p *Policy) {
 	})
 }
 
+// AddKubeRouterPermissions adds IAM permissions used by kube-router
+// for disabling the source/destination check on EC2 instances.
+func AddKubeRouterPermissions(b *PolicyBuilder, p *Policy) {
+	p.clusterTaggedAction.Insert(
+		"ec2:ModifyInstanceAttribute",
+	)
+}
+
 func addKMSIAMPolicies(p *Policy, resource stringorslice.StringOrSlice) {
 	// TODO could use "kms:ViaService" Condition Key here?
 	p.unconditionalAction.Insert(

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kops/pkg/model/components/addonmanifests/dnscontroller"
 	"k8s.io/kops/pkg/model/components/addonmanifests/externaldns"
 	"k8s.io/kops/pkg/model/components/addonmanifests/karpenter"
+	"k8s.io/kops/pkg/model/components/addonmanifests/kuberouter"
 	"k8s.io/kops/pkg/model/components/addonmanifests/nodeterminationhandler"
 	"k8s.io/kops/pkg/model/iam"
 	"k8s.io/kops/pkg/templates"
@@ -955,6 +956,11 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*Addon
 				Manifest: fi.String(location),
 				Id:       id,
 			})
+		}
+
+		// Generate kube-router ServiceAccount IAM permissions
+		if b.UseServiceAccountExternalPermissions() {
+			serviceAccountRoles = append(serviceAccountRoles, &kuberouter.ServiceAccount{})
 		}
 	}
 


### PR DESCRIPTION
[kube-router jobs are failing](https://testgrid.k8s.io/kops-network-plugins#kops-aws-cni-kuberouter) now that k8s 1.24 is released. the jobs use the release/stable k8s version marker, so they're now on 1.24 which kops defaults to enabling IRSA.

[kube-router pod logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-cni-kuberouter/1521995867320487936/artifacts/cluster-info/kube-system/kube-router-c69fn/logs.txt) show failed attempts to disable the src/dest check on ec2 instances:

`E0504 23:37:12.829945       1 aws.go:60] Node does not have necessary IAM creds to modify instance attribute. So skipping disabling src-dst check.`

Before 1.24, [pod logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-cni-kuberouter/1521392063394877440/artifacts/cluster-info/kube-system/kube-router-h6csr/logs.txt) confirm the src-dst check is able to be disabled:

`I0503 07:37:01.551179       1 aws.go:65] Disabled source destination check for the instance: i-08feeddb530837cd8`


This sets up IRSA for the kube-router service account to have the necessary permissions. Its likely we'll run into this issue with multiple CNIs so I kept the iambuilder function name generic.