### PR TITLE
Avoid "/etc/resolv.conf" file loopback for Flatcar Container Linux distribution

### DIFF
--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -99,6 +99,9 @@ func (d *Distribution) HasLoopbackEtcResolvConf() bool {
 		// Ubuntu > 16.04 has it
 		return d.version > 16.04
 	}
+	if d.project == "flatcar" {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
In [Flatcar Container Linux versions at 2748.0](https://www.flatcar-linux.org/releases#release-2748.0.0) and later, configure the kubelet to use an alternate DNS resolver configuration. Rather than using the _/etc/resolv.conf_ file, use _systemd-resolved_'s _/run/systemd/resolve/resolv.conf_ file.

Without this configuration, pods like CoreDNS that use [the "Default" DNS policy](https://github.com/kubernetes/api/blob/5e2f5add2db54c6b8eec87c2e467b53d2409dbf3/core/v1/types.go#L2716-L2718) wind up with [a DNS forwarding loop](https://coredns.io/plugins/loop/#troubleshooting).

See flatcar-linux/Flatcar#285 for pertinent discussion, as well as [a thread in the "kops-users" channel](https://kubernetes.slack.com/archives/C3QUFP0QM/p1650573952888199) of the "Kubernetes" Slack workspace that arose from diagnosing failures in the CoreDNS containers.