### PR TITLE
[WIP] Add feature flag for using registry-sandbox.k8s.io

### DIFF
--- a/pkg/assets/builder.go
+++ b/pkg/assets/builder.go
@@ -156,6 +156,10 @@ func (a *AssetBuilder) RemapImage(image string) (string, error) {
 		}
 	}
 
+	if !featureflag.RegistrySandbox.Enabled() {
+		image = strings.ReplaceAll(image, "registry.k8s.io", "registry-sandbox.k8s.io")
+	}
+
 	if a.AssetsLocation != nil && a.AssetsLocation.ContainerProxy != nil {
 		containerProxy := strings.TrimSuffix(*a.AssetsLocation.ContainerProxy, "/")
 		normalized := image

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -92,6 +92,8 @@ var (
 	Karpenter = new("Karpenter", Bool(false))
 	// ImageDigest remaps all manifests with image digests
 	ImageDigest = new("ImageDigest", Bool(true))
+	// RegistrySandbox switches images pulled from registry.k8s.io to registry-sandbox.k8s.io
+	RegistrySandbox = new("RegistrySandbox", Bool(false))
 	// Hetzner toggles the Hetzner Cloud support.
 	Hetzner = new("Hetzner", Bool(false))
 )


### PR DESCRIPTION
In case all other approaches will fail this is the easiest way to override `registry.k8s.io` with `registry-sandbox.k8s.io`.
/cc @rifelpet @justinsb @BenTheElder