### PR TITLE
Use csi-snapshotter for OS only when the controller is enabled

### DIFF
--- a/docs/releases/1.25-NOTES.md
+++ b/docs/releases/1.25-NOTES.md
@@ -12,6 +12,14 @@ This is a document to gather the release notes prior to the release.
 
 # Breaking changes
 
+## Cinder CSI snapthot controller changes
+
+The CSI Cinder plugin for OpenStack will now only use the CSI snapshotter when the CSI snapshot controller is enabled in the cluster spec.
+
+This changes the default behavior where the CSI snaphotter container was always present, but spammed the log with error messages (see [#13890](https://github.com/kubernetes/kops/pull/13890))
+
+So in case of manually deployed CRDs to make the snapshotter work it is now necessary to [enable the snapshot controller](https://kops.sigs.k8s.io/addons/#snapshot-controller).
+
 ## Other breaking changes
 
 * Support for Kubernetes version 1.19 has been removed.
@@ -25,5 +33,6 @@ This is a document to gather the release notes prior to the release.
 * Support for Kubernetes version 1.21 is deprecated and will be removed in kOps 1.27.
 
 # Other changes of note
+
 
 # Full change list since 1.24.0 release

--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -280,6 +280,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+        {{ if HasSnapshotController }}
         - name: csi-snapshotter
           image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           args:
@@ -294,6 +295,7 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+        {{ end }}
         - name: csi-resizer
           image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
           args:


### PR DESCRIPTION
With this change the csi-snapshotter container for the csi-cinder-plugin will only be added when the controller for it is enabled in the cluster spec.

This will avoid the following error:

```
csi-snapshotter E0627 15:03:09.327512       1 reflector.go:138] github.com/kubernetes-csi/external-snapshotter/client/v4/informers/externalversions/factory.go:117: Failed to watch *v1.VolumeSnapshotClass: failed to list *v1.VolumeSnapshotClass: the serve
r could not find the requested resource (get volumesnapshotclasses.snapshot.storage.k8s.io)
csi-snapshotter E0627 15:03:21.091312       1 reflector.go:138] github.com/kubernetes-csi/external-snapshotter/client/v4/informers/externalversions/factory.go:117: Failed to watch *v1.VolumeSnapshotContent: failed to list *v1.VolumeSnapshotContent: the s
erver could not find the requested resource (get volumesnapshotcontents.snapshot.storage.k8s.io)
csi-snapshotter E0627 15:03:45.763809       1 reflector.go:138] github.com/kubernetes-csi/external-snapshotter/client/v4/informers/externalversions/factory.go:117: Failed to watch *v1.VolumeSnapshotClass: failed to list *v1.VolumeSnapshotClass: the serve
r could not find the requested resource (get volumesnapshotclasses.snapshot.storage.k8s.io)
csi-snapshotter E0627 15:04:02.515010       1 reflector.go:138] github.com/kubernetes-csi/external-snapshotter/client/v4/informers/externalversions/factory.go:117: Failed to watch *v1.VolumeSnapshotContent: failed to list *v1.VolumeSnapshotContent: the s
erver could not find the requested resource (get volumesnapshotcontents.snapshot.storage.k8s.io)
```

Related: https://github.com/kubernetes/kops/pull/13453