### PR TITLE
remove bind address for occm

### DIFF
--- a/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
+++ b/upup/models/cloudup/resources/addons/openstack.addons.k8s.io/k8s-1.13.yaml.template
@@ -218,7 +218,6 @@ spec:
 {{- range $arg := CloudControllerConfigArgv }}
           - {{ $arg }}
 {{- end }}
-          - --bind-address=127.0.0.1
         resources:
           requests:
             cpu: {{ or .ExternalCloudControllerManager.CPURequest "200m" }}


### PR DESCRIPTION
if we use bind-address 127.0.0.1 we cannot fetch for instance prometheus metrics from the controller.