### PR TITLE
Automated cherry pick of #13990: Update etcd-manager to v3.0.20220717

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -183,7 +183,7 @@ metadata:
   namespace: kube-system
 spec:
   containers:
-  - image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+  - image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/minimal/tasks.yaml
@@ -87,7 +87,7 @@ Contents: |
         --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
         --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
       name: etcd-manager
       resources:
         requests:
@@ -157,7 +157,7 @@ Contents: |
         --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
         --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
         --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/overwrite_settings/tasks.yaml
@@ -90,7 +90,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
       name: etcd-manager
       resources:
         requests:
@@ -163,7 +163,7 @@ Contents: |
       env:
       - name: ETCD_QUOTA_BACKEND_BYTES
         value: "10737418240"
-      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/pollinterval/tasks.yaml
@@ -88,7 +88,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
       name: etcd-manager
       resources:
         requests:
@@ -159,7 +159,7 @@ Contents: |
         --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
         --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/minimal.example.com=owned
         > /tmp/pipe 2>&1
-      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
       name: etcd-manager
       resources:
         requests:

--- a/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
+++ b/pkg/model/components/etcdmanager/tests/proxy/tasks.yaml
@@ -96,7 +96,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
       name: etcd-manager
       resources:
         requests:
@@ -175,7 +175,7 @@ Contents: |
         value: http://proxy.example.com
       - name: no_proxy
         value: noproxy.example.com
-      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+      image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
       name: etcd-manager
       resources:
         requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/bastionuserdata.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/complex.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/compress.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/123.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/existing-iam.example.com=owned
       > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/existingsg.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/externallb.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/externalpolicies.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/ha.example.com=owned
       > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=ha-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-ipv6.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/this.is.truly.a.really.really.long.cluster-name.minimal.example.com=owned
       > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal-warmpool.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-events --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --v=6 --volume-name-tag=k8s-io-etcd-main --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
       --volume-tag=k8s-io-etcd-events --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=gce --volume-tag=k8s-io-cluster-name=minimal-gce-private-example-com
       --volume-tag=k8s-io-etcd-main --volume-tag=k8s-io-role-master=master > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.k8s.local=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/mixedinstances.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/events --volume-provider=aws --volume-tag=k8s.io/etcd/events
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/nthsqsresources.longclustername.example.com=owned
       > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/main --volume-provider=aws --volume-tag=k8s.io/etcd/main
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/nthsqsresources.longclustername.example.com=owned
       > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/private-shared-ip.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
       /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/private-shared-subnet.example.com=owned >
       /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecalico.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecanal.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecanal.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatecilium.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-cilium_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-cilium_content
@@ -21,7 +21,7 @@ spec:
       --v=6 --volume-name-tag=k8s.io/etcd/cilium --volume-provider=aws --volume-tag=k8s.io/etcd/cilium
       --volume-tag=k8s.io/role/master=1 --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned
       > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
       /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateciliumadvanced.example.com=owned >
       /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatedns1.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatedns2.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateflannel.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privatekopeio.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateweave.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/privateweave.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -21,7 +21,7 @@ spec:
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/sharedsubnet.example.com=owned > /tmp/pipe
       2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/sharedvpc.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/unmanaged.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-etcdmanager-events_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3995 --v=6 --volume-name-tag=k8s.io/etcd/events
       --volume-provider=aws --volume-tag=k8s.io/etcd/events --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-etcdmanager-main_content
@@ -20,7 +20,7 @@ spec:
       --quarantine-client-urls=https://__name__:3994 --v=6 --volume-name-tag=k8s.io/etcd/main
       --volume-provider=aws --volume-tag=k8s.io/etcd/main --volume-tag=k8s.io/role/master=1
       --volume-tag=kubernetes.io/cluster/minimal.example.com=owned > /tmp/pipe 2>&1
-    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220417
+    image: k8s.gcr.io/etcdadm/etcd-manager:v3.0.20220717
     name: etcd-manager
     resources:
       requests:


### PR DESCRIPTION
Cherry pick of #13990 on release-1.22.

#13990: Update etcd-manager to v3.0.20220717

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```