### PR TITLE
Automated cherry pick of #14041: Check keyset existence before attempting to distrust

### DIFF
--- a/cmd/kops/distrust_keypair.go
+++ b/cmd/kops/distrust_keypair.go
@@ -148,6 +148,8 @@ func distrustKeypair(out io.Writer, name string, keypairIDs []string, keyStore f
 	keyset, err := keyStore.FindKeyset(name)
 	if err != nil {
 		return err
+	} else if keyset == nil {
+		return fmt.Errorf("keyset not found")
 	}
 
 	if len(keypairIDs) == 0 {


### PR DESCRIPTION
Cherry pick of #14041 on release-1.22.

#14041: Check keyset existence before attempting to distrust

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```