### PR TITLE
Automated cherry pick of #13781: Fix broken node selector for node termination handler

### DIFF
--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -117,20 +117,18 @@ spec:
         kubernetes.io/os: linux
     spec:
       nodeSelector: null
+      {{ if not UseServiceAccountExternalPermissions }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              {{ if not UseServiceAccountExternalPermissions }}
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-              {{ end }}
             - matchExpressions:
-              {{ if not UseServiceAccountExternalPermissions }}
               - key: node-role.kubernetes.io/master
                 operator: Exists
-              {{ end }}
+      {{ end }}
       priorityClassName: system-cluster-critical
       serviceAccountName: aws-node-termination-handler
       securityContext:


### PR DESCRIPTION
Cherry pick of #13781 on release-1.24.

#13781: Fix broken node selector for node termination handler

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```