### PR TITLE
Automated cherry pick of #14015: Switch to latest MacOS version for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           make all examples test
 
   build-macos-amd64:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
     - name: Set up go
       uses: actions/setup-go@v2


### PR DESCRIPTION
Cherry pick of #14015 on release-1.23.

#14015: Switch to latest MacOS version for CI

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```