### PR TITLE
Automated cherry pick of #13866: Limit GCE tag for role to 63 chars

### DIFF
--- a/upup/pkg/fi/cloudup/gce/labels.go
+++ b/upup/pkg/fi/cloudup/gce/labels.go
@@ -67,5 +67,5 @@ func DecodeGCELabel(s string) (string, error) {
 
 // TagForRole return the instance (network) tag used for instances with the given role.
 func TagForRole(clusterName string, role kops.InstanceGroupRole) string {
-	return SafeClusterName(clusterName) + "-" + GceLabelNameRolePrefix + strings.ToLower(string(role))
+	return ClusterPrefixedName(GceLabelNameRolePrefix+strings.ToLower(string(role)), clusterName, 63)
 }

--- a/upup/pkg/fi/cloudup/gce/utils.go
+++ b/upup/pkg/fi/cloudup/gce/utils.go
@@ -49,6 +49,24 @@ func IsNotReady(err error) bool {
 	return false
 }
 
+// ClusterPrefixedName returns a cluster-prefixed name, with a maxLength
+func ClusterPrefixedName(objectName string, clusterName string, maxLength int) string {
+	suffix := "-" + objectName
+	suffixLength := maxLength - len(suffix)
+
+	// GCE does not support . in tags / names
+	safeClusterName := strings.Replace(clusterName, ".", "-", -1)
+
+	opt := truncate.TruncateStringOptions{
+		MaxLength:     suffixLength,
+		AlwaysAddHash: false,
+		HashLength:    6,
+	}
+	prefix := truncate.TruncateString(safeClusterName, opt)
+
+	return prefix + suffix
+}
+
 // ClusterSuffixedName returns a cluster-suffixed name, with a maxLength
 func ClusterSuffixedName(objectName string, clusterName string, maxLength int) (string, error) {
 	prefix := objectName + "-"


### PR DESCRIPTION
Cherry pick of #13866 on release-1.24.

#13866: Limit GCE tag for role to 63 chars

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```