### PR TITLE
Wait for load balancer to be ready for Hetzner

### DIFF
--- a/pkg/model/bootstrapscript.go
+++ b/pkg/model/bootstrapscript.go
@@ -86,7 +86,8 @@ func (b *BootstrapScript) kubeEnv(ig *kops.InstanceGroup, c *fi.Context) (string
 			return "", fmt.Errorf("error finding address for %v: %v", hasAddress, err)
 		}
 		if len(addresses) == 0 {
-			klog.Warningf("Task did not have an address: %v", hasAddress)
+			// Such tasks won't have an address in dry-run mode, until the resource is created
+			klog.V(2).Infof("Task did not have an address: %v", hasAddress)
 			continue
 		}
 		for _, address := range addresses {

--- a/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
+++ b/upup/pkg/fi/cloudup/hetznertasks/loadbalancer.go
@@ -54,11 +54,12 @@ func (e *LoadBalancer) IsForAPIServer() bool {
 }
 
 func (v *LoadBalancer) FindAddresses(c *fi.Context) ([]string, error) {
+	ctx := context.TODO()
 	cloud := c.Cloud.(hetzner.HetznerCloud)
 	client := cloud.LoadBalancerClient()
 
 	// TODO(hakman): Find using label selector
-	loadbalancers, err := client.All(context.TODO())
+	loadbalancers, err := client.All(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +67,14 @@ func (v *LoadBalancer) FindAddresses(c *fi.Context) ([]string, error) {
 	for _, loadbalancer := range loadbalancers {
 		if loadbalancer.Name == fi.StringValue(v.Name) {
 			var addresses []string
+			if loadbalancer.PublicNet.IPv4.IP == nil {
+				return nil, fmt.Errorf("failed to find load-balancer %q public address", fi.StringValue(v.Name))
+			}
 			addresses = append(addresses, loadbalancer.PublicNet.IPv4.IP.String())
 			for _, privateNetwork := range loadbalancer.PrivateNet {
+				if privateNetwork.IP == nil {
+					return nil, fmt.Errorf("failed to find load-balancer %q private address", fi.StringValue(v.Name))
+				}
 				addresses = append(addresses, privateNetwork.IP.String())
 			}
 			return addresses, nil
@@ -78,11 +85,12 @@ func (v *LoadBalancer) FindAddresses(c *fi.Context) ([]string, error) {
 }
 
 func (v *LoadBalancer) Find(c *fi.Context) (*LoadBalancer, error) {
+	ctx := context.TODO()
 	cloud := c.Cloud.(hetzner.HetznerCloud)
 	client := cloud.LoadBalancerClient()
 
 	// TODO(hakman): Find using label selector
-	loadbalancers, err := client.All(context.TODO())
+	loadbalancers, err := client.All(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -174,9 +182,10 @@ func (_ *LoadBalancer) CheckChanges(a, e, changes *LoadBalancer) error {
 }
 
 func (_ *LoadBalancer) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes *LoadBalancer) error {
+	ctx := context.TODO()
+	actionClient := t.Cloud.ActionClient()
 	client := t.Cloud.LoadBalancerClient()
 
-	var loadbalancer *hcloud.LoadBalancer
 	if a == nil {
 		if e.Network == nil {
 			return fmt.Errorf("failed to find network for loadbalancer %q", fi.StringValue(e.Name))
@@ -201,26 +210,38 @@ func (_ *LoadBalancer) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes 
 					DestinationPort: fi.Int(443),
 				},
 			},
+			Targets: []hcloud.LoadBalancerCreateOptsTarget{
+				{
+					Type: hcloud.LoadBalancerTargetTypeLabelSelector,
+					LabelSelector: hcloud.LoadBalancerCreateOptsTargetLabelSelector{
+						Selector: e.Target,
+					},
+					UsePrivateIP: fi.Bool(true),
+				},
+			},
 			Network: &hcloud.Network{
 				ID: fi.IntValue(e.Network.ID),
 			},
 		}
-		result, _, err := client.Create(context.TODO(), opts)
+		result, _, err := client.Create(ctx, opts)
 		if err != nil {
 			return err
 		}
-		loadbalancer = result.LoadBalancer
+		_, errCh := actionClient.WatchProgress(ctx, result.Action)
+		if err := <-errCh; err != nil {
+			return err
+		}
 
 	} else {
 		var err error
-		loadbalancer, _, err = client.Get(context.TODO(), strconv.Itoa(fi.IntValue(a.ID)))
+		loadbalancer, _, err := client.Get(ctx, strconv.Itoa(fi.IntValue(a.ID)))
 		if err != nil {
 			return err
 		}
 
 		// Update the labels
 		if changes.Name != nil || len(changes.Labels) != 0 {
-			_, _, err := client.Update(context.TODO(), loadbalancer, hcloud.LoadBalancerUpdateOpts{
+			_, _, err := client.Update(ctx, loadbalancer, hcloud.LoadBalancerUpdateOpts{
 				Name:   fi.StringValue(e.Name),
 				Labels: e.Labels,
 			})
@@ -232,7 +253,7 @@ func (_ *LoadBalancer) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes 
 		// Update the services
 		if len(changes.Services) > 0 {
 			for _, service := range e.Services {
-				_, _, err := client.AddService(context.TODO(), loadbalancer, hcloud.LoadBalancerAddServiceOpts{
+				action, _, err := client.AddService(ctx, loadbalancer, hcloud.LoadBalancerAddServiceOpts{
 					Protocol:        hcloud.LoadBalancerServiceProtocol(service.Protocol),
 					ListenPort:      service.ListenerPort,
 					DestinationPort: service.DestinationPort,
@@ -242,20 +263,24 @@ func (_ *LoadBalancer) RenderHetzner(t *hetzner.HetznerAPITarget, a, e, changes 
 						return err
 					}
 				}
+				_, errCh := actionClient.WatchProgress(ctx, action)
+				if err := <-errCh; err != nil {
+					return err
+				}
 			}
 		}
 
-	}
-
-	// Add the target separately, otherwise UsePrivateIP cannot be set
-	// https://github.com/hetznercloud/hcloud-go/pull/198
-	if a == nil || a.Target == "" {
-		_, _, err := client.AddLabelSelectorTarget(context.TODO(), loadbalancer, hcloud.LoadBalancerAddLabelSelectorTargetOpts{
-			Selector:     e.Target,
-			UsePrivateIP: fi.Bool(true),
-		})
-		if err != nil {
+		// Update the targets
+		if a.Target == "" {
+			action, _, err := client.AddLabelSelectorTarget(ctx, loadbalancer, hcloud.LoadBalancerAddLabelSelectorTargetOpts{
+				Selector:     e.Target,
+				UsePrivateIP: fi.Bool(true),
+			})
 			if err != nil {
+				return err
+			}
+			_, errCh := actionClient.WatchProgress(ctx, action)
+			if err := <-errCh; err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
`FindAddresses()` may run before the public addresses are allocated and the Kubernetes API certificate will not work.