### PR TITLE
Replace manifests after apply

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -111,7 +111,7 @@ cp "${KOPS_B}" "${WORKSPACE}/kops"
 
 "${KOPS_B}" export kubecfg --name "${CLUSTER_NAME}" --admin
 
-if [[ -z ${KOPS_SKIP_E2E:-} ]]; then
+if [[ -n ${KOPS_SKIP_E2E:-} ]]; then
   exit
 fi
 


### PR DESCRIPTION
* `kubectl replace --force=true` always deletes and creates objects, causing havoc and breakage everywhere.
* `kubectl apply` can update and create objects, but does a strategic merge, which means in many cases arrays are merged. This leaves behind containers, ports and other things that causes apply to fail.
* `kubectl replace --force=false` cannot create objects, but does a "normal" merge of objects, meaning lists are _not_ merged, but replaced entirely. This is the behavior we want.

Combining `kubectl apply` with `kubectl replace` seems to be what we want right now until we know the kubectl client side apply doesnt' manage any fields.

/kind office-hours