### PR TITLE
Automated cherry pick of #13939: Bump EBS CSI driver to 1.8.0

### DIFF
--- a/pkg/model/components/awsebscsidriver.go
+++ b/pkg/model/components/awsebscsidriver.go
@@ -48,7 +48,7 @@ func (b *AWSEBSCSIDriverOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == nil {
-		version := "v1.6.2"
+		version := "v1.8.0"
 		c.Version = fi.String(version)
 	}
 

--- a/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/apiservernodes/cloudformation.json.extracted.yaml
@@ -127,7 +127,7 @@ Resources.AWSEC2LaunchTemplateapiserverapiserversminimalexamplecom.Properties.La
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   containerRuntime: containerd
   containerd:
@@ -303,7 +303,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalexamplecom.Properties.
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   containerRuntime: containerd
   containerd:
@@ -574,7 +574,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalexamplecom.Properties.LaunchTemplateDa
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   containerRuntime: containerd
   containerd:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
@@ -12,7 +12,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -627,13 +631,13 @@ spec:
         - --extra-tags=KubernetesCluster=minimal.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -668,13 +680,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -686,7 +699,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -697,15 +711,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -747,7 +762,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -765,7 +780,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1a02f68791328817283cfc9ddc991be63de41be4150b8801a5e25ad834dcf3e8
+    manifestHash: f2139d8741d42373dfebd0bc2ae689f39dbe5b9e52d2808574a77614f22b2947
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -623,13 +627,13 @@ spec:
         - --extra-tags=KubernetesCluster=minimal.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         resources: {}
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -672,8 +684,8 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
@@ -682,7 +694,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         resources: {}
         volumeMounts:
@@ -702,7 +715,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         resources: {}
         volumeMounts:
@@ -721,7 +735,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v4.0.0
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
+        imagePullPolicy: IfNotPresent
         name: csi-snapshotter
         resources: {}
         volumeMounts:
@@ -740,8 +755,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         resources: {}
         volumeMounts:
@@ -757,7 +772,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources: {}
         volumeMounts:
@@ -810,7 +826,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -828,7 +844,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -127,7 +127,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c3f59bf89c2329e944274ad613a7049952dc8a91089aab23c341ac7ad4abb2ce
+    manifestHash: 6a8fb957f27764628a5f7ecf96c17fb64de0540c8245283b8ed750e173f839e5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -623,13 +627,13 @@ spec:
         - --extra-tags=KubernetesCluster=minimal.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         resources: {}
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -672,8 +684,8 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
@@ -682,7 +694,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         resources: {}
         volumeMounts:
@@ -702,7 +715,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         resources: {}
         volumeMounts:
@@ -721,7 +735,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v4.0.0
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
+        imagePullPolicy: IfNotPresent
         name: csi-snapshotter
         resources: {}
         volumeMounts:
@@ -740,8 +755,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         resources: {}
         volumeMounts:
@@ -757,7 +772,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources: {}
         volumeMounts:
@@ -810,7 +826,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -828,7 +844,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -134,7 +134,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c3f59bf89c2329e944274ad613a7049952dc8a91089aab23c341ac7ad4abb2ce
+    manifestHash: 6a8fb957f27764628a5f7ecf96c17fb64de0540c8245283b8ed750e173f839e5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -623,13 +627,13 @@ spec:
         - --extra-tags=KubernetesCluster=minimal.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         resources: {}
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -672,8 +684,8 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
@@ -682,7 +694,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         resources: {}
         volumeMounts:
@@ -702,7 +715,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         resources: {}
         volumeMounts:
@@ -721,7 +735,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v4.0.0
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
+        imagePullPolicy: IfNotPresent
         name: csi-snapshotter
         resources: {}
         volumeMounts:
@@ -740,8 +755,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         resources: {}
         volumeMounts:
@@ -757,7 +772,8 @@ spec:
           value: arn:aws-test:iam::123456789012:role/ebs-csi-controller-sa.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         resources: {}
         volumeMounts:
@@ -810,7 +826,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -828,7 +844,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -134,7 +134,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c3f59bf89c2329e944274ad613a7049952dc8a91089aab23c341ac7ad4abb2ce
+    manifestHash: 6a8fb957f27764628a5f7ecf96c17fb64de0540c8245283b8ed750e173f839e5
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -627,13 +631,13 @@ spec:
         - --extra-tags=KubernetesCluster=minimal.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -668,13 +680,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -686,7 +699,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -697,7 +711,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v4.0.0
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
+        imagePullPolicy: IfNotPresent
         name: csi-snapshotter
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -708,15 +723,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -758,7 +774,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -776,7 +792,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -127,7 +127,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7e6ec9e506e4d261e1e3ff3ebb69710a6baf3b63a59fa2cdfb5b8df5a535eb22
+    manifestHash: 9466c77d0a8a75ce16f4e6b5ce0248870d2eef6802d2cada9e5383ab840ddd68
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
@@ -16,7 +16,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudProvider: aws
   clusterAutoscaler:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -627,13 +631,13 @@ spec:
         - --extra-tags=KubernetesCluster=minimal.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -668,13 +680,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -686,7 +699,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -697,7 +711,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-snapshotter:v4.0.0
+        image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
+        imagePullPolicy: IfNotPresent
         name: csi-snapshotter
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -708,15 +723,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -758,7 +774,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -776,7 +792,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -120,7 +120,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7e6ec9e506e4d261e1e3ff3ebb69710a6baf3b63a59fa2cdfb5b8df5a535eb22
+    manifestHash: 9466c77d0a8a75ce16f4e6b5ce0248870d2eef6802d2cada9e5383ab840ddd68
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_cluster-completed.spec_content
@@ -12,7 +12,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -627,13 +631,13 @@ spec:
         - --extra-tags=KubernetesCluster=minimal.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -668,13 +680,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -686,7 +699,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -697,15 +711,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -747,7 +762,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -765,7 +780,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1a02f68791328817283cfc9ddc991be63de41be4150b8801a5e25ad834dcf3e8
+    manifestHash: f2139d8741d42373dfebd0bc2ae689f39dbe5b9e52d2808574a77614f22b2947
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_launch_template_nodes.minimal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_cluster-completed.spec_content
@@ -12,7 +12,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -627,13 +631,13 @@ spec:
         - --extra-tags=KubernetesCluster=minimal.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -668,13 +680,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -686,7 +699,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -697,15 +711,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -747,7 +762,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -765,7 +780,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1a02f68791328817283cfc9ddc991be63de41be4150b8801a5e25ad834dcf3e8
+    manifestHash: f2139d8741d42373dfebd0bc2ae689f39dbe5b9e52d2808574a77614f22b2947
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/cloudformation.json.extracted.yaml
@@ -127,7 +127,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Propert
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6
@@ -400,7 +400,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTempla
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
   nodeIPFamilies:
   - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
   nodeIPFamilies:
   - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
@@ -14,7 +14,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -492,7 +493,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -525,7 +527,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -541,7 +544,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -581,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -599,7 +603,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -631,13 +635,13 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -650,7 +654,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -665,6 +669,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -672,13 +684,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -690,7 +703,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -701,15 +715,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -751,7 +766,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -769,7 +784,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7a8dee1431494e565daf0d8fdf65a2381fb10b8a8e4e95f189f47f308939414c
+    manifestHash: 228441cdd52298194b8294ae676f580253fa157a004bf14b234e87dc685dff2b
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/cloudformation.json.extracted.yaml
@@ -127,7 +127,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Propert
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6
@@ -400,7 +400,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTempla
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
   nodeIPFamilies:
   - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
   nodeIPFamilies:
   - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -14,7 +14,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -492,7 +493,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -525,7 +527,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -541,7 +544,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -581,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -599,7 +603,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -631,13 +635,13 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -650,7 +654,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -665,6 +669,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -672,13 +684,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -690,7 +703,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -701,15 +715,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -751,7 +766,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -769,7 +784,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -63,7 +63,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7a8dee1431494e565daf0d8fdf65a2381fb10b8a8e4e95f189f47f308939414c
+    manifestHash: 228441cdd52298194b8294ae676f580253fa157a004bf14b234e87dc685dff2b
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
   nodeIPFamilies:
   - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
   nodeIPFamilies:
   - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_cluster-completed.spec_content
@@ -14,7 +14,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -492,7 +493,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -525,7 +527,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -541,7 +544,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -581,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -599,7 +603,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -631,13 +635,13 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -650,7 +654,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -665,6 +669,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -672,13 +684,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -690,7 +703,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -701,15 +715,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -751,7 +766,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -769,7 +784,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7a8dee1431494e565daf0d8fdf65a2381fb10b8a8e4e95f189f47f308939414c
+    manifestHash: 228441cdd52298194b8294ae676f580253fa157a004bf14b234e87dc685dff2b
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/minimal-ipv6/cloudformation.json.extracted.yaml
@@ -127,7 +127,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersminimalipv6examplecom.Propert
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6
@@ -400,7 +400,7 @@ Resources.AWSEC2LaunchTemplatenodesminimalipv6examplecom.Properties.LaunchTempla
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
   nodeIPFamilies:
   - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
   nodeIPFamilies:
   - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
@@ -14,7 +14,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
     nodeIPFamilies:
     - ipv6

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -492,7 +493,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -525,7 +527,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -541,7 +544,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -581,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -599,7 +603,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -631,13 +635,13 @@ spec:
         env:
         - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
           value: IPv6
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -650,7 +654,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -665,6 +669,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -672,13 +684,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -690,7 +703,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -701,15 +715,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -751,7 +766,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -769,7 +784,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 7a8dee1431494e565daf0d8fdf65a2381fb10b8a8e4e95f189f47f308939414c
+    manifestHash: 228441cdd52298194b8294ae676f580253fa157a004bf14b234e87dc685dff2b
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: Lm5UtBedePcxbHQcVb4+rsLwCFCh0K6nDLVYp0Q703U=
+NodeupConfigHash: /VQjQFfNW9a3TOgtOAikUAJFycuJKNZEGwx8X8H6bhg=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -12,7 +12,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -627,13 +631,13 @@ spec:
         - --extra-tags=KubernetesCluster=minimal-warmpool.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -668,13 +680,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -686,7 +699,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -697,15 +711,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -747,7 +762,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -765,7 +780,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: c1c06239be3afc561bce192a96394ee43e90d234af90595aaa99141964b6f663
+    manifestHash: 9877dcb22e8486a8f91796dd08ad57a1756355868de3fbeb1dc6bfa7c5b47cd1
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -70,7 +70,6 @@ warmPoolImages:
 - quay.io/cilium/cilium:v1.11.6
 - quay.io/cilium/operator:v1.11.6
 - registry.k8s.io/kube-proxy:v1.21.0
-- registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
-- registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
-- registry.k8s.io/sig-storage/livenessprobe:v2.2.0
-- registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+- registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+- registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+- registry.k8s.io/sig-storage/livenessprobe:v2.5.0

--- a/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
+++ b/tests/integration/update_cluster/privatecalico/cloudformation.json.extracted.yaml
@@ -128,7 +128,7 @@ Resources.AWSEC2LaunchTemplatemasterustest1amastersprivatecalicoexamplecom.Prope
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   containerRuntime: containerd
   containerd:
@@ -397,7 +397,7 @@ Resources.AWSEC2LaunchTemplatenodesprivatecalicoexamplecom.Properties.LaunchTemp
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   containerRuntime: containerd
   containerd:

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
+++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
@@ -14,7 +14,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudControllerManager:
     allocateNodeCIDRs: true

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -627,13 +631,13 @@ spec:
         - --extra-tags=KubernetesCluster=privatecalico.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -668,13 +680,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -686,7 +699,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -697,15 +711,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -747,7 +762,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -765,7 +780,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -69,7 +69,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: bc40b15bc0ea747a6d37bee53321ddc0ed802b3aa96c56079f29830805304203
+    manifestHash: 44d445b7ec44fe6ef132c393e21b23dfda34f4289e103258c9863d59c48ec9a2
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_master-us-test-1a.masters.privatecanal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
+++ b/tests/integration/update_cluster/privatecanal/data/aws_launch_template_nodes.privatecanal.example.com_user_data
@@ -126,7 +126,7 @@ cat > conf/cluster_spec.yaml << '__EOF_CLUSTER_SPEC'
 cloudConfig:
   awsEBSCSIDriver:
     enabled: true
-    version: v1.6.2
+    version: v1.8.0
   manageStorageClasses: true
 containerRuntime: containerd
 containerd:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_cluster-completed.spec_content
@@ -14,7 +14,7 @@ spec:
   cloudConfig:
     awsEBSCSIDriver:
       enabled: true
-      version: v1.6.2
+      version: v1.8.0
     manageStorageClasses: true
   cloudProvider: aws
   clusterDNSDomain: cluster.local

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller-sa
   namespace: kube-system
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-attacher-role
 rules:
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-provisioner-role
 rules:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-resizer-role
 rules:
@@ -250,7 +250,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-external-snapshotter-role
 rules:
@@ -290,6 +290,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -308,7 +309,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-attacher-binding
 roleRef:
@@ -331,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-provisioner-binding
 roleRef:
@@ -354,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-resizer-binding
 roleRef:
@@ -377,7 +378,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-snapshotter-binding
 roleRef:
@@ -441,7 +442,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node-sa
   namespace: kube-system
@@ -457,7 +458,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-node
   namespace: kube-system
@@ -474,7 +475,7 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       containers:
@@ -490,7 +491,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -523,7 +525,8 @@ spec:
           value: /csi/csi.sock
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
-        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+        imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
             exec:
@@ -539,7 +542,8 @@ spec:
           name: registration-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -579,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system
@@ -597,7 +601,7 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/instance: aws-ebs-csi-driver
         app.kubernetes.io/name: aws-ebs-csi-driver
-        app.kubernetes.io/version: v1.6.2
+        app.kubernetes.io/version: v1.8.0
         kops.k8s.io/managed-by: kops
     spec:
       affinity:
@@ -627,13 +631,13 @@ spec:
         - --extra-tags=KubernetesCluster=privatecanal.example.com
         - --v=5
         env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: CSI_NODE_NAME
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: CSI_ENDPOINT
-          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
@@ -646,7 +650,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2
+        image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5
@@ -661,6 +665,14 @@ spec:
         - containerPort: 9808
           name: healthz
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
@@ -668,13 +680,14 @@ spec:
         - --csi-address=$(ADDRESS)
         - --v=5
         - --feature-gates=Topology=true
+        - --extra-create-metadata
         - --leader-election=true
-        - --extra-create-metadata=true
         - --default-fstype=ext4
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+        image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+        imagePullPolicy: IfNotPresent
         name: csi-provisioner
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -686,7 +699,8 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+        image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-attacher
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -697,15 +711,16 @@ spec:
         env:
         - name: ADDRESS
           value: /var/lib/csi/sockets/pluginproxy/csi.sock
-        image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-        imagePullPolicy: Always
+        image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+        imagePullPolicy: IfNotPresent
         name: csi-resizer
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
       - args:
         - --csi-address=/csi/csi.sock
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+        imagePullPolicy: IfNotPresent
         name: liveness-probe
         volumeMounts:
         - mountPath: /csi
@@ -747,7 +762,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs.csi.aws.com
 spec:
@@ -765,7 +780,7 @@ metadata:
     app.kubernetes.io/instance: aws-ebs-csi-driver
     app.kubernetes.io/managed-by: kops
     app.kubernetes.io/name: aws-ebs-csi-driver
-    app.kubernetes.io/version: v1.6.2
+    app.kubernetes.io/version: v1.8.0
     k8s-addon: aws-ebs-csi-driver.addons.k8s.io
   name: ebs-csi-controller
   namespace: kube-system

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: ed4f240e791f3619a16473331d9d1590e5cf02eb789158bd1f266f2d83705a7a
+    manifestHash: a34d1e45a0bff0117e84c610b17d4610ce8d29f7c57da8f4703718702c257605
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
+++ b/upup/models/cloudup/resources/addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml.template
@@ -134,7 +134,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
@@ -290,6 +290,7 @@ spec:
           securityContext:
             privileged: true
           image: registry.k8s.io/provider-aws/aws-ebs-csi-driver:{{ .Version }}
+          imagePullPolicy: IfNotPresent
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)
@@ -330,7 +331,8 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -350,7 +352,8 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.2.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:
@@ -466,13 +469,13 @@ spec:
             - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
               value: IPv6
             {{- end }}
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: CSI_NODE_NAME
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -500,14 +503,23 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
             - --feature-gates=Topology=true
+            - --extra-create-metadata
             - --leader-election=true
-            - --extra-create-metadata=true
             - --default-fstype=ext4
           env:
             - name: ADDRESS
@@ -516,7 +528,8 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v3.2.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -529,7 +542,8 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
         {{ if HasSnapshotController }}
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
@@ -541,8 +555,8 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
         {{ end }}
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.1.0
-          imagePullPolicy: Always
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -553,7 +567,8 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.4.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+          imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1a02f68791328817283cfc9ddc991be63de41be4150b8801a5e25ad834dcf3e8
+    manifestHash: f2139d8741d42373dfebd0bc2ae689f39dbe5b9e52d2808574a77614f22b2947
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -56,7 +56,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.17
     manifest: aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
-    manifestHash: 1a02f68791328817283cfc9ddc991be63de41be4150b8801a5e25ad834dcf3e8
+    manifestHash: f2139d8741d42373dfebd0bc2ae689f39dbe5b9e52d2808574a77614f22b2947
     name: aws-ebs-csi-driver.addons.k8s.io
     selector:
       k8s-addon: aws-ebs-csi-driver.addons.k8s.io


### PR DESCRIPTION
Cherry pick of #13939 on release-1.24.

#13939: Bump EBS CSI driver to 1.8.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```