### PR TITLE
Automated cherry pick of #13617: Avoid resolv.conf file loopback for Flatcar distro

### DIFF
--- a/util/pkg/distributions/distributions.go
+++ b/util/pkg/distributions/distributions.go
@@ -100,6 +100,9 @@ func (d *Distribution) HasLoopbackEtcResolvConf() bool {
 		// Ubuntu > 16.04 has it
 		return d.version > 16.04
 	}
+	if d.project == "flatcar" {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
Cherry pick of #13617 on release-1.22.

#13617: Avoid resolv.conf file loopback for Flatcar distro

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```