### PR TITLE
cilium: fix wrong pod annotations templating

### DIFF
--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -165,6 +165,10 @@ spec:
   networkCIDR: 172.20.0.0/16
   networking:
     cilium:
+      agentPodAnnotations:
+        test1: "true"
+        test2: "123"
+        test3: awesome
       agentPrometheusPort: 9090
       bpfCTGlobalAnyMax: 262144
       bpfCTGlobalTCPMax: 524288

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 198c6022ba7a63e596a1734db37c3f60742f4d695a51d3dd309ec8e4c3639523
+    manifestHash: 668b99732903d15d343b82769f8b7e4bee95dbb43a0529d23810e0421dea1740
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -317,6 +317,10 @@ spec:
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
+      annotations:
+        test1: "true"
+        test2: "123"
+        test3: awesome
       creationTimestamp: null
       labels:
         k8s-app: cilium

--- a/tests/integration/update_cluster/privatecilium/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/privatecilium/in-v1alpha2.yaml
@@ -26,7 +26,11 @@ spec:
   masterPublicName: api.privatecilium.example.com
   networkCIDR: 172.20.0.0/16
   networking:
-    cilium: {}
+    cilium:
+      agentPodAnnotations:
+        test1: "true"
+        test2: "123"
+        test3: awesome
   nonMasqueradeCIDR: 100.64.0.0/10
   sshAccess:
   - 0.0.0.0/0

--- a/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.cilium.io/k8s-1.16-v1.11.yaml.template
@@ -591,9 +591,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .AgentPrometheusPort }}"
         {{ end }}
-{{- with .AgentPodAnnotations }}
-        {{- . | nindent 8 }}
-{{- end }}
+        {{- range $key, $value := .AgentPodAnnotations }}
+        {{ $key }}: "{{ $value }}"
+        {{- end }}
       labels:
         k8s-app: cilium
         kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
Same as https://github.com/kubernetes/kops/pull/14105 but for latest kops version