### PR TITLE
Automated cherry pick of #13965: Use control-plane node role for AWS IAM Authenticator

### DIFF
--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -181,13 +181,14 @@ func (i *integrationTest) withAddons(addons ...string) *integrationTest {
 }
 
 const (
-	awsCCMAddon         = "aws-cloud-controller.addons.k8s.io-k8s-1.18"
-	awsEBSCSIAddon      = "aws-ebs-csi-driver.addons.k8s.io-k8s-1.17"
-	calicoAddon         = "networking.projectcalico.org-k8s-1.23"
-	certManagerAddon    = "certmanager.io-k8s-1.16"
-	ciliumAddon         = "networking.cilium.io-k8s-1.16"
-	dnsControllerAddon  = "dns-controller.addons.k8s.io-k8s-1.12"
-	leaderElectionAddon = "leader-migration.rbac.addons.k8s.io-k8s-1.23"
+	awsAuthenticatorAddon = "authentication.aws-k8s-1.12"
+	awsCCMAddon           = "aws-cloud-controller.addons.k8s.io-k8s-1.18"
+	awsEBSCSIAddon        = "aws-ebs-csi-driver.addons.k8s.io-k8s-1.17"
+	calicoAddon           = "networking.projectcalico.org-k8s-1.23"
+	certManagerAddon      = "certmanager.io-k8s-1.16"
+	ciliumAddon           = "networking.cilium.io-k8s-1.16"
+	dnsControllerAddon    = "dns-controller.addons.k8s.io-k8s-1.12"
+	leaderElectionAddon   = "leader-migration.rbac.addons.k8s.io-k8s-1.23"
 )
 
 // TestMinimal runs the test on a minimum configuration, similar to kops create cluster minimal.example.com --zones us-west-1a
