### PR TITLE
Automated cherry pick of #13922: Mount /etc/hosts from host for CoreDNS

### DIFF
--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: a91d17afb2fa51ae1dab22f9ea3111eea9d1762a61bb1f2bc84cb095778d8b87
+    manifestHash: 4c3d7db483e774b957a996d0b9b8721f97243a4d3ed546bb80bf743ac4f80b57
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -80,7 +80,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
         }
-        hosts /etc/coredns/hosts k8s.local {
+        hosts /rootfs/etc/hosts k8s.local {
           ttl 30
           fallthrough
         }
@@ -184,6 +184,9 @@ spec:
         - mountPath: /etc/coredns
           name: config-volume
           readOnly: true
+        - mountPath: /rootfs/etc/hosts
+          name: etc-hosts
+          readOnly: true
       dnsPolicy: Default
       nodeSelector:
         kubernetes.io/os: linux
@@ -209,6 +212,10 @@ spec:
       - configMap:
           name: coredns
         name: config-volume
+      - hostPath:
+          path: /etc/hosts
+          type: File
+        name: etc-hosts
 
 ---
 

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -14,7 +14,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: a91d17afb2fa51ae1dab22f9ea3111eea9d1762a61bb1f2bc84cb095778d8b87
+    manifestHash: 4c3d7db483e774b957a996d0b9b8721f97243a4d3ed546bb80bf743ac4f80b57
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -80,7 +80,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
         }
-        hosts /etc/coredns/hosts k8s.local {
+        hosts /rootfs/etc/hosts k8s.local {
           ttl 30
           fallthrough
         }
@@ -184,6 +184,9 @@ spec:
         - mountPath: /etc/coredns
           name: config-volume
           readOnly: true
+        - mountPath: /rootfs/etc/hosts
+          name: etc-hosts
+          readOnly: true
       dnsPolicy: Default
       nodeSelector:
         kubernetes.io/os: linux
@@ -209,6 +212,10 @@ spec:
       - configMap:
           name: coredns
         name: config-volume
+      - hostPath:
+          path: /etc/hosts
+          type: File
+        name: etc-hosts
 
 ---
 

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -77,7 +77,7 @@ data:
           ttl 30
         }
     {{- if GossipDomains }}
-        hosts /etc/coredns/hosts {{ join GossipDomains " " }} {
+        hosts /rootfs/etc/hosts {{ join GossipDomains " " }} {
           ttl 30
           fallthrough
         }
@@ -167,6 +167,11 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true
+{{- if GossipDomains }}
+        - name: etc-hosts
+          mountPath: /rootfs/etc/hosts
+          readOnly: true
+{{- end }}
         ports:
         - containerPort: 53
           name: dns
@@ -204,6 +209,12 @@ spec:
         - name: config-volume
           configMap:
             name: coredns
+{{- if GossipDomains }}
+        - name: etc-hosts
+          hostPath:
+            path: /etc/hosts
+            type: File
+{{- end }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Cherry pick of #13922 on release-1.24.

#13922: Mount /etc/hosts from host for CoreDNS

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```