### PR TITLE
Automated cherry pick of #13903: gce: Move out of beta, drop feature flag

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -985,7 +985,7 @@ func completeNetworking(options *CreateClusterOptions) func(cmd *cobra.Command, 
 				completions = append(completions, "amazonvpc")
 			}
 
-			if featureflag.AlphaAllowGCE.Enabled() && (options.CloudProvider == "gce" || options.CloudProvider == "") {
+			if options.CloudProvider == "gce" || options.CloudProvider == "" {
 				completions = append(completions, "gce")
 			}
 		}

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -1287,8 +1287,6 @@ func (i *integrationTest) runTestPhase(t *testing.T, phase cloudup.Phase) {
 }
 
 func (i *integrationTest) runTestTerraformGCE(t *testing.T) {
-	featureflag.ParseFlags("+AlphaAllowGCE")
-
 	h := testutils.NewIntegrationTestHarness(t)
 	defer h.Close()
 

--- a/cmd/kops/lifecycle_integration_test.go
+++ b/cmd/kops/lifecycle_integration_test.go
@@ -473,8 +473,6 @@ func runLifecycleTestGCE(o *LifecycleTestOptions) {
 
 	h.MockKopsVersion("1.21.0-alpha.1")
 
-	featureflag.ParseFlags("AlphaAllowGCE")
-
 	cloud := h.SetupMockGCE()
 
 	var beforeIds []string

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -73,7 +73,7 @@ kops create cluster [CLUSTER] [flags]
       --authorization string             Authorization mode: AlwaysAllow or RBAC (default "RBAC")
       --bastion                          Enable a bastion instance group. Only applies to private topology.
       --channel string                   Channel for default versions and configuration to use (default "stable")
-      --cloud string                     Cloud provider to use - aws, digitalocean, openstack
+      --cloud string                     Cloud provider to use - aws, digitalocean, gce, openstack
       --cloud-labels string              A list of key/value pairs used to tag all instance groups (for example "Owner=John Doe,Team=Some Team").
       --container-runtime string         Container runtime to use: containerd, docker
       --disable-subnet-tags              Disable automatic subnet tagging

--- a/docs/getting_started/gce.md
+++ b/docs/getting_started/gce.md
@@ -34,7 +34,6 @@ You can also put this in your `~/.bashrc` or similar.
 
 
     PROJECT=`gcloud config get-value project`
-    export KOPS_FEATURE_FLAGS=AlphaAllowGCE # to unlock the GCE features
     kops create cluster simple.k8s.local --zones us-central1-a --state ${KOPS_STATE_STORE}/ --project=${PROJECT}
 
 

--- a/hack/dev-build-gce.sh
+++ b/hack/dev-build-gce.sh
@@ -44,7 +44,4 @@ KOPS_STATE_STORE="gs://kops-state-$(gcloud config get-value project)"
 export KOPS_STATE_STORE
 gsutil ls "${KOPS_STATE_STORE}" || gsutil mb "${KOPS_STATE_STORE}" || return
 
-# Set feature flags needed on GCE
-export KOPS_FEATURE_FLAGS=AlphaAllowGCE
-
 echo "SUCCESS"

--- a/pkg/clouds/supported.go
+++ b/pkg/clouds/supported.go
@@ -25,13 +25,11 @@ func SupportedClouds() []kops.CloudProviderID {
 	clouds := []kops.CloudProviderID{
 		kops.CloudProviderAWS,
 		kops.CloudProviderDO,
+		kops.CloudProviderGCE,
 		kops.CloudProviderOpenstack,
 	}
 	if featureflag.Azure.Enabled() {
 		clouds = append(clouds, kops.CloudProviderAzure)
-	}
-	if featureflag.AlphaAllowGCE.Enabled() {
-		clouds = append(clouds, kops.CloudProviderGCE)
 	}
 	if featureflag.Hetzner.Enabled() {
 		clouds = append(clouds, kops.CloudProviderHetzner)

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -86,8 +86,6 @@ var (
 	UseAddonOperators = new("UseAddonOperators", Bool(false))
 	// TerraformManagedFiles enables rendering managed files into the Terraform configuration.
 	TerraformManagedFiles = new("TerraformManagedFiles", Bool(true))
-	// AlphaAllowGCE is a feature flag that gates GCE support while it is alpha.
-	AlphaAllowGCE = new("AlphaAllowGCE", Bool(false))
 	// Karpenter enables karpenter-managed Instance Groups
 	Karpenter = new("Karpenter", Bool(false))
 	// ImageDigest remaps all manifests with image digests

--- a/tests/e2e/kubetest2-kops/deployer/common.go
+++ b/tests/e2e/kubetest2-kops/deployer/common.go
@@ -212,7 +212,6 @@ func (d *deployer) env() []string {
 func (d *deployer) featureFlags() string {
 	ff := []string{
 		"+SpecOverrideFlag",
-		"+AlphaAllowGCE",
 	}
 	val := strings.Join(ff, ",")
 	for _, env := range d.Env {

--- a/tests/e2e/scenarios/upgrade-ha-leader-migration/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ha-leader-migration/run-test.sh
@@ -41,7 +41,6 @@ OVERRIDES=("--channel=alpha" "--node-count=1" "--master-count=3")
 
 case "${CLOUD_PROVIDER}" in
 gce)
-	export KOPS_FEATURE_FLAGS="${KOPS_FEATURE_FLAGS},AlphaAllowGCE"
 	OVERRIDES+=(
 		"--zones=us-central1-a,us-central1-b,us-central1-c"
 		"--master-zones=us-central1-a,us-central1-b,us-central1-c"

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -401,11 +401,6 @@ func (c *ApplyClusterCmd) Run(ctx context.Context) error {
 		{
 			gceCloud := cloud.(gce.GCECloud)
 			project = gceCloud.Project()
-
-			if !featureflag.AlphaAllowGCE.Enabled() {
-				return fmt.Errorf("GCE support is currently alpha, and is feature-gated.  export KOPS_FEATURE_FLAGS=AlphaAllowGCE")
-			}
-
 		}
 
 	case kops.CloudProviderHetzner:


### PR DESCRIPTION
Cherry pick of #13903 on release-1.24.

#13903: gce: Move out of beta, drop feature flag

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```