### PR TITLE
Automated cherry pick of #13896: Log errors from detachInstance

### DIFF
--- a/pkg/instancegroups/instancegroups.go
+++ b/pkg/instancegroups/instancegroups.go
@@ -157,6 +157,7 @@ func (c *RollingUpdateCluster) rollingUpdateInstanceGroup(group *cloudinstances.
 				if err := c.detachInstance(u); err != nil {
 					// If detaching a node fails, we simply proceed to the next one instead of
 					// bubbling up the error.
+					klog.Errorf("Failed to detach instance %q: %v", u.ID, err)
 					skippedNodes++
 					numSurge--
 					if maxSurge > len(update)-skippedNodes {


### PR DESCRIPTION
Cherry pick of #13896 on release-1.24.

#13896: Log errors from detachInstance

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```