### PR TITLE
Automated cherry pick of #13748: Update AWS CCM images for k8s 1.20-1.22

### DIFF
--- a/pkg/model/components/awscloudcontrollermanager.go
+++ b/pkg/model/components/awscloudcontrollermanager.go
@@ -90,17 +90,17 @@ func (b *AWSCloudControllerManagerOptionsBuilder) BuildOptions(o interface{}) er
 		case 19:
 			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.19.0-alpha.1"
 		case 20:
-			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.20.0-alpha.0"
+			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.20.1"
 		case 21:
-			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0"
+			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0"
 		case 22:
-			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.22.0"
+			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.22.2"
 		case 23:
 			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.23.1"
 		case 24:
 			eccm.Image = "registry.k8s.io/provider-aws/cloud-controller-manager:v1.24.0"
 		default:
-			eccm.Image = "gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.24.0-2-g06c1641"
+			eccm.Image = "gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.24.0-27-g1477d6e"
 		}
 	}
 

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterCIDR: 172.20.0.0/16
     clusterName: minimal.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -48,7 +48,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/aws-cloud-controller-manager.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: 68b06d3d8c32968ccbb4fce151ad898fbb5869e338cc405ec39d3bd6fb906d1b
+    manifestHash: 3dc5f8afaeca391ef2cfff7103af4e3ea5cb8f905af098af45eb6f1b5c03c724
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterCIDR: 172.20.0.0/16
     clusterName: minimal.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -126,7 +126,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: fcf7666060026a529413766cae2ccce28ea8f0f7ad3bda035f7356dd70a0e236
+    manifestHash: 140a865d26bc123ed259a90e0d12aa0b644e336362d5f83fef78142b9ea65161
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterCIDR: ::/0
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b81b968335bd806a35ab6a455a7a682cb03b6723fcf0a0061b1206661d1163ba
+    manifestHash: 5a63e09de5abc8e5944e44dc102c000711bdfcceedb84039b2555c9da9f9043c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -24,7 +24,7 @@ spec:
     clusterCIDR: ::/0
     clusterName: minimal-ipv6.example.com
     configureCloudRoutes: false
-    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+    image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0
     leaderElection:
       leaderElect: true
   cloudProvider: aws

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-cloud-controller.addons.k8s.io-k8s-1.18_content
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0-alpha.0
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.21.0
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: b81b968335bd806a35ab6a455a7a682cb03b6723fcf0a0061b1206661d1163ba
+    manifestHash: 5a63e09de5abc8e5944e44dc102c000711bdfcceedb84039b2555c9da9f9043c
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/aws-cloud-controller.addons.k8s.io-k8s-1.18.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.20.0-alpha.0
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.20.1
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
         resources:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.18
     manifest: aws-cloud-controller.addons.k8s.io/k8s-1.18.yaml
-    manifestHash: d047be37262e0f55e6cf0ee768815a1f0e95657bc5f328f5a91f97f451a4f098
+    manifestHash: 2102ef7a14aaad0aa67e20831a65462e7ef22e92ef5b33adc265833948c3e573
     name: aws-cloud-controller.addons.k8s.io
     selector:
       k8s-addon: aws-cloud-controller.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #13748 on release-1.24.

#13748: Update AWS CCM images for k8s 1.20-1.22

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```