### PR TITLE
release 1.23.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,13 @@ GITSHA := $(shell cd ${KOPS_ROOT}; git describe --always)
 # We lock the versions of our controllers also
 # We need to keep in sync with:
 #   upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.23.2
+DNS_CONTROLLER_TAG=1.23.3
 DNS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_DNS_CONTROLLER_TAG | awk '{print $$2}')
 #   upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/
-KOPS_CONTROLLER_TAG=1.23.2
+KOPS_CONTROLLER_TAG=1.23.3
 KOPS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KOPS_CONTROLLER_TAG | awk '{print $$2}')
 #   pkg/model/components/kubeapiserver/model.go
-KUBE_APISERVER_HEALTHCHECK_TAG=1.23.2
+KUBE_APISERVER_HEALTHCHECK_TAG=1.23.3
 KUBE_APISERVER_HEALTHCHECK_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KUBE_APISERVER_HEALTHCHECK_TAG | awk '{print $$2}')
 
 

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -79,7 +79,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -12,7 +12,7 @@ Contents: |
       - --client-key=/secrets/client.key
       command:
       - /kube-apiserver-healthcheck
-      image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+      image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5ebbe3b0e4f637a12ce76d15baa751e5b9c06d7fd610ca22fa7af5ea794343d2
+    manifestHash: 96d7e4980aa5bc31a2a29a4065db84fad7bbe456cdb427d2096738e8ebca1e22
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
+    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 01711b271a794640d02e73d83e593dda464a06d9b2cbca8c396cbd577295ab75
+    manifestHash: aabfd2646bac3d5f339b1bed641693414f38c8b5b08a7c536b9fbcc55643865a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0ed99bab16253c80782b2045276df8e3522e7e034704ce94b878f25ded5f9e82
+    manifestHash: 61c6927d5e7c71416e836fcd8ecf48b06fb36ea22770eba76d79b4a274768e26
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: bdae68e46a22d6b3b49cb238e8a6295b747cdd069d1022284096d2b8c4418675
+    manifestHash: ed282111072d319a3c0e77bb085d9750c87f738118ff37cb546f56503610f429
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a1776338c97f03f2dfc852343e087a64bc8af03f2fcdd74e15b34458611f5410
+    manifestHash: d58411252c4bb19ca4e1cc506889ac74b60e158018535e754dcfeec11f7047f0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 09d301f4cdfb944b91bd0d98a368563278c68e3ed0b317ba27123721ffea0021
+    manifestHash: 3707521b92032ae70f59e20a561620340c258b00af7c486ae5de68ae25edb81c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4a782d0180352e11b9eed916960938113a3f875cf99d783c4aacbd9517678eea
+    manifestHash: a6c32aec56f6122bffb7a02379748f74c2eab7c97ccfaec09e0bfb25a66a561b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 47fffea4bf6a2c2ce48bb5e5d1be781ea17c72f82f0d6f7a77c9e19b076e019a
+    manifestHash: f3f953803281ad4f0daf7bc116f934e55626ed70e468b191a5ec75be716351eb
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: eb120856b64f9aca05f8102a141fcb239789a21d3d0eba2cb0d39e0e1b03b9b3
+    manifestHash: 28285bc979b7bba7cb27adc273d4e250eb7f33da23d7a5acc7e302db045eb8bf
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 635cd2940b87a609116f3b7c696d3e44267beabd9c7504ee05f957c852d0ec14
+    manifestHash: 1f362698421c03f44cdf76c911eefaed05fc458c7d55cd227a886ebedef05eb4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b2b8802c517b73a3076d301537ecdccf42d167c45f27bfd7e83d4b91e23a243a
+    manifestHash: 41fc7158505e984094529b5267e5d9691641538190fb98db3d9a1efbe5ec30a2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 50db4e3f31a924b5c2834c7e00b92cd6ac74f28fdc00b1ed32b6ea343560e298
+    manifestHash: c2d50c45f8d4fcae3a215f4837bb1741b175d5505b7eb501cdb25e2d0b8494ea
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
+    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 22298145e788fbb48d69ec0c2f709af3527d05cb8eb0d892de7e0a0c70fb077f
+    manifestHash: 83a3ad2437f61243a93be5722650208a7eb443b0165f7d68b0dc78dfd3a40981
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
+    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b6047e990d474cd6a881a61eda787caac20028cc5cf31a9253e6238fb17f084f
+    manifestHash: 09f9c45da7c7c520763828bd2ab61f919abe89f5132479261cb185056396403f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 057cc5a5166a5e050a123464ef7c2f7fc4a39d5c9c592c77a39e5233ceb1dd4c
+    manifestHash: 09177b6ce86654fc4d49740721900f37201d054038b86568c0b2116157a08926
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 43f09285f00b573a5ff76bf48be84922b3a02c1a87b5480ef87f3680a7731cdf
+    manifestHash: ffb2e4e97efb5697cf6864179c64af87be9a9ec7c9960616e43e220a04a29d69
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 057cc5a5166a5e050a123464ef7c2f7fc4a39d5c9c592c77a39e5233ceb1dd4c
+    manifestHash: 09177b6ce86654fc4d49740721900f37201d054038b86568c0b2116157a08926
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 43f09285f00b573a5ff76bf48be84922b3a02c1a87b5480ef87f3680a7731cdf
+    manifestHash: ffb2e4e97efb5697cf6864179c64af87be9a9ec7c9960616e43e220a04a29d69
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 057cc5a5166a5e050a123464ef7c2f7fc4a39d5c9c592c77a39e5233ceb1dd4c
+    manifestHash: 09177b6ce86654fc4d49740721900f37201d054038b86568c0b2116157a08926
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 43f09285f00b573a5ff76bf48be84922b3a02c1a87b5480ef87f3680a7731cdf
+    manifestHash: ffb2e4e97efb5697cf6864179c64af87be9a9ec7c9960616e43e220a04a29d69
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 057cc5a5166a5e050a123464ef7c2f7fc4a39d5c9c592c77a39e5233ceb1dd4c
+    manifestHash: 09177b6ce86654fc4d49740721900f37201d054038b86568c0b2116157a08926
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 43f09285f00b573a5ff76bf48be84922b3a02c1a87b5480ef87f3680a7731cdf
+    manifestHash: ffb2e4e97efb5697cf6864179c64af87be9a9ec7c9960616e43e220a04a29d69
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 31bbef3c77b5c9f37bb15fe6776b267e8161b85a8dc9cfd8cc09c11292d1c476
+    manifestHash: 56af37086104cb56823990384fb059998f64d3d137721209493af3ea7a90ce31
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 062d92c623590973f73c1beef844c8d7516247c9e28036d969f4ce714ae05cf6
+    manifestHash: 497edf4b86b919dc2aff6d92e84cd5cda64bea6b72f5973f38b52c93625ad0ca
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9929aa2e0b7557f84a3e2c72345e5a185a043149e33767584b05f269fc29c49f
+    manifestHash: fb6245e4d9a5d2f567358935242366b364b990161774e2c77adfbb49b7a67d1a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 50db4e3f31a924b5c2834c7e00b92cd6ac74f28fdc00b1ed32b6ea343560e298
+    manifestHash: c2d50c45f8d4fcae3a215f4837bb1741b175d5505b7eb501cdb25e2d0b8494ea
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 66890d43cde81011921b8688e388caa6adcf7a6579a82c043972ea581c229e01
+    manifestHash: 14bc3252c02b612a73028b01e07509cc4b92f4a8624aded8f96241e83a093b62
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 50db4e3f31a924b5c2834c7e00b92cd6ac74f28fdc00b1ed32b6ea343560e298
+    manifestHash: c2d50c45f8d4fcae3a215f4837bb1741b175d5505b7eb501cdb25e2d0b8494ea
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1f2170109a6590d0f067926a4efb189f0ac846ce0e87a3810042ee4db0c277bd
+    manifestHash: c521c897d6471e0f27738571822e1845efcc5909bd7d721f9802452939ce4f61
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: bc5165e9f233dffd91ba7ecdb79b258404d11c94d38d4d986fc6991c50fa4c03
+    manifestHash: c18a1c4a0bd377267a4a498169acc812b13d558ad622ff55717be825352b787e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1f2170109a6590d0f067926a4efb189f0ac846ce0e87a3810042ee4db0c277bd
+    manifestHash: c521c897d6471e0f27738571822e1845efcc5909bd7d721f9802452939ce4f61
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 2f4b9abbdaa570f78e10917a56179704e5774a62ca8cda5a603a6625e2906be6
+    manifestHash: 3a2c2807e13498f25537aafb4f4e2c9bdb6d2169b67fe6f8e107e60a7380c52e
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6508f2654e7a65fb5a1a3a4aa22e1ce7b1f4a02102897a787e732a982b33ae07
+    manifestHash: e95e045f0ad5842a8ac97341406ef59f888b9abfd7cac0a792ae76095193f1c7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6508f2654e7a65fb5a1a3a4aa22e1ce7b1f4a02102897a787e732a982b33ae07
+    manifestHash: e95e045f0ad5842a8ac97341406ef59f888b9abfd7cac0a792ae76095193f1c7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9ed41a562885d91104c199640aa9a0f2ed5beacd86be9eb6fd3c14cbfd891cbc
+    manifestHash: fe8f03fd9d917e73633f005b89d10480ea736158a8c3bec0828c8578015579f5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a90bb9dd73352b042bb47848faefff2205b9e4b100a1f9b1d1294489b11be69d
+    manifestHash: 3d6ba2d177ebf8f6e4130cc0e0f6f83750b9b7327e58d8b26536357b55c563a9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 52fd67b675d3317d13def66151823308e6dc7ac3eddad319088504e54778cea5
+    manifestHash: 91d6b5342c5973a4a16ecf69afbf175e7976a52e568103758b2003d859b167d4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 4d6aa1aedf71e27accd11ae0af11b4d39420ff20e1fb1d843ac0ee92869d1ef3
+    manifestHash: e8fd660e605442d88d0f699f1543b6c977480609b58b796daa0021109c845e64
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 44926af5da4fd51f5f203ac2ea113dcefb9b0d8c4cac3219ceaa7d0b4a58d17a
+    manifestHash: 6e1ac660e669df1c014a944413a59e7aa817d6db013da114da70125cc4e1ddd7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c9cd04d73e54117d30c59525cd5226a24b57d942d4f3b2f40c57fa577756c68c
+    manifestHash: 1e26419c433db91042505363d78c9287c95cade8381b0af578004c60e5943b7e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f881ab47767113b448dc674a91bab6241e7b44bf5910d331c8beff7eaa6b76ab
+    manifestHash: c5e263fef0fdfbf6a01aa8fd1d21bd42b4c6a734e32cf0d65f24e74375f145c1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f1f4e0d6ede152b0d311f380fbeb57dfc0bd961a5915aeae5af729751b966a67
+    manifestHash: 1cf6f267a4dce799f396dd003f47c5cf2619e7ad373c605cd09cc857ddaae397
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b248b2a99e64c3206eb008ea9a9adeb2c76f0625d5ac3527478f85bd75101bf4
+    manifestHash: 70cafb930f38211ff907ccecb48146e27d150d1d8920becbfeb19609a891ded9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 4030a17c69ef9139677fff5d28f16d965c29541b533c468008107e2bb4fe5095
+    manifestHash: 490593652dc1cb24106911675b02f73e61b50e174fe94d20a18d27fa08dfc18d
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 9b6f9b5c8216d3197823507363ff421fe7ec118abd0095df931cd62d6e770b9c
+    manifestHash: 1263b62be25505da4b1d6acac7a25c53f6755254dcb545a773fc08ef9ce2da84
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e34c1a140ab7a03480e1f0db9ef9b3c9e4da3bd135323e565ac08fc6e689ec84
+    manifestHash: 622587b96c933d889f017fdea21f6667bc2020615e97db3fffcfb0b6cb41440f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: da4bd4ee49d4f5f765753236b3615dc818928d8ee062cd63253ca97984112b6f
+    manifestHash: faf836c052bbce50555a8b740438e7216e17d57f5ec2a31b18c63914ca412693
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2bb56955fece14a586e84755295e7f873f5dd7c39d08b4ce36333ba66bc736cd
+    manifestHash: c74e70955cd8bff80ff3330899d1421c9fb120376fd7d5e91b452fda3be020ae
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a26f62c36981960ed3fc87dc9d8ccf4e8b85bda42024517fe3b2cde6395be06f
+    manifestHash: ec3eaf2643ead4b0975a777b452c47a3f24358e4f713e3804fbc513559892427
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
+    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ffc7b674441492e13c0372f2329cef0159f8b53268ad87e691729897f9b8ce83
+    manifestHash: b47b3119e6ae46c943a052197cd56bf61542697499a41e6cbe0fbd5efd5c9059
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 06ba868a86f56d545aca822d63454420d1e9fe35b201817fedeaf15b4cb79ddd
+    manifestHash: a707ee820f42106ccc331c872d49ee506b704a5d804c7ad42f38fe5cf463b5ff
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f83d0e914fa805cc7650b56cf1953742c4effd1004e4160c3b304abdfe6e208d
+    manifestHash: 2420e372ef1cb0d233aadcb4eb10fd54647173ddd2f34d294b26c27ec1616781
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.2
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f289dc17ee978e2a80d0bf27277bac1a688c8c29dbe1191e62aae34f8ed38f7
+    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
 spec:
   replicas: 1
   strategy:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.23.2
