### PR TITLE
Automated cherry pick of #14015: Switch to latest MacOS version for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           make all examples test
 
   build-macos-amd64:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
     - name: Set up go
       uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923


### PR DESCRIPTION
Cherry pick of #14015 on release-1.24.

#14015: Switch to latest MacOS version for CI

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```