### PR TITLE
Generate cli docs after updating dependencies

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -37,5 +37,5 @@ jobs:
           body: |
             Updating go.mod with latest dependencies:
             ```
-            ${{ steps.update_deps.outputs.changes }}
+            ${{ join(steps.update_deps.outputs.changes, "\n") }}
             ```

--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ goget:
 	go get $(shell go list -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' -mod=mod -m all)
 
 .PHONY: depup
-depup: goget gomod
+depup: goget gomod gen-cli-docs
 
 .PHONY: gofmt
 gofmt:


### PR DESCRIPTION
Some dependencies require updated cli docs, as it can be seen in https://github.com/kubernetes/kops/pull/13882.

/cc @olemarkus @rifelpet 