### PR TITLE
Automated cherry pick of #13809: replace flexdriver with busybox

### DIFF
--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: networking.projectcalico.org/k8s-1.23.yaml
-    manifestHash: 5c8d7e98d34e92f128508c2d00efed7e866251aec643309cbbdf0f9934a95f82
+    manifestHash: 881a7a81b9197ad49624cc3894c497a812d5f629c9ec31cd69b6ddae0fafe5c1
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.23_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.projectcalico.org-k8s-1.23_content
@@ -4582,6 +4582,12 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
+      - command:
+        - sh
+        - -c
+        - echo Temporary fix to avoid server side apply issues
+        image: busybox
+        name: flexvol-driver
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -61,7 +61,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.23
     manifest: networking.projectcalico.org/k8s-1.23.yaml
-    manifestHash: 73aec25bade185c9929399be7809330abd3f75d86fb7f36334f44d185f7981c0
+    manifestHash: a8944d4c2d1651f30eeaced654ccbf6179cbf26c2bb42aaf44849d360837c4af
     name: networking.projectcalico.org
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.23_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-networking.projectcalico.org-k8s-1.23_content
@@ -4579,6 +4579,12 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
+      - command:
+        - sh
+        - -c
+        - echo Temporary fix to avoid server side apply issues
+        image: busybox
+        name: flexvol-driver
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.23.yaml.template
@@ -4545,6 +4545,9 @@ spec:
               name: cni-net-dir
           securityContext:
             privileged: true
+        - name: flexvol-driver
+          image: busybox
+          command: ['sh', '-c', 'echo Temporary fix to avoid server side apply issues']
       containers:
         # Runs calico-node container on each Kubernetes node. This
         # container programs network policy and routes on each


### PR DESCRIPTION
Cherry pick of #13809 on release-1.24.

#13809: replace flexdriver with busybox

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```