### PR TITLE
Document OpenStack CSI breaking changes

### DIFF
--- a/docs/releases/1.24-NOTES.md
+++ b/docs/releases/1.24-NOTES.md
@@ -31,13 +31,13 @@ kOps will directly manage the Karpenter Provisioner resources. Read more about h
 
 * Adds support for overriding the Kubernetes version when upgrading a cluster by using the `--kubernetes-version` flag.
 
-* The minimum version for the Terraform AWS Provider has been bumped to 4.0.0 to address the deprecation of the aws_s3_bucket_object resource and its replacement with the aws_s3_object resource. Such resources will be destroyed and recreated without downtime when applying the changes. 
+* The minimum version for the Terraform AWS Provider has been bumped to 4.0.0 to address the deprecation of the aws_s3_bucket_object resource and its replacement with the aws_s3_object resource. Such resources will be destroyed and recreated without downtime when applying the changes.
 
 * ARM64 support for nvidia device driver. Nvidia nodes on ARM64 requires Ubuntu 22.04 AMIs.
 
 # Breaking changes
 
-* The nfs-common/nfs-utils package is no longer installed by default. Use the [packages](https://kops.sigs.k8s.io/instance_groups/#packages) option at instance group level to add it back. 
+* The nfs-common/nfs-utils package is no longer installed by default. Use the [packages](https://kops.sigs.k8s.io/instance_groups/#packages) option at instance group level to add it back.
 
 ## Control plane taints and labels
 
@@ -74,6 +74,16 @@ The deprecated `kubernetes.io/role` label has been removed for all roles as of K
 Cert Manager upgraded from 1.6 to 1.8. This has backwards-breaking changes. See upgrading from [1.6 to 1.7](https://cert-manager.io/docs/installation/upgrading/upgrading-1.6-1.7/) and [1.[1.7 to 1.8](https://cert-manager.io/docs/installation/upgrading/upgrading-1.7-1.8/).
 
 In particular, if you are using the snapshot-controller addon, upgrade your cluster to kOps 1.23 before upgrading to kOps 1.24 to ensure the certificate has the correct API version.
+
+## OpenStack CSI changes
+
+The deployment model of the `csi-cinder-controllerplugin` changes from `StatefulSet` to `Deployment`.
+
+Also, redundant `Role` and `RoleBinding` for the CSI resizer were removed.
+
+So when updating from an earlier kOps version it is necessary to manually cleanup those resources.
+
+See [#13603](https://github.com/kubernetes/kops/pull/13603)
 
 ## Other breaking changes
 


### PR DESCRIPTION
This documents the changes done in https://github.com/kubernetes/kops/pull/13603 as breaking changes since it is necessary to manually delete the old `StatefulSet` when upgrading from an old kOps version.