### PR TITLE
cilium: fix wrong pod annotations templating #1.23

### DIFF
--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_cluster-completed.spec_content
@@ -167,6 +167,10 @@ spec:
   networkCIDR: 172.20.0.0/16
   networking:
     cilium:
+      agentPodAnnotations:
+        test1: "true"
+        test2: "123"
+        test3: awesome
       agentPrometheusPort: 9090
       bpfCTGlobalAnyMax: 262144
       bpfCTGlobalTCPMax: 524288

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -54,7 +54,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.10.yaml
-    manifestHash: 0865fbd16dad7ae036b1b88510f1adc9136d2cbf113df71134e009fd109c96db
+    manifestHash: 29a7f614844380ecc6b7b7c701c14a660d023de7bfda62293ea63600a7be0d3f
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -330,6 +330,9 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        test1: "true"
+        test2: "123"
+        test3: awesome
       creationTimestamp: null
       labels:
         k8s-app: cilium

--- a/tests/integration/update_cluster/privatecilium/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatecilium/in-v1alpha2.yaml
@@ -26,7 +26,11 @@ spec:
   masterPublicName: api.privatecilium.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    cilium: {}
+    cilium:
+      agentPodAnnotations:
+        test1: "true"
+        test2: "123"
+        test3: awesome
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
   - 0.0.0.0/0

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.12-v1.9.yaml.template
@@ -554,9 +554,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .AgentPrometheusPort }}"
         {{ end }}
-{{- with .AgentPodAnnotations }}
-        {{- . | nindent 8 }}
-{{- end }}
+        {{- range $key, $value := .AgentPodAnnotations }}
+        {{ $key }}: "{{ $value }}"
+        {{- end }}
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.10.yaml.template
@@ -595,9 +595,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .AgentPrometheusPort }}"
         {{ end }}
-{{- with .AgentPodAnnotations }}
-        {{- . | nindent 8 }}
-{{- end }}
+        {{- range $key, $value := .AgentPodAnnotations }}
+        {{ $key }}: "{{ $value }}"
+        {{- end }}
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
This patch fixes cilium pod annotations templating for 1.9 & 1.10.

very similar to https://github.com/kubernetes/kops/pull/13536