### PR TITLE
Limit GCE tag for role to 63 chars

### DIFF
--- a/upup/pkg/fi/cloudup/gce/labels.go
+++ b/upup/pkg/fi/cloudup/gce/labels.go
@@ -67,5 +67,5 @@ func DecodeGCELabel(s string) (string, error) {
 
 // TagForRole return the instance (network) tag used for instances with the given role.
 func TagForRole(clusterName string, role kops.InstanceGroupRole) string {
-	return SafeClusterName(clusterName) + "-" + GceLabelNameRolePrefix + strings.ToLower(string(role))
+	return ClusterPrefixedName(GceLabelNameRolePrefix+strings.ToLower(string(role)), clusterName, 63)
 }

--- a/upup/pkg/fi/cloudup/gce/utils.go
+++ b/upup/pkg/fi/cloudup/gce/utils.go
@@ -49,6 +49,24 @@ func IsNotReady(err error) bool {
 	return false
 }
 
+// ClusterPrefixedName returns a cluster-prefixed name, with a maxLength
+func ClusterPrefixedName(objectName string, clusterName string, maxLength int) string {
+	suffix := "-" + objectName
+	suffixLength := maxLength - len(suffix)
+
+	// GCE does not support . in tags / names
+	safeClusterName := strings.Replace(clusterName, ".", "-", -1)
+
+	opt := truncate.TruncateStringOptions{
+		MaxLength:     suffixLength,
+		AlwaysAddHash: false,
+		HashLength:    6,
+	}
+	prefix := truncate.TruncateString(safeClusterName, opt)
+
+	return prefix + suffix
+}
+
 // ClusterSuffixedName returns a cluster-suffixed name, with a maxLength
 func ClusterSuffixedName(objectName string, clusterName string, maxLength int) (string, error) {
 	prefix := objectName + "-"


### PR DESCRIPTION
Some tests still fail:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-grid-gce-calico-u2004-k22-containerd/1540027335678365696
```
W0623 17:44:09.192151    6112 executor.go:139] error running task "FirewallRule/master-to-master-e2e-e2e-kops-grid-gce-calico-u2004-k22--1m2qc6" (9m46s remaining to succeed): error creating FirewallRule: googleapi: Error 400: Invalid value for field 'resource.sourceTags[0]': 'e2e-e2e-kops-grid-gce-calico-u2004-k22-containerd-k8s-local-k8s-io-role-master'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
More details:
Reason: invalid, Message: Invalid value for field 'resource.sourceTags[0]': 'e2e-e2e-kops-grid-gce-calico-u2004-k22-containerd-k8s-local-k8s-io-role-master'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
Reason: invalid, Message: Invalid value for field 'resource.targetTags[0]': 'e2e-e2e-kops-grid-gce-calico-u2004-k22-containerd-k8s-local-k8s-io-role-master'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
```

/cc @rifelpet @justinsb