### PR TITLE
fix typo in docs/instance-groups.md

### DIFF
--- a/docs/instance_groups.md
+++ b/docs/instance_groups.md
@@ -269,7 +269,7 @@ Instead of configuring specific machine types, the InstanceGroup can be configur
 ```
 spec:
   mixedInstancesPolicy:
-    instanceRquirements:
+    instanceRequirements:
       cpu:
         min: "2"
         max: "16"


### PR DESCRIPTION
Fix a typo found in instance groups documentation.