### PR TITLE
[DigitalOcean]: make droplet image constant when building droplet in for fitask

### DIFF
--- a/upup/pkg/fi/cloudup/dotasks/droplet.go
+++ b/upup/pkg/fi/cloudup/dotasks/droplet.go
@@ -84,7 +84,7 @@ func (d *Droplet) Find(c *fi.Context) (*Droplet, error) {
 		Count:     count,
 		Region:    fi.String(foundDroplet.Region.Slug),
 		Size:      fi.String(foundDroplet.Size.Slug),
-		Image:     fi.String(foundDroplet.Image.Slug),
+		Image:     d.Image, //Image should not change so we keep it as-is
 		Tags:      foundDroplet.Tags,
 		SSHKey:    d.SSHKey,   // TODO: get from droplet or ignore change
 		UserData:  d.UserData, // TODO: get from droplet or ignore change


### PR DESCRIPTION
we might as well remove the checks, but it's ok to keep them I guess.

Fixes: #13627 