### PR TITLE
Automated cherry pick of #13692: Fix Protokube gossip flag

### DIFF
--- a/protokube/cmd/protokube/main.go
+++ b/protokube/cmd/protokube/main.go
@@ -61,7 +61,7 @@ func run() error {
 	var dnsUpdateInterval int
 
 	flag.BoolVar(&containerized, "containerized", containerized, "Set if we are running containerized")
-	flag.BoolVar(&master, "gossip", gossip, "Set if we are using gossip dns")
+	flag.BoolVar(&gossip, "gossip", gossip, "Set if we are using gossip dns")
 	flag.BoolVar(&master, "master", master, "Whether or not this node is a master")
 	flag.StringVar(&cloud, "cloud", "aws", "CloudProvider we are using (aws,digitalocean,gce,openstack)")
 	flag.StringVar(&clusterID, "cluster-id", clusterID, "Cluster ID")


### PR DESCRIPTION
Cherry pick of #13692 on release-1.23.

#13692: Fix Protokube gossip flag

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```