### PR TITLE
Add missing namespace to external-dns Service

### DIFF
--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: external-dns.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: b152f563273ed52518b323dbf558f551df1b59a5676e36514cf461d009a49743
+    manifestHash: dedc0c4373249e7479ee433d117d63d9f434e7b05bacb1c5a4ad8f5e735beea6
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
@@ -111,6 +111,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: external-dns.addons.k8s.io
   name: external-dns
+  namespace: kube-system
 spec:
   ports:
   - name: http

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.19
     manifest: external-dns.addons.k8s.io/k8s-1.19.yaml
-    manifestHash: 92e79aeb76c1740fc7920aa27231a2f3d9c58dbca531b6b76d11190e9b93fb60
+    manifestHash: 6ba6be22a3e8afb07cc3aa15c0945df321a4f8d9934752260b67ad508ad3c01f
     name: external-dns.addons.k8s.io
     selector:
       k8s-addon: external-dns.addons.k8s.io

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-external-dns.addons.k8s.io-k8s-1.19_content
@@ -127,6 +127,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: external-dns.addons.k8s.io
   name: external-dns
+  namespace: kube-system
 spec:
   ports:
   - name: http

--- a/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
+++ b/upup/models/cloudup/resources/addons/external-dns.addons.k8s.io/k8s-1.19.yaml.template
@@ -95,6 +95,7 @@ metadata:
   labels:
     k8s-addon: external-dns.addons.k8s.io
   name: external-dns
+  namespace: kube-system
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
external-dns e2e job [started failing recently](https://testgrid.k8s.io/kops-misc#kops-aws-external-dns). The external-dns pods are never created and protokube reports these logs:

`I0718 22:38:45.861661    6318 apply.go:70] applying objects of kind: Deployment.apps`
`I0718 22:38:45.868537    6318 apply.go:116] updating apps/v1, Resource=deployments kube-system/external-dns`
`I0718 22:38:45.876239    6318 apply.go:70] applying objects of kind: Service`
`I0718 22:38:45.883606    6318 apply.go:123] creating /v1, Resource=services /external-dns
updating "external-dns.addons.k8s.io": error applying update from "s3://k8s-kops-prow/e2e-e2e-kops-aws-external-dns.test-cncf-aws.k8s.io/addons/external-dns.addons.k8s.io/k8s-1.19.yaml": failed to apply objects of kind Service: failed to create /external-dns: the server does not allow this method on the requested resource`
`W0718 22:38:45.889276    3464 kube_boot.go:89] error applying channel "s3://k8s-kops-prow/e2e-e2e-kops-aws-external-dns.test-cncf-aws.k8s.io/addons/bootstrap-channel.yaml": error running channels: exit status 1`

Notice the `/external-dns` resource name whereas the Deployment has `kube-system/external-dns`. This leads me to believe the Service is missing the namespace field.