### PR TITLE
Automated cherry pick of #13567: Add a nameservers parameter for cert-manager

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -92,6 +92,22 @@ spec:
     managed: false
 ```
 
+##### DNS nameserver configuration for cert-manager pod
+{{ kops_feature_table(kops_added_default='1.23.3', k8s_min='1.16') }}
+
+Optional list of DNS nameserver IP addresses for the cert-manager pod to use.
+This is useful if you have a public and private DNS zone for the same domain to ensure that cert-manager can access ingress, or DNS01 challenge TXT records at all times.
+
+You can set pod DNS nameserver configuration for cert-manager like so:
+```yaml
+spec:
+  certManager:
+    enabled: true
+    nameservers:
+      - 1.1.1.1
+      - 8.8.8.8
+```
+
 
 Read more about cert-manager in the [official documentation](https://cert-manager.io/docs/)
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -289,6 +289,12 @@ spec:
                       by kOps. The deployment of cert-manager is skipped if this is
                       set to false.
                     type: boolean
+                  nameservers:
+                    description: 'nameservers is a list of nameserver IP addresses
+                      to use instead of the pod defaults. Default: none'
+                    items:
+                      type: string
+                    type: array
                 type: object
               channel:
                 description: The Channel we are following

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -1037,6 +1037,10 @@ type CertManagerConfig struct {
 	// defaultIssuer sets a default clusterIssuer
 	// Default: none
 	DefaultIssuer *string `json:"defaultIssuer,omitempty"`
+
+	// nameservers is a list of nameserver IP addresses to use instead of the pod defaults.
+	// Default: none
+	Nameservers []string `json:"nameservers,omitempty"`
 }
 
 // AWSLoadBalancerControllerConfig determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -1057,6 +1057,10 @@ type CertManagerConfig struct {
 	// defaultIssuer sets a default clusterIssuer
 	// Default: none
 	DefaultIssuer *string `json:"defaultIssuer,omitempty"`
+
+	// nameservers is a list of nameserver IP addresses to use instead of the pod defaults.
+	// Default: none
+	Nameservers []string `json:"nameservers,omitempty"`
 }
 
 // AWSLoadBalancerControllerConfig determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1840,6 +1840,7 @@ func autoConvert_v1alpha2_CertManagerConfig_To_kops_CertManagerConfig(in *CertMa
 	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
+	out.Nameservers = in.Nameservers
 	return nil
 }
 
@@ -1853,6 +1854,7 @@ func autoConvert_kops_CertManagerConfig_To_v1alpha2_CertManagerConfig(in *kops.C
 	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
+	out.Nameservers = in.Nameservers
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -512,6 +512,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Nameservers != nil {
+		in, out := &in.Nameservers, &out.Nameservers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -1034,6 +1034,10 @@ type CertManagerConfig struct {
 	// defaultIssuer sets a default clusterIssuer
 	// Default: none
 	DefaultIssuer *string `json:"defaultIssuer,omitempty"`
+
+	// nameservers is a list of nameserver IP addresses to use instead of the pod defaults.
+	// Default: none
+	Nameservers []string `json:"nameservers,omitempty"`
 }
 
 // AWSLoadBalancerControllerConfig determines the AWS LB controller configuration.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1798,6 +1798,7 @@ func autoConvert_v1alpha3_CertManagerConfig_To_kops_CertManagerConfig(in *CertMa
 	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
+	out.Nameservers = in.Nameservers
 	return nil
 }
 
@@ -1811,6 +1812,7 @@ func autoConvert_kops_CertManagerConfig_To_v1alpha3_CertManagerConfig(in *kops.C
 	out.Managed = in.Managed
 	out.Image = in.Image
 	out.DefaultIssuer = in.DefaultIssuer
+	out.Nameservers = in.Nameservers
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -513,6 +513,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Nameservers != nil {
+		in, out := &in.Nameservers, &out.Nameservers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -512,6 +512,11 @@ func (in *CertManagerConfig) DeepCopyInto(out *CertManagerConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Nameservers != nil {
+		in, out := &in.Nameservers, &out.Nameservers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -17129,6 +17129,14 @@ spec:
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      {{ if .CertManager.Nameservers }}
+      dnsConfig:
+        nameservers:
+        {{ range $nameserver := .CertManager.Nameservers }}
+        - "{{ $nameserver }}"
+        {{ end }}
+      dnsPolicy: None
+      {{ end }}
       priorityClassName: system-cluster-critical
       serviceAccountName: cert-manager
       securityContext:


### PR DESCRIPTION
Cherry pick of #13567 on release-1.23.

#13567: Add a nameservers parameter for cert-manager

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```