### PR TITLE
Remove namespaces from cluster-scoped resources in CNI manifests

### DIFF
--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 9493d40dd966279ba340de08b22472ce14e16da49b269fe3b2cf428735ba0972
+    manifestHash: c58a7acc6ed931d26b59892beb1f43e240fd51cbde223e3d95e15b3e04ced54d
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-networking.weave-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-networking.weave-k8s-1.12_content
@@ -22,7 +22,6 @@ metadata:
     name: weave-net
     role.kubernetes.io/networking: "1"
   name: weave-net
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -70,7 +69,6 @@ metadata:
     name: weave-net
     role.kubernetes.io/networking: "1"
   name: weave-net
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: 9493d40dd966279ba340de08b22472ce14e16da49b269fe3b2cf428735ba0972
+    manifestHash: c58a7acc6ed931d26b59892beb1f43e240fd51cbde223e3d95e15b3e04ced54d
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-networking.weave-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-networking.weave-k8s-1.12_content
@@ -22,7 +22,6 @@ metadata:
     name: weave-net
     role.kubernetes.io/networking: "1"
   name: weave-net
-  namespace: kube-system
 rules:
 - apiGroups:
   - ""
@@ -70,7 +69,6 @@ metadata:
     name: weave-net
     role.kubernetes.io/networking: "1"
   name: weave-net
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.12.yaml.template
@@ -146,7 +146,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""

--- a/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.weave/k8s-1.12.yaml.template
@@ -25,7 +25,6 @@ metadata:
   name: weave-net
   labels:
     name: weave-net
-  namespace: kube-system
 rules:
   - apiGroups:
       - ''
@@ -67,7 +66,6 @@ metadata:
   name: weave-net
   labels:
     name: weave-net
-  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: weave-net

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: networking.weave/k8s-1.12.yaml
-    manifestHash: eb848eaccd84305e17ea213aa255625fb3c35cc76fd2386adbc5385e2ed72557
+    manifestHash: 88a53d6a9d91f7515d7d369200e3773db2244222bbb964a5119611b45a6db1d6
     name: networking.weave
     selector:
       role.kubernetes.io/networking: "1"


### PR DESCRIPTION
should fix these jobs:

https://testgrid.k8s.io/kops-network-plugins#kops-aws-cni-kuberouter

https://testgrid.k8s.io/kops-network-plugins#kops-aws-cni-weave


[protokube](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-cni-weave/1552757304317710336/artifacts/ip-172-20-59-182.ap-northeast-2.compute.internal/protokube.log) reports these errors:

`updating "networking.weave": error applying update from "s3://k8s-kops-prow/e2e-e2e-kops-aws-cni-weave.test-cncf-aws.k8s.io/addons/networking.weave/k8s-1.12.yaml": failed to apply objects of kind rbac.authorization.k8s.io/v1, Kind=ClusterRole: namespace was set for cluster-scoped object "kube-system/weave-net"; failed to apply objects of kind rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding: namespace was set for cluster-scoped object "kube-system/weave-net"`