### PR TITLE
Skip known failing cilium e2e test

### DIFF
--- a/tests/e2e/pkg/tester/skip_regex.go
+++ b/tests/e2e/pkg/tester/skip_regex.go
@@ -60,6 +60,7 @@ func (t *Tester) setSkipRegexFlag() error {
 		}
 		// https://github.com/cilium/cilium/issues/18241
 		skipRegex += "|Services.should.create.endpoints.for.unready.pods"
+		skipRegex += "|Services.should.be.able.to.connect.to.terminating.and.unready.endpoints.if.PublishNotReadyAddresses.is.true"
 	} else if networking.Kuberouter != nil {
 		skipRegex += "|load-balancer|hairpin|affinity\\stimeout|service\\.kubernetes\\.io|CLOSE_WAIT"
 	} else if networking.Kubenet != nil {


### PR DESCRIPTION
All cilium tests started failing recently: https://testgrid.k8s.io/kops-network-plugins#kops-aws-cni-cilium

Related to https://github.com/cilium/cilium/issues/18241