### PR TITLE
Automated cherry pick of #14046: Fix SIGSEGV when deleting a Hetzner instance

### DIFF
--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -217,6 +217,7 @@ func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, opti
 	}
 
 	d := &instancegroups.RollingUpdateCluster{
+		Clientset:         clientSet,
 		Cluster:           cluster,
 		Ctx:               ctx,
 		MasterInterval:    0,


### PR DESCRIPTION
Cherry pick of #14046 on release-1.24.

#14046: Fix SIGSEGV when deleting a Hetzner instance

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```