### PR TITLE
add metric port to nth deployment

### DIFF
--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: b00959d209cb73161173970727425d39b8b88ce7c9fbfc60970c20dbe5ce9a97
+    manifestHash: fdea063ac413e3ebaf12c2523f47aefdebaa52dfe53179a090cf0f6ac9927b31
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -221,6 +221,9 @@ spec:
         - containerPort: 8080
           name: liveness-probe
           protocol: TCP
+        - containerPort: 9092
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 50m

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -167,7 +167,7 @@ spec:
         - name: JSON_LOGGING
           value: "true"
         - name: ENABLE_PROMETHEUS_SERVER
-          value: "false"
+          value: "{{ WithDefaultBool .EnablePrometheusMetrics false }}"
         - name: PROMETHEUS_SERVER_PORT
           value: "9092"
         - name: CHECK_ASG_TAG_BEFORE_DRAINING
@@ -212,6 +212,9 @@ spec:
         - name: liveness-probe
           protocol: TCP
           containerPort: 8080
+        - name: metrics
+          protocol: TCP
+          containerPort: 9092
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
I am missing the port declaration for metrics in the nth deployment.
Also it seems its not possible to enable it at all.