### PR TITLE
Fix GCE resource tracking

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -146,7 +146,7 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.ModelBuilderC
 			t.Labels = map[string]string{
 				gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
 				roleLabel:                         "",
-				gce.GceLabelNameInstanceGroup:     name,
+				gce.GceLabelNameInstanceGroup:     ig.ObjectMeta.Name,
 			}
 
 			if gce.UsesIPAliases(b.Cluster) {

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -1237,7 +1237,14 @@ func (d *clusterDiscoveryGCE) matchesClusterNameMultipart(name string, maxParts 
 		if id == "" {
 			continue
 		}
-		if name == gce.SafeObjectName(id, d.clusterName) {
+
+		safeName := gce.SafeObjectName(id, d.clusterName)
+		suffixedName, err := gce.ClusterSuffixedName(id, d.clusterName, 63)
+		if err != nil {
+			return false
+		}
+
+		if name == safeName || name == suffixedName {
 			return true
 		}
 	}

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -533,7 +533,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
   }
   labels = {
     "k8s-io-cluster-name"   = "ha-gce-example-com"
-    "k8s-io-instance-group" = "master-us-test1-a-ha-gce-example-com"
+    "k8s-io-instance-group" = "master-us-test1-a"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -579,7 +579,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
   }
   labels = {
     "k8s-io-cluster-name"   = "ha-gce-example-com"
-    "k8s-io-instance-group" = "master-us-test1-b-ha-gce-example-com"
+    "k8s-io-instance-group" = "master-us-test1-b"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -625,7 +625,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
   }
   labels = {
     "k8s-io-cluster-name"   = "ha-gce-example-com"
-    "k8s-io-instance-group" = "master-us-test1-c-ha-gce-example-com"
+    "k8s-io-instance-group" = "master-us-test1-c"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -671,7 +671,7 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
   }
   labels = {
     "k8s-io-cluster-name"   = "ha-gce-example-com"
-    "k8s-io-instance-group" = "nodes-ha-gce-example-com"
+    "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
   }
   machine_type = "n1-standard-2"

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -437,7 +437,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-examp
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-example-com"
-    "k8s-io-instance-group" = "master-us-test1-a-minimal-gce-example-com"
+    "k8s-io-instance-group" = "master-us-test1-a"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -483,7 +483,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-example-com"
-    "k8s-io-instance-group" = "nodes-minimal-gce-example-com"
+    "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
   }
   machine_type = "n1-standard-2"

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -432,7 +432,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-ilb-e
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-ilb-example-com"
-    "k8s-io-instance-group" = "master-us-test1-a-minimal-gce-ilb-example-com"
+    "k8s-io-instance-group" = "master-us-test1-a"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -476,7 +476,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-ilb-example-com" 
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-ilb-example-com"
-    "k8s-io-instance-group" = "nodes-minimal-gce-ilb-example-com"
+    "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
   }
   machine_type = "n1-standard-2"

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -429,7 +429,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-priva
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-private-example-com"
-    "k8s-io-instance-group" = "master-us-test1-a-minimal-gce-private-example-com"
+    "k8s-io-instance-group" = "master-us-test1-a"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -473,7 +473,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-private-example-c
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-private-example-com"
-    "k8s-io-instance-group" = "nodes-minimal-gce-private-example-com"
+    "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
   }
   machine_type = "n1-standard-2"


### PR DESCRIPTION
Issues:
* resource tracking misses some of the FirewallRule resources:
```
	Network:e2e-pr13857-pull-kops-e2e-k8s-gce-k8s-local
E0623 10:05:51.789873   38732 op.go:136] GCE operation failed: googleapi: Error 400: The network resource 'projects/k8s-jkns-gce-serial-1-4/global/networks/e2e-pr13857-pull-kops-e2e-k8s-gce-k8s-local' is already being used by 'projects/k8s-jkns-gce-serial-1-4/global/firewalls/ssh-external-to-node-ipv6-e2e-pr13857-pull-kops-e2e-k8s--dkfkq0'
Network:e2e-pr13857-pull-kops-e2e-k8s-gce-k8s-local	error deleting resources, will retry: googleapi: Error 400: The network resource 'projects/k8s-jkns-gce-serial-1-4/global/networks/e2e-pr13857-pull-kops-e2e-k8s-gce-k8s-local' is already being used by 'projects/k8s-jkns-gce-serial-1-4/global/firewalls/ssh-external-to-node-ipv6-e2e-pr13857-pull-kops-e2e-k8s--dkfkq0'
Not all resources deleted; waiting before reattempting deletion
```
* InstanceTemplate labels are not limited to 63 chars in the case for the InstanceGroup name:
```
W0623 09:52:05.702282   38616 executor.go:139] error running task "InstanceTemplate/master-us-central1-a-e2e-pr13857-pull-kops-e2e-k8s-gce-k8s-local" (1m26s remaining to succeed): error creating InstanceTemplate: googleapi: Error 400: Invalid value for field 'resource.properties.labels': ''. Label value 'master-us-central1-a-e2e-pr13857-pull-kops-e2e-k8s-gce-k8s-local' violates format constraints. The value can only contain lowercase letters, numeric characters, underscores and dashes. The value can be at most 63 characters long. International characters are allowed., invalid
```

Fixes: #13855