+        version: v1.23.3
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -38,7 +38,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
 spec:
   selector:
     matchLabels:
@@ -31,7 +31,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.23.2
+        version: v1.23.3
 {{ if UseKopsControllerForNodeBootstrap }}
       annotations:
         dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
@@ -53,7 +53,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 782b6cf94a38cdc5b6efde0d119101dc55b65d534f5e5bef50d6e6a5d1899284
+    manifestHash: ea11d747b0efe5c1e7cf795e0c525006a4268d7d77ff037f4319a1a91d8d1622
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 782b6cf94a38cdc5b6efde0d119101dc55b65d534f5e5bef50d6e6a5d1899284
+    manifestHash: ea11d747b0efe5c1e7cf795e0c525006a4268d7d77ff037f4319a1a91d8d1622
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 782b6cf94a38cdc5b6efde0d119101dc55b65d534f5e5bef50d6e6a5d1899284
+    manifestHash: ea11d747b0efe5c1e7cf795e0c525006a4268d7d77ff037f4319a1a91d8d1622
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.2
+    version: v1.23.3
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.2
+        image: k8s.gcr.io/kops/dns-controller:1.23.3
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 853c5c311c25559376ae5b7f8b1c144571248b9c06d5fd2cd75cdb2231b6d75f
+    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.2
+    version: v1.23.3
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.2
+        version: v1.23.3
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.2
+        image: k8s.gcr.io/kops/kops-controller:1.23.3
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f57e126003c360718c3de31a425f059b266d9a8498fadb7cb295ab78429f8c7e
+    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 89912a365e02b0fb54d728e2fdd6185c726401e49adc1b9aa9ea51d225f8c221
+    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/urls_test.go
+++ b/upup/pkg/fi/cloudup/urls_test.go
@@ -36,29 +36,29 @@ func Test_BuildMirroredAsset(t *testing.T) {
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-amd64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.2/images/protokube-linux-amd64",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.2/images-protokube-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.3/images/protokube-linux-amd64",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.3/images-protokube-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-arm64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.2/images/protokube-linux-arm64",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.2/images-protokube-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.3/images/protokube-linux-arm64",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.3/images-protokube-linux-arm64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/amd64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.2/linux/amd64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.2/nodeup-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.3/linux/amd64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.3/nodeup-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/arm64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.2/linux/arm64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.2/nodeup-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.3/linux/arm64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.3/nodeup-linux-arm64",
 			},
 		},
 	}

