### PR TITLE
Add S3_REGION to Hetzner docs

### DIFF
--- a/docs/getting_started/hetzner.md
+++ b/docs/getting_started/hetzner.md
@@ -23,6 +23,11 @@ export S3_SECRET_ACCESS_KEY=<secret-key>
 export KOPS_STATE_STORE=s3://<bucket-name>
 ```
 
+Some S3 compatible stores may also require to set the region:
+```bash
+export S3_REGION=<region>
+```
+
 ## Creating a Single Master Cluster
 
 In the following examples, `example.k8s.local` is a [gossip-based DNS ](../gossip.md) cluster name.


### PR DESCRIPTION
Mentions the need to set `S3_REGION` when using AWS S3 with Hetzner.