@@ -301,11 +302,17 @@ func TestHighAvailabilityGCE(t *testing.T) {
 // TestComplex runs the test on a more complex configuration, intended to hit more of the edge cases
 func TestComplex(t *testing.T) {
 	newIntegrationTest("complex.example.com", "complex").withoutSSHKey().
-		withAddons(dnsControllerAddon).
+		withAddons(
+			dnsControllerAddon,
+			awsAuthenticatorAddon,
+		).
 		runTestTerraformAWS(t)
 	newIntegrationTest("complex.example.com", "complex").withoutSSHKey().runTestCloudformation(t)
 	newIntegrationTest("complex.example.com", "complex").withoutSSHKey().withVersion("legacy-v1alpha2").
-		withAddons(dnsControllerAddon).
+		withAddons(
+			dnsControllerAddon,
+			awsAuthenticatorAddon,
+		).
 		runTestTerraformAWS(t)
 }
 

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
@@ -22,6 +22,8 @@ spec:
       - allocationId: eipalloc-012345a678b9cdefa
         name: us-test-1a
       type: Public
+  authentication:
+    aws: {}
   authorization:
     alwaysAllow: {}
   channel: stable

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content
@@ -1,0 +1,225 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    role.kubernetes.io/authentication: "1"
+  name: iamidentitymappings.iamauthenticator.k8s.aws
+spec:
+  group: iamauthenticator.k8s.aws
+  names:
+    categories:
+    - all
+    kind: IAMIdentityMapping
+    plural: iamidentitymappings
+    singular: iamidentitymapping
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              arn:
+                type: string
+              groups:
+                items:
+                  type: string
+                type: array
+              username:
+                type: string
+            required:
+            - arn
+            - username
+            type: object
+          status:
+            properties:
+              canonicalARN:
+                type: string
+              userID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+rules:
+- apiGroups:
+  - iamauthenticator.k8s.aws
+  resources:
+  - iamidentitymappings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - iamauthenticator.k8s.aws
+  resources:
+  - iamidentitymappings/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - aws-auth
+  resources:
+  - configmaps
+  verbs:
+  - get
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-iam-authenticator
+subjects:
+- kind: ServiceAccount
+  name: aws-iam-authenticator
+  namespace: kube-system
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: runtime/default
+  creationTimestamp: null
+  labels:
+    addon.kops.k8s.io/name: authentication.aws
+    app.kubernetes.io/managed-by: kops
+    k8s-app: aws-iam-authenticator
+    role.kubernetes.io/authentication: "1"
+  name: aws-iam-authenticator
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: aws-iam-authenticator
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      creationTimestamp: null
+      labels:
+        k8s-app: aws-iam-authenticator
+        kops.k8s.io/managed-by: kops
+    spec:
+      containers:
+      - args:
+        - server
+        - --config=/etc/aws-iam-authenticator/config.yaml
+        - --state-dir=/var/aws-iam-authenticator
+        - --kubeconfig-pregenerated=true
+        image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.5
+        livenessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 21362
+            scheme: HTTPS
+        name: aws-iam-authenticator
+        resources:
+          limits:
+            cpu: 100m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 10000
+          runAsUser: 10000
+        volumeMounts:
+        - mountPath: /etc/aws-iam-authenticator/
+          name: config
+        - mountPath: /var/aws-iam-authenticator/
+          name: state
+        - mountPath: /etc/kubernetes/aws-iam-authenticator/
+          name: output
+      hostNetwork: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-node-critical
+      serviceAccountName: aws-iam-authenticator
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/api-server
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      volumes:
+      - configMap:
+          name: aws-iam-authenticator
+        name: config
+      - hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/
+        name: output
+      - hostPath:
+          path: /srv/kubernetes/aws-iam-authenticator/
+        name: state
+  updateStrategy:
+    type: RollingUpdate

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -46,3 +46,10 @@ spec:
     selector:
       k8s-addon: storage-aws.addons.k8s.io
     version: 9.99.0
+  - id: k8s-1.12
+    manifest: authentication.aws/k8s-1.12.yaml
+    manifestHash: 853d0d96e385e22dba8e7c0673a7990748a454900f1bb40ca94e7f1b959d8dc5
+    name: authentication.aws
+    selector:
+      role.kubernetes.io/authentication: "1"
+    version: 9.99.0

--- a/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-legacy-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
           allocationId: eipalloc-012345a678b9cdefa
       accessLog:
         bucket: access-log-example
+  authentication:
+    aws: {}
   kubernetesApiAccess:
   - 1.1.1.0/24
   - pl-44444444

--- a/tests/integration/update_cluster/complex/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/complex/in-v1alpha2.yaml
@@ -19,6 +19,8 @@ spec:
           allocationId: eipalloc-012345a678b9cdefa
       accessLog:
         bucket: access-log-example
+  authentication:
+    aws: {}
   kubernetesApiAccess:
   - 1.1.1.0/24
   - pl-44444444

--- a/tests/integration/update_cluster/complex/kubernetes.tf
+++ b/tests/integration/update_cluster/complex/kubernetes.tf
@@ -698,6 +698,14 @@ resource "aws_s3_object" "cluster-completed-spec" {
   server_side_encryption = "AES256"
 }
 
+resource "aws_s3_object" "complex-example-com-addons-authentication-aws-k8s-1-12" {
+  bucket                 = "testingBucket"
+  content                = file("${path.module}/data/aws_s3_object_complex.example.com-addons-authentication.aws-k8s-1.12_content")
+  key                    = "clusters.example.com/complex.example.com/addons/authentication.aws/k8s-1.12.yaml"
+  provider               = aws.files
+  server_side_encryption = "AES256"
+}
+
 resource "aws_s3_object" "complex-example-com-addons-bootstrap" {
   bucket                 = "testingBucket"
   content                = file("${path.module}/data/aws_s3_object_complex.example.com-addons-bootstrap_content")

--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -389,6 +389,8 @@ func (tf *TemplateFunctions) ControlPlaneControllerReplicas(deployOnWorkersIfExt
 func (tf *TemplateFunctions) APIServerNodeRole() string {
 	if featureflag.APIServerNodes.Enabled() {
 		return "node-role.kubernetes.io/api-server"
+	} else if tf.Cluster.IsKubernetesGTE("1.24") {
+		return "node-role.kubernetes.io/control-plane"
 	}
 	return "node-role.kubernetes.io/master"
 }


### PR DESCRIPTION
Cherry pick of #13965 on release-1.24.

#13965: Use control-plane node role for AWS IAM Authenticator

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```