### PR TITLE
Automated cherry pick of #14024: Revert to using instance private DNS name to lookup hostname

### DIFF
--- a/upup/pkg/fi/nodeup/BUILD.bazel
+++ b/upup/pkg/fi/nodeup/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/aws/ec2metadata:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/autoscaling:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/kms:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],


### PR DESCRIPTION
Cherry pick of #14024 on release-1.23.

#14024: Revert to using instance private DNS name to lookup hostname

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```