### PR TITLE
Only rewrite to k8s.gcr.io until k8s 1.25

### DIFF
--- a/nodeup/pkg/model/kube_apiserver.go
+++ b/nodeup/pkg/model/kube_apiserver.go
@@ -607,7 +607,7 @@ func (b *KubeAPIServerBuilder) buildPod(kubeAPIServer *kops.KubeAPIServerConfig)
 	}
 
 	image := kubeAPIServer.Image
-	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) {
+	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) && b.IsKubernetesLT("1.25") {
 		image = strings.Replace(image, "registry.k8s.io", "k8s.gcr.io", 1)
 	}
 	if b.Architecture != architectures.ArchitectureAmd64 {

--- a/nodeup/pkg/model/kube_controller_manager.go
+++ b/nodeup/pkg/model/kube_controller_manager.go
@@ -208,7 +208,7 @@ func (b *KubeControllerManagerBuilder) buildPod(kcm *kops.KubeControllerManagerC
 	flags = append(flags, "--flex-volume-plugin-dir="+volumePluginDir)
 
 	image := kcm.Image
-	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) {
+	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) && b.IsKubernetesLT("1.25") {
 		image = strings.Replace(image, "registry.k8s.io", "k8s.gcr.io", 1)
 	}
 	if b.Architecture != architectures.ArchitectureAmd64 {

--- a/nodeup/pkg/model/kube_proxy.go
+++ b/nodeup/pkg/model/kube_proxy.go
@@ -167,7 +167,7 @@ func (b *KubeProxyBuilder) buildPod() (*v1.Pod, error) {
 	if b.Architecture != architectures.ArchitectureAmd64 {
 		image = strings.Replace(image, "-amd64", "-"+string(b.Architecture), 1)
 	}
-	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) {
+	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) && b.IsKubernetesLT("1.25") {
 		image = strings.Replace(image, "registry.k8s.io", "k8s.gcr.io", 1)
 	}
 

--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -215,7 +215,7 @@ func (b *KubeSchedulerBuilder) buildPod(kubeScheduler *kops.KubeSchedulerConfig)
 	}
 
 	image := kubeScheduler.Image
-	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) {
+	if components.IsBaseURL(b.Cluster.Spec.KubernetesVersion) && b.IsKubernetesLT("1.25") {
 		image = strings.Replace(image, "registry.k8s.io", "k8s.gcr.io", 1)
 	}
 	if b.Architecture != architectures.ArchitectureAmd64 {


### PR DESCRIPTION
1.25 is when official images have been migrated to registry.k8s.io, so we only need to rewrite until 1.25

This should fix all the prow jobs using the CI k8s version markers like https://testgrid.k8s.io/kops-misc#kops-grid-scenario-cilium10-amd64

They started failing between these k/k commits which include the upstream registry migration: https://github.com/kubernetes/kubernetes/compare/5219122d0ccd36...8415ae647d2c43