### PR TITLE
Automated cherry pick of #13750: Fix API group being incorrect for ingresses

### DIFF
--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f094ab831eb3e67174657d078750cd5e3462dc08f161adb5d5f6744f13beea36
+    manifestHash: 7a22c110a05cb5f47ccc61e16bf5cb7fbfc1012f6f898e5441bfdc6d3fe186a8
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -128,7 +128,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 28fa2cdf68c45ca10a717ea4365790e4eb450830261d4b4978bf06b7463b8c5e
+    manifestHash: a5b67c130d65dd184b9dd98c6f8f2b869ce82f5ff93cc8a2960e4e393abb8214
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f094ab831eb3e67174657d078750cd5e3462dc08f161adb5d5f6744f13beea36
+    manifestHash: 7a22c110a05cb5f47ccc61e16bf5cb7fbfc1012f6f898e5441bfdc6d3fe186a8
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -128,7 +128,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f094ab831eb3e67174657d078750cd5e3462dc08f161adb5d5f6744f13beea36
+    manifestHash: 7a22c110a05cb5f47ccc61e16bf5cb7fbfc1012f6f898e5441bfdc6d3fe186a8
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -128,7 +128,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f094ab831eb3e67174657d078750cd5e3462dc08f161adb5d5f6744f13beea36
+    manifestHash: 7a22c110a05cb5f47ccc61e16bf5cb7fbfc1012f6f898e5441bfdc6d3fe186a8
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -128,7 +128,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f094ab831eb3e67174657d078750cd5e3462dc08f161adb5d5f6744f13beea36
+    manifestHash: 7a22c110a05cb5f47ccc61e16bf5cb7fbfc1012f6f898e5441bfdc6d3fe186a8
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -128,7 +128,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88b527a2190751d31e483fb18f5937f1ebaed459e1913d520d1424a3e5d4e59a
+    manifestHash: 8b36096d939c9a1532ff9b991dc8199c5f647b8f2ed1fcf852a14d72389a2e58
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88b527a2190751d31e483fb18f5937f1ebaed459e1913d520d1424a3e5d4e59a
+    manifestHash: 8b36096d939c9a1532ff9b991dc8199c5f647b8f2ed1fcf852a14d72389a2e58
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88b527a2190751d31e483fb18f5937f1ebaed459e1913d520d1424a3e5d4e59a
+    manifestHash: 8b36096d939c9a1532ff9b991dc8199c5f647b8f2ed1fcf852a14d72389a2e58
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 88b527a2190751d31e483fb18f5937f1ebaed459e1913d520d1424a3e5d4e59a
+    manifestHash: 8b36096d939c9a1532ff9b991dc8199c5f647b8f2ed1fcf852a14d72389a2e58
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 28fa2cdf68c45ca10a717ea4365790e4eb450830261d4b4978bf06b7463b8c5e
+    manifestHash: a5b67c130d65dd184b9dd98c6f8f2b869ce82f5ff93cc8a2960e4e393abb8214
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 28fa2cdf68c45ca10a717ea4365790e4eb450830261d4b4978bf06b7463b8c5e
+    manifestHash: a5b67c130d65dd184b9dd98c6f8f2b869ce82f5ff93cc8a2960e4e393abb8214
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 28fa2cdf68c45ca10a717ea4365790e4eb450830261d4b4978bf06b7463b8c5e
+    manifestHash: a5b67c130d65dd184b9dd98c6f8f2b869ce82f5ff93cc8a2960e4e393abb8214
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 9c5df74b9969dd972c296de16dd6e72caf8dd3286f7c3a68d03cfe5fcacc5606
+    manifestHash: d526ce4197b9d231db34bd2cebcffd6c7a68f7a3316fc29494d634b64bddf07e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -114,7 +114,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 20eb1d6938e632e90b6f2911f64c6d830eda35d260cd8928e9369c27ed3e5bf7
+    manifestHash: 2699ed968542c2acb1430df0ee3a3c77c2ddf51d4c60ec034c5ded6b110d12d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -131,7 +131,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 68f99842a29ddc298ae7a007a8ba765cdcd5c07dc7e10e1b2c782d63efa44ae2
+    manifestHash: 8a05e48ff1115bc8ef905051f823c8cdd699a5d514a7226cab0d6a663991892f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 817a46092acbb3953d357b45b7ddd402b56e6c65380999ac7acb7c08d07f8944
+    manifestHash: 94092d02cbab4c84e74381abb3de26b03b8e8c9b2799e95eb9e1d3aa99538df8
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f094ab831eb3e67174657d078750cd5e3462dc08f161adb5d5f6744f13beea36
+    manifestHash: 7a22c110a05cb5f47ccc61e16bf5cb7fbfc1012f6f898e5441bfdc6d3fe186a8
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -128,7 +128,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -111,7 +111,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -110,7 +110,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - "networking"
+  - "networking.k8s.io"
   resources:
   - ingresses
   verbs:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -128,7 +128,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: f094ab831eb3e67174657d078750cd5e3462dc08f161adb5d5f6744f13beea36
+    manifestHash: 7a22c110a05cb5f47ccc61e16bf5cb7fbfc1012f6f898e5441bfdc6d3fe186a8
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8061a2555e4e467b962242f3d53fc3a47ea3b19b80823365b708b19a4ab5db58
+    manifestHash: 7055214e9b561c76dfa6cd0c19f7e9ce69bbfb9601e99e129ce387e1349825de
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #13750 on release-1.24.

#13750: Fix API group being incorrect for ingresses

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```