### PR TITLE
Bump kubetest2 to test rundir

### DIFF
--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/klog/v2 v2.60.1
 	k8s.io/kops v1.24.0-beta.2
 	sigs.k8s.io/boskos v0.0.0-20200710214748-f5935686c7fc
-	sigs.k8s.io/kubetest2 v0.0.0-20220411203323-036d47c48813
+	sigs.k8s.io/kubetest2 v0.0.0-20220625123257-6d8d7ca3e95c
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -158,7 +158,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/release v0.7.1-0.20210204090829-09fb5e3883b8 // indirect
 	k8s.io/test-infra v0.0.0-20200617221206-ea73eaeab7ff // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -2806,7 +2806,6 @@ k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
@@ -2878,8 +2877,8 @@ sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKG
 sigs.k8s.io/controller-runtime v0.5.4/go.mod h1:JZUwSMVbxDupo0lTJSSFP5pimEyxGynROImSsqIOx1A=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
-sigs.k8s.io/kubetest2 v0.0.0-20220411203323-036d47c48813 h1:RKcl4omAGujM+pzdT2mcDSNOGh6zCOzYXeTU9Hb2E7g=
-sigs.k8s.io/kubetest2 v0.0.0-20220411203323-036d47c48813/go.mod h1:99HO7HbhRZ1kJ7j9Ell5bdsYISpkYvyllTK9Y58ysdM=
+sigs.k8s.io/kubetest2 v0.0.0-20220625123257-6d8d7ca3e95c h1:nPGPcaTtOnepSc/m4e9fQ1hKXW7zFWyZtLG58lDnRaw=
+sigs.k8s.io/kubetest2 v0.0.0-20220625123257-6d8d7ca3e95c/go.mod h1:iq9r9WRrDLyxKuEDjY+lOEag/ZlAUNXyDusL4ss9D9A=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/mdtoc v1.0.1/go.mod h1:COYBtOjsaCg7o7SC4eaLwEXPuVRSuiVuLLRrHd7kShw=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=


### PR DESCRIPTION
Ref https://github.com/kubernetes-sigs/kubetest2/pull/183

I faintly remember something about us assuming binaries are in artifacts.