### PR TITLE
Merge cmd factories

### DIFF
--- a/channels/cmd/channels/main.go
+++ b/channels/cmd/channels/main.go
@@ -22,12 +22,13 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/kops/channels/pkg/cmd"
+	"k8s.io/kops/cmd/kops/util"
 )
 
 func main() {
 	klog.InitFlags(nil)
 
-	f := &cmd.DefaultFactory{}
+	f := util.NewFactory(nil)
 	if err := cmd.Execute(f, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "\n%v\n", err)
 		os.Exit(1)

--- a/cmd/kops/create.go
+++ b/cmd/kops/create.go
@@ -95,7 +95,7 @@ func NewCmdCreate(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunCreate(ctx context.Context, f *util.Factory, out io.Writer, c *CreateOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -488,7 +488,7 @@ func RunCreateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Cr
 		}
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_cluster_integration_test.go
+++ b/cmd/kops/create_cluster_integration_test.go
@@ -222,7 +222,7 @@ func runCreateClusterIntegrationTest(t *testing.T, srcDir string, version string
 		}
 	}
 
-	clientset, err := factory.Clientset()
+	clientset, err := factory.KopsClient()
 	if err != nil {
 		t.Fatalf("error getting clientset: %v", err)
 	}

--- a/cmd/kops/create_instancegroup.go
+++ b/cmd/kops/create_instancegroup.go
@@ -154,7 +154,7 @@ func RunCreateInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer,
 		return fmt.Errorf("error getting cluster: %q: %v", options.ClusterName, err)
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_keypair.go
+++ b/cmd/kops/create_keypair.go
@@ -153,7 +153,7 @@ func RunCreateKeypair(ctx context.Context, f *util.Factory, out io.Writer, optio
 		return fmt.Errorf("error getting cluster: %q: %v", options.ClusterName, err)
 	}
 
-	clientSet, err := f.Clientset()
+	clientSet, err := f.KopsClient()
 	if err != nil {
 		return fmt.Errorf("error getting clientset: %v", err)
 	}

--- a/cmd/kops/create_secret_ciliumpassword.go
+++ b/cmd/kops/create_secret_ciliumpassword.go
@@ -85,13 +85,13 @@ func NewCmdCreateSecretCiliumPassword(f *util.Factory, out io.Writer) *cobra.Com
 	return cmd
 }
 
