### PR TITLE
Automated cherry pick of #13922: Mount /etc/hosts from host for CoreDNS

### DIFF
--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 129d5fcc0a70520fa203d1f3e84fa32ecd71ac4ef97f3bc44c638884ffe22acf
+    manifestHash: def963de6d3c4c572ea56e76201a123534ca71c250df00fb49da741c17dac033
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -80,7 +80,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
         }
-        hosts /etc/coredns/hosts k8s.local {
+        hosts /rootfs/etc/hosts k8s.local {
           ttl 30
           fallthrough
         }
@@ -196,6 +196,9 @@ spec:
         - mountPath: /etc/coredns
           name: config-volume
           readOnly: true
+        - mountPath: /rootfs/etc/hosts
+          name: etc-hosts
+          readOnly: true
       dnsPolicy: Default
       nodeSelector:
         kubernetes.io/os: linux
@@ -208,6 +211,10 @@ spec:
       - configMap:
           name: coredns
         name: config-volume
+      - hostPath:
+          path: /etc/hosts
+          type: File
+        name: etc-hosts
 
 ---
 

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -20,7 +20,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: coredns.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 129d5fcc0a70520fa203d1f3e84fa32ecd71ac4ef97f3bc44c638884ffe22acf
+    manifestHash: def963de6d3c4c572ea56e76201a123534ca71c250df00fb49da741c17dac033
     name: coredns.addons.k8s.io
     selector:
       k8s-addon: coredns.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-coredns.addons.k8s.io-k8s-1.12_content
@@ -80,7 +80,7 @@ data:
           fallthrough in-addr.arpa ip6.arpa
           ttl 30
         }
-        hosts /etc/coredns/hosts k8s.local {
+        hosts /rootfs/etc/hosts k8s.local {
           ttl 30
           fallthrough
         }
@@ -196,6 +196,9 @@ spec:
         - mountPath: /etc/coredns
           name: config-volume
           readOnly: true
+        - mountPath: /rootfs/etc/hosts
+          name: etc-hosts
+          readOnly: true
       dnsPolicy: Default
       nodeSelector:
         kubernetes.io/os: linux
@@ -208,6 +211,10 @@ spec:
       - configMap:
           name: coredns
         name: config-volume
+      - hostPath:
+          path: /etc/hosts
+          type: File
+        name: etc-hosts
 
 ---
 

--- a/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/coredns.addons.k8s.io/k8s-1.12.yaml.template
@@ -77,7 +77,7 @@ data:
           ttl 30
         }
     {{- if GossipDomains }}
-        hosts /etc/coredns/hosts {{ join GossipDomains " " }} {
+        hosts /rootfs/etc/hosts {{ join GossipDomains " " }} {
           ttl 30
           fallthrough
         }
@@ -164,6 +164,11 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true
+{{- if GossipDomains }}
+        - name: etc-hosts
+          mountPath: /rootfs/etc/hosts
+          readOnly: true
+{{- end }}
         ports:
         - containerPort: 53
           name: dns
@@ -201,6 +206,12 @@ spec:
         - name: config-volume
           configMap:
             name: coredns
+{{- if GossipDomains }}
+        - name: etc-hosts
+          hostPath:
+            path: /etc/hosts
+            type: File
+{{- end }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Cherry pick of #13922 on release-1.23.

#13922: Mount /etc/hosts from host for CoreDNS

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```