### PR TITLE
Automated cherry pick of #13715: Add support for setting mode field on file assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ clean:
 
 .PHONY: codegen
 codegen:
-	go build -o ${KOPS_ROOT}/_output/bin k8s.io/kops/upup/tools/generators/...
+	go build -o ${KOPS_ROOT}/_output/bin/ k8s.io/kops/upup/tools/generators/...
 	${KOPS_ROOT}/_output/bin/fitask \
 		--input-dirs k8s.io/kops/upup/pkg/fi/... \
 		--go-header-file hack/boilerplate/boilerplate.generatego.txt \
@@ -151,7 +151,7 @@ codegen:
 
 .PHONY: verify-codegen
 verify-codegen:
-	go build -o ${KOPS_ROOT}/_output/bin k8s.io/kops/upup/tools/generators/...
+	go build -o ${KOPS_ROOT}/_output/bin/ k8s.io/kops/upup/tools/generators/...
 	${KOPS_ROOT}/_output/bin/fitask --verify-only \
 		--input-dirs k8s.io/kops/upup/pkg/fi/... \
 		--go-header-file hack/boilerplate/boilerplate.generatego.txt \
@@ -464,7 +464,7 @@ apimachinery-codegen-client:
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
 	go run k8s.io/code-generator/cmd/client-gen@${CODEGEN_VERSION} --v=0 --clientset-name="clientset" \
 		 --input-base=k8s.io/kops/pkg/apis --input-dirs=. --input="kops/,kops/v1alpha2,kops/v1alpha3" \
- 		 --output-package=k8s.io/kops/pkg/client/clientset_generated/  --output-base=$(TMPDIR) \
+		 --output-package=k8s.io/kops/pkg/client/clientset_generated/ --output-base=$(TMPDIR) \
 		 --go-header-file "hack/boilerplate/boilerplate.generatego.txt"
 	cp -r $(TMPDIR)/k8s.io/kops/pkg .
 	rm -rf $(TMPDIR)

--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -389,7 +389,7 @@ spec:
     oidcGroupsPrefix: "oidc:"
     oidcCAFile: /etc/kubernetes/ssl/kc-ca.pem
     oidcRequiredClaim:
-    	- "key=value"
+    - "key=value"
 ```
 
 ### Audit Logging
@@ -1090,19 +1090,38 @@ spec:
 
 ## fileAssets
 
-FileAssets permits you to place inline file content into the cluster and instanceGroup specification. This is useful for deploying additional configuration files that kubernetes components requires, such as auditlogs or admission controller configurations.
+FileAssets permit you to place inline file content into the Cluster and [Instance Group](instance_groups.md) specifications. This is useful for deploying additional files that Kubernetes components require, such as audit logging or admission controller configurations.
 
 ```yaml
 spec:
   fileAssets:
   - name: iptable-restore
-    # Note if not path is specified the default path it /srv/kubernetes/assets/<name>
+    # Note if path is not specified, the default is /srv/kubernetes/assets/<name>
     path: /var/lib/iptables/rules-save
