### PR TITLE
Add deployment-specific selectors to nth pdb

### DIFF
--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: fdea063ac413e3ebaf12c2523f47aefdebaa52dfe53179a090cf0f6ac9927b31
+    manifestHash: da86a57a95265f04686e7d5be0a9b987f376ebc513f0b3c0937c269b4c13ccc3
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -130,6 +130,7 @@ spec:
         app.kubernetes.io/name: aws-node-termination-handler
         k8s-app: aws-node-termination-handler
         kops.k8s.io/managed-by: kops
+        kops.k8s.io/nth-mode: sqs
         kubernetes.io/os: linux
     spec:
       affinity:
@@ -246,6 +247,7 @@ spec:
           matchLabels:
             app.kubernetes.io/instance: aws-node-termination-handler
             app.kubernetes.io/name: aws-node-termination-handler
+            kops.k8s.io/nth-mode: sqs
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
         whenUnsatisfiable: ScheduleAnyway
@@ -253,6 +255,7 @@ spec:
           matchLabels:
             app.kubernetes.io/instance: aws-node-termination-handler
             app.kubernetes.io/name: aws-node-termination-handler
+            kops.k8s.io/nth-mode: sqs
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: DoNotSchedule
@@ -277,3 +280,4 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: aws-node-termination-handler
       app.kubernetes.io/name: aws-node-termination-handler
+      kops.k8s.io/nth-mode: sqs

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -102,7 +102,7 @@ metadata:
     k8s-app: aws-node-termination-handler
     app.kubernetes.io/version: "{{ .Version }}"
 spec:
-  replicas: 1
+  replicas: {{ ControlPlaneControllerReplicas true }}
   selector:
     matchLabels:
       app.kubernetes.io/name: aws-node-termination-handler
@@ -115,6 +115,7 @@ spec:
         app.kubernetes.io/instance: aws-node-termination-handler
         k8s-app: aws-node-termination-handler
         kubernetes.io/os: linux
+        kops.k8s.io/nth-mode: sqs
     spec:
       nodeSelector: null
       {{ if not UseServiceAccountExternalPermissions }}
@@ -237,6 +238,7 @@ spec:
           matchLabels:
             app.kubernetes.io/name: aws-node-termination-handler
             app.kubernetes.io/instance: aws-node-termination-handler
+            kops.k8s.io/nth-mode: sqs
       - maxSkew: 1
         topologyKey: "kubernetes.io/hostname"
         whenUnsatisfiable: DoNotSchedule
@@ -244,7 +246,7 @@ spec:
           matchLabels:
             app.kubernetes.io/name: aws-node-termination-handler
             app.kubernetes.io/instance: aws-node-termination-handler
-
+            kops.k8s.io/nth-mode: sqs
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -259,6 +261,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: aws-node-termination-handler
       app.kubernetes.io/instance: aws-node-termination-handler
+      kops.k8s.io/nth-mode: sqs
   maxUnavailable: 1
 {{ else }}
 ---


### PR DESCRIPTION
If not, when migrating from imds-mode to sqs-mode, the selectors will match the daemonset pods, which doesn't work with pdb.

This will only break when upgrading from a somewhat old kops version, but it's the cause of https://testgrid.k8s.io/kops-k8s-ci#kops-aws-addon-resource-tracking flakiness.