### PR TITLE
gce: set ProvisioningModel on InstanceTemplate

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -249,6 +249,7 @@ func (e *InstanceTemplate) mapToGCE(project string, region string) (*compute.Ins
 		scheduling = &compute.Scheduling{
 			AutomaticRestart:  fi.Bool(false),
 			OnHostMaintenance: "TERMINATE",
+			ProvisioningModel: "STANDARD", // TODO: Support Spot?
 			Preemptible:       true,
 		}
 	} else {
@@ -256,6 +257,7 @@ func (e *InstanceTemplate) mapToGCE(project string, region string) (*compute.Ins
 			AutomaticRestart: fi.Bool(true),
 			// TODO: Migrate or terminate?
 			OnHostMaintenance: "MIGRATE",
+			ProvisioningModel: "STANDARD",
 			Preemptible:       false,
 		}
 	}


### PR DESCRIPTION
Because of how we compare InstanceTemplates, this was causing spurious
differences.

Add the minimal support, setting the value to the default.
