### PR TITLE
Bump nvidia device plugin to 0.12.0

### DIFF
--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: nvidia.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0b5963253c1cf13686226a8893b9b9e3ffd1373d5e2fb0699588d8714a4ba78a
+    manifestHash: b69ab4301c67af1a7edd934caf0ca7a37c7e40035e5f19fc1794f565c19eb9cf
     name: nvidia.addons.k8s.io
     selector:
       k8s-addon: nvidia.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-nvidia.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-nvidia.addons.k8s.io-k8s-1.16_content
@@ -22,7 +22,7 @@ spec:
       containers:
       - args:
         - --fail-on-init-error=false
-        image: docker.io/nvidia/k8s-device-plugin:v0.11.0
+        image: nvcr.io/nvidia/k8s-device-plugin:v0.12.0
         name: nvidia-device-plugin-ctr
         securityContext:
           allowPrivilegeEscalation: false

--- a/upup/models/cloudup/resources/addons/nvidia.addons.k8s.io/k8s-1.16.yaml
+++ b/upup/models/cloudup/resources/addons/nvidia.addons.k8s.io/k8s-1.16.yaml
@@ -17,7 +17,7 @@ spec:
         name: nvidia-device-plugin-ds
     spec:
       containers:
-      - image: docker.io/nvidia/k8s-device-plugin:v0.11.0
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.12.0
         name: nvidia-device-plugin-ctr
         args: ["--fail-on-init-error=false"]
         securityContext:


### PR DESCRIPTION
nvidia has stopped publishing to docker hub:

> As of the v0.12.0 release, no new images will be published to dockerhub
> 
> Please use the images from the NGC catalog instead https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-device-plugin

ref https://github.com/kubernetes/kops/pull/13580#issuecomment-1148576210