### PR TITLE
Wait longer after update in the e2e upgrade scenario

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -95,7 +95,7 @@ fi
 kubectl get nodes -owide --kubeconfig "${KUBECONFIG_A}"
 
 # Sleep to ensure channels has done its thing
-sleep 60s
+sleep 120s
 
 ${CHANNELS} apply channel "$KOPS_STATE_STORE"/"${CLUSTER_NAME}"/addons/bootstrap-channel.yaml --yes -v4
 


### PR DESCRIPTION
We have occasional flakes in the upgrade tests due to channels applying in the e2e test at the same time as the control plane nodes tries to apply leading to "the object has been modified; please apply your changes to the latest version and try again".