### PR TITLE
 Check keyset existence before attempting to distrust

### DIFF
--- a/cmd/kops/distrust_keypair.go
+++ b/cmd/kops/distrust_keypair.go
@@ -148,6 +148,8 @@ func distrustKeypair(out io.Writer, name string, keypairIDs []string, keyStore f
 	keyset, err := keyStore.FindKeyset(name)
 	if err != nil {
 		return err
+	} else if keyset == nil {
+		return fmt.Errorf("keyset not found")
 	}
 
 	if len(keypairIDs) == 0 {


### PR DESCRIPTION
Fixes #14040


```bash
λ kops distrust keypair this-is-not-a-keypair 12345678910
Using cluster from kubectl context: my-cluster.local

Error: keyset not found
```