### PR TITLE
Automated cherry pick of #13857: Fix GCE resource tracking

### DIFF
--- a/pkg/model/gcemodel/autoscalinggroup.go
+++ b/pkg/model/gcemodel/autoscalinggroup.go
@@ -146,7 +146,7 @@ func (b *AutoscalingGroupModelBuilder) buildInstanceTemplate(c *fi.ModelBuilderC
 			t.Labels = map[string]string{
 				gce.GceLabelNameKubernetesCluster: gce.SafeClusterName(b.ClusterName()),
 				roleLabel:                         "",
-				gce.GceLabelNameInstanceGroup:     name,
+				gce.GceLabelNameInstanceGroup:     ig.ObjectMeta.Name,
 			}
 
 			if gce.UsesIPAliases(b.Cluster) {

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -1237,7 +1237,14 @@ func (d *clusterDiscoveryGCE) matchesClusterNameMultipart(name string, maxParts 
 		if id == "" {
 			continue
 		}
-		if name == gce.SafeObjectName(id, d.clusterName) {
+
+		safeName := gce.SafeObjectName(id, d.clusterName)
+		suffixedName, err := gce.ClusterSuffixedName(id, d.clusterName, 63)
+		if err != nil {
+			return false
+		}
+
+		if name == safeName || name == suffixedName {
 			return true
 		}
 	}

--- a/tests/integration/update_cluster/ha_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/ha_gce/kubernetes.tf
@@ -541,7 +541,7 @@ resource "google_compute_instance_template" "master-us-test1-a-ha-gce-example-co
   }
   labels = {
     "k8s-io-cluster-name"   = "ha-gce-example-com"
-    "k8s-io-instance-group" = "master-us-test1-a-ha-gce-example-com"
+    "k8s-io-instance-group" = "master-us-test1-a"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -587,7 +587,7 @@ resource "google_compute_instance_template" "master-us-test1-b-ha-gce-example-co
   }
   labels = {
     "k8s-io-cluster-name"   = "ha-gce-example-com"
-    "k8s-io-instance-group" = "master-us-test1-b-ha-gce-example-com"
+    "k8s-io-instance-group" = "master-us-test1-b"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -633,7 +633,7 @@ resource "google_compute_instance_template" "master-us-test1-c-ha-gce-example-co
   }
   labels = {
     "k8s-io-cluster-name"   = "ha-gce-example-com"
-    "k8s-io-instance-group" = "master-us-test1-c-ha-gce-example-com"
+    "k8s-io-instance-group" = "master-us-test1-c"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -679,7 +679,7 @@ resource "google_compute_instance_template" "nodes-ha-gce-example-com" {
   }
   labels = {
     "k8s-io-cluster-name"   = "ha-gce-example-com"
-    "k8s-io-instance-group" = "nodes-ha-gce-example-com"
+    "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
   }
   machine_type = "n1-standard-2"

--- a/tests/integration/update_cluster/minimal_gce/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce/kubernetes.tf
@@ -445,7 +445,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-examp
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-example-com"
-    "k8s-io-instance-group" = "master-us-test1-a-minimal-gce-example-com"
+    "k8s-io-instance-group" = "master-us-test1-a"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -491,7 +491,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-example-com" {
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-example-com"
-    "k8s-io-instance-group" = "nodes-minimal-gce-example-com"
+    "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
   }
   machine_type = "n1-standard-2"

--- a/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb/kubernetes.tf
@@ -440,7 +440,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-ilb-e
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-ilb-example-com"
-    "k8s-io-instance-group" = "master-us-test1-a-minimal-gce-ilb-example-com"
+    "k8s-io-instance-group" = "master-us-test1-a"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -484,7 +484,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-ilb-example-com" 
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-ilb-example-com"
-    "k8s-io-instance-group" = "nodes-minimal-gce-ilb-example-com"
+    "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
   }
   machine_type = "n1-standard-2"

--- a/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_private/kubernetes.tf
@@ -437,7 +437,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-priva
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-private-example-com"
-    "k8s-io-instance-group" = "master-us-test1-a-minimal-gce-private-example-com"
+    "k8s-io-instance-group" = "master-us-test1-a"
     "k8s-io-role-master"    = ""
   }
   machine_type = "n1-standard-1"
@@ -481,7 +481,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-private-example-c
   }
   labels = {
     "k8s-io-cluster-name"   = "minimal-gce-private-example-com"
-    "k8s-io-instance-group" = "nodes-minimal-gce-private-example-com"
+    "k8s-io-instance-group" = "nodes"
     "k8s-io-role-node"      = ""
   }
   machine_type = "n1-standard-2"


### PR DESCRIPTION
Cherry pick of #13857 on release-1.24.

#13857: Fix GCE resource tracking

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```