### PR TITLE
Make the cert-manager breaking change more visible.

### DIFF
--- a/docs/releases/1.24-NOTES.md
+++ b/docs/releases/1.24-NOTES.md
@@ -69,6 +69,12 @@ spec:
 
 The deprecated `kubernetes.io/role` label has been removed for all roles as of Kubernetes version 1.24. Use `node-role.kubernetes.io/<role>` label instead.
 
+## Cert Manager removes old API versions
+
+Cert Manager upgraded from 1.6 to 1.8. This has backwards-breaking changes. See upgrading from [1.6 to 1.7](https://cert-manager.io/docs/installation/upgrading/upgrading-1.6-1.7/) and [1.[1.7 to 1.8](https://cert-manager.io/docs/installation/upgrading/upgrading-1.7-1.8/).
+
+In particular, if you are using the snapshot-controller addon, upgrade your cluster to kOps 1.23 before upgrading to kOps 1.24 to ensure the certificate has the correct API version.
+
 ## Other breaking changes
 
 * Support for Kubernetes version 1.18 has been removed.
@@ -76,8 +82,6 @@ The deprecated `kubernetes.io/role` label has been removed for all roles as of K
 * Support for Aliyun/Alibaba Cloud has been removed.
 
 * Support for Docker has been removed for Kubernetes 1.24+. See https://kubernetes.io/blog/2020/12/02/dockershim-faq
-
-* Cert Manager upgraded from 1.6 to 1.8. This has backwards-breaking changes. See upgrading from [1.6 to 1.7](https://cert-manager.io/docs/installation/upgrading/upgrading-1.6-1.7/) and [1.[1.7 to 1.8](https://cert-manager.io/docs/installation/upgrading/upgrading-1.7-1.8/).
 
 # Required actions
 


### PR DESCRIPTION
The reason kops 1.23 is that SSA will ensure the API version of the snapshot controller is updated. CSA does not support this.