### PR TITLE
Fix SIGSEGV when deleting a Hetzner instance

### DIFF
--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -217,6 +217,7 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 	}
 
 	d := &instancegroups.RollingUpdateCluster{
+		Clientset:         clientSet,
 		Cluster:           cluster,
 		Ctx:               ctx,
 		MasterInterval:    0,


### PR DESCRIPTION
OpenStack and DigitalOcean should exhibit a similar behaviour:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x1071272b4]

goroutine 1 [running]:
k8s.io/kops/pkg/instancegroups.(*RollingUpdateCluster).reconcileInstanceGroup(0x1400111bc78)
	k8s.io/kops/pkg/instancegroups/instancegroups.go:450 +0x2e4
k8s.io/kops/pkg/instancegroups.(*RollingUpdateCluster).drainTerminateAndWait(0x1400111bc78, 0x14000678c80, 0x19?)
	k8s.io/kops/pkg/instancegroups/instancegroups.go:430 +0x7f8
k8s.io/kops/pkg/instancegroups.(*RollingUpdateCluster).UpdateSingleInstance(0x1400101fc78?, 0x14000678c80?, 0x50?)
	k8s.io/kops/pkg/instancegroups/instancegroups.go:699 +0x194
main.RunDeleteInstance({0x108bb1b28, 0x140001a6008}, 0x0?, {0x108b984d8, 0x140001a8008}, 0x1400012d2c0)
	k8s.io/kops/cmd/kops/delete_instance.go:251 +0x58c
main.NewCmdDeleteInstance.func2(0x14000c56a00?, {0x140006f1140?, 0x1?, 0x4?})
	k8s.io/kops/cmd/kops/delete_instance.go:136 +0x44
github.com/spf13/cobra.(*Command).execute(0x14000c56a00, {0x140006f1100, 0x4, 0x4})
	github.com/spf13/cobra@v1.5.0/command.go:872 +0x4d0
github.com/spf13/cobra.(*Command).ExecuteC(0x10ac835e0)
	github.com/spf13/cobra@v1.5.0/command.go:990 +0x354
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.5.0/command.go:918
main.Execute()
	k8s.io/kops/cmd/kops/root.go:95 +0x74
main.main()
	k8s.io/kops/cmd/kops/main.go:20 +0x20
```