### PR TITLE
flannel: future proof flannel from shutting down of quay.io repository

### DIFF
--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.22
     manifest: networking.projectcalico.org.canal/k8s-1.22.yaml
-    manifestHash: ff8bbeaba0ec65a71b29563278683bcfe8130d023a388b5321f347b1ff932136
+    manifestHash: a62b936ae4ffd00ffc80eb87713953e4166f8329970204039112d5cff900d4c2
     name: networking.projectcalico.org.canal
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-networking.projectcalico.org.canal-k8s-1.22_content
@@ -4534,7 +4534,7 @@ spec:
             configMapKeyRef:
               key: masquerade
               name: canal-config
-        image: quay.io/coreos/flannel:v0.15.1
+        image: rancher/mirrored-flannelcni-flannel:v0.18.0
         name: kube-flannel
         securityContext:
           privileged: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.16.yaml.template
@@ -777,7 +777,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.11.0
+          image: rancher/mirrored-flannelcni-flannel:v0.18.0
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org.canal/k8s-1.22.yaml.template
@@ -4656,7 +4656,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: quay.io/coreos/flannel:v0.15.1
+          image: rancher/mirrored-flannelcni-flannel:v0.18.0
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -1509,7 +1509,8 @@ func (n *nodeUpConfigBuilder) buildWarmPoolImages(ig *kops.InstanceGroup) []stri
 		"registry.k8s.io/sig-storage/livenessprobe:",
 		"quay.io/calico/",
 		"quay.io/cilium/",
-		"quay.io/coreos/flannel:",
+		//"quay.io/coreos/flannel:",
+		"docker.io/rancher/mirrored-flannelcni-flannel:",
 		"quay.io/weaveworks/",
 	}
 	assetBuilder := n.assetBuilder


### PR DESCRIPTION
**Issue:**
On 15.06.22 quay.io [will no longer provide repository services](https://quay.io/). To prevent future issues with flannel CNI we updated image used by kops. Image used is proposed by flannel in their [project repository](https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml).


Co-authored-by: David Sieciński <david.siecinski@goldenoakit.pl>