### PR TITLE
Automated cherry pick of #13926: Make IRSA webhook configure apps to use regional STS and set

### DIFF
--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3cb2a206a51d01886014383dca7a94d99e941a7eb6eec663c607bb14a28fb907
+    manifestHash: 0bec2a812bd438f03cb28b18391b78453430e17c7123c4b87a165cb5a1a03a92
     name: eks-pod-identity-webhook.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-eks-pod-identity-webhook.addons.k8s.io-k8s-1.16_content
@@ -127,6 +127,8 @@ spec:
         - --token-audience=amazonaws.com
         - --logtostderr
         - --watch-config-map
+        - --sts-regional-endpoint
+        - --aws-default-region=us-test-1
         - --v=5
         image: amazon/amazon-eks-pod-identity-webhook:v0.4.0
         name: pod-identity-webhook

--- a/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
@@ -90,6 +90,8 @@ spec:
         - --token-audience=amazonaws.com
         - --logtostderr
         - --watch-config-map
+        - --sts-regional-endpoint
+        - --aws-default-region={{ Region }}
         - --v=5
         readinessProbe:
           httpGet:


### PR DESCRIPTION
Cherry pick of #13926 on release-1.24.

#13926: Make IRSA webhook configure apps to use regional STS and set

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```