### PR TITLE
bump k8s versions and ubuntu ami (aws) in alpha channel

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -58,11 +58,11 @@ spec:
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.17.0 <1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220509
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
       providerID: aws
       architectureID: amd64
       kubernetesVersion: ">=1.18.0"
-    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220509
+    - name: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20220615
       providerID: aws
       architectureID: arm64
       kubernetesVersion: ">=1.20.0"
@@ -88,13 +88,13 @@ spec:
       kubenet: {}
   kubernetesVersions:
   - range: ">=1.23.0"
-    recommendedVersion: 1.23.7
+    recommendedVersion: 1.23.8
     requiredVersion: 1.23.0
   - range: ">=1.22.0"
-    recommendedVersion: 1.22.10
+    recommendedVersion: 1.22.11
     requiredVersion: 1.22.0
   - range: ">=1.21.0"
-    recommendedVersion: 1.21.13
+    recommendedVersion: 1.21.14
     requiredVersion: 1.21.0
   - range: ">=1.20.0"
     recommendedVersion: 1.20.15
@@ -133,15 +133,15 @@ spec:
   - range: ">=1.23.0-alpha.1"
     recommendedVersion: "1.23.0"
     #requiredVersion: 1.22.0
-    kubernetesVersion: 1.23.7
+    kubernetesVersion: 1.23.8
   - range: ">=1.22.0-alpha.1"
     recommendedVersion: "1.23.0"
     #requiredVersion: 1.22.0
-    kubernetesVersion: 1.22.10
+    kubernetesVersion: 1.22.11
   - range: ">=1.21.0-alpha.1"
     recommendedVersion: "1.23.0"
     #requiredVersion: 1.21.0
-    kubernetesVersion: 1.21.13
+    kubernetesVersion: 1.21.14
   - range: ">=1.20.0-alpha.1"
     recommendedVersion: "1.23.0"
     #requiredVersion: 1.20.0


### PR DESCRIPTION
* https://github.com/kubernetes/kubernetes/releases/tag/v1.21.14
* https://github.com/kubernetes/kubernetes/releases/tag/v1.22.11
* https://github.com/kubernetes/kubernetes/releases/tag/v1.23.8
* https://cloud-images.ubuntu.com/locator/ec2/