### PR TITLE
Automated cherry pick of #13761: Revert "Use kubectl replace instead of apply when updating

### DIFF
--- a/channels/pkg/channels/apply.go
+++ b/channels/pkg/channels/apply.go
@@ -46,7 +46,7 @@ func Apply(data []byte) error {
 		return fmt.Errorf("error writing temp file: %v", err)
 	}
 
-	_, err = execKubectl("replace", "-f", localManifestFile, "--force", "--field-manager=kops")
+	_, err = execKubectl("apply", "-f", localManifestFile, "--server-side", "--force-conflicts", "--field-manager=kops")
 	return err
 }
 


### PR DESCRIPTION
Cherry pick of #13761 on release-1.24.

#13761: Revert "Use kubectl replace instead of apply when updating

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```