### PR TITLE
Allow returning multiple addresses for API

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -81,16 +81,18 @@ func (b *BootstrapScript) kubeEnv(ig *kops.InstanceGroup, c *fi.Context) (string
 	var alternateNames []string
 
 	for _, hasAddress := range b.alternateNameTasks {
-		address, err := hasAddress.FindIPAddress(c)
+		addresses, err := hasAddress.FindAddresses(c)
 		if err != nil {
 			return "", fmt.Errorf("error finding address for %v: %v", hasAddress, err)
 		}
-		if address == nil {
+		if len(addresses) == 0 {
 			klog.Warningf("Task did not have an address: %v", hasAddress)
 			continue
 		}
-		klog.V(8).Infof("Resolved alternateName %q for %q", *address, hasAddress)
-		alternateNames = append(alternateNames, *address)
+		for _, address := range addresses {
+			klog.V(8).Infof("Resolved alternateName %q for %q", address, hasAddress)
+			alternateNames = append(alternateNames, address)
+		}
 	}
 
 	sort.Strings(alternateNames)

--- a/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/classic_load_balancer.go
@@ -346,7 +346,7 @@ func (e *ClassicLoadBalancer) IsForAPIServer() bool {
 	return e.ForAPIServer
 }
 
-func (e *ClassicLoadBalancer) FindIPAddress(context *fi.Context) (*string, error) {
+func (e *ClassicLoadBalancer) FindAddresses(context *fi.Context) ([]string, error) {
 	cloud := context.Cloud.(awsup.AWSCloud)
 
 	lb, err := cloud.FindELBByNameTag(fi.StringValue(e.Name))
@@ -361,7 +361,7 @@ func (e *ClassicLoadBalancer) FindIPAddress(context *fi.Context) (*string, error
 	if lbDnsName == "" {
 		return nil, nil
 	}
-	return &lbDnsName, nil
+	return []string{lbDnsName}, nil
 }
 
 func (e *ClassicLoadBalancer) Run(c *fi.Context) error {

--- a/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
+++ b/upup/pkg/fi/cloudup/awstasks/network_load_balancer.go
@@ -430,7 +430,7 @@ func (e *NetworkLoadBalancer) IsForAPIServer() bool {
 	return e.ForAPIServer
 }
 
-func (e *NetworkLoadBalancer) FindIPAddress(context *fi.Context) (*string, error) {
+func (e *NetworkLoadBalancer) FindAddresses(context *fi.Context) ([]string, error) {
 	cloud := context.Cloud.(awsup.AWSCloud)
 
 	lb, err := cloud.FindELBV2ByNameTag(e.Tags["Name"])
@@ -445,7 +445,7 @@ func (e *NetworkLoadBalancer) FindIPAddress(context *fi.Context) (*string, error
 	if lbDnsName == "" {
 		return nil, nil
 	}
-	return &lbDnsName, nil
+	return []string{lbDnsName}, nil
 }
 
 func (e *NetworkLoadBalancer) Run(c *fi.Context) error {

--- a/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/dotasks/loadbalancer.go
@@ -153,7 +153,7 @@ func (_ *LoadBalancer) RenderDO(t *do.DOAPITarget, a, e, changes *LoadBalancer) 
 		if strings.Contains(loadbalancer.Name, fi.StringValue(e.Name)) {
 			// load balancer already exists.
 			e.ID = fi.String(loadbalancer.ID)
-			e.IPAddress = fi.String(loadbalancer.IP) // This will be empty on create, but will be filled later on FindIPAddress invokation.
+			e.IPAddress = fi.String(loadbalancer.IP) // This will be empty on create, but will be filled later on FindAddresses invokation.
 			return nil
 		}
 	}
@@ -183,7 +183,7 @@ func (_ *LoadBalancer) RenderDO(t *do.DOAPITarget, a, e, changes *LoadBalancer) 
 	}
 
 	e.ID = fi.String(loadbalancer.ID)
-	e.IPAddress = fi.String(loadbalancer.IP) // This will be empty on create, but will be filled later on FindIPAddress invokation.
+	e.IPAddress = fi.String(loadbalancer.IP) // This will be empty on create, but will be filled later on FindAddresses invokation.
 
 	klog.V(2).Infof("load balancer for DO created with id: %s", loadbalancer.ID)
 	return nil
@@ -193,7 +193,7 @@ func (lb *LoadBalancer) IsForAPIServer() bool {
 	return lb.ForAPIServer
 }
 
-func (lb *LoadBalancer) FindIPAddress(c *fi.Context) (*string, error) {
+func (lb *LoadBalancer) FindAddresses(c *fi.Context) ([]string, error) {
 	cloud := c.Cloud.(do.DOCloud)
 	loadBalancerService := cloud.LoadBalancersService()
 	address := ""
@@ -217,7 +217,7 @@ func (lb *LoadBalancer) FindIPAddress(c *fi.Context) (*string, error) {
 			return false, nil
 		})
 		if done {
-			return &address, nil
+			return []string{address}, nil
 		} else {
 			if err == nil {
 				err = wait.ErrWaitTimeout

--- a/upup/pkg/fi/cloudup/gcetasks/address.go
+++ b/upup/pkg/fi/cloudup/gcetasks/address.go
@@ -100,7 +100,7 @@ func (e *Address) IsForAPIServer() bool {
 	return e.ForAPIServer
 }
 
-func (e *Address) FindIPAddress(context *fi.Context) (*string, error) {
+func (e *Address) FindAddresses(context *fi.Context) ([]string, error) {
 	actual, err := e.find(context.Cloud.(gce.GCECloud))
 	if err != nil {
 		return nil, fmt.Errorf("error querying for IP Address: %v", err)
@@ -108,7 +108,7 @@ func (e *Address) FindIPAddress(context *fi.Context) (*string, error) {
 	if actual == nil {
 		return nil, nil
 	}
-	return actual.IPAddress, nil
+	return []string{fi.StringValue(actual.IPAddress)}, nil
 }
 
 func (e *Address) Run(c *fi.Context) error {

--- a/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/floatingip.go
@@ -77,7 +77,7 @@ func (e *FloatingIP) IsForAPIServer() bool {
 	return e.ForAPIServer
 }
 
-func (e *FloatingIP) FindIPAddress(context *fi.Context) (*string, error) {
+func (e *FloatingIP) FindAddresses(context *fi.Context) ([]string, error) {
 	if e.ID == nil {
 		if e.LB != nil && e.LB.ID == nil {
 			return nil, nil
@@ -94,7 +94,7 @@ func (e *FloatingIP) FindIPAddress(context *fi.Context) (*string, error) {
 			return nil, err
 		}
 		if len(fips) == 1 && fips[0].PortID == fi.StringValue(e.LB.PortID) {
-			return &fips[0].FloatingIP, nil
+			return []string{fips[0].FloatingIP}, nil
 		}
 		return nil, fmt.Errorf("Could not find port floatingips port=%s", fi.StringValue(e.LB.PortID))
 	}
@@ -103,7 +103,7 @@ func (e *FloatingIP) FindIPAddress(context *fi.Context) (*string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &fip.FloatingIP, nil
+	return []string{fip.FloatingIP}, nil
 }
 
 // GetDependencies returns the dependencies of the Instance task

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -98,7 +98,7 @@ func (e *Instance) IsForAPIServer() bool {
 	return e.ForAPIServer
 }
 
-func (e *Instance) FindIPAddress(context *fi.Context) (*string, error) {
+func (e *Instance) FindAddresses(context *fi.Context) ([]string, error) {
 	cloud := context.Cloud.(openstack.OpenstackCloud)
 	if e.Port == nil {
 		return nil, nil
@@ -110,7 +110,7 @@ func (e *Instance) FindIPAddress(context *fi.Context) (*string, error) {
 	}
 
 	for _, port := range ports.FixedIPs {
-		return fi.String(port.IPAddress), nil
+		return []string{port.IPAddress}, nil
 	}
 
 	return nil, nil

--- a/upup/pkg/fi/has_address.go
+++ b/upup/pkg/fi/has_address.go
@@ -23,5 +23,5 @@ type HasAddress interface {
 	// IsForAPIServer indicates whether the implementation provides an address that needs to be added to the api-server server certificate.
 	IsForAPIServer() bool
 	// FindIPAddress returns the address associated with the implementor.  If there is no address, returns (nil, nil).
-	FindIPAddress(context *Context) (*string, error)
+	FindAddresses(context *Context) ([]string, error)
 }


### PR DESCRIPTION
Hetzner load balancers have internal IPv4, external IPv4 and external IPv6.
This PR makes it possible for tasks with `HasAddress` implemented to return multiple addresses via `FindAddresses()`. 