### PR TITLE
Automated cherry pick of #14017: Allow configuring OpenStack CCM networking options

### DIFF
--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -479,6 +479,16 @@ spec:
                             items:
                               type: string
                             type: array
+                          internalNetworkNames:
+                            items:
+                              type: string
+                            type: array
+                          ipv6SupportDisabled:
+                            type: boolean
+                          publicNetworkNames:
+                            items:
+                              type: string
+                            type: array
                         type: object
                       router:
                         description: OpenstackRouter defines the config for a router

--- a/nodeup/pkg/model/cloudconfig.go
+++ b/nodeup/pkg/model/cloudconfig.go
@@ -190,6 +190,28 @@ func (b *CloudConfigBuilder) build(c *fi.ModelBuilderContext, inTree bool) error
 				fmt.Sprintf("ignore-volume-az=%t", fi.BoolValue(bs.IgnoreAZ)),
 				"")
 		}
+
+		if networking := osc.Network; networking != nil {
+			// Networking Config
+			// https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#networking
+			var networkingLines []string
+
+			if networking.IPv6SupportDisabled != nil {
+				networkingLines = append(networkingLines, fmt.Sprintf("ipv6-support-disabled=%t", fi.BoolValue(networking.IPv6SupportDisabled)))
+			}
+			for _, name := range networking.PublicNetworkNames {
+				networkingLines = append(networkingLines, fmt.Sprintf("public-network-name=%s", fi.StringValue(name)))
+			}
+			for _, name := range networking.InternalNetworkNames {
+				networkingLines = append(networkingLines, fmt.Sprintf("internal-network-name=%s", fi.StringValue(name)))
+			}
+
+			if len(networkingLines) > 0 {
+				lines = append(lines, "[Networking]")
+				lines = append(lines, networkingLines...)
+				lines = append(lines, "")
+			}
+		}
 	case "azure":
 		requireGlobal = false
 

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -807,6 +807,9 @@ type OpenstackRouter struct {
 // OpenstackNetwork defines the config for a network
 type OpenstackNetwork struct {
 	AvailabilityZoneHints []*string `json:"availabilityZoneHints,omitempty"`
+	IPv6SupportDisabled   *bool     `json:"ipv6SupportDisabled,omitempty"`
+	PublicNetworkNames    []*string `json:"publicNetworkNames,omitempty"`
+	InternalNetworkNames  []*string `json:"internalNetworkNames,omitempty"`
 }
 
 // OpenstackMetadata defines config for metadata service related settings

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -806,6 +806,9 @@ type OpenstackRouter struct {
 // OpenstackNetwork defines the config for a network
 type OpenstackNetwork struct {
 	AvailabilityZoneHints []*string `json:"availabilityZoneHints,omitempty"`
+	IPv6SupportDisabled   *bool     `json:"ipv6SupportDisabled,omitempty"`
+	PublicNetworkNames    []*string `json:"publicNetworkNames,omitempty"`
+	InternalNetworkNames  []*string `json:"internalNetworkNames,omitempty"`
 }
 
 // OpenstackMetadata defines config for metadata service related settings

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -6620,6 +6620,9 @@ func Convert_kops_OpenstackMonitor_To_v1alpha2_OpenstackMonitor(in *kops.Opensta
 
 func autoConvert_v1alpha2_OpenstackNetwork_To_kops_OpenstackNetwork(in *OpenstackNetwork, out *kops.OpenstackNetwork, s conversion.Scope) error {
 	out.AvailabilityZoneHints = in.AvailabilityZoneHints
+	out.IPv6SupportDisabled = in.IPv6SupportDisabled
+	out.PublicNetworkNames = in.PublicNetworkNames
+	out.InternalNetworkNames = in.InternalNetworkNames
 	return nil
 }
 
@@ -6630,6 +6633,9 @@ func Convert_v1alpha2_OpenstackNetwork_To_kops_OpenstackNetwork(in *OpenstackNet
 
 func autoConvert_kops_OpenstackNetwork_To_v1alpha2_OpenstackNetwork(in *kops.OpenstackNetwork, out *OpenstackNetwork, s conversion.Scope) error {
 	out.AvailabilityZoneHints = in.AvailabilityZoneHints
+	out.IPv6SupportDisabled = in.IPv6SupportDisabled
+	out.PublicNetworkNames = in.PublicNetworkNames
+	out.InternalNetworkNames = in.InternalNetworkNames
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -4723,6 +4723,33 @@ func (in *OpenstackNetwork) DeepCopyInto(out *OpenstackNetwork) {
 			}
 		}
 	}
+	if in.IPv6SupportDisabled != nil {
+		in, out := &in.IPv6SupportDisabled, &out.IPv6SupportDisabled
+		*out = new(bool)
+		**out = **in
+	}
+	if in.PublicNetworkNames != nil {
+		in, out := &in.PublicNetworkNames, &out.PublicNetworkNames
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
+	if in.InternalNetworkNames != nil {
+		in, out := &in.InternalNetworkNames, &out.InternalNetworkNames
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -804,6 +804,9 @@ type OpenstackRouter struct {
 // OpenstackNetwork defines the config for a network
 type OpenstackNetwork struct {
 	AvailabilityZoneHints []*string `json:"availabilityZoneHints,omitempty"`
+	IPv6SupportDisabled   *bool     `json:"ipv6SupportDisabled,omitempty"`
+	PublicNetworkNames    []*string `json:"publicNetworkNames,omitempty"`
+	InternalNetworkNames  []*string `json:"internalNetworkNames,omitempty"`
 }
 
 // OpenstackMetadata defines config for metadata service related settings

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -6619,6 +6619,9 @@ func Convert_kops_OpenstackMonitor_To_v1alpha3_OpenstackMonitor(in *kops.Opensta
 
 func autoConvert_v1alpha3_OpenstackNetwork_To_kops_OpenstackNetwork(in *OpenstackNetwork, out *kops.OpenstackNetwork, s conversion.Scope) error {
 	out.AvailabilityZoneHints = in.AvailabilityZoneHints
+	out.IPv6SupportDisabled = in.IPv6SupportDisabled
+	out.PublicNetworkNames = in.PublicNetworkNames
+	out.InternalNetworkNames = in.InternalNetworkNames
 	return nil
 }
 
@@ -6629,6 +6632,9 @@ func Convert_v1alpha3_OpenstackNetwork_To_kops_OpenstackNetwork(in *OpenstackNet
 
 func autoConvert_kops_OpenstackNetwork_To_v1alpha3_OpenstackNetwork(in *kops.OpenstackNetwork, out *OpenstackNetwork, s conversion.Scope) error {
 	out.AvailabilityZoneHints = in.AvailabilityZoneHints
+	out.IPv6SupportDisabled = in.IPv6SupportDisabled
+	out.PublicNetworkNames = in.PublicNetworkNames
+	out.InternalNetworkNames = in.InternalNetworkNames
 	return nil
 }
 

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -4649,6 +4649,33 @@ func (in *OpenstackNetwork) DeepCopyInto(out *OpenstackNetwork) {
 			}
 		}
 	}
+	if in.IPv6SupportDisabled != nil {
+		in, out := &in.IPv6SupportDisabled, &out.IPv6SupportDisabled
+		*out = new(bool)
+		**out = **in
+	}
+	if in.PublicNetworkNames != nil {
+		in, out := &in.PublicNetworkNames, &out.PublicNetworkNames
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
+	if in.InternalNetworkNames != nil {
+		in, out := &in.InternalNetworkNames, &out.InternalNetworkNames
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -4924,6 +4924,33 @@ func (in *OpenstackNetwork) DeepCopyInto(out *OpenstackNetwork) {
 			}
 		}
 	}
+	if in.IPv6SupportDisabled != nil {
+		in, out := &in.IPv6SupportDisabled, &out.IPv6SupportDisabled
+		*out = new(bool)
+		**out = **in
+	}
+	if in.PublicNetworkNames != nil {
+		in, out := &in.PublicNetworkNames, &out.PublicNetworkNames
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
+	if in.InternalNetworkNames != nil {
+		in, out := &in.InternalNetworkNames, &out.InternalNetworkNames
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Cherry pick of #14017 on release-1.24.

#14017: Allow configuring OpenStack CCM networking options

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```