### PR TITLE
Don't add previous-gen instances to Karpenter provisioners

### DIFF
--- a/upup/pkg/fi/cloudup/template_functions.go
+++ b/upup/pkg/fi/cloudup/template_functions.go
@@ -884,6 +884,7 @@ func karpenterInstanceTypes(cloud awsup.AWSCloud, ig kops.InstanceGroupSpec) ([]
 				VCpuCount:            &ec2.VCpuCountRangeRequest{},
 				MemoryMiB:            &ec2.MemoryMiBRequest{},
 				BurstablePerformance: fi.String("included"),
+				InstanceGenerations:  []*string{fi.String("current")},
 			}
 			cpu := instanceRequirements.CPU
 			if cpu != nil {


### PR DESCRIPTION
Previous-gen instances lack a lot of features. For example CCM will fail to update NLBs if these are added to the cluster.