### PR TITLE
Fix broken links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,6 @@ For a better viewing experience please check out our live documentation site at 
 * [Low level description on how kops works](contributing/how_it_works.md)
 * [Notes on Gossip design](contributing/gossip.md)
 * [Notes on master instance sizing](contributing/instancesizes.md)
-* [Our release process](contributing/release.md)
+* [Our release process](contributing/release-process.md)
 * [Releasing with Homebrew](contributing/homebrew.md)
-* [Rolling Update Diagrams](contributing/rolling_update.md)
+* [Rolling Updates](operations/rolling-update.md)


### PR DESCRIPTION
Fix broken links.

> **note**
> The diagram has been already removed in the following PR.
> ref: https://github.com/kubernetes/kops/commit/9187f3bd8d8579831ed5fe6dea8b8ed6708f3938