### PR TITLE
Automated cherry pick of #13917: Update Cilium to 1.11.6

### DIFF
--- a/pkg/apis/kops/validation/validation_test.go
+++ b/pkg/apis/kops/validation/validation_test.go
@@ -921,7 +921,7 @@ func Test_Validate_Cilium(t *testing.T) {
 		},
 		{
 			Cilium: kops.CiliumNetworkingSpec{
-				Version: "v1.8.0",
+				Version: "v1.11.6",
 				Hubble: &kops.HubbleSpec{
 					Enabled: fi.Bool(true),
 				},

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.11.5"
+		c.Version = "v1.11.6"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -223,7 +223,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.11.5
+      version: v1.11.6
   nonMasqueradeCIDR: ::/0
   secretStore: memfs://clusters.example.com/minimal-ipv6.example.com/secrets
   serviceClusterIPRange: fd00:5e4f:ce::/108

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 72833833b7b7bc871347d491216e2f8496df762e8bfb5775c71424c878dc48c5
+    manifestHash: 99b8da549d0a419996ad845a414086285af3d17de813c5668f31bccea3c0ff2b
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -317,8 +317,6 @@ spec:
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       creationTimestamp: null
       labels:
         k8s-app: cilium
@@ -368,7 +366,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.5
+        image: quay.io/cilium/cilium:v1.11.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -388,7 +386,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           periodSeconds: 30
           successThreshold: 1
@@ -402,7 +400,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 30
@@ -422,7 +420,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           periodSeconds: 2
           successThreshold: null
@@ -464,7 +462,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.5
+        image: quay.io/cilium/cilium:v1.11.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -600,7 +598,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.5
+        image: quay.io/cilium/operator:v1.11.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: lyCL7WxoVDMh7vbyMre6Ta+m0vp/oTo4t0qdhxbMcq4=
+NodeupConfigHash: Lm5UtBedePcxbHQcVb4+rsLwCFCh0K6nDLVYp0Q703U=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -206,7 +206,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.11.5
+      version: v1.11.6
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/minimal-warmpool.example.com/secrets

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 375707f2c54fb09676a0ce6e971a2de8213860aeee1ed7f3abd179313dc0490d
+    manifestHash: 1b13dfbe5888a602daac1e46d8f41547c9c5aaa4b48cbbccc4a04a4c2aa59795
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -317,8 +317,6 @@ spec:
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       creationTimestamp: null
       labels:
         k8s-app: cilium
@@ -368,7 +366,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.5
+        image: quay.io/cilium/cilium:v1.11.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -388,7 +386,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           periodSeconds: 30
           successThreshold: 1
@@ -402,7 +400,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 30
@@ -422,7 +420,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           periodSeconds: 2
           successThreshold: null
@@ -464,7 +462,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.5
+        image: quay.io/cilium/cilium:v1.11.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -600,7 +598,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.5
+        image: quay.io/cilium/operator:v1.11.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -67,8 +67,8 @@ containerdConfig:
   logLevel: info
   version: 1.4.13
 warmPoolImages:
-- quay.io/cilium/cilium:v1.11.5
-- quay.io/cilium/operator:v1.11.5
+- quay.io/cilium/cilium:v1.11.6
+- quay.io/cilium/operator:v1.11.6
 - registry.k8s.io/kube-proxy:v1.21.0
 - registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
 - registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -192,7 +192,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.11.5
+      version: v1.11.6
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/privatecilium.example.com/secrets

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 377cd477c63b62dbf7a458500824a0d9c2e227cebb334b6f5c70a9ceaa3a6b98
+    manifestHash: 198c6022ba7a63e596a1734db37c3f60742f4d695a51d3dd309ec8e4c3639523
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -317,8 +317,6 @@ spec:
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       creationTimestamp: null
       labels:
         k8s-app: cilium
@@ -368,7 +366,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.5
+        image: quay.io/cilium/cilium:v1.11.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -388,7 +386,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           periodSeconds: 30
           successThreshold: 1
@@ -402,7 +400,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 30
@@ -422,7 +420,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           periodSeconds: 2
           successThreshold: null
@@ -464,7 +462,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.5
+        image: quay.io/cilium/cilium:v1.11.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -600,7 +598,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.5
+        image: quay.io/cilium/operator:v1.11.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -202,7 +202,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.11.5
+      version: v1.11.6
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/privateciliumadvanced.example.com/secrets

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 791bef8c3da2a69f8954d83393b97b0964db6e1d3056b49140850cb46563416b
+    manifestHash: ca97616234027899e1780d84efe12db5132018a486c983fbdd4531256d413923
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -331,8 +331,6 @@ spec:
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       creationTimestamp: null
       labels:
         k8s-app: cilium
@@ -382,7 +380,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.5
+        image: quay.io/cilium/cilium:v1.11.6
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -402,7 +400,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           periodSeconds: 30
           successThreshold: 1
@@ -416,7 +414,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 30
@@ -436,7 +434,7 @@ spec:
             - name: brief
               value: "true"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
           periodSeconds: 2
           successThreshold: null
@@ -484,7 +482,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.5
+        image: quay.io/cilium/cilium:v1.11.6
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -631,7 +629,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.5
+        image: quay.io/cilium/operator:v1.11.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.11.yaml.template
@@ -1,5 +1,6 @@
 {{ with .Networking.Cilium }}
 {{ $semver := (trimPrefix "v" .Version) }}
+{{ $healthPort := (ternary 9879 9876 (semverCompare ">=1.11.6" $semver)) }}
 {{- if CiliumSecret }}
 apiVersion: v1
 kind: Secret
@@ -584,11 +585,6 @@ spec:
   template:
     metadata:
       annotations:
-        # This annotation plus the CriticalAddonsOnly toleration makes
-        # cilium to be a critical pod in the cluster, which ensures cilium
-        # gets priority scheduling.
-        # https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
-        scheduler.alpha.kubernetes.io/critical-pod: ""
         {{ if .EnablePrometheusMetrics }}
         # Annotation required for prometheus auto-discovery scraping
         # https://docs.cilium.io/en/v1.9/operations/metrics/#installation
@@ -620,7 +616,7 @@ spec:
           httpGet:
             host: '{{- if IsIPv6Only -}}::1{{- else -}}127.0.0.1{{- end -}}'
             path: /healthz
-            port: 9876
+            port: {{ $healthPort }}
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -632,7 +628,7 @@ spec:
           httpGet:
             host: '{{- if IsIPv6Only -}}::1{{- else -}}127.0.0.1{{- end -}}'
             path: /healthz
-            port: 9876
+            port: {{ $healthPort }}
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -649,7 +645,7 @@ spec:
           httpGet:
             host: '{{- if IsIPv6Only -}}::1{{- else -}}127.0.0.1{{- end -}}'
             path: /healthz
-            port: 9876
+            port: {{ $healthPort }}
             scheme: HTTP
             httpHeaders:
             - name: "brief"

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -102,6 +102,7 @@ func (tf *TemplateFunctions) AddTo(dest template.FuncMap, secretStore fi.SecretS
 	dest["contains"] = sprigTxtFuncMap["contains"]
 	dest["trimPrefix"] = sprigTxtFuncMap["trimPrefix"]
 	dest["semverCompare"] = sprigTxtFuncMap["semverCompare"]
+	dest["ternary"] = sprigTxtFuncMap["ternary"]
 
 	dest["ClusterName"] = tf.ClusterName
 	dest["WithDefaultBool"] = func(v *bool, defaultValue bool) bool {

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 1a6377642426fac2aee248a206b8bde8fd58dda23d1d2cc138ed05a0ea2469ea
+    manifestHash: c36bf98b69107c123dffc67ad70a023401b5fa4cc7d384a184e6a46b8637ada4
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 1a6377642426fac2aee248a206b8bde8fd58dda23d1d2cc138ed05a0ea2469ea
+    manifestHash: c36bf98b69107c123dffc67ad70a023401b5fa4cc7d384a184e6a46b8637ada4
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 1a6377642426fac2aee248a206b8bde8fd58dda23d1d2cc138ed05a0ea2469ea
+    manifestHash: c36bf98b69107c123dffc67ad70a023401b5fa4cc7d384a184e6a46b8637ada4
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #13917 on release-1.24.

#13917: Update Cilium to 1.11.6

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```