### PR TITLE
Automated cherry pick of #13982: Use only IPv4 for Hetzner servers

### DIFF
--- a/pkg/model/hetznermodel/servers.go
+++ b/pkg/model/hetznermodel/servers.go
@@ -54,15 +54,17 @@ func (b *ServerModelBuilder) Build(c *fi.ModelBuilderContext) error {
 			// https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/f7d624e83c2c3475c5606306214814250922cb8a/hcloud/util.go#L39
 			name := ig.Name + "-" + strconv.Itoa(i)
 			server := hetznertasks.Server{
-				Name:      fi.String(name),
-				Lifecycle: b.Lifecycle,
-				SSHKey:    b.LinkToSSHKey(),
-				Network:   b.LinkToNetwork(),
-				Location:  ig.Spec.Subnets[0],
-				Size:      ig.Spec.MachineType,
-				Image:     ig.Spec.Image,
-				UserData:  userData,
-				Labels:    labels,
+				Name:       fi.String(name),
+				Lifecycle:  b.Lifecycle,
+				SSHKey:     b.LinkToSSHKey(),
+				Network:    b.LinkToNetwork(),
+				Location:   ig.Spec.Subnets[0],
+				Size:       ig.Spec.MachineType,
+				Image:      ig.Spec.Image,
+				EnableIPv4: true,
+				EnableIPv6: false,
+				UserData:   userData,
+				Labels:     labels,
 			}
 
 			c.AddTask(&server)

--- a/upup/pkg/fi/cloudup/hetznertasks/server.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/server.go
@@ -38,6 +38,9 @@ type Server struct {
 	Size     string
 	Image    string
 
+	EnableIPv4 bool
+	EnableIPv6 bool
+
 	UserData fi.Resource
 
 	Labels map[string]string
@@ -76,6 +79,12 @@ func (v *Server) Find(c *fi.Context) (*Server, error) {
 			}
 			if server.Image != nil {
 				matches.Image = server.Image.Name
+			}
+			if server.PublicNet.IPv4.IP != nil {
+				matches.EnableIPv4 = true
+			}
+			if server.PublicNet.IPv6.IP != nil {
+				matches.EnableIPv4 = true
 			}
 
 			// Ignore fields that are not returned by the Hetzner Cloud API
@@ -176,6 +185,10 @@ func (_ *Server) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *Serve
 			},
 			UserData: userData,
 			Labels:   e.Labels,
+			PublicNet: &hcloud.ServerCreatePublicNet{
+				EnableIPv4: e.EnableIPv4,
+				EnableIPv6: e.EnableIPv6,
+			},
 		}
 
 		_, _, err = client.Create(context.TODO(), opts)


### PR DESCRIPTION
Cherry pick of #13982 on release-1.24.

#13982: Use only IPv4 for Hetzner servers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```