### PR TITLE
Automated cherry pick of #13852: Fix unsetting ASG max price

### DIFF
--- a/pkg/model/awsmodel/autoscalinggroup.go
+++ b/pkg/model/awsmodel/autoscalinggroup.go
@@ -539,7 +539,12 @@ func (b *AutoscalingGroupModelBuilder) buildAutoScalingGroupTask(c *fi.ModelBuil
 		t.MixedOnDemandBase = spec.OnDemandBase
 		t.MixedSpotAllocationStrategy = spec.SpotAllocationStrategy
 		t.MixedSpotInstancePools = spec.SpotInstancePools
-		t.MixedSpotMaxPrice = ig.Spec.MaxPrice
+		// In order to unset maxprice, the value needs to be ""
+		if ig.Spec.MaxPrice == nil {
+			t.MixedSpotMaxPrice = fi.String("")
+		} else {
+			t.MixedSpotMaxPrice = ig.Spec.MaxPrice
+		}
 	}
 
 	return t, nil

--- a/tests/integration/update_cluster/mixed_instances/cloudformation.json
+++ b/tests/integration/update_cluster/mixed_instances/cloudformation.json
@@ -363,7 +363,8 @@
           },
           "InstancesDistribution": {
             "OnDemandPercentageAboveBaseCapacity": 5,
-            "SpotInstancePools": 3
+            "SpotInstancePools": 3,
+            "SpotMaxPrice": ""
           }
         }
       }

--- a/tests/integration/update_cluster/mixed_instances/kubernetes.tf
+++ b/tests/integration/update_cluster/mixed_instances/kubernetes.tf
@@ -296,6 +296,7 @@ resource "aws_autoscaling_group" "nodes-mixedinstances-example-com" {
     instances_distribution {
       on_demand_percentage_above_base_capacity = 5
       spot_instance_pools                      = 3
+      spot_max_price                           = ""
     }
     launch_template {
       launch_template_specification {

--- a/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
+++ b/upup/pkg/fi/cloudup/awstasks/autoscalinggroup.go
@@ -218,6 +218,10 @@ func (e *AutoscalingGroup) Find(c *fi.Context) (*AutoscalingGroup, error) {
 			actual.MixedSpotAllocationStrategy = mpd.SpotAllocationStrategy
 			actual.MixedSpotInstancePools = mpd.SpotInstancePools
 			actual.MixedSpotMaxPrice = mpd.SpotMaxPrice
+			// MixedSpotMaxPrice must be set to "" in order to unset.
+			if mpd.SpotMaxPrice == nil {
+				actual.MixedSpotMaxPrice = fi.String("")
+			}
 		}
 
 		if g.MixedInstancesPolicy.LaunchTemplate != nil {


### PR DESCRIPTION
Cherry pick of #13852 on release-1.24.

#13852: Fix unsetting ASG max price

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```