### PR TITLE
Mount /etc/hosts from host for CoreDNS

### DIFF
--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6dabf9f8a386bcc317bc95fee1d6e0aa2ef7b7f7d6cbb42e2fefb89523a3f628
+    manifestHash: 3c968681538b2e2130b2c31b1b7e186b997dfdc0e349cfa69fb8249be1d224c8
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -80,7 +80,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
         }
-        hosts /etc/coredns/hosts k8s.local {
+        hosts /rootfs/etc/hosts k8s.local {
           ttl 30
           fallthrough
         }
@@ -184,6 +184,9 @@ spec:
         - mountPath: /etc/coredns
           name: config-volume
           readOnly: true
+        - mountPath: /rootfs/etc/hosts
+          name: etc-hosts
+          readOnly: true
       dnsPolicy: Default
       nodeSelector:
         kubernetes.io/os: linux
@@ -209,6 +212,10 @@ spec:
       - configMap:
           name: coredns
         name: config-volume
+      - hostPath:
+          path: /etc/hosts
+          type: File
+        name: etc-hosts
 
 ---
 

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 6dabf9f8a386bcc317bc95fee1d6e0aa2ef7b7f7d6cbb42e2fefb89523a3f628
+    manifestHash: 3c968681538b2e2130b2c31b1b7e186b997dfdc0e349cfa69fb8249be1d224c8
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -80,7 +80,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
         }
-        hosts /etc/coredns/hosts k8s.local {
+        hosts /rootfs/etc/hosts k8s.local {
           ttl 30
           fallthrough
         }
@@ -184,6 +184,9 @@ spec:
         - mountPath: /etc/coredns
           name: config-volume
           readOnly: true
+        - mountPath: /rootfs/etc/hosts
+          name: etc-hosts
+          readOnly: true
       dnsPolicy: Default
       nodeSelector:
         kubernetes.io/os: linux
@@ -209,6 +212,10 @@ spec:
       - configMap:
           name: coredns
         name: config-volume
+      - hostPath:
+          path: /etc/hosts
+          type: File
+        name: etc-hosts
 
 ---
 

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -77,7 +77,7 @@ data:
           ttl 30
         }
     {{- if GossipDomains }}
-        hosts /etc/coredns/hosts {{ join GossipDomains " " }} {
+        hosts /rootfs/etc/hosts {{ join GossipDomains " " }} {
           ttl 30
           fallthrough
         }
@@ -167,6 +167,11 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true
+{{- if GossipDomains }}
+        - name: etc-hosts
+          mountPath: /rootfs/etc/hosts
+          readOnly: true
+{{- end }}
         ports:
         - containerPort: 53
           name: dns
@@ -204,6 +209,12 @@ spec:
         - name: config-volume
           configMap:
             name: coredns
+{{- if GossipDomains }}
+        - name: etc-hosts
+          hostPath:
+            path: /etc/hosts
+            type: File
+{{- end }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This should fix the failing `ServiceAccounts ServiceAccountIssuerDiscovery should support OIDC discovery of service account issuer` test for GCE:
https://testgrid.k8s.io/kops-gce#kops-grid-gce-calico-u2004-k24-containerd