### PR TITLE
Fix links to go docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@
 
 # kOps - Kubernetes Operations
 
-[GoDoc]: https://pkg.go.dev/k8s.io/kOps
-[GoDoc Widget]: https://godoc.org/k8s.io/kOps?status.svg
+[GoDoc]: https://pkg.go.dev/k8s.io/kops
+[GoDoc Widget]: https://godoc.org/k8s.io/kops?status.svg
 
 The easiest way to get a production grade Kubernetes cluster up and running.
 

--- a/docs/manifests_and_customizing_via_api.md
+++ b/docs/manifests_and_customizing_via_api.md
@@ -19,7 +19,7 @@ This document also applies to using the `kops` API to customize a Kubernetes clu
 
 Because of the above statement `kops` includes an API which provides a feature for users to utilize YAML or JSON manifests for managing their `kops` created Kubernetes installations. In the same way that you can use a YAML manifest to deploy a Job, you can deploy and manage a `kops` Kubernetes instance with a manifest. All of these values are also usable via the interactive editor with `kops edit`.
 
-> You can see all the options that are currently supported in kOps [here](https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/componentconfig.go) or [more prettily here](https://pkg.go.dev/k8s.io/kops/pkg/apis/kOps#ClusterSpec)
+> You can see all the options that are currently supported in kOps [here](https://github.com/kubernetes/kops/blob/master/pkg/apis/kops/componentconfig.go) or [more prettily here](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec)
 
 The following is a list of the benefits of using a file to manage instances.
 
@@ -290,7 +290,7 @@ spec:
   api:
 ```
 
-Full documentation is accessible via [godoc](https://pkg.go.dev/k8s.io/kops/pkg/apis/kOps#ClusterSpec).
+Full documentation is accessible via [godoc](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#ClusterSpec).
 
 The `ClusterSpec` allows a user to set configurations for such values as Docker log driver, Kubernetes API server log level, VPC for reusing a VPC (`NetworkID`), and the Kubernetes version.
 
@@ -321,7 +321,7 @@ metadata:
 spec:
 ```
 
-Full documentation is accessible via [godocs](https://pkg.go.dev/k8s.io/kops/pkg/apis/kOps#InstanceGroupSpec).
+Full documentation is accessible via [godocs](https://pkg.go.dev/k8s.io/kops/pkg/apis/kops#InstanceGroupSpec).
 
 Instance Groups map to Auto Scaling Groups in AWS, and Instance Groups in GCE. They are an API level description of a group of compute instances used as Masters or Nodes.
 


### PR DESCRIPTION
/kind documentation

Go doc link path is case-sensitive, so use all-lowercase `kops` in the path.