### PR TITLE
[DigitalOcean] Restart journald service on node startup

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -397,6 +397,8 @@ func (b *BootstrapScript) Run(c *fi.Context) error {
 	// See https://github.com/kubernetes/kops/issues/10206 for details.
 	nodeupScript.SetSysctls = setSysctls()
 
+	nodeupScript.CloudProvider = string(c.Cluster.Spec.GetCloudProvider())
+
 	nodeupScriptResource, err := nodeupScript.Build()
 	if err != nil {
 		return err


### PR DESCRIPTION
Digital Ocean cloud provider image has `/etc/machine-id` baked into the image. And as a result when nodeup executes `system-id-machine-setup` it re-creates a new machine-id and as a result we lose track of journal entries. The only fix is to restart journald to view the system logs again. 

The fix here will ensure that journald is restarted on node startup so we don't need an explicit restart manually.

This should also help us to view the logs in our test-grid artifacts. Currently it shows empty [here](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-do-calico/1532344823695020032/artifacts/10.124.0.7/journal.log) 

FYI - @timoreimann 
Reference - https://serverfault.com/questions/1058259/journalctl-stops-working-randomly-after-boot-on-digitalocean-droplet