### PR TITLE
Use stable kops release for kops 1.21

### DIFF
--- a/tests/e2e/scenarios/addon-resource-tracking/run-test.sh
+++ b/tests/e2e/scenarios/addon-resource-tracking/run-test.sh
@@ -26,7 +26,7 @@ function haveds() {
 # Start a cluster with an old version of channel
 
 export KOPS_BASE_URL
-KOPS_BASE_URL="$(curl -s https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.21/latest-ci.txt)"
+KOPS_BASE_URL="https://artifacts.k8s.io/binaries/kops/1.21.5"
 KOPS=$(kops-download-from-base)
 
 # Start with a cluster running nodeTerminationHandler


### PR DESCRIPTION
The staging artifacts for 1.21 has been removed, so using stable instead.