### PR TITLE
WIP: Make it possible to configure IPv6 with Calico

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -49,7 +49,7 @@ data:
           "mtu": __CNI_MTU__,
           "ipam": {
               "assign_ipv4": "{{ not IsIPv6Only }}",
-              "assign_ipv6": "{{ IsIPv6Only }}",
+              "assign_ipv6": "{{ CalicoUseIPv6 }}",
               {{- if IsIPv6Only }}
               "type": "host-local",
               "ranges": [[{ "subnet": "usePodCidr" }]]
@@ -3916,7 +3916,7 @@ rules:
     resources:
       - endpointslices
     verbs:
-      - watch 
+      - watch
       - list
   - apiGroups: [""]
     resources:
@@ -4383,7 +4383,7 @@ spec:
             - name: IP
               value: "{{- if not IsIPv6Only -}}autodetect{{- else -}}none{{- end -}}"
             - name: IP6
-              value: "{{- if IsIPv6Only -}}autodetect{{- else -}}none{{- end -}}"
+              value: "{{- if CalicoUseIPv6) -}}autodetect{{- else -}}none{{- end -}}"
             {{- if IsIPv6Only }}
             - name: IP_AUTODETECTION_METHOD
               value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "none" }}"
@@ -4430,6 +4430,8 @@ spec:
             {{- else }}
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .KubeControllerManager.ClusterCIDR }}"
+            - name: CALICO_IPV6POOL_NAT_OUTGOING
+              value: "{{- CalicoUseIPv6 }}"
             {{- end }}
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
@@ -4439,7 +4441,7 @@ spec:
               value: "ACCEPT"
             # Set IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
-              value: "{{ IsIPv6Only }}"
+              value: "{{ CalicoUseIPv6 }}"
             - name: FELIX_HEALTHENABLED
               value: "true"
 

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.16.yaml.template
@@ -4383,7 +4383,7 @@ spec:
             - name: IP
               value: "{{- if not IsIPv6Only -}}autodetect{{- else -}}none{{- end -}}"
             - name: IP6
-              value: "{{- if CalicoUseIPv6) -}}autodetect{{- else -}}none{{- end -}}"
+              value: "{{- if CalicoUseIPv6 -}}autodetect{{- else -}}none{{- end -}}"
             {{- if IsIPv6Only }}
             - name: IP_AUTODETECTION_METHOD
               value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "none" }}"

--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.23.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.23.yaml.template
@@ -49,7 +49,7 @@ data:
           "mtu": __CNI_MTU__,
           "ipam": {
               "assign_ipv4": "{{ not IsIPv6Only }}",
-              "assign_ipv6": "{{ IsIPv6Only }}",
+              "assign_ipv6": "{{ CalicoUseIPv6 }}",
               {{- if IsIPv6Only }}
               "type": "host-local",
               "ranges": [[{ "subnet": "usePodCidrIPv6" }]]
@@ -4605,7 +4605,7 @@ spec:
             - name: IP
               value: "{{- if not IsIPv6Only -}}autodetect{{- else -}}none{{- end -}}"
             - name: IP6
-              value: "{{- if IsIPv6Only -}}autodetect{{- else -}}none{{- end -}}"
+              value: "{{- if CalicoUseIPv6 -}}autodetect{{- else -}}none{{- end -}}"
             {{- if IsIPv6Only }}
             - name: IP_AUTODETECTION_METHOD
               value: "{{- or .Networking.Calico.IPv4AutoDetectionMethod "none" }}"
@@ -4652,6 +4652,8 @@ spec:
             {{- else }}
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ .KubeControllerManager.ClusterCIDR }}"
+            - name: CALICO_IPV6POOL_NAT_OUTGOING
+              value: "{{- CalicoUseIPv6 }}"
             {{- end }}
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
@@ -4661,7 +4663,7 @@ spec:
               value: "ACCEPT"
             # Set IPv6 on Kubernetes.
             - name: FELIX_IPV6SUPPORT
-              value: "{{ IsIPv6Only }}"
+              value: "{{ CalicoUseIPv6 }}"
             - name: FELIX_HEALTHENABLED
               value: "true"
 

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -248,6 +248,10 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			return "CrossSubnet"
 		}
 		dest["CalicoUseIPv6"] = func() bool {
+			// TODO:
+			// In the templates this is done:
+			// value: "{{- or .Networking.Calico.IPv6AutoDetectionMethod "none" }}"
+			// But doc states that default is "first-found", so this might not work like expected (IPv6 always on)
 			return cluster.Spec.IsIPv6Only() || c.IPv6AutoDetectionMethod != "none"
 		}
 	}

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -247,6 +247,9 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 			}
 			return "CrossSubnet"
 		}
+		dest["CalicoUseIPv6"] = func() bool {
+			return cluster.Spec.IsIPv6Only() || c.IPv6AutoDetectionMethod != "none"
+		}
 	}
 
 	if cluster.Spec.Networking != nil && cluster.Spec.Networking.Cilium != nil {


### PR DESCRIPTION
This will enable users to configure IPv6 for the pod network with Calico when setting the IPv6AutodetectionMethod to something else than none.

The motivation behind this is to let users bring their own IPv6 net. For example in OpenStack adding an additional port with an IPv6 address can do this (depends on https://github.com/kubernetes/kops/pull/13861, and also https://github.com/kubernetes-sigs/etcdadm/pull/317).

Limitations:
* Users have to care about adding an IPv6 to the host(s)
* Default IPv6 pool of Calico is used right now
* The config for if `IsIpv6Only()` is true has priority