### PR TITLE
Fix kops update for OpenStack with LB

### DIFF
--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -269,7 +269,8 @@ type OpenstackCloud interface {
 	AssociateToPool(server *servers.Server, poolID string, opts v2pools.CreateMemberOpts) (*v2pools.Member, error)
 	CreatePool(opts v2pools.CreateOpts) (*v2pools.Pool, error)
 	CreatePoolMonitor(opts monitors.CreateOpts) (*monitors.Monitor, error)
-	GetPool(poolID string, memberID string) (*v2pools.Member, error)
+	GetPool(poolID string) (*v2pools.Pool, error)
+	GetPoolMember(poolID string, memberID string) (*v2pools.Member, error)
 	ListPools(v2pools.ListOpts) ([]v2pools.Pool, error)
 
 	// ListMonitors will list HealthMonitors matching the provided options

--- a/upup/pkg/fi/cloudup/openstack/mock_cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/mock_cloud.go
@@ -369,8 +369,12 @@ func (c *MockCloud) GetLBFloatingSubnet() (subnet *subnets.Subnet, err error) {
 	return getLBFloatingSubnet(c, c.floatingSubnet)
 }
 
-func (c *MockCloud) GetPool(poolID string, memberID string) (member *v2pools.Member, err error) {
-	return getPool(c, poolID, memberID)
+func (c *MockCloud) GetPool(poolID string) (pool *v2pools.Pool, err error) {
+	return getPool(c, poolID)
+}
+
+func (c *MockCloud) GetPoolMember(poolID string, memberID string) (member *v2pools.Member, err error) {
+	return getPoolMember(c, poolID, memberID)
 }
 
 func (c *MockCloud) GetPort(id string) (*ports.Port, error) {

--- a/upup/pkg/fi/cloudup/openstacktasks/lb.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/lb.go
@@ -139,6 +139,7 @@ func NewLBTaskFromCloud(cloud openstack.OpenstackCloud, lifecycle fi.Lifecycle, 
 		find.ID = actual.ID
 		find.PortID = actual.PortID
 		find.VipSubnet = actual.VipSubnet
+		find.Provider = actual.Provider
 	}
 	return actual, nil
 }

--- a/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/poolassociation.go
@@ -85,7 +85,7 @@ func (p *PoolAssociation) Find(context *fi.Context) (*PoolAssociation, error) {
 	// check is member already created
 	var found *v2pools.Member
 	for _, member := range a.Members {
-		poolMember, err := cloud.GetPool(a.ID, member.ID)
+		poolMember, err := cloud.GetPoolMember(a.ID, member.ID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In the last PR to support OVN provider for LB, listener will refer to
load balancer provider for ACL settings. While currently get listener
API returns empty Pools, which will cause nil pointer dereference when
referring Pool.Loadbalancer.Provider.

This commit fix this issue by getting pool information with
DefaultPoolID when Pools is empty. As I added GetPool function, the
origin GetPool function is renamed to GetPoolMember.