### PR TITLE
gce: Refactor ClusterPrefixedName and ClusterSuffixedName to not return error

### DIFF
--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -61,11 +61,7 @@ func (c *GCEModelContext) NameForIPAliasRange(key string) string {
 func (c *GCEModelContext) LinkToSubnet(subnet *kops.ClusterSubnetSpec) *gcetasks.Subnet {
 	name := subnet.ProviderID
 	if name == "" {
-		var err error
-		name, err = gce.ClusterSuffixedName(subnet.Name, c.Cluster.ObjectMeta.Name, 63)
-		if err != nil {
-			klog.Fatalf("failed to construct subnet name: %w", err)
-		}
+		name = gce.ClusterSuffixedName(subnet.Name, c.Cluster.ObjectMeta.Name, 63)
 	}
 
 	return &gcetasks.Subnet{Name: s(name)}
@@ -119,11 +115,7 @@ func (c *GCEModelContext) NameForHealthcheck(id string) string {
 }
 
 func (c *GCEModelContext) NameForFirewallRule(id string) string {
-	name, err := gce.ClusterSuffixedName(id, c.Cluster.ObjectMeta.Name, 63)
-	if err != nil {
-		klog.Fatalf("failed to construct firewallrule name: %w", err)
-	}
-	return name
+	return gce.ClusterSuffixedName(id, c.Cluster.ObjectMeta.Name, 63)
 }
 
 func (c *GCEModelContext) NetworkingIsIPAlias() bool {
@@ -163,10 +155,7 @@ func (c *GCEModelContext) LinkToServiceAccount(ig *kops.InstanceGroup) *gcetasks
 		klog.Fatalf("unknown role %q", role)
 	}
 
-	accountID, err := gce.ServiceAccountName(name, c.ClusterName())
-	if err != nil {
-		klog.Fatalf("failed to construct serviceaccount name: %w", err)
-	}
+	accountID := gce.ServiceAccountName(name, c.ClusterName())
 	projectID := c.ProjectID
 
 	email := accountID + "@" + projectID + ".iam.gserviceaccount.com"

--- a/pkg/model/master_volumes.go
+++ b/pkg/model/master_volumes.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"k8s.io/klog/v2"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/apis/kops/model"
 	"k8s.io/kops/upup/pkg/fi"
@@ -276,10 +275,7 @@ func (b *MasterVolumeBuilder) addGCEVolume(c *fi.ModelBuilderContext, prefix str
 	if strings.IndexByte("0123456789-", prefix[0]) != -1 {
 		prefix = "d" + prefix
 	}
-	name, err := gce.ClusterSuffixedName(prefix, b.Cluster.ObjectMeta.Name, 63)
-	if err != nil {
-		klog.Fatalf("failed to construct disk name: %w", err)
-	}
+	name := gce.ClusterSuffixedName(prefix, b.Cluster.ObjectMeta.Name, 63)
 
 	t := &gcetasks.Disk{
 		Name:      fi.String(name),

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -1012,10 +1012,7 @@ func (d *clusterDiscoveryGCE) listServiceAccounts() ([]*resources.Resource, erro
 		accountID := tokens[0]
 		names := []string{gce.ControlPlane, gce.Bastion, gce.Node}
 		for _, name := range names {
-			generatedName, err := gce.ServiceAccountName(name, d.clusterName)
-			if err != nil {
-				return nil, err
-			}
+			generatedName := gce.ServiceAccountName(name, d.clusterName)
 			if generatedName == accountID {
 				resourceTracker := &resources.Resource{
 					Name:    gce.LastComponent(sa.Name),


### PR DESCRIPTION
This will help simplify long resource name fixing for GCE.

/cc @rifelpet @olemarkus 