### PR TITLE
Automated cherry pick of #13975: Add option to set etcd-manager backup interval

### DIFF
--- a/docs/cluster_spec.md
+++ b/docs/cluster_spec.md
@@ -226,6 +226,21 @@ etcdClusters:
 
 *Note:* If you are running multiple etcd clusters you need to expose the metrics on different ports for each cluster as etcd is running as a service on the master nodes.
 
+### etcd backups interval
+{{ kops_feature_table(kops_added_default='1.24.1') }}
+
+You can set the interval between backups using the `backupInterval` parameter:
+
+```yaml
+etcdClusters:
+- etcdMembers:
+  - instanceGroup: master-us-east-1a
+    name: a
+  name: main
+  manager:
+    backupInterval: 1h
+```
+
 ### etcd backups retention
 {{ kops_feature_table(kops_added_default='1.18') }}
 

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -1100,6 +1100,10 @@ spec:
                     manager:
                       description: Manager describes the manager configuration
                       properties:
+                        backupInterval:
+                          description: BackupInterval which is used for backups. The
+                            default is 15 minutes.
+                          type: string
                         discoveryPollInterval:
                           description: DiscoveryPollInterval which is used for discovering
                             other cluster members. The default is 60 seconds.

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -647,8 +647,10 @@ type EtcdManagerSpec struct {
 	// This allows etcd setting to be overwriten. No config validation is done.
 	// A list of etcd config ENV vars can be found at https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/configuration.md
 	Env []EnvVar `json:"env,omitempty"`
+	// BackupInterval which is used for backups. The default is 15 minutes.
+	BackupInterval *metav1.Duration `json:"backupInterval,omitempty"`
 	// DiscoveryPollInterval which is used for discovering other cluster members. The default is 60 seconds.
-	DiscoveryPollInterval *string `json:"discoveryPollInterval,omitempty"`
+	DiscoveryPollInterval *metav1.Duration `json:"discoveryPollInterval,omitempty"`
 	// LogLevel allows the klog library verbose log level to be set for etcd-manager. The default is 6.
 	// https://github.com/google/glog#verbose-logging
 	LogLevel *int32 `json:"logLevel,omitempty"`

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -633,8 +633,10 @@ type EtcdManagerSpec struct {
 	// This allows etcd setting to be configured/overwriten. No config validation is done.
 	// A list of etcd config ENV vars can be found at https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/configuration.md
 	Env []EnvVar `json:"env,omitempty"`
+	// BackupInterval which is used for backups. The default is 15 minutes.
+	BackupInterval *metav1.Duration `json:"backupInterval,omitempty"`
 	// DiscoveryPollInterval which is used for discovering other cluster members. The default is 60 seconds.
-	DiscoveryPollInterval *string `json:"discoveryPollInterval,omitempty"`
+	DiscoveryPollInterval *metav1.Duration `json:"discoveryPollInterval,omitempty"`
 	// LogLevel allows the klog library verbose log level to be set for etcd-manager. The default is 6.
 	// https://github.com/google/glog#verbose-logging
 	LogLevel *int32 `json:"logLevel,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -3752,6 +3752,7 @@ func autoConvert_v1alpha2_EtcdManagerSpec_To_kops_EtcdManagerSpec(in *EtcdManage
 	} else {
 		out.Env = nil
 	}
+	out.BackupInterval = in.BackupInterval
 	out.DiscoveryPollInterval = in.DiscoveryPollInterval
 	out.LogLevel = in.LogLevel
 	return nil
@@ -3775,6 +3776,7 @@ func autoConvert_kops_EtcdManagerSpec_To_v1alpha2_EtcdManagerSpec(in *kops.EtcdM
 	} else {
 		out.Env = nil
 	}
+	out.BackupInterval = in.BackupInterval
 	out.DiscoveryPollInterval = in.DiscoveryPollInterval
 	out.LogLevel = in.LogLevel
 	return nil

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -1815,9 +1815,14 @@ func (in *EtcdManagerSpec) DeepCopyInto(out *EtcdManagerSpec) {
 		*out = make([]EnvVar, len(*in))
 		copy(*out, *in)
 	}
+	if in.BackupInterval != nil {
+		in, out := &in.BackupInterval, &out.BackupInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.DiscoveryPollInterval != nil {
 		in, out := &in.DiscoveryPollInterval, &out.DiscoveryPollInterval
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.LogLevel != nil {

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -609,8 +609,10 @@ type EtcdManagerSpec struct {
 	// This allows etcd setting to be configured/overwriten. No config validation is done.
 	// A list of etcd config ENV vars can be found at https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/configuration.md
 	Env []EnvVar `json:"env,omitempty"`
+	// BackupInterval which is used for backups. The default is 15 minutes.
+	BackupInterval *metav1.Duration `json:"backupInterval,omitempty"`
 	// DiscoveryPollInterval which is used for discovering other cluster members. The default is 60 seconds.
-	DiscoveryPollInterval *string `json:"discoveryPollInterval,omitempty"`
+	DiscoveryPollInterval *metav1.Duration `json:"discoveryPollInterval,omitempty"`
 	// LogLevel allows the klog library verbose log level to be set for etcd-manager. The default is 6.
 	// https://github.com/google/glog#verbose-logging
 	LogLevel *int32 `json:"logLevel,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -3848,6 +3848,7 @@ func autoConvert_v1alpha3_EtcdManagerSpec_To_kops_EtcdManagerSpec(in *EtcdManage
 	} else {
 		out.Env = nil
 	}
+	out.BackupInterval = in.BackupInterval
 	out.DiscoveryPollInterval = in.DiscoveryPollInterval
 	out.LogLevel = in.LogLevel
 	return nil
@@ -3871,6 +3872,7 @@ func autoConvert_kops_EtcdManagerSpec_To_v1alpha3_EtcdManagerSpec(in *kops.EtcdM
 	} else {
 		out.Env = nil
 	}
+	out.BackupInterval = in.BackupInterval
 	out.DiscoveryPollInterval = in.DiscoveryPollInterval
 	out.LogLevel = in.LogLevel
 	return nil

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -1794,9 +1794,14 @@ func (in *EtcdManagerSpec) DeepCopyInto(out *EtcdManagerSpec) {
 		*out = make([]EnvVar, len(*in))
 		copy(*out, *in)
 	}
+	if in.BackupInterval != nil {
+		in, out := &in.BackupInterval, &out.BackupInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.DiscoveryPollInterval != nil {
 		in, out := &in.DiscoveryPollInterval, &out.DiscoveryPollInterval
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.LogLevel != nil {

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -1941,9 +1941,14 @@ func (in *EtcdManagerSpec) DeepCopyInto(out *EtcdManagerSpec) {
 		*out = make([]EnvVar, len(*in))
 		copy(*out, *in)
 	}
+	if in.BackupInterval != nil {
+		in, out := &in.BackupInterval, &out.BackupInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.DiscoveryPollInterval != nil {
 		in, out := &in.DiscoveryPollInterval, &out.DiscoveryPollInterval
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.LogLevel != nil {

--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -348,8 +348,12 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec) (*v1.Pod
 		config.LogLevel = int(*etcdCluster.Manager.LogLevel)
 	}
 
+	if etcdCluster.Manager != nil && etcdCluster.Manager.BackupInterval != nil {
+		config.BackupInterval = fi.String(etcdCluster.Manager.BackupInterval.Duration.String())
+	}
+
 	if etcdCluster.Manager != nil && etcdCluster.Manager.DiscoveryPollInterval != nil {
-		config.DiscoveryPollInterval = etcdCluster.Manager.DiscoveryPollInterval
+		config.DiscoveryPollInterval = fi.String(etcdCluster.Manager.DiscoveryPollInterval.Duration.String())
 	}
 
 	{
@@ -530,6 +534,7 @@ type config struct {
 	QuarantineClientUrls  string   `flag:"quarantine-client-urls"`
 	ClusterName           string   `flag:"cluster-name"`
 	BackupStore           string   `flag:"backup-store"`
+	BackupInterval        *string  `flag:"backup-interval"`
 	DataDir               string   `flag:"data-dir"`
 	VolumeProvider        string   `flag:"volume-provider"`
 	VolumeTag             []string `flag:"volume-tag,repeat"`

--- a/pkg/model/components/etcdmanager/model_test.go
+++ b/pkg/model/components/etcdmanager/model_test.go
@@ -33,7 +33,7 @@ func Test_RunEtcdManagerBuilder(t *testing.T) {
 	featureflag.ParseFlags("-ImageDigest")
 	tests := []string{
 		"tests/minimal",
-		"tests/pollinterval",
+		"tests/interval",
 		"tests/proxy",
 		"tests/overwrite_settings",
 	}

--- a/pkg/model/components/etcdmanager/tests/interval/cluster.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/cluster.yaml
@@ -17,6 +17,7 @@ spec:
     memoryRequest: 100Mi
     name: main
     manager:
+      backupInterval: 1h
       discoveryPollInterval: 75s
     provider: Manager
     backups:

--- a/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/interval/tasks.yaml
@@ -81,7 +81,7 @@ Contents: |
       - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
         --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-events
         --client-urls=https://__name__:4002 --cluster-name=etcd-events --containerized=true
-        --discovery-poll-interval=75s --dns-suffix=.internal.minimal.example.com --grpc-port=3997
+        --discovery-poll-interval=1m15s --dns-suffix=.internal.minimal.example.com --grpc-port=3997
         --peer-urls=https://__name__:2381 --quarantine-client-urls=https://__name__:3995
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
@@ -148,9 +148,9 @@ Contents: |
       - /bin/sh
       - -c
       - mkfifo /tmp/pipe; (tee -a /var/log/etcd.log < /tmp/pipe & ) ; exec /etcd-manager
-        --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
+        --backup-interval=1h0m0s --backup-store=memfs://clusters.example.com/minimal.example.com/backups/etcd-main
         --client-urls=https://__name__:4001 --cluster-name=etcd --containerized=true
-        --discovery-poll-interval=75s --dns-suffix=.internal.minimal.example.com --grpc-port=3996
+        --discovery-poll-interval=1m15s --dns-suffix=.internal.minimal.example.com --grpc-port=3996
         --peer-urls=https://__name__:2380 --quarantine-client-urls=https://__name__:3994
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned


### PR DESCRIPTION
Cherry pick of #13975 on release-1.24.

#13975: Add option to set etcd-manager backup interval

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```