-    roles: [Master,Node,Bastion] # a list of roles to apply the asset to, zero defaults to all
+    # Note if roles are not specified, the default is all roles
+    roles: [Master,Node,Bastion] # a list of roles to apply the asset to
     content: |
       some file content
 ```
 
+### mode
+
+{{ kops_feature_table(kops_added_default='1.24') }}
+
+Optionally, `mode` allows you to specify a file's mode and permission bits.
+
+**NOTE**: If not specified, the default is `"0440"`, which matches the behaviour of older versions of kOps.
+
+```yaml
+spec:
+  fileAssets:
+  - name: my-script
+    path: /usr/local/bin/my-script
+    mode: "0550"
+    content: |
+      #! /usr/bin/env bash
+      ...
+```
 
 ## cloudConfig
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1201,6 +1201,9 @@ spec:
                     isBase64:
                       description: IsBase64 indicates the contents is base64 encoded
                       type: boolean
+                    mode:
+                      description: Mode is this file's mode and permission bits
+                      type: string
                     name:
                       description: Name is a shortened reference to the asset
                       type: string

--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
+++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
@@ -203,6 +203,9 @@ spec:
                     isBase64:
                       description: IsBase64 indicates the contents is base64 encoded
                       type: boolean
+                    mode:
+                      description: Mode is this file's mode and permission bits
+                      type: string
                     name:
                       description: Name is a shortened reference to the asset
                       type: string

--- a/nodeup/pkg/model/file_assets.go
+++ b/nodeup/pkg/model/file_assets.go
@@ -72,6 +72,11 @@ func (f *FileAssetsBuilder) buildFileAssets(c *fi.ModelBuilderContext, assets []
 			content = string(decoded)
 		}
 
+		// If not specified, the default Mode is 0440
+		if asset.Mode == "" {
+			asset.Mode = "0440"
+		}
+
 		// We use EnsureTask so that we don't have to check if the asset directories have already been done
 		c.EnsureTask(&nodetasks.File{
 			Path: filepath.Dir(assetPath),
@@ -81,7 +86,7 @@ func (f *FileAssetsBuilder) buildFileAssets(c *fi.ModelBuilderContext, assets []
 
 		c.AddTask(&nodetasks.File{
 			Contents: fi.NewStringResource(content),
-			Mode:     s("0440"),
+			Mode:     s(asset.Mode),
 			Path:     assetPath,
 			Type:     nodetasks.FileType_File,
 		})

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -334,6 +334,8 @@ type FileAssetSpec struct {
 	Content string `json:"content,omitempty"`
 	// IsBase64 indicates the contents is base64 encoded
 	IsBase64 bool `json:"isBase64,omitempty"`
+	// Mode is this file's mode and permission bits
+	Mode string `json:"mode,omitempty"`
 }
 
 // Assets defines the privately hosted assets

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -301,6 +301,8 @@ type FileAssetSpec struct {
 	Content string `json:"content,omitempty"`
 	// IsBase64 indicates the contents is base64 encoded
 	IsBase64 bool `json:"isBase64,omitempty"`
+	// Mode is this file's mode and permission bits
+	Mode string `json:"mode,omitempty"`
 }
 
 // Assets defined the privately hosted assets

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3856,6 +3856,7 @@ func autoConvert_v1alpha2_FileAssetSpec_To_kops_FileAssetSpec(in *FileAssetSpec,
 	}
 	out.Content = in.Content
 	out.IsBase64 = in.IsBase64
+	out.Mode = in.Mode
 	return nil
 }
 
@@ -3878,6 +3879,7 @@ func autoConvert_kops_FileAssetSpec_To_v1alpha2_FileAssetSpec(in *kops.FileAsset
 	}
 	out.Content = in.Content
 	out.IsBase64 = in.IsBase64
+	out.Mode = in.Mode
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -305,6 +305,8 @@ type FileAssetSpec struct {
 	Content string `json:"content,omitempty"`
 	// IsBase64 indicates the contents is base64 encoded
 	IsBase64 bool `json:"isBase64,omitempty"`
+	// Mode is this file's mode and permission bits
+	Mode string `json:"mode,omitempty"`
 }
 
 // Assets defined the privately hosted assets

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -3961,6 +3961,7 @@ func autoConvert_v1alpha3_FileAssetSpec_To_kops_FileAssetSpec(in *FileAssetSpec,
 	}
 	out.Content = in.Content
 	out.IsBase64 = in.IsBase64
+	out.Mode = in.Mode
 	return nil
 }
 
@@ -3983,6 +3984,7 @@ func autoConvert_kops_FileAssetSpec_To_v1alpha3_FileAssetSpec(in *kops.FileAsset
 	}
 	out.Content = in.Content
 	out.IsBase64 = in.IsBase64
+	out.Mode = in.Mode
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #13715 on release-1.24.

#13715: Fix codegen targets and whitespace errors in Makefile

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```