### PR TITLE
Fix code block in manageStorageClasses docs

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -1132,7 +1132,7 @@ spec:
 {{ kops_feature_table(kops_added_default='1.20') }}
 
 
-By default kops will create `StorageClass` resources with some opinionated settings specific to cloud provider on which the cluster is installed. One of those storage classes will be defined as default applying the annotation `storageclass.kubernetes.io/is-default-class: "true"`. This may not always be a desirable behaviour and some cluster admins rather prefer to have more control of storage classes and manage them outside of kops. When set to `false`, kOps will no longer create any `StorageClass` objects. Any such objects that kOps created in the past are left as is, and kOps and will no longer reconcile them against future changes.
+By default kops will create `StorageClass` resources with some opinionated settings specific to cloud provider on which the cluster is installed. One of those storage classes will be defined as default applying the annotation `storageclass.kubernetes.io/is-default-class: "true"`. This may not always be a desirable behaviour and some cluster admins rather prefer to have more control of storage classes and manage them outside of kops. When set to `false`, kOps will no longer create any `StorageClass` objects. Any such objects that kOps created in the past are left as is, and kOps will no longer reconcile them against future changes.
 
 The existing `spec.cloudConfig.openstack.blockStorage.createStorageClass` field remains in place. However, if both that and the new `spec.cloudConfig.manageStorageClasses` field are populated, they must agree: It is invalid both to disable management of `StorageClass` objects globally but to enable them for OpenStack and, conversely, to enable management globally but disable it for OpenStack.
 
@@ -1140,6 +1140,7 @@ The existing `spec.cloudConfig.openstack.blockStorage.createStorageClass` field 
 spec:
   cloudConfig:
     manageStorageClasses: false
+```
 
 ## containerRuntime
 {{ kops_feature_table(kops_added_default='1.18', k8s_min='1.11') }}


### PR DESCRIPTION
When posting the initial PR https://github.com/kubernetes/kops/pull/13641 I didn't build the docs and didn't realise
that code block was not closed. Fixing it now.

Here's the broken doc:

![image](https://user-images.githubusercontent.com/16339898/168239802-39e733a0-4656-424a-a869-95b11103ff21.png)

Here's the fixed one after this PR:

<img width="792" alt="image" src="https://user-images.githubusercontent.com/16339898/168239918-ef75003e-af83-4f34-a5fa-7423bbc2698c.png">