### PR TITLE
Hide klog flags from --help output

### DIFF
--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -119,6 +119,23 @@ func NewCmdRoot(f *util.Factory, out io.Writer) *cobra.Command {
 		case "cloud-provider-gce-l7lb-src-cidrs":
 			// Skip; these is dragged in by the google cloudprovider dependency
 
+		// Hide klog flags that just clutter the --help output; they are still supported, we just don't show them
+		case "add_dir_header",
+			"alsologtostderr",
+			"log_backtrace_at",
+			"log_dir",
+			"log_file",
+			"log_file_max_size",
+			"logtostderr",
+			"one_output",
+			"skip_headers",
+			"skip_log_headers",
+			"stderrthreshold",
+			"vmodule":
+			// We keep "v" as that flag is generally useful
+			cmd.PersistentFlags().AddGoFlag(goflag)
+			cmd.PersistentFlags().Lookup(goflag.Name).Hidden = true
+
 		default:
 			cmd.PersistentFlags().AddGoFlag(goflag)
 		}

--- a/docs/cli/kops.md
+++ b/docs/cli/kops.md
@@ -16,23 +16,11 @@ kOps is Kubernetes Operations.
 ### Options
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-  -h, --help                             help for kops
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+  -h, --help            help for kops
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_completion.md
+++ b/docs/cli/kops_completion.md
@@ -20,22 +20,10 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_completion_bash.md
+++ b/docs/cli/kops_completion_bash.md
@@ -43,22 +43,10 @@ kops completion bash
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_completion_fish.md
+++ b/docs/cli/kops_completion_fish.md
@@ -34,22 +34,10 @@ kops completion fish [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_completion_powershell.md
+++ b/docs/cli/kops_completion_powershell.md
@@ -31,22 +31,10 @@ kops completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_completion_zsh.md
+++ b/docs/cli/kops_completion_zsh.md
@@ -45,22 +45,10 @@ kops completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create.md
+++ b/docs/cli/kops_create.md
@@ -42,22 +42,10 @@ kops create {-f FILENAME}... [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -131,22 +131,10 @@ kops create cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create_instancegroup.md
+++ b/docs/cli/kops_create_instancegroup.md
@@ -43,22 +43,10 @@ kops create instancegroup INSTANCE_GROUP [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create_keypair.md
+++ b/docs/cli/kops_create_keypair.md
@@ -48,22 +48,10 @@ kops create keypair {KEYSET | all} [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create_secret.md
+++ b/docs/cli/kops_create_secret.md
@@ -14,22 +14,10 @@ Create a secret.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create_secret_ciliumpassword.md
+++ b/docs/cli/kops_create_secret_ciliumpassword.md
@@ -41,22 +41,10 @@ kops create secret ciliumpassword -f FILENAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create_secret_dockerconfig.md
+++ b/docs/cli/kops_create_secret_dockerconfig.md
@@ -44,22 +44,10 @@ kops create secret dockerconfig -f FILENAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create_secret_encryptionconfig.md
+++ b/docs/cli/kops_create_secret_encryptionconfig.md
@@ -40,22 +40,10 @@ kops create secret encryptionconfig -f FILENAME [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create_secret_weavepassword.md
+++ b/docs/cli/kops_create_secret_weavepassword.md
@@ -48,22 +48,10 @@ kops create secret weavepassword [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_create_sshpublickey.md
+++ b/docs/cli/kops_create_sshpublickey.md
@@ -30,22 +30,10 @@ kops create sshpublickey [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_delete.md
+++ b/docs/cli/kops_delete.md
@@ -30,22 +30,10 @@ kops delete {-f FILENAME}... [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_delete_cluster.md
+++ b/docs/cli/kops_delete_cluster.md
@@ -34,22 +34,10 @@ kops delete cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_delete_instance.md
+++ b/docs/cli/kops_delete_instance.md
@@ -44,22 +44,10 @@ kops delete instance INSTANCE|NODE [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_delete_instancegroup.md
+++ b/docs/cli/kops_delete_instancegroup.md
@@ -32,22 +32,10 @@ kops delete instancegroup INSTANCE_GROUP [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_delete_secret.md
+++ b/docs/cli/kops_delete_secret.md
@@ -25,22 +25,10 @@ kops delete secret SECRET_NAME... [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_delete_sshpublickey.md
+++ b/docs/cli/kops_delete_sshpublickey.md
@@ -25,22 +25,10 @@ kops delete sshpublickey [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_distrust.md
+++ b/docs/cli/kops_distrust.md
@@ -14,22 +14,10 @@ Distrust keypairs.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_distrust_keypair.md
+++ b/docs/cli/kops_distrust_keypair.md
@@ -43,22 +43,10 @@ kops distrust keypair {KEYSET [ID]... | all} [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_edit.md
+++ b/docs/cli/kops_edit.md
@@ -14,22 +14,10 @@ Edit clusters and other resources.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_edit_cluster.md
+++ b/docs/cli/kops_edit_cluster.md
@@ -38,22 +38,10 @@ kops edit cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_edit_instancegroup.md
+++ b/docs/cli/kops_edit_instancegroup.md
@@ -38,22 +38,10 @@ kops edit instancegroup INSTANCE_GROUP [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_export.md
+++ b/docs/cli/kops_export.md
@@ -14,22 +14,10 @@ Export configuration.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_export_kubeconfig.md
+++ b/docs/cli/kops_export_kubeconfig.md
@@ -41,22 +41,10 @@ kops export kubeconfig [CLUSTER | --all] [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_get.md
+++ b/docs/cli/kops_get.md
@@ -40,22 +40,10 @@ kops get [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_get_assets.md
+++ b/docs/cli/kops_get_assets.md
@@ -37,23 +37,11 @@ kops get assets [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-  -o, --output string                    output format. One of: table, yaml, json (default "table")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+  -o, --output string   output format. One of: table, yaml, json (default "table")
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_get_clusters.md
+++ b/docs/cli/kops_get_clusters.md
@@ -39,23 +39,11 @@ kops get clusters [CLUSTER]... [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-  -o, --output string                    output format. One of: table, yaml, json (default "table")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+  -o, --output string   output format. One of: table, yaml, json (default "table")
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_get_instancegroups.md
+++ b/docs/cli/kops_get_instancegroups.md
@@ -35,23 +35,11 @@ kops get instancegroups [INSTANCE_GROUP]... [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-  -o, --output string                    output format. One of: table, yaml, json (default "table")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+  -o, --output string   output format. One of: table, yaml, json (default "table")
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_get_instances.md
+++ b/docs/cli/kops_get_instances.md
@@ -25,23 +25,11 @@ kops get instances [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-  -o, --output string                    output format. One of: table, yaml, json (default "table")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+  -o, --output string   output format. One of: table, yaml, json (default "table")
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_get_keypairs.md
+++ b/docs/cli/kops_get_keypairs.md
@@ -29,23 +29,11 @@ kops get keypairs [KEYSET]... [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-  -o, --output string                    output format. One of: table, yaml, json (default "table")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+  -o, --output string   output format. One of: table, yaml, json (default "table")
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_get_secrets.md
+++ b/docs/cli/kops_get_secrets.md
@@ -28,23 +28,11 @@ kops get secrets [SECRET_NAME]... [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-  -o, --output string                    output format. One of: table, yaml, json (default "table")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+  -o, --output string   output format. One of: table, yaml, json (default "table")
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_get_sshpublickeys.md
+++ b/docs/cli/kops_get_sshpublickeys.md
@@ -25,23 +25,11 @@ kops get sshpublickeys [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-  -o, --output string                    output format. One of: table, yaml, json (default "table")
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+  -o, --output string   output format. One of: table, yaml, json (default "table")
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_promote.md
+++ b/docs/cli/kops_promote.md
@@ -14,22 +14,10 @@ Promote a resource.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_promote_keypair.md
+++ b/docs/cli/kops_promote_keypair.md
@@ -42,22 +42,10 @@ kops promote keypair {KEYSET [ID] | all} [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_replace.md
+++ b/docs/cli/kops_replace.md
@@ -37,22 +37,10 @@ kops replace {-f FILENAME}... [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_rolling-update.md
+++ b/docs/cli/kops_rolling-update.md
@@ -14,22 +14,10 @@ Rolling update a cluster.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -77,22 +77,10 @@ kops rolling-update cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_toolbox.md
+++ b/docs/cli/kops_toolbox.md
@@ -14,22 +14,10 @@ Miscellaneous, infrequently used commands.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_toolbox_dump.md
+++ b/docs/cli/kops_toolbox_dump.md
@@ -33,22 +33,10 @@ kops toolbox dump [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_toolbox_instance-selector.md
+++ b/docs/cli/kops_toolbox_instance-selector.md
@@ -68,22 +68,10 @@ kops toolbox instance-selector INSTANCE_GROUP [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_toolbox_template.md
+++ b/docs/cli/kops_toolbox_template.md
@@ -44,22 +44,10 @@ kops toolbox template [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_trust.md
+++ b/docs/cli/kops_trust.md
@@ -14,22 +14,10 @@ Trust keypairs.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_trust_keypair.md
+++ b/docs/cli/kops_trust_keypair.md
@@ -31,22 +31,10 @@ kops trust keypair KEYSET ID... [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_update.md
+++ b/docs/cli/kops_update.md
@@ -14,22 +14,10 @@ Update a cluster.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -42,22 +42,10 @@ kops update cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_upgrade.md
+++ b/docs/cli/kops_upgrade.md
@@ -14,22 +14,10 @@ Upgrade a kubernetes cluster.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_upgrade_cluster.md
+++ b/docs/cli/kops_upgrade_cluster.md
@@ -34,22 +34,10 @@ kops upgrade cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_validate.md
+++ b/docs/cli/kops_validate.md
@@ -14,22 +14,10 @@ Validate a kOps cluster.
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -39,22 +39,10 @@ kops validate cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO

--- a/docs/cli/kops_version.md
+++ b/docs/cli/kops_version.md
@@ -30,22 +30,10 @@ kops version [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header of the log messages
-      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
-      --config string                    yaml config file (default is $HOME/.kops.yaml)
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-      --name string                      Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
-      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --state string                     Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
-      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --config string   yaml config file (default is $HOME/.kops.yaml)
+      --name string     Name of cluster. Overrides KOPS_CLUSTER_NAME environment variable
+      --state string    Location of state storage (kops 'config' file). Overrides KOPS_STATE_STORE environment variable
+  -v, --v Level         number for the log level verbosity
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
The klog flags just clutter the output and often push the most
important output off of smaller screens.

The flags are still supported, just hidden.
