### PR TITLE
Automated cherry pick of #13986: Add option to set number of replicas for pod-identity-webhook

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -5331,6 +5331,8 @@ spec:
                 properties:
                   enabled:
                     type: boolean
+                  replicas:
+                    type: integer
                 type: object
               project:
                 description: Project is the cloud project we should use, required

--- a/pkg/apis/kops/cluster.go
+++ b/pkg/apis/kops/cluster.go
@@ -223,7 +223,8 @@ type ClusterSpec struct {
 
 // PodIdentityWebhookConfig configures an EKS Pod Identity Webhook.
 type PodIdentityWebhookConfig struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled  bool `json:"enabled,omitempty"`
+	Replicas int  `json:"replicas,omitempty"`
 }
 
 // CloudProviderSpec configures the cloud provider to use.

--- a/pkg/apis/kops/v1alpha2/cluster.go
+++ b/pkg/apis/kops/v1alpha2/cluster.go
@@ -222,7 +222,8 @@ type ClusterSpec struct {
 
 // PodIdentityWebhookConfig configures an EKS Pod Identity Webhook.
 type PodIdentityWebhookConfig struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled  bool `json:"enabled,omitempty"`
+	Replicas int  `json:"replicas,omitempty"`
 }
 
 type KarpenterConfig struct {

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6820,6 +6820,7 @@ func Convert_kops_PackagesConfig_To_v1alpha2_PackagesConfig(in *kops.PackagesCon
 
 func autoConvert_v1alpha2_PodIdentityWebhookConfig_To_kops_PodIdentityWebhookConfig(in *PodIdentityWebhookConfig, out *kops.PodIdentityWebhookConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Replicas = in.Replicas
 	return nil
 }
 
@@ -6830,6 +6831,7 @@ func Convert_v1alpha2_PodIdentityWebhookConfig_To_kops_PodIdentityWebhookConfig(
 
 func autoConvert_kops_PodIdentityWebhookConfig_To_v1alpha2_PodIdentityWebhookConfig(in *kops.PodIdentityWebhookConfig, out *PodIdentityWebhookConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Replicas = in.Replicas
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/cluster.go
+++ b/pkg/apis/kops/v1alpha3/cluster.go
@@ -220,7 +220,8 @@ type ClusterSpec struct {
 
 // PodIdentityWebhookConfig configures an EKS Pod Identity Webhook.
 type PodIdentityWebhookConfig struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled  bool `json:"enabled,omitempty"`
+	Replicas int  `json:"replicas,omitempty"`
 }
 
 // CloudProviderSpec configures the cloud provider to use.

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6819,6 +6819,7 @@ func Convert_kops_PackagesConfig_To_v1alpha3_PackagesConfig(in *kops.PackagesCon
 
 func autoConvert_v1alpha3_PodIdentityWebhookConfig_To_kops_PodIdentityWebhookConfig(in *PodIdentityWebhookConfig, out *kops.PodIdentityWebhookConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Replicas = in.Replicas
 	return nil
 }
 
@@ -6829,6 +6830,7 @@ func Convert_v1alpha3_PodIdentityWebhookConfig_To_kops_PodIdentityWebhookConfig(
 
 func autoConvert_kops_PodIdentityWebhookConfig_To_v1alpha3_PodIdentityWebhookConfig(in *kops.PodIdentityWebhookConfig, out *PodIdentityWebhookConfig, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Replicas = in.Replicas
 	return nil
 }
 

--- a/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/eks-pod-identity-webhook.addons.k8s.io/k8s-1.16.yaml.template
@@ -68,7 +68,7 @@ metadata:
   name: pod-identity-webhook
   namespace: kube-system
 spec:
-  replicas: 2
+  replicas: {{ or .PodIdentityWebhook.Replicas "2" }}
   selector:
     matchLabels:
       app: pod-identity-webhook


### PR DESCRIPTION
Cherry pick of #13986 on release-1.24.

#13986: Add option to set number of replicas for pod-identity-webhook

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```