### PR TITLE
Allow overriding the kubernetes version when upgrading the cluster

### DIFF
--- a/docs/cli/kops_upgrade_cluster.md
+++ b/docs/cli/kops_upgrade_cluster.md
@@ -25,9 +25,10 @@ kops upgrade cluster [CLUSTER] [flags]
 ### Options
 
 ```
-      --channel string   Channel to use for upgrade
-  -h, --help             help for cluster
-  -y, --yes              Apply update
+      --channel string              Channel to use for upgrade
+  -h, --help                        help for cluster
+      --kubernetes-version string   Kubernetes version to use for upgrade
+  -y, --yes                         Apply update
 ```
 
 ### Options inherited from parent commands

--- a/docs/releases/1.24-NOTES.md
+++ b/docs/releases/1.24-NOTES.md
@@ -25,6 +25,8 @@ kOps will directly manage the Karpenter Provisioner resources. Read more about h
 
 * Adds support for Rocky Linux 8
 
+* Adds support for overriding the Kubernetes version when upgrading a cluster by using the `--kubernetes-version` flag.
+
 * The minimum version for the Terraform AWS Provider has been bumped to 4.0.0 to address the deprecation of the aws_s3_bucket_object resource and its replacement with the aws_s3_object resource. Such resources will be destroyed and recreated without downtime when applying the changes. 
 
 * ARM64 support for nvidia device driver. Nvidia nodes on ARM64 requires Ubuntu 22.04 AMIs.


### PR DESCRIPTION
This will allow setting the exact (patch) k8s version when upgrading a cluster:
```sh
$ kops upgrade cluster --kubernetes-version=1.23.6
```

Fixes: #13614