### PR TITLE
Automated cherry pick of #13779: Add back the metrics-server 443 port with a new name

### DIFF
--- a/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/metrics-server.addons.k8s.io/k8s-1.11.yaml.template
@@ -153,6 +153,9 @@ spec:
           periodSeconds: 10
         name: metrics-server
         ports:
+        - containerPort: 443 # We need to rename this port to keep the name unique due to SSA
+          name: oldhttps
+          protocol: TCP
         - containerPort: 4443
           name: https
           protocol: TCP

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: dcc45685fd1de2514d806f6e96f36bfc6fb18af68a8de6a9e5def5af833b1f43
+    manifestHash: adf0d82183bfe88c7fdc262670758f88eb15ab338d3728fae67d00ad71d82413
     name: metrics-server.addons.k8s.io
     selector:
       k8s-app: metrics-server

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -184,6 +184,9 @@ spec:
           periodSeconds: 10
         name: metrics-server
         ports:
+        - containerPort: 443
+          name: oldhttps
+          protocol: TCP
         - containerPort: 4443
           name: https
           protocol: TCP

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: metrics-server.addons.k8s.io/k8s-1.11.yaml
-    manifestHash: 11c1aee62e84644780c05cd8f7d0bd9a99bc9f0b45a43ab796b51ee335f5ecf6
+    manifestHash: 99a34f2447f52376c332bd494d2f8a8c638d235351062e1c8579bdba77a14dc0
     name: metrics-server.addons.k8s.io
     needsPKI: true
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/metrics-server.addons.k8s.io-k8s-1.11.yaml
@@ -184,6 +184,9 @@ spec:
           periodSeconds: 10
         name: metrics-server
         ports:
+        - containerPort: 443
+          name: oldhttps
+          protocol: TCP
         - containerPort: 4443
           name: https
           protocol: TCP


### PR DESCRIPTION
Cherry pick of #13779 on release-1.24.

#13779: Add back the metrics-server 443 port with a new name

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```