### PR TITLE
Automated cherry pick of #13902: gce: set ProvisioningModel on InstanceTemplate

### DIFF
--- a/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
+++ b/upup/pkg/fi/cloudup/gcetasks/instancetemplate.go
@@ -249,6 +249,7 @@ func (e *InstanceTemplate) mapToGCE(project string, region string) (*compute.Ins
 		scheduling = &compute.Scheduling{
 			AutomaticRestart:  fi.Bool(false),
 			OnHostMaintenance: "TERMINATE",
+			ProvisioningModel: "STANDARD", // TODO: Support Spot?
 			Preemptible:       true,
 		}
 	} else {
@@ -256,6 +257,7 @@ func (e *InstanceTemplate) mapToGCE(project string, region string) (*compute.Ins
 			AutomaticRestart: fi.Bool(true),
 			// TODO: Migrate or terminate?
 			OnHostMaintenance: "MIGRATE",
+			ProvisioningModel: "STANDARD",
 			Preemptible:       false,
 		}
 	}


### PR DESCRIPTION
Cherry pick of #13902 on release-1.24.

#13902: gce: set ProvisioningModel on InstanceTemplate

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```