### PR TITLE
Automated cherry pick of #13819: Replace manifests after apply

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -104,6 +104,10 @@ cp "${KOPS_B}" "${WORKSPACE}/kops"
 
 "${KOPS_B}" export kubecfg --name "${CLUSTER_NAME}" --admin
 
+if [[ -n ${KOPS_SKIP_E2E:-} ]]; then
+  exit
+fi
+
 ${KUBETEST2} \
 		--cloud-provider="${CLOUD_PROVIDER}" \
 		--kops-binary-path="${KOPS}" \


### PR DESCRIPTION
Cherry pick of #13819 on release-1.24.

#13819: Replace manifests after apply

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```