-func RunCreateSecretCiliumEncryptionConfig(ctx context.Context, f *util.Factory, out io.Writer, options *CreateSecretCiliumPasswordOptions) error {
+func RunCreateSecretCiliumEncryptionConfig(ctx context.Context, f commandutils.Factory, out io.Writer, options *CreateSecretCiliumPasswordOptions) error {
 	cluster, err := GetCluster(ctx, f, options.ClusterName)
 	if err != nil {
 		return err
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_secret_dockerconfig.go
+++ b/cmd/kops/create_secret_dockerconfig.go
@@ -90,13 +90,13 @@ func NewCmdCreateSecretDockerConfig(f *util.Factory, out io.Writer) *cobra.Comma
 	return cmd
 }
 
-func RunCreateSecretDockerConfig(ctx context.Context, f *util.Factory, out io.Writer, options *CreateSecretDockerConfigOptions) error {
+func RunCreateSecretDockerConfig(ctx context.Context, f commandutils.Factory, out io.Writer, options *CreateSecretDockerConfigOptions) error {
 	cluster, err := GetCluster(ctx, f, options.ClusterName)
 	if err != nil {
 		return err
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_secret_encryptionconfig.go
+++ b/cmd/kops/create_secret_encryptionconfig.go
@@ -84,13 +84,13 @@ func NewCmdCreateSecretEncryptionConfig(f *util.Factory, out io.Writer) *cobra.C
 	return cmd
 }
 
-func RunCreateSecretEncryptionConfig(ctx context.Context, f *util.Factory, out io.Writer, options *CreateSecretEncryptionConfigOptions) error {
+func RunCreateSecretEncryptionConfig(ctx context.Context, f commandutils.Factory, out io.Writer, options *CreateSecretEncryptionConfigOptions) error {
 	cluster, err := GetCluster(ctx, f, options.ClusterName)
 	if err != nil {
 		return err
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_secret_weavepassword.go
+++ b/cmd/kops/create_secret_weavepassword.go
@@ -88,7 +88,7 @@ func NewCmdCreateSecretWeavePassword(f *util.Factory, out io.Writer) *cobra.Comm
 	return cmd
 }
 
-func RunCreateSecretWeavePassword(ctx context.Context, f *util.Factory, out io.Writer, options *CreateSecretWeavePasswordOptions) error {
+func RunCreateSecretWeavePassword(ctx context.Context, f commandutils.Factory, out io.Writer, options *CreateSecretWeavePasswordOptions) error {
 	secret, err := fi.CreateSecret()
 	if err != nil {
 		return fmt.Errorf("creating Weave password: %v", err)
@@ -99,7 +99,7 @@ func RunCreateSecretWeavePassword(ctx context.Context, f *util.Factory, out io.W
 		return err
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/create_sshpublickey.go
+++ b/cmd/kops/create_sshpublickey.go
@@ -86,7 +86,7 @@ func RunCreateSSHPublicKey(ctx context.Context, f *util.Factory, out io.Writer, 
 		return err
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -186,7 +186,7 @@ func RunDeleteCluster(ctx context.Context, f *util.Factory, out io.Writer, optio
 			}
 			return nil
 		}
-		clientset, err := f.Clientset()
+		clientset, err := f.KopsClient()
 		if err != nil {
 			return err
 		}

--- a/cmd/kops/delete_instance.go
+++ b/cmd/kops/delete_instance.go
@@ -153,7 +153,7 @@ func NewCmdDeleteInstance(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunDeleteInstance(ctx context.Context, f *util.Factory, out io.Writer, options *DeleteInstanceOptions) error {
-	clientSet, err := f.Clientset()
+	clientSet, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/delete_instancegroup.go
+++ b/cmd/kops/delete_instancegroup.go
@@ -133,7 +133,7 @@ func RunDeleteInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer,
 		return err
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/delete_secret.go
+++ b/cmd/kops/delete_secret.go
@@ -93,7 +93,7 @@ func RunDeleteSecret(ctx context.Context, f *util.Factory, out io.Writer, option
 		})
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/delete_sshpublickey.go
+++ b/cmd/kops/delete_sshpublickey.go
@@ -62,7 +62,7 @@ func NewCmdDeleteSSHPublicKey(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunDeleteSSHPublicKey(ctx context.Context, f *util.Factory, out io.Writer, options *DeleteSSHPublicKeyOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/distrust_keypair.go
+++ b/cmd/kops/distrust_keypair.go
@@ -109,7 +109,7 @@ func NewCmdDistrustKeypair(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunDistrustKeypair(ctx context.Context, f *util.Factory, out io.Writer, options *DistrustKeypairOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -110,7 +110,7 @@ func RunEditCluster(ctx context.Context, f *util.Factory, out io.Writer, options
 		return err
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/edit_instancegroup.go
+++ b/cmd/kops/edit_instancegroup.go
@@ -135,7 +135,7 @@ func RunEditInstanceGroup(ctx context.Context, f *util.Factory, out io.Writer, o
 		klog.Warningf("%v", err)
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/export_kubeconfig.go
+++ b/cmd/kops/export_kubeconfig.go
@@ -107,7 +107,7 @@ func NewCmdExportKubeconfig(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunExportKubeconfig(ctx context.Context, f *util.Factory, out io.Writer, options *ExportKubeconfigOptions, args []string) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get.go
+++ b/cmd/kops/get.go
@@ -99,7 +99,7 @@ func NewCmdGet(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunGet(ctx context.Context, f commandutils.Factory, out io.Writer, options *GetOptions) error {
-	client, err := f.Clientset()
+	client, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_cluster.go
+++ b/cmd/kops/get_cluster.go
@@ -118,7 +118,7 @@ func NewCmdGetCluster(f *util.Factory, out io.Writer, getOptions *GetOptions) *c
 }
 
 func RunGetClusters(ctx context.Context, f commandutils.Factory, out io.Writer, options *GetClusterOptions) error {
-	client, err := f.Clientset()
+	client, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_instancegroups.go
+++ b/cmd/kops/get_instancegroups.go
@@ -89,7 +89,7 @@ func NewCmdGetInstanceGroups(f *util.Factory, out io.Writer, getOptions *GetOpti
 }
 
 func RunGetInstanceGroups(ctx context.Context, f commandutils.Factory, out io.Writer, options *GetInstanceGroupsOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_instances.go
+++ b/cmd/kops/get_instances.go
@@ -81,7 +81,7 @@ func NewCmdGetInstances(f *util.Factory, out io.Writer, options *GetOptions) *co
 }
 
 func RunGetInstances(ctx context.Context, f *util.Factory, out io.Writer, options *GetOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_keypairs.go
+++ b/cmd/kops/get_keypairs.go
@@ -156,7 +156,7 @@ func listKeypairs(keyStore fi.CAStore, names []string, includeDistrusted bool) (
 }
 
 func RunGetKeypairs(ctx context.Context, f commandutils.Factory, out io.Writer, options *GetKeypairsOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_secrets.go
+++ b/cmd/kops/get_secrets.go
@@ -110,7 +110,7 @@ func RunGetSecrets(ctx context.Context, f *util.Factory, out io.Writer, options 
 		return fmt.Errorf("unknown secret type %q", options.Type)
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/get_sshpublickeys.go
+++ b/cmd/kops/get_sshpublickeys.go
@@ -70,7 +70,7 @@ type SSHKeyItem struct {
 }
 
 func RunGetSSHPublicKeys(ctx context.Context, f *util.Factory, out io.Writer, options *GetSSHPublicKeysOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/integration_test.go
+++ b/cmd/kops/integration_test.go
@@ -1040,7 +1040,7 @@ func (i *integrationTest) setupCluster(t *testing.T, inputYAML string, ctx conte
 		t.Fatalf("error getting cluster: %v", err)
 	}
 
-	clientSet, err := factory.Clientset()
+	clientSet, err := factory.KopsClient()
 	if err != nil {
 		t.Fatalf("error getting clientset: %v", err)
 	}

--- a/cmd/kops/lifecycle_integration_test.go
+++ b/cmd/kops/lifecycle_integration_test.go
@@ -210,7 +210,7 @@ func runLifecycleTest(h *testutils.IntegrationTestHarness, o *LifecycleTestOptio
 		if err != nil {
 			t.Fatalf("error getting cluster: %v", err)
 		}
-		clientset, err := factory.Clientset()
+		clientset, err := factory.KopsClient()
 		if err != nil {
 			t.Fatalf("error getting clientset: %v", err)
 		}

--- a/cmd/kops/promote_keypair.go
+++ b/cmd/kops/promote_keypair.go
@@ -123,7 +123,7 @@ func RunPromoteKeypair(ctx context.Context, f *util.Factory, out io.Writer, opti
 		return fmt.Errorf("getting cluster: %q: %v", options.ClusterName, err)
 	}
 
-	clientSet, err := f.Clientset()
+	clientSet, err := f.KopsClient()
 	if err != nil {
 		return fmt.Errorf("getting clientset: %v", err)
 	}

--- a/cmd/kops/replace.go
+++ b/cmd/kops/replace.go
@@ -85,7 +85,7 @@ func NewCmdReplace(f *util.Factory, out io.Writer) *cobra.Command {
 
 // RunReplace processes the replace command
 func RunReplace(ctx context.Context, f *util.Factory, out io.Writer, c *ReplaceOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -218,7 +218,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunRollingUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, options *RollingUpdateOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -311,7 +311,7 @@ func GetCluster(ctx context.Context, factory commandutils.Factory, clusterName s
 		return nil, field.Required(field.NewPath("clusterName"), "Cluster name is required")
 	}
 
-	clientset, err := factory.Clientset()
+	clientset, err := factory.KopsClient()
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +361,7 @@ func GetClusterForCompletion(ctx context.Context, factory commandutils.Factory, 
 		return nil, nil, completions, directive
 	}
 
-	clientSet, err = factory.Clientset()
+	clientSet, err = factory.KopsClient()
 	if err != nil {
 		completions, directive := commandutils.CompletionError("getting clientset", err)
 		return nil, nil, completions, directive

--- a/cmd/kops/toolbox.go
+++ b/cmd/kops/toolbox.go
@@ -20,13 +20,13 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"k8s.io/kops/cmd/kops/util"
+	"k8s.io/kops/pkg/commands/commandutils"
 	"k8s.io/kubectl/pkg/util/i18n"
 )
 
 var toolboxShort = i18n.T(`Miscellaneous, infrequently used commands.`)
 
-func NewCmdToolbox(f *util.Factory, out io.Writer) *cobra.Command {
+func NewCmdToolbox(f commandutils.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "toolbox",
 		Short: toolboxShort,

--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	"k8s.io/kops/cmd/kops/util"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/commands/commandutils"
 	"k8s.io/kops/pkg/dump"
@@ -71,7 +70,7 @@ func (o *ToolboxDumpOptions) InitDefaults() {
 	o.SSHUser = "ubuntu"
 }
 
-func NewCmdToolboxDump(f *util.Factory, out io.Writer) *cobra.Command {
+func NewCmdToolboxDump(f commandutils.Factory, out io.Writer) *cobra.Command {
 	options := &ToolboxDumpOptions{}
 	options.InitDefaults()
 
@@ -101,8 +100,8 @@ func NewCmdToolboxDump(f *util.Factory, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func RunToolboxDump(ctx context.Context, f *util.Factory, out io.Writer, options *ToolboxDumpOptions) error {
-	clientset, err := f.Clientset()
+func RunToolboxDump(ctx context.Context, f commandutils.Factory, out io.Writer, options *ToolboxDumpOptions) error {
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/toolbox_instance-selector.go
+++ b/cmd/kops/toolbox_instance-selector.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kops/cmd/kops/util"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/client/simple"
 	"k8s.io/kops/pkg/commands/commandutils"
@@ -111,7 +110,7 @@ var (
 )
 
 // NewCmdToolboxInstanceSelector defines the cobra command for the instance-selector tool
-func NewCmdToolboxInstanceSelector(f *util.Factory, out io.Writer) *cobra.Command {
+func NewCmdToolboxInstanceSelector(f commandutils.Factory, out io.Writer) *cobra.Command {
 	options := &InstanceSelectorOptions{}
 
 	commandline := cli.New(
@@ -233,7 +232,7 @@ func NewCmdToolboxInstanceSelector(f *util.Factory, out io.Writer) *cobra.Comman
 }
 
 // RunToolboxInstanceSelector executes the instance-selector tool to create instance groups with declarative resource specifications
-func RunToolboxInstanceSelector(ctx context.Context, f *util.Factory, out io.Writer, commandline *cli.CommandLineInterface, options *InstanceSelectorOptions) error {
+func RunToolboxInstanceSelector(ctx context.Context, f commandutils.Factory, out io.Writer, commandline *cli.CommandLineInterface, options *InstanceSelectorOptions) error {
 	clientset, cluster, channel, err := retrieveClusterRefs(ctx, f, options.ClusterName)
 	if err != nil {
 		return err
@@ -372,8 +371,8 @@ func processAndValidateFlags(commandline *cli.CommandLineInterface) error {
 	return nil
 }
 
-func retrieveClusterRefs(ctx context.Context, f *util.Factory, clusterName string) (simple.Clientset, *kops.Cluster, *kops.Channel, error) {
-	clientset, err := f.Clientset()
+func retrieveClusterRefs(ctx context.Context, f commandutils.Factory, clusterName string) (simple.Clientset, *kops.Cluster, *kops.Channel, error) {
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/kops/toolbox_template.go
+++ b/cmd/kops/toolbox_template.go
@@ -34,7 +34,6 @@ import (
 
 	helmvalues "helm.sh/helm/v3/pkg/cli/values"
 
-	"k8s.io/kops/cmd/kops/util"
 	kopsapi "k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/try"
 	"k8s.io/kops/pkg/util/templater"
@@ -74,7 +73,7 @@ type ToolboxTemplateOptions struct {
 }
 
 // NewCmdToolboxTemplate returns a new templating command.
-func NewCmdToolboxTemplate(f *util.Factory, out io.Writer) *cobra.Command {
+func NewCmdToolboxTemplate(f commandutils.Factory, out io.Writer) *cobra.Command {
 	options := &ToolboxTemplateOptions{
 		channel: kopsapi.DefaultChannel,
 	}
@@ -121,7 +120,7 @@ func NewCmdToolboxTemplate(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 // RunToolBoxTemplate is the action for the command
-func RunToolBoxTemplate(f *util.Factory, out io.Writer, options *ToolboxTemplateOptions) error {
+func RunToolBoxTemplate(f commandutils.Factory, out io.Writer, options *ToolboxTemplateOptions) error {
 	// @step: read in the configuration if any
 	context, err := newTemplateContext(options.configPath, options.values, options.stringValues)
 	if err != nil {

--- a/cmd/kops/trust_keypair.go
+++ b/cmd/kops/trust_keypair.go
@@ -93,7 +93,7 @@ func NewCmdTrustKeypair(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunTrustKeypair(ctx context.Context, f *util.Factory, out io.Writer, options *TrustKeypairOptions) error {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -205,7 +205,7 @@ func RunUpdateCluster(ctx context.Context, f *util.Factory, out io.Writer, c *Up
 		return results, err
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return results, err
 	}

--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -103,7 +103,7 @@ func RunUpgradeCluster(ctx context.Context, f *util.Factory, out io.Writer, opti
 		return err
 	}
 
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -62,7 +62,7 @@ For example, a valid value follows the format s3://<bucket>.
 Trailing slash will be trimmed.`
 )
 
-func (f *Factory) Clientset() (simple.Clientset, error) {
+func (f *Factory) KopsClient() (simple.Clientset, error) {
 	if f.clientset == nil {
 		registryPath := f.options.RegistryPath
 		klog.V(2).Infof("state store %s", registryPath)

--- a/cmd/kops/util/factory.go
+++ b/cmd/kops/util/factory.go
@@ -21,9 +21,16 @@ import (
 	"net/url"
 	"strings"
 
+	certmanager "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	channelscmd "k8s.io/kops/channels/pkg/cmd"
 	gceacls "k8s.io/kops/pkg/acls/gce"
 	s3acls "k8s.io/kops/pkg/acls/s3"
 	kopsclient "k8s.io/kops/pkg/client/clientset_generated/clientset"
@@ -38,8 +45,16 @@ type FactoryOptions struct {
 }
 
 type Factory struct {
-	options   *FactoryOptions
-	clientset simple.Clientset
+	ConfigFlags genericclioptions.ConfigFlags
+	options     *FactoryOptions
+	clientset   simple.Clientset
+
+	kubernetesClient  kubernetes.Interface
+	certManagerClient certmanager.Interface
+
+	cachedRESTConfig *rest.Config
+	dynamicClient    dynamic.Interface
+	restMapper       *restmapper.DeferredDiscoveryRESTMapper
 }
 
 func NewFactory(options *FactoryOptions) *Factory {
@@ -128,4 +143,81 @@ func (f *Factory) KopsClient() (simple.Clientset, error) {
 // KopsStateStore returns the configured KOPS_STATE_STORE in use
 func (f *Factory) KopsStateStore() string {
 	return f.options.RegistryPath
+}
+
+var _ channelscmd.Factory = &Factory{}
+
+func (f *Factory) restConfig() (*rest.Config, error) {
+	if f.cachedRESTConfig == nil {
+		restConfig, err := f.ConfigFlags.ToRESTConfig()
+		if err != nil {
+			return nil, fmt.Errorf("cannot load kubecfg settings: %w", err)
+		}
+		restConfig.UserAgent = "kops"
+		f.cachedRESTConfig = restConfig
+	}
+	return f.cachedRESTConfig, nil
+}
+
+func (f *Factory) KubernetesClient() (kubernetes.Interface, error) {
+	if f.kubernetesClient == nil {
+		restConfig, err := f.restConfig()
+		if err != nil {
+			return nil, err
+		}
+		k8sClient, err := kubernetes.NewForConfig(restConfig)
+		if err != nil {
+			return nil, fmt.Errorf("cannot build kube client: %w", err)
+		}
+		f.kubernetesClient = k8sClient
+	}
+
+	return f.kubernetesClient, nil
+}
+
+func (f *Factory) DynamicClient() (dynamic.Interface, error) {
+	if f.dynamicClient == nil {
+		restConfig, err := f.restConfig()
+		if err != nil {
+			return nil, fmt.Errorf("cannot load kubecfg settings: %w", err)
+		}
+		dynamicClient, err := dynamic.NewForConfig(restConfig)
+		if err != nil {
+			return nil, fmt.Errorf("cannot build dynamicClient client: %v", err)
+		}
+		f.dynamicClient = dynamicClient
+	}
+
+	return f.dynamicClient, nil
+}
+
+func (f *Factory) CertManagerClient() (certmanager.Interface, error) {
+	if f.certManagerClient == nil {
+		restConfig, err := f.restConfig()
+		if err != nil {
+			return nil, err
+		}
+		certManagerClient, err := certmanager.NewForConfig(restConfig)
+		if err != nil {
+			return nil, fmt.Errorf("cannot build kube client: %v", err)
+		}
+		f.certManagerClient = certManagerClient
+	}
+
+	return f.certManagerClient, nil
+}
+
+func (f *Factory) RESTMapper() (*restmapper.DeferredDiscoveryRESTMapper, error) {
+	if f.restMapper == nil {
+		discoveryClient, err := f.ConfigFlags.ToDiscoveryClient()
+		if err != nil {
+			return nil, err
+		}
+
+		restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+
+		f.restMapper = restMapper
+	}
+
+	return f.restMapper, nil
 }

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -111,7 +111,7 @@ func NewCmdValidateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunValidateCluster(ctx context.Context, f *util.Factory, out io.Writer, options *ValidateClusterOptions) (*validation.ValidationCluster, error) {
-	clientSet, err := f.Clientset()
+	clientSet, err := f.KopsClient()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/commandutils/cluster.go
+++ b/pkg/commands/commandutils/cluster.go
@@ -33,7 +33,7 @@ func CompleteClusterName(f Factory, suppressIfArgs bool, suppressArgs bool) func
 
 		ConfigureKlogForCompletion()
 
-		client, err := f.Clientset()
+		client, err := f.KopsClient()
 		if err != nil {
 			return CompletionError("getting clientset", err)
 		}

--- a/pkg/commands/commandutils/factory.go
+++ b/pkg/commands/commandutils/factory.go
@@ -19,5 +19,5 @@ package commandutils
 import "k8s.io/kops/pkg/client/simple"
 
 type Factory interface {
-	Clientset() (simple.Clientset, error)
+	KopsClient() (simple.Clientset, error)
 }

--- a/pkg/commands/helpers/kubectl_auth.go
+++ b/pkg/commands/helpers/kubectl_auth.go
@@ -218,7 +218,7 @@ func loadCachedExecCredential(cacheFilePath string) (*ExecCredential, error) {
 }
 
 func buildCredentials(ctx context.Context, f *util.Factory, options *HelperKubectlAuthOptions) (*ExecCredentialStatus, error) {
-	clientset, err := f.Clientset()
+	clientset, err := f.KopsClient()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We had two cmd factories, one for kops and one for channels. Both include functions for reducing boilerplates, so could be useful to merge. Will also make #14072 easier.