### PR TITLE
Revert "Use kubectl replace instead of apply when updating addons"

### DIFF
--- a/channels/pkg/channels/apply.go
+++ b/channels/pkg/channels/apply.go
@@ -46,7 +46,7 @@ func Apply(data []byte) error {
 		return fmt.Errorf("error writing temp file: %v", err)
 	}
 
-	_, err = execKubectl("replace", "-f", localManifestFile, "--force", "--field-manager=kops")
+	_, err = execKubectl("apply", "-f", localManifestFile, "--server-side", "--force-conflicts", "--field-manager=kops")
 	return err
 }
 


### PR DESCRIPTION
Fixes: #13754

This reverts commit 18c5d184e77508b9e742fa1067175761a01c398a.

/cc @olemarkus @rifelpet 