### PR TITLE
Update AWS CCM to 13.05.2022 releases

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -96,9 +96,11 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		case 22:
 			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.22.0"
 		case 23:
-			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0"
+			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.1"
+		case 24:
+			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.0"
 		default:
-			eccm.Image = "gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.24.0-alpha.0-23-gf6b92bb"
+			eccm.Image = "gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.24.0-2-g06c1641"
 		}
 	}
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterCIDR: 172.20.0.0/16
     clusterName: minimal.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.1
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -48,7 +48,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-cloud-controller-manager.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.1
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -133,7 +133,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: d9893fa0c53058765199524a48c3410808f1c57ea87c4ecda79414e6916ec871
+    manifestHash: 3d10e5986df7b91bb4370438493911d538331bfe7225bc37aed2f38a4c1c9ec9
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
@@ -25,7 +25,7 @@ spec:
     clusterName: minimal.example.com
     configureCloudRoutes: false
     enableLeaderMigration: true
-    image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.24.0-alpha.0-23-gf6b92bb
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.0
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -49,7 +49,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-cloud-controller-manager.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.24.0-alpha.0-23-gf6b92bb
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -133,7 +133,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: c38091031df0df39625bdceb35df3d439bffe80c86ab625e2b2bb60f2ef66473
+    manifestHash: 2184fba1fc470722507962a3092d48f53d9f3b5aae11e298248cf08f2b954938
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
@@ -20,7 +20,7 @@ spec:
     clusterName: minimal.example.com
     configureCloudRoutes: false
     enableLeaderMigration: true
-    image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.24.0-alpha.0-23-gf6b92bb
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.0
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -45,7 +45,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.24.0-alpha.0-23-gf6b92bb
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 695a86c879ffa6f7362786ed9e6133c2858e50b63cce425c4d776d1a542c4034
+    manifestHash: bab18fd3fa809e9b2ed27b1d362fc3fa7b55818753b2372446e4fe64b4bccb85
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterCIDR: ::/0
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.1
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.0-alpha.0
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.1
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 12d77635de64a84d75ca6524e8c7f12ddb256fa062debf869a2ba9ea56c73e32
+    manifestHash: f7e43b1e3154dcdff37bf7d31a81820c875ee3f775b921318a94fb9c179b0984
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
/hold for images to be published
https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/US/provider-aws/cloud-controller-manager

The build for 1.21.0 has failed so image cannot be promoted for now:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/cloud-provider-aws-push-images/1524937450936340480

The build for 1.22.1 cannot start due to a version related bug:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kops/13644/pull-kops-latest-e2e-aws-k8s-1-22/1525104500518424576/artifacts/cluster-info/kube-system/aws-cloud-controller-manager-kbrzg/logs.txt

/cc @olemarkus @rifelpet 