### PR TITLE
Switch to latest MacOS version for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           make all examples test
 
   build-macos-amd64:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
     - name: Set up go
       uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a


### PR DESCRIPTION
The CI workflow for MacOS stopped working, probably due to https://github.com/actions/virtual-environments/issues/5583.