### PR TITLE
Automated cherry pick of #13750: Fix API group being incorrect for ingresses

### DIFF
--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e022841e0cfb06399045e63c832f8e5a3aa3ddfbc500152fcf5459fc611f22ea
+    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -119,7 +119,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: a34a4e959faaeeab835ff6378c3a615939fe244e6e77bbe99b1e1a96a47c7084
+    manifestHash: 50db4e3f31a924b5c2834c7e00b92cd6ac74f28fdc00b1ed32b6ea343560e298
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e022841e0cfb06399045e63c832f8e5a3aa3ddfbc500152fcf5459fc611f22ea
+    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -119,7 +119,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e022841e0cfb06399045e63c832f8e5a3aa3ddfbc500152fcf5459fc611f22ea
+    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -119,7 +119,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 1288bf80fe4e30466e4499c07a58ee9c63c3011ac9111794825c121347b032dd
+    manifestHash: 43f09285f00b573a5ff76bf48be84922b3a02c1a87b5480ef87f3680a7731cdf
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 1288bf80fe4e30466e4499c07a58ee9c63c3011ac9111794825c121347b032dd
+    manifestHash: 43f09285f00b573a5ff76bf48be84922b3a02c1a87b5480ef87f3680a7731cdf
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 1288bf80fe4e30466e4499c07a58ee9c63c3011ac9111794825c121347b032dd
+    manifestHash: 43f09285f00b573a5ff76bf48be84922b3a02c1a87b5480ef87f3680a7731cdf
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 1288bf80fe4e30466e4499c07a58ee9c63c3011ac9111794825c121347b032dd
+    manifestHash: 43f09285f00b573a5ff76bf48be84922b3a02c1a87b5480ef87f3680a7731cdf
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: a34a4e959faaeeab835ff6378c3a615939fe244e6e77bbe99b1e1a96a47c7084
+    manifestHash: 50db4e3f31a924b5c2834c7e00b92cd6ac74f28fdc00b1ed32b6ea343560e298
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: a34a4e959faaeeab835ff6378c3a615939fe244e6e77bbe99b1e1a96a47c7084
+    manifestHash: 50db4e3f31a924b5c2834c7e00b92cd6ac74f28fdc00b1ed32b6ea343560e298
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: cff1e30210ee93cac5af1e31a3e6be260649477b4089b33e5b731ba1e8ae2c6f
+    manifestHash: bc5165e9f233dffd91ba7ecdb79b258404d11c94d38d4d986fc6991c50fa4c03
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -103,7 +103,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8153fe1052a3adb5983256344b2ef695faa99b6428f218b520f3d3ed2d88901c
+    manifestHash: 2f4b9abbdaa570f78e10917a56179704e5774a62ca8cda5a603a6625e2906be6
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -122,7 +122,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 8910bc8920a74437229e5919b6dd77bb3e8fd21fd24ca00ed70c8623acd10017
+    manifestHash: 4030a17c69ef9139677fff5d28f16d965c29541b533c468008107e2bb4fe5095
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 40f55161243c13b458443d70d1c3b86f68c640f3d2a3d21ace1588651644796a
+    manifestHash: e34c1a140ab7a03480e1f0db9ef9b3c9e4da3bd135323e565ac08fc6e689ec84
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e022841e0cfb06399045e63c832f8e5a3aa3ddfbc500152fcf5459fc611f22ea
+    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -119,7 +119,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -100,7 +100,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -98,7 +98,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - "networking"
+  - "networking.k8s.io"
   resources:
   - ingresses
   verbs:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -119,7 +119,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - networking
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e022841e0cfb06399045e63c832f8e5a3aa3ddfbc500152fcf5459fc611f22ea
+    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 37d231d76e29f210571d4b4c426051f8f58bad648496b3ef2b748801a48bbec5
+    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #13750 on release-1.23.

#13750: Fix API group being incorrect for ingresses

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```