--- a/version.go
+++ b/version.go
@@ -21,8 +21,8 @@ var Version = KOPS_RELEASE_VERSION
 
 // These constants are parsed by build tooling - be careful about changing the formats
 const (
-	KOPS_RELEASE_VERSION = "1.23.2"
-	KOPS_CI_VERSION      = "1.23.3"
+	KOPS_RELEASE_VERSION = "1.23.3"
+	KOPS_CI_VERSION      = "1.23.4"
 )
 
 // GitVersion should be replaced by the makefile


### PR DESCRIPTION
- Make service topology for cilium configurable
- Remove support for Weave as of k8s 1.23
- Update Go to v1.17.5
- Update controller-runtime to v0.11.0
- Update containerd to v1.6.0-beta.4
- Run hack/update-expected.sh
- Ignore images hosted in private ECR repositories as containerd cannot actually pull these
- Prevent creation of unsupported etcd clusters
- Update k8s dependencies to v1.23.1
- Remove TerraformJSON feature flag and functionality
- Remove unused json field tags from terraform structs
- Remove remaining references to TerraformJSON feature flag
- Add managed-by label to static kube-proxy pods
- Kube components log to stdout
- Fix OpenStack SecurityGroupRule/LB with IPv6 CIDR
- external CCM for GCE
- generated: ./hack/update-bazel.sh
- update deps
- Migrate to GCE CCM in k8s 1.24
- Bump Cluster Autoscaler and update manifest
- Remove the v1alpha3 API version
- force update dependencies
- Add action for automatically tagging releases
- Remove temporary restrictions on automatically tagging releases
- Bump external-snapshotted to v5.0.0
- Support price and priority cluster-autoscaler expanders.
- Fix CRDs, clarify docs, and add cloud provider check for price expander.
- Warn that the price expander is only supported on GCE in the docs.
- Less crashing when validating.
- Fix StringValue nit
- Keep docs DRY.
- fix ipv4+ipv6 sec groups/listeners in OpenStack
- make gazelle
- Update containerd to v1.6.0-beta.5
- Run hack/update-expected.sh
- Update containerd to v1.6.0-rc.0
- Run hack/update-expected.sh
- Don't try to add node name to instances without node object
- Do not create an IAM role for dns-controller on gossip clusters
- Add DescribeRegions to nodeup privs
- Create helper function for ec2 create/tag-on-create IAM permissions
- Remove tag condition on listeners
- Update to aws-sdk-go to v1.42.37
- use 1.23.1 ccm for openstack
- expose external ccm metrics for OpenStack
- OpenStack - Add loadbalancer pool monitor to API LB
- Bump CCM images
- No need to set kubelet in tests
- Don't set legacy IAM by default
- Update pause image to v3.6
- Run hack/update-expected.sh
- Bump etcd-manager to v3.0.20220128
- JWKS / IRSA: Expose public ACLs to terraform
- add drain-timeout flag to rolling-update cluster
- Use etcd-manager pre-release until final release has been cut
- Update Calico to v3.21.2
- Update Canal to v3.21.2
- Run hack/update-expected.sh
- Update Calico to v3.21.4
- Update Canal to v3.21.4
- Run hack/update-expected.sh
- Fix etcd-manager for ipv6
- Update containerd to v1.6.0-rc.2
- Run hack/update-expected.sh
- Fix CSI migration feature gates
- Remove snapshot controller dependency on ebs csi driver
- always enable Leader Election
- always enable Leader Election
- generated: ./hack/update-expected.sh
- use pkg/flagbuilder to build argv
- update test ordering and tests for leader election.
- generated: ./hack/update-bazel.sh
- generated: ./hack/update-expected.sh
- Update containerd to v1.6.0-rc.3
- Run hack/update-expected.sh
- always enable Leader Election
- Minor fix for json response to keep it consistent for single or multiple clusters
- Fix irsa for k8s < 1.20
- Add test for irsa on k8s 1.19
- Refactor serviceaccountissuerdiscovery validation
- Add support for graceful node shutdown
- hack update-expected
- Install runc from opencontainers/runc
- Run hack/update-expected.sh
- Do not enable graceful shutdown if k8s version < 1.21
- Fix nilpointer when graceful shutdown is not configured
- update expected
- Install contained from the release package
- Run hack/update-expected.sh
- Bump aws-cni to 1.10.2
- Align manifest with master of aws-cni repo
- Apply suggestions
- Run hack/update-expected.sh
- Allow PrefixList for sshAccess and kubernetesApiAccess
- Update containerd to v1.6.0
- Run hack/update-expected.sh
- Update LBC to 2.4.0
- Disable some flags in kube-apiserver when logging-format is not text
- Enable RBN with AWS CCM 1.22.0-alpha.1
- Improve HA for various addons
- LBC has to run on the control plane, so set replicas accordingly
- Validate taints in IG spec
- Prevent populate ig from adding nvidia taint if it has already been set
- Fix backporting issues
- Do not create a cert-manager namespace
- Add missing permissions to aws lbc for irsa
- Initial changes for vpc
- Release 1.23.0-beta.2
- Update to etcd-manager v3.0.20220203
- Update expected test output for etcd-manager bump
- use own function to define CSI image version
- Add support to install EKS Pod Identity Webhook
- Add managed-by label to addon pods
- Use cert-manager and pod-identity-webhook in integration test of irsa
- Update addons document for Pod Identity Webhook
- Add PodDisruptionBudget and topologySpreadConstraints for eks-pod-identity-webhook
- Minor cleanup of the Deployment
- Update expected test data
- check if UsePolicyConfigMap flag is true
- use suggested changes
- add support for ed25519 keys
- Bump AWS SDK to v1.43.11
- Update containerd to v1.6.1
- Run hack/update-expected.sh
- Use proper image and add health check
- Release 1.23.0 (#13339)
- Add missing permissions to aws lbc for IP targeting
- Allow taints with unique key,value,effect
- Add protocol explicitly to services
- Add integration test for really long cluster names
- If kubetest2 fails cluster validation, we run down before exiting
- Truncate the standard role names
- update k8s dependencies
- Correctly detect GovCloud regions
- Update golangci-lint to v1.45.0
- Do not return a '-1' exit if no keys found and json/yaml output
- Require tag on create for external AWS CCM
- Add a k8s 1.23 version of the ccm test
- Push partition into the policy struct
- Add CreateSecurityGroup permission for vpcs
- Update containerd to v1.6.2
- Run hack/update-expected.sh
- Add back hash for containerd v1.6.1
- Enable etcd corruption check as mitigatio of 3.5 corruption issue
- Pick the right OS server group when creating cloud groups
- Only delete node object on GCE
- Remove checks that doesn't work when we do not delete the node object
- bump aws cni to version 1.10.3
- output of hack/update-expected.sh
- Update Calico to v3.21.5
- Update Canal to v3.21.5
- Run hack/update-expected.sh
- Update to etcd-manager 3.0.20220417
- Revert "Enable etcd corruption check as mitigatio of 3.5 corruption issue"
- Use etcd 3.5.3 instead of 3.5.1
- Update test data for etcd 3.5.3
- Bump CCM 1.22 and 1.23 images to stable versions
- Revert to using 1.23.0-alpha.0 for AWS CCM
- Run hack/update-expected.sh
- Update aws-sdk-go to v1.43.41
- add cluster autoscaler pod annotations
- add apimachinery generations
- change template yaml
- Release 1.23.1 (#13527)
- Allow cluster autoscaler to get EC2 instance types
- Use a pointer type in type assertion
- Update Go to v1.17.9
- Add back support for Ubuntu 18.04
- Add support for Rocky Linux 8
- Update Canal's Flannel to v0.15.1
- Include sysctls in toolbox dump
- Fix OIDC Provider cleanup
- Re-add net.bridge settings for flannel
- Update containerd to v1.6.3
- Run hack/update-expected.sh
- Revert "Update containerd to v1.6.3"
- Revert "Run hack/update-expected.sh"
- Fix unexpected type for object metadata when using gossip DNS
- Update containerd to v1.6.4
- Run hack/update-expected.sh
- Update etcd-manager to v3.0.20220503
- Run hack/update-expected.sh
- Add hashes for containerd and Docker in order to fix CVE-2022-23648
- Avoid resolv.conf file loopback for Flatcar distro
- Release 1.23.2 (#13630)
- Increase timeout for pushing binaries to staging
- Update runc to v1.1.2
- Run hack/update-expected.sh
- Add a nameservers parameter for cert-manager
- Remove unused DNS logic from Protokube
- Run hack/update-bazel.sh
- Fix Protokube gossip flag
- Add hashes for latest Docker versions
- Update Docker to v20.10.17
- Run hack/update-expected.sh
- Add hashes for latest containerd versions
- Update containerd to v1.6.6
- Run hack/update-expected.sh
- Update containerd fallback to v1.4.13
- Fix codegen targets and whitespace errors in Makefile
- Add support for setting mode field on file assets
- Update documentation for fileAssets and fix whitespace error
- Fix API group being incorrect for ingresses
- Update after running hack/update-expected.sh
- Update runc to v1.1.3
- Run hack/update-expected.sh
- Update AWS CCM images for k8s 1.20-1.22
- Run hack/update-expected.sh
- Avoid spurious changes with ed25519 keys
- Update etcd-manager to v3.0.20220617
- Run hack/update-expected.sh
- Mount /etc/hosts from host for CoreDNS
- Run hack/update-expected.sh
- Update etcd-manager to v3.0.20220717
- Run hack/update-expected.sh
- Update Go to v1.17.12
- Switch to latest MacOS version for CI
- Revert to using instance private DNS name to lookup hostname
- Run hack/update-bazel.sh
- Check keyset existence before attempting to distrust
- Fix SIGSEGV when deleting a Hetzner instance
- Release 1.23.3
