### PR TITLE
Make it possible to enable the shield addon for LBC

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -45,7 +45,16 @@ a given ALB at a time, despite it accepting both the
 "alb.ingress.kubernetes.io/wafv2-acl-arn" annotations on the same
 _Ingress_ object.
 
-Support for this WAF service in kOps is currently **beta**, meaning
+You can enable use of Shield Advanced by including the following fields in the cluster spec:
+
+```yaml
+spec:
+  awsLoadBalancerController:
+    enabled: true
+    enableShield: true
+```
+
+Support for the WAF and Shield services in kOps is currently **beta**, meaning
 that the accepted configuration and the AWS resources involved may
 change.
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -262,6 +262,10 @@ spec:
                 description: AWSLoadbalancerControllerConfig determines the AWS LB
                   controller configuration.
                 properties:
+                  enableShield:
+                    description: 'EnableShield specifies whether the controller can
+                      enable Shield Advanced. Default: false'
+                    type: boolean
                   enableWAF:
                     description: 'EnableWAF specifies whether the controller can use
                       WAFs (Classic Regional). Default: false'

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -1069,6 +1069,9 @@ type AWSLoadBalancerControllerConfig struct {
 	// EnableWAFv2 specifies whether the controller can use WAFs (V2).
 	// Default: false
 	EnableWAFv2 bool `json:"enableWAFv2,omitempty"`
+	// EnableShield specifies whether the controller can enable Shield Advanced.
+	// Default: false
+	EnableShield bool `json:"enableShield,omitempty"`
 }
 
 // HasAdmissionController checks if a specific admission controller is enabled

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -1095,6 +1095,9 @@ type AWSLoadBalancerControllerConfig struct {
 	// EnableWAFv2 specifies whether the controller can use WAFs (V2).
 	// Default: false
 	EnableWAFv2 bool `json:"enableWAFv2,omitempty"`
+	// EnableShield specifies whether the controller can enable Shield Advanced.
+	// Default: false
+	EnableShield bool `json:"enableShield,omitempty"`
 }
 
 // HasAdmissionController checks if a specific admission controller is enabled

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1336,6 +1336,7 @@ func autoConvert_v1alpha2_AWSLoadBalancerControllerConfig_To_kops_AWSLoadBalance
 	out.Version = in.Version
 	out.EnableWAF = in.EnableWAF
 	out.EnableWAFv2 = in.EnableWAFv2
+	out.EnableShield = in.EnableShield
 	return nil
 }
 
@@ -1349,6 +1350,7 @@ func autoConvert_kops_AWSLoadBalancerControllerConfig_To_v1alpha2_AWSLoadBalance
 	out.Version = in.Version
 	out.EnableWAF = in.EnableWAF
 	out.EnableWAFv2 = in.EnableWAFv2
+	out.EnableShield = in.EnableShield
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -1066,4 +1066,7 @@ type AWSLoadBalancerControllerConfig struct {
 	// EnableWAFv2 specifies whether the controller can use WAFs (V2).
 	// Default: false
 	EnableWAFv2 bool `json:"enableWAFv2,omitempty"`
+	// EnableShield specifies whether the controller can enable Shield Advanced.
+	// Default: false
+	EnableShield bool `json:"enableShield,omitempty"`
 }

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1336,6 +1336,7 @@ func autoConvert_v1alpha3_AWSLoadBalancerControllerConfig_To_kops_AWSLoadBalance
 	out.Version = in.Version
 	out.EnableWAF = in.EnableWAF
 	out.EnableWAFv2 = in.EnableWAFv2
+	out.EnableShield = in.EnableShield
 	return nil
 }
 
@@ -1349,6 +1350,7 @@ func autoConvert_kops_AWSLoadBalancerControllerConfig_To_v1alpha3_AWSLoadBalance
 	out.Version = in.Version
 	out.EnableWAF = in.EnableWAF
 	out.EnableWAFv2 = in.EnableWAFv2
