### PR TITLE
Automated cherry pick of #13873: Limit GCE names to 63 chars for various resources

### DIFF
--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -72,6 +72,11 @@ func (c *GCEModelContext) SafeObjectName(name string) string {
 	return gce.SafeObjectName(name, c.Cluster.ObjectMeta.Name)
 }
 
+// SafeSuffixedObjectName returns the object name and cluster name escaped for GCE, limited to 63 chars
+func (c *GCEModelContext) SafeSuffixedObjectName(name string) string {
+	return gce.ClusterSuffixedName(name, c.Cluster.ObjectMeta.Name, 63)
+}
+
 // SafeClusterName returns the cluster name escaped for use as a GCE resource name
 func (c *GCEModelContext) SafeClusterName() string {
 	return gce.SafeClusterName(c.Cluster.ObjectMeta.Name)
@@ -87,7 +92,7 @@ func (c *GCEModelContext) LinkToTargetPool(id string) *gcetasks.TargetPool {
 }
 
 func (c *GCEModelContext) NameForTargetPool(id string) string {
-	return c.SafeObjectName(id)
+	return c.SafeSuffixedObjectName(id)
 }
 
 func (c *GCEModelContext) NameForHealthCheck(id string) string {
@@ -99,11 +104,11 @@ func (c *GCEModelContext) NameForBackendService(id string) string {
 }
 
 func (c *GCEModelContext) NameForForwardingRule(id string) string {
-	return c.SafeObjectName(id)
+	return c.SafeSuffixedObjectName(id)
 }
 
 func (c *GCEModelContext) NameForIPAddress(id string) string {
-	return c.SafeObjectName(id)
+	return c.SafeSuffixedObjectName(id)
 }
 
 func (c *GCEModelContext) NameForPoolHealthcheck(id string) string {
@@ -111,7 +116,7 @@ func (c *GCEModelContext) NameForPoolHealthcheck(id string) string {
 }
 
 func (c *GCEModelContext) NameForHealthcheck(id string) string {
-	return c.SafeObjectName(id)
+	return c.SafeSuffixedObjectName(id)
 }
 
 func (c *GCEModelContext) NameForFirewallRule(id string) string {

--- a/upup/pkg/fi/cloudup/gce/gce_cloud.go
+++ b/upup/pkg/fi/cloudup/gce/gce_cloud.go
@@ -304,7 +304,7 @@ func (c *gceCloudImplementation) GetApiIngressStatus(cluster *kops.Cluster) ([]f
 	var ingresses []fi.ApiIngressStatus
 
 	// Note that this must match GCEModelContext::NameForForwardingRule
-	name := SafeObjectName("api", cluster.ObjectMeta.Name)
+	name := ClusterSuffixedName("api", cluster.ObjectMeta.Name, 63)
 
 	klog.V(2).Infof("Querying GCE to find ForwardingRules for API (%q)", name)
 	// These are the ingress rules, so we search for them in the network project.


### PR DESCRIPTION
Cherry pick of #13873 on release-1.24.

#13873: Limit GCE names to 63 chars for various resources

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```