### PR TITLE
Fix GCE firewall rule listing logic for teardown

### DIFF
--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -516,7 +516,7 @@ func deleteForwardingRule(cloud fi.Cloud, r *resources.Resource) error {
 	return c.WaitForOp(op)
 }
 
-// listFirewallRules discovers Firewall objects for the cluster
+// listFirewallRules discovers firewalls, forwarding rules, target pools, and health checks for the cluster
 func (d *clusterDiscoveryGCE) listFirewallRules() ([]*resources.Resource, error) {
 	c := d.gceCloud
 
@@ -538,11 +538,12 @@ nextFirewallRule:
 		// TODO: Check network?  (or other fields?)  No label support currently.
 
 		// We consider only firewall rules that target our cluster tags, which include the cluster name
-		tagPrefix := gce.SafeClusterName(d.clusterName) + "-"
+		legacyTagPrefix := gce.SafeClusterName(d.clusterName) + "-"
+		tagPrefix := gce.ClusterSuffixedName(id, c.Cluster.ObjectMeta.Name, 63)
 		if len(firewallRule.TargetTags) != 0 {
 			tagMatchCount := 0
 			for _, target := range firewallRule.TargetTags {
-				if strings.HasPrefix(target, tagPrefix) {
+				if strings.HasPrefix(target, tagPrefix) || strings.HasPrefix(target, legacyTagPrefix) {
 					tagMatchCount++
 				}
 			}


### PR DESCRIPTION
In https://github.com/kubernetes/kops/pull/13513 we updated the firewall name logic to support clusters with names longer than GCE naming limits.
This updates the listing logic for teardown to match.

Should fix at least some of the GCE periodic jobs:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-latest/1536707209835057152#1:build-log.txt%3A84439

`Network:e2e-e2e-kops-gce-latest-k8s-local	error deleting resources, will retry: googleapi: Error 400: The network resource 'projects/k8s-jkns-e2e-gce-gci-serial/global/networks/e2e-e2e-kops-gce-latest-k8s-local' is already being used by 'projects/k8s-jkns-e2e-gce-gci-serial/global/firewalls/nodeport-external-to-node-ipv6-e2e-e2e-kops-gce-latest-k-vqb8db'`