### PR TITLE
Add back conversion struct to cert-manager CRDs

### DIFF
--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 2b1fc2ca18c196c00252385cd9b7dc3f7f6dbb0c669089f9b9e1962279a433c4
+    manifestHash: fa3e4adb14fc2f64a688763b14c13aa599f17a03db832ce9e404983cfec43a97
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -11,6 +11,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificaterequests.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -270,6 +282,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificates.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -795,6 +819,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: challenges.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:
@@ -2769,6 +2805,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: clusterissuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -5323,6 +5371,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: issuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -7876,6 +7936,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: orders.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 2b1fc2ca18c196c00252385cd9b7dc3f7f6dbb0c669089f9b9e1962279a433c4
+    manifestHash: fa3e4adb14fc2f64a688763b14c13aa599f17a03db832ce9e404983cfec43a97
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -11,6 +11,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificaterequests.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -270,6 +282,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificates.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -795,6 +819,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: challenges.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:
@@ -2769,6 +2805,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: clusterissuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -5323,6 +5371,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: issuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -7876,6 +7936,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: orders.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 2b1fc2ca18c196c00252385cd9b7dc3f7f6dbb0c669089f9b9e1962279a433c4
+    manifestHash: fa3e4adb14fc2f64a688763b14c13aa599f17a03db832ce9e404983cfec43a97
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -11,6 +11,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificaterequests.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -270,6 +282,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificates.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -795,6 +819,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: challenges.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:
@@ -2769,6 +2805,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: clusterissuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -5323,6 +5371,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: issuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -7876,6 +7936,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: orders.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 2b1fc2ca18c196c00252385cd9b7dc3f7f6dbb0c669089f9b9e1962279a433c4
+    manifestHash: fa3e4adb14fc2f64a688763b14c13aa599f17a03db832ce9e404983cfec43a97
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -11,6 +11,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificaterequests.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -270,6 +282,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificates.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -795,6 +819,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: challenges.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:
@@ -2769,6 +2805,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: clusterissuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -5323,6 +5371,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: issuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -7876,6 +7936,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: orders.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 2b1fc2ca18c196c00252385cd9b7dc3f7f6dbb0c669089f9b9e1962279a433c4
+    manifestHash: fa3e4adb14fc2f64a688763b14c13aa599f17a03db832ce9e404983cfec43a97
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -11,6 +11,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificaterequests.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -270,6 +282,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificates.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -795,6 +819,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: challenges.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:
@@ -2769,6 +2805,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: clusterissuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -5323,6 +5371,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: issuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -7876,6 +7936,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: orders.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 2b1fc2ca18c196c00252385cd9b7dc3f7f6dbb0c669089f9b9e1962279a433c4
+    manifestHash: fa3e4adb14fc2f64a688763b14c13aa599f17a03db832ce9e404983cfec43a97
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -11,6 +11,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificaterequests.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -270,6 +282,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificates.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -795,6 +819,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: challenges.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:
@@ -2769,6 +2805,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: clusterissuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -5323,6 +5371,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: issuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -7876,6 +7936,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: orders.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 2b1fc2ca18c196c00252385cd9b7dc3f7f6dbb0c669089f9b9e1962279a433c4
+    manifestHash: fa3e4adb14fc2f64a688763b14c13aa599f17a03db832ce9e404983cfec43a97
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-certmanager.io-k8s-1.16_content
@@ -11,6 +11,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificaterequests.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -270,6 +282,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificates.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -795,6 +819,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: challenges.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:
@@ -2769,6 +2805,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: clusterissuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -5323,6 +5371,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: issuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -7876,6 +7936,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: orders.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 2b1fc2ca18c196c00252385cd9b7dc3f7f6dbb0c669089f9b9e1962279a433c4
+    manifestHash: fa3e4adb14fc2f64a688763b14c13aa599f17a03db832ce9e404983cfec43a97
     name: certmanager.io
     selector: null
     version: 9.99.0

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-certmanager.io-k8s-1.16_content
@@ -11,6 +11,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificaterequests.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -270,6 +282,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: certificates.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -795,6 +819,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: challenges.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:
@@ -2769,6 +2805,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: clusterissuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -5323,6 +5371,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: issuers.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: cert-manager.io
   names:
     categories:
@@ -7876,6 +7936,18 @@ metadata:
     app.kubernetes.io/version: v1.8.0
   name: orders.acme.cert-manager.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+      - v1beta1
   group: acme.cert-manager.io
   names:
     categories:

--- a/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/certmanager.io/k8s-1.16.yaml.template
@@ -25,6 +25,18 @@ metadata:
     # Generated labels
     app.kubernetes.io/version: "v1.8.0"
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1beta1
   group: cert-manager.io
   names:
     kind: CertificateRequest
@@ -225,6 +237,18 @@ metadata:
     # Generated labels
     app.kubernetes.io/version: "v1.8.0"
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1beta1
   group: cert-manager.io
   names:
     kind: Certificate
@@ -595,6 +619,18 @@ metadata:
     # Generated labels
     app.kubernetes.io/version: "v1.8.0"
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1beta1
   group: acme.cert-manager.io
   names:
     kind: Challenge
@@ -1630,6 +1666,18 @@ metadata:
     # Generated labels
     app.kubernetes.io/version: "v1.8.0"
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1beta1
   group: cert-manager.io
   names:
     kind: ClusterIssuer
@@ -2882,6 +2930,18 @@ metadata:
     # Generated labels
     app.kubernetes.io/version: "v1.8.0"
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1beta1
   group: cert-manager.io
   names:
     kind: Issuer
@@ -4134,6 +4194,18 @@ metadata:
     # Generated labels
     app.kubernetes.io/version: "v1.8.0"
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: ""
+        service:
+          name: cert-manager-webhook
+          namespace: kube-system
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1beta1
   group: acme.cert-manager.io
   names:
     kind: Order

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -49,7 +49,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: certmanager.io/k8s-1.16.yaml
-    manifestHash: 2b1fc2ca18c196c00252385cd9b7dc3f7f6dbb0c669089f9b9e1962279a433c4
+    manifestHash: fa3e4adb14fc2f64a688763b14c13aa599f17a03db832ce9e404983cfec43a97
     name: certmanager.io
     selector: null
     version: 9.99.0


### PR DESCRIPTION
A combination of apiserver map handling when using server-side apply, CA injection and resource validation made it impossible for kops to remove this struct. However, kops should claim ownership of all fields so we can remove them all in a future version