### PR TITLE
Fix unexpected symbol error in  update-deps workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -35,7 +35,4 @@ jobs:
           delete-branch: true
           labels: ok-to-test
           body: |
-            Updating go.mod with latest dependencies:
-            ```
-            ${{ join(steps.update_deps.outputs.changes, "\n") }}
-            ```
+            Updating go.mod with latest dependencies...


### PR DESCRIPTION
```
[Invalid workflow file: .github/workflows/update-deps.yml#L37](https://github.com/kubernetes/kops/actions/runs/2567197138/workflow)
The workflow is not valid. .github/workflows/update-deps.yml (Line: 37, Col: 17): Unexpected symbol: '"\n"'. Located at position 41 within expression: join(steps.update_deps.outputs.changes, "\n")
```
https://github.com/kubernetes/kops/actions/runs/2567197138

/cc @olemarkus 