### PR TITLE
Automated cherry pick of #14054: Use cabundle for etcd CA files

### DIFF
--- a/nodeup/pkg/model/etcd_manager_tls.go
+++ b/nodeup/pkg/model/etcd_manager_tls.go
@@ -17,7 +17,10 @@ limitations under the License.
 package model
 
 import (
+	"path/filepath"
+
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/nodeup/nodetasks"
 )
 
 // EtcdManagerTLSBuilder configures TLS support for etcd-manager
@@ -50,9 +53,16 @@ func (b *EtcdManagerTLSBuilder) Build(ctx *fi.ModelBuilderContext) error {
 		}
 
 		for fileName, keystoreName := range keys {
-			if err := b.buildCertificatePairTask(ctx, keystoreName, d, fileName, nil, nil, true); err != nil {
+			if err := b.buildCertificatePairTask(ctx, keystoreName, d, fileName, nil, nil, false); err != nil {
 				return err
 			}
+			ctx.AddTask(&nodetasks.File{
+				Path:     filepath.Join(d, fileName+".crt"),
+				Contents: fi.NewStringResource(b.NodeupConfig.CAs[keystoreName]),
+				Type:     nodetasks.FileType_File,
+				Mode:     fi.String("0644"),
+			})
+
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #14054 on release-1.24.

#14054: Use cabundle for etcd CA files

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```