+	out.EnableShield = in.EnableShield
 	return nil
 }
 

--- a/pkg/model/components/addonmanifests/awsloadbalancercontroller/iam.go
+++ b/pkg/model/components/addonmanifests/awsloadbalancercontroller/iam.go
@@ -34,11 +34,13 @@ func (r *ServiceAccount) BuildAWSPolicy(b *iam.PolicyBuilder) (*iam.Policy, erro
 
 	var enableWAF bool
 	var enableWAFv2 bool
+	var enableShield bool
 	if c := b.Cluster.Spec.AWSLoadBalancerController; c != nil {
 		enableWAF = c.EnableWAF
 		enableWAFv2 = c.EnableWAFv2
+		enableShield = c.EnableShield
 	}
-	iam.AddAWSLoadbalancerControllerPermissions(p, enableWAF, enableWAFv2)
+	iam.AddAWSLoadbalancerControllerPermissions(p, enableWAF, enableWAFv2, enableShield)
 
 	return p, nil
 }

--- a/pkg/model/iam/iam_builder.go
+++ b/pkg/model/iam/iam_builder.go
@@ -425,7 +425,7 @@ func (r *NodeRoleMaster) BuildAWSPolicy(b *PolicyBuilder) (*Policy, error) {
 		}
 
 		if c := b.Cluster.Spec.AWSLoadBalancerController; c != nil && fi.BoolValue(b.Cluster.Spec.AWSLoadBalancerController.Enabled) {
-			AddAWSLoadbalancerControllerPermissions(p, c.EnableWAF, c.EnableWAFv2)
+			AddAWSLoadbalancerControllerPermissions(p, c.EnableWAF, c.EnableWAFv2, c.EnableShield)
 		}
 
 		var useStaticInstanceList bool
@@ -956,7 +956,7 @@ func AddCCMPermissions(p *Policy, cloudRoutes bool) {
 }
 
 // AddAWSLoadbalancerControllerPermissions adds the permissions needed for the AWS Load Balancer Controller to the givnen policy
-func AddAWSLoadbalancerControllerPermissions(p *Policy, enableWAF bool, enableWAFv2 bool) {
+func AddAWSLoadbalancerControllerPermissions(p *Policy, enableWAF, enableWAFv2, enableShield bool) {
 	p.unconditionalAction.Insert(
 		"acm:DescribeCertificate",
 		"acm:ListCertificates",
@@ -998,6 +998,16 @@ func AddAWSLoadbalancerControllerPermissions(p *Policy, enableWAF bool, enableWA
 			"wafv2:GetWebACLForResource",
 		)
 	}
+
+	if enableShield {
+		p.unconditionalAction.Insert(
+			"shield:GetSubscriptionState",
+			"shield:DescribeProtection",
+			"shield:CreateProtection",
+			"shield:DeleteProtection",
+		)
+	}
+
 	p.clusterTaggedAction.Insert(
 		"ec2:AuthorizeSecurityGroupIngress", // aws.go
 		"ec2:DeleteSecurityGroup",           // aws.go

--- a/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-load-balancer-controller.addons.k8s.io/k8s-1.19.yaml.template
@@ -744,7 +744,7 @@ spec:
         - --cluster-name={{ ClusterName }}
         - --enable-waf={{ .AWSLoadBalancerController.EnableWAF }}
         - --enable-wafv2={{ .AWSLoadBalancerController.EnableWAFv2 }}
-        - --enable-shield=false
+        - --enable-shield={{ .AWSLoadBalancerController.EnableShield }}
         - --ingress-class=alb
         - "--default-tags={{ CloudLabels }}"
         - --aws-region={{ Region }}


### PR DESCRIPTION
I sort of broke my own principle of adding something to 1.24 now, but this completes the work done by allowing WAF plugins to be enabled. The plugin is marked as beta in the docs and disabled by default, so the risk should be low.