### PR TITLE
Automated cherry pick of #13970: Skip deregistering the instance during rolling update for

### DIFF
--- a/upup/pkg/fi/cloudup/awsup/aws_cloud.go
+++ b/upup/pkg/fi/cloudup/awsup/aws_cloud.go
@@ -542,14 +542,17 @@ func (c *awsCloudImplementation) DeleteInstance(i *cloudinstances.CloudInstance)
 	return deleteInstance(c, i)
 }
 
-// DeregisterInstance drains a cloud instance and loadbalancers.
+// DeregisterInstance drains a cloud instance and load balancers.
 func (c *awsCloudImplementation) DeregisterInstance(i *cloudinstances.CloudInstance) error {
-	if i.CloudInstanceGroup.InstanceGroup.Spec.Manager != kops.InstanceManagerKarpenter {
-		err := deregisterInstance(c, i)
-		if err != nil {
-			return fmt.Errorf("failed to deregister instance from loadBalancer before terminating: %v", err)
-		}
+	if c.spotinst != nil || i.CloudInstanceGroup.InstanceGroup.Spec.Manager == kops.InstanceManagerKarpenter {
+		return nil
 	}
+
+	err := deregisterInstance(c, i)
+	if err != nil {
+		return fmt.Errorf("failed to deregister instance from loadBalancer before terminating: %v", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #13970 on release-1.24.

#13970: Skip deregistering the instance during rolling update for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```