### PR TITLE
Use cabundle for etcd CA files to fix key rotation in HA clusters

### DIFF
--- a/nodeup/pkg/model/etcd_manager_tls.go
+++ b/nodeup/pkg/model/etcd_manager_tls.go
@@ -17,7 +17,10 @@ limitations under the License.
 package model
 
 import (
+	"path/filepath"
+
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 )
 
 // EtcdManagerTLSBuilder configures TLS support for etcd-manager
@@ -50,9 +53,16 @@ func (b *EtcdManagerTLSBuilder) Build(ctx *fi.ModelBuilderContext) error {
 		}
 
 		for fileName, keystoreName := range keys {
-			if err := b.buildCertificatePairTask(ctx, keystoreName, d, fileName, nil, nil, true); err != nil {
+			if err := b.buildCertificatePairTask(ctx, keystoreName, d, fileName, nil, nil, false); err != nil {
 				return err
 			}
+			ctx.AddTask(&nodetasks.File{
+				Path:     filepath.Join(d, fileName+".crt"),
+				Contents: fi.NewStringResource(b.NodeupConfig.CAs[keystoreName]),
+				Type:     nodetasks.FileType_File,
+				Mode:     fi.String("0644"),
+			})
+
 		}
 	}
 


### PR DESCRIPTION
etcd-manager should accept using bundles already, and it will match current cert by matching with the primary key.

Fixes #14037