### PR TITLE
Automated cherry pick of #13890: Use csi-snapshotter for OS only when the controller is

### DIFF
--- a/docs/releases/1.24-NOTES.md
+++ b/docs/releases/1.24-NOTES.md
@@ -31,13 +31,13 @@ kOps will directly manage the Karpenter Provisioner resources. Read more about h
 
 * Adds support for overriding the Kubernetes version when upgrading a cluster by using the `--kubernetes-version` flag.
 
-* The minimum version for the Terraform AWS Provider has been bumped to 4.0.0 to address the deprecation of the aws_s3_bucket_object resource and its replacement with the aws_s3_object resource. Such resources will be destroyed and recreated without downtime when applying the changes. 
+* The minimum version for the Terraform AWS Provider has been bumped to 4.0.0 to address the deprecation of the aws_s3_bucket_object resource and its replacement with the aws_s3_object resource. Such resources will be destroyed and recreated without downtime when applying the changes.
 
 * ARM64 support for nvidia device driver. Nvidia nodes on ARM64 requires Ubuntu 22.04 AMIs.
 
 # Breaking changes
 
-* The nfs-common/nfs-utils package is no longer installed by default. Use the [packages](https://kops.sigs.k8s.io/instance_groups/#packages) option at instance group level to add it back. 
+* The nfs-common/nfs-utils package is no longer installed by default. Use the [packages](https://kops.sigs.k8s.io/instance_groups/#packages) option at instance group level to add it back.
 
 ## Control plane taints and labels
 
@@ -68,6 +68,14 @@ spec:
 ## Removing the `kubernetes.io/role` label
 
 The deprecated `kubernetes.io/role` label has been removed for all roles as of Kubernetes version 1.24. Use `node-role.kubernetes.io/<role>` label instead.
+
+## Cinder CSI snapthot controller changes
+
+The CSI Cinder plugin for OpenStack will now only use the CSI snapshotter when the CSI snapshot controller is enabled in the cluster spec.
+
+This changes the default behavior where the CSI snaphotter container was always present, but spammed the log with error messages (see [#13890](https://github.com/kubernetes/kops/pull/13890))
+
+So in case of manually deployed CRDs to make the snapshotter work it is now necessary to [enable the snapshot controller](https://kops.sigs.k8s.io/addons/#snapshot-controller).
 
 ## Other breaking changes
 

--- a/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/storage-openstack.addons.k8s.io/k8s-1.16.yaml.template
@@ -280,6 +280,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+        {{ if HasSnapshotController }}
         - name: csi-snapshotter
           image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           args:
@@ -294,6 +295,7 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
+        {{ end }}
         - name: csi-resizer
           image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
           args:


### PR DESCRIPTION
Cherry pick of #13890 on release-1.24.

#13890: Use csi-snapshotter for OS only when the controller is

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```