### PR TITLE
Merge kubeletConfigs earlier

### DIFF
--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -261,6 +261,9 @@ func (b *KubeletBuilder) kubeletPath() string {
 
 // buildManifestDirectory creates the directory where kubelet expects static manifests to reside
 func (b *KubeletBuilder) buildManifestDirectory(kubeletConfig *kops.KubeletConfigSpec) (*nodetasks.File, error) {
+	if kubeletConfig.PodManifestPath == "" {
+		return nil, fmt.Errorf("failed to build manifest path. Path was empty")
+	}
 	directory := &nodetasks.File{
 		Path: kubeletConfig.PodManifestPath,
 		Type: nodetasks.FileType_Directory,

--- a/nodeup/pkg/model/kubelet.go
+++ b/nodeup/pkg/model/kubelet.go
@@ -69,7 +69,7 @@ func (b *KubeletBuilder) Build(c *fi.ModelBuilderContext) error {
 		return fmt.Errorf("error building kubelet server cert: %v", err)
 	}
 
-	kubeletConfig, err := b.buildKubeletConfig()
+	kubeletConfig, err := b.buildKubeletConfigSpec()
 	if err != nil {
 		return fmt.Errorf("error building kubelet config: %v", err)
 	}
@@ -407,17 +407,6 @@ func (b *KubeletBuilder) buildSystemdService() *nodetasks.Service {
 	}
 
 	return service
-}
-
-// buildKubeletConfig is responsible for creating the kubelet configuration
-func (b *KubeletBuilder) buildKubeletConfig() (*kops.KubeletConfigSpec, error) {
-	kubeletConfigSpec, err := b.buildKubeletConfigSpec()
-	if err != nil {
-		return nil, fmt.Errorf("error building kubelet config: %v", err)
-	}
-
-	// TODO: Memoize if we reuse this
-	return kubeletConfigSpec, nil
 }
 
 // usesContainerizedMounter returns true if we use the containerized mounter

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -321,6 +321,8 @@ func BuildNodeupModelContext(model *testutils.Model) (*NodeupModelContext, error
 	}
 	nodeupModelContext.NodeupConfig.UpdatePolicy = *updatePolicy
 
+	nodeupModelContext.NodeupConfig.KubeletConfig.PodManifestPath = "/etc/kubernetes/manifests"
+
 	return nodeupModelContext, nil
 }
 

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -218,7 +218,7 @@ func runKubeletBuilder(t *testing.T, context *fi.ModelBuilderContext, nodeupMode
 
 	builder := KubeletBuilder{NodeupModelContext: nodeupModelContext}
 
-	kubeletConfig, err := builder.buildKubeletConfig()
+	kubeletConfig, err := builder.buildKubeletConfigSpec()
 	if err != nil {
 		t.Fatalf("error from KubeletBuilder buildKubeletConfig: %v", err)
 		return

--- a/nodeup/pkg/model/kubelet_test.go
+++ b/nodeup/pkg/model/kubelet_test.go
@@ -92,7 +92,13 @@ func TestTaintsApplied(t *testing.T) {
 
 	for _, g := range tests {
 		cluster := &kops.Cluster{Spec: kops.ClusterSpec{KubernetesVersion: g.version}}
-		ig := &kops.InstanceGroup{Spec: kops.InstanceGroupSpec{Role: kops.InstanceGroupRoleMaster, Taints: g.taints}}
+		input := testutils.BuildMinimalMasterInstanceGroup("eu-central-1a")
+		input.Spec.Taints = g.taints
+
+		ig, err := cloudup.PopulateInstanceGroupSpec(cluster, &input, nil, nil)
+		if err != nil {
+			t.Fatalf("failed to populate ig: %v", err)
+		}
 
 		config, bootConfig := nodeup.NewConfig(cluster, ig)
 		b := &KubeletBuilder{

--- a/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/featuregates/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --cgroup-driver=systemd --cgroup-root=/ --client-ca-file=/srv/kubernetes/ca.crt --cloud-provider=external --cluster-dns=100.64.0.10 --cluster-domain=cluster.local --enable-debugging-handlers=true --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5% --feature-gates=AllowExtTrafficLocalEndpoints=false,CSIMigrationAWS=true,ExperimentalCriticalPodAnnotation=true,InTreePluginAWSUnregister=true --kubeconfig=/var/lib/kubelet/kubeconfig --pod-infra-container-image=registry.k8s.io/pause:3.6 --pod-manifest-path=/etc/kubernetes/manifests --protect-kernel-defaults=true --register-schedulable=true --v=2 --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf"
+  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --client-ca-file=/srv/kubernetes/ca.crt --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file
@@ -37,8 +37,8 @@ contents: |
   nodeStatusReportFrequency: 0s
   nodeStatusUpdateFrequency: 0s
   runtimeRequestTimeout: 0s
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
+  shutdownGracePeriod: 0s
+  shutdownGracePeriodCriticalPods: 0s
   streamingConnectionIdleTimeout: 0s
   syncFrequency: 0s
   volumeStatsAggPeriod: 0s

--- a/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
+++ b/nodeup/pkg/model/tests/kubelet/warmpool/tasks.yaml
@@ -3,7 +3,7 @@ path: /etc/kubernetes/manifests
 type: directory
 ---
 contents: |
-  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --cgroup-driver=systemd --cgroup-root=/ --client-ca-file=/srv/kubernetes/ca.crt --cloud-provider=external --cluster-dns=100.64.0.10 --cluster-domain=cluster.local --enable-debugging-handlers=true --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5% --feature-gates=CSIMigrationAWS=true,InTreePluginAWSUnregister=true --kubeconfig=/var/lib/kubelet/kubeconfig --pod-infra-container-image=registry.k8s.io/pause:3.6 --pod-manifest-path=/etc/kubernetes/manifests --protect-kernel-defaults=true --register-schedulable=true --v=2 --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf"
+  DAEMON_ARGS="--authentication-token-webhook=true --authorization-mode=Webhook --client-ca-file=/srv/kubernetes/ca.crt --pod-manifest-path=/etc/kubernetes/manifests --register-schedulable=true --volume-plugin-dir=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ --cloud-config=/etc/kubernetes/in-tree-cloud.config --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock --tls-cert-file=/srv/kubernetes/kubelet-server.crt --tls-private-key-file=/srv/kubernetes/kubelet-server.key --config=/var/lib/kubelet/kubelet.conf"
   HOME="/root"
 path: /etc/sysconfig/kubelet
 type: file
@@ -37,8 +37,8 @@ contents: |
   nodeStatusReportFrequency: 0s
   nodeStatusUpdateFrequency: 0s
   runtimeRequestTimeout: 0s
-  shutdownGracePeriod: 30s
-  shutdownGracePeriodCriticalPods: 10s
+  shutdownGracePeriod: 0s
+  shutdownGracePeriodCriticalPods: 0s
   streamingConnectionIdleTimeout: 0s
   syncFrequency: 0s
   volumeStatsAggPeriod: 0s

--- a/pkg/model/tests/data/bootstrapscript_0.txt
+++ b/pkg/model/tests/data/bootstrapscript_0.txt
@@ -177,7 +177,7 @@ cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
 InstanceGroupName: testIG
 InstanceGroupRole: Master
-NodeupConfigHash: L9npiRTZoJ1W2sV9djQigAKS/Bg1SHddDfAZQ6CQAA4=
+NodeupConfigHash: 6auBaW1ndtw6OqCNSUTBHmtW6bXH/kMU3WzRyFTeybQ=
 
 __EOF_KUBE_ENV
 

--- a/pkg/model/tests/data/bootstrapscript_1.txt
+++ b/pkg/model/tests/data/bootstrapscript_1.txt
@@ -177,7 +177,7 @@ cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
 InstanceGroupName: testIG
 InstanceGroupRole: Master
-NodeupConfigHash: vB51JBmy+BhFYBTDlPnoR0TB5D8VUdMQrHeNa5Lj1bU=
+NodeupConfigHash: LCv1ZDd/8Ynuu2gWmHWnRUDDg9CEpFmjnutcYrzMHYs=
 
 __EOF_KUBE_ENV
 

--- a/pkg/model/tests/data/bootstrapscript_2.txt
+++ b/pkg/model/tests/data/bootstrapscript_2.txt
@@ -177,7 +177,7 @@ cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
 InstanceGroupName: testIG
 InstanceGroupRole: Master
-NodeupConfigHash: vB51JBmy+BhFYBTDlPnoR0TB5D8VUdMQrHeNa5Lj1bU=
+NodeupConfigHash: LCv1ZDd/8Ynuu2gWmHWnRUDDg9CEpFmjnutcYrzMHYs=
 
 __EOF_KUBE_ENV
 

--- a/pkg/model/tests/data/bootstrapscript_3.txt
+++ b/pkg/model/tests/data/bootstrapscript_3.txt
@@ -162,7 +162,7 @@ cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
 InstanceGroupName: testIG
 InstanceGroupRole: Node
-NodeupConfigHash: eTDaduFsjC2TKb+AiKZQXzn8M2eV4IOeu8A2AYWtug4=
+NodeupConfigHash: Bh4YTRR4vo/SNr+XIt/XQmPIBYtoyuQRLW/8w60U/Vg=
 
 __EOF_KUBE_ENV
 

--- a/pkg/model/tests/data/bootstrapscript_4.txt
+++ b/pkg/model/tests/data/bootstrapscript_4.txt
@@ -162,7 +162,7 @@ cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
 InstanceGroupName: testIG
 InstanceGroupRole: Node
-NodeupConfigHash: fMJM2U2CVyei2c7CA7yW+E+AdElvlON5ftZ8f/pFa6M=
+NodeupConfigHash: aK1PZEMBgHAGOeumVRsKASOjZqW+GHyIe/NV9G/xOQI=
 
 __EOF_KUBE_ENV
 

--- a/pkg/model/tests/data/bootstrapscript_5.txt
+++ b/pkg/model/tests/data/bootstrapscript_5.txt
@@ -162,7 +162,7 @@ cat > conf/kube_env.yaml << '__EOF_KUBE_ENV'
 CloudProvider: aws
 InstanceGroupName: testIG
 InstanceGroupRole: Node
-NodeupConfigHash: fMJM2U2CVyei2c7CA7yW+E+AdElvlON5ftZ8f/pFa6M=
+NodeupConfigHash: aK1PZEMBgHAGOeumVRsKASOjZqW+GHyIe/NV9G/xOQI=
 
 __EOF_KUBE_ENV
 

--- a/pkg/model/tests/data/nodeupconfig_0.txt
+++ b/pkg/model/tests/data/nodeupconfig_0.txt
@@ -16,15 +16,4 @@ Hooks:
 KeypairIDs: {}
 KubeletConfig:
   kubeconfigPath: /etc/kubernetes/igconfig.txt
-  nodeLabels:
-    kops.k8s.io/kops-controller-pki: ""
-    kubernetes.io/role: master
-    label2: value2
-    labelname: labelvalue
-    node-role.kubernetes.io/control-plane: ""
-    node-role.kubernetes.io/master: ""
-    node.kubernetes.io/exclude-from-external-load-balancers: ""
-  taints:
-  - key1=value1:NoSchedule
-  - key2=value2:NoExecute
 UpdatePolicy: automatic

--- a/pkg/model/tests/data/nodeupconfig_1.txt
+++ b/pkg/model/tests/data/nodeupconfig_1.txt
@@ -34,15 +34,4 @@ Hooks:
 KeypairIDs: {}
 KubeletConfig:
   kubeconfigPath: /etc/kubernetes/igconfig.txt
-  nodeLabels:
-    kops.k8s.io/kops-controller-pki: ""
-    kubernetes.io/role: master
-    label2: value2
-    labelname: labelvalue
-    node-role.kubernetes.io/control-plane: ""
-    node-role.kubernetes.io/master: ""
-    node.kubernetes.io/exclude-from-external-load-balancers: ""
-  taints:
-  - key1=value1:NoSchedule
-  - key2=value2:NoExecute
 UpdatePolicy: automatic

--- a/pkg/model/tests/data/nodeupconfig_2.txt
+++ b/pkg/model/tests/data/nodeupconfig_2.txt
@@ -34,15 +34,4 @@ Hooks:
 KeypairIDs: {}
 KubeletConfig:
   kubeconfigPath: /etc/kubernetes/igconfig.txt
-  nodeLabels:
-    kops.k8s.io/kops-controller-pki: ""
-    kubernetes.io/role: master
-    label2: value2
-    labelname: labelvalue
-    node-role.kubernetes.io/control-plane: ""
-    node-role.kubernetes.io/master: ""
-    node.kubernetes.io/exclude-from-external-load-balancers: ""
-  taints:
-  - key1=value1:NoSchedule
-  - key2=value2:NoExecute
 UpdatePolicy: automatic

--- a/pkg/model/tests/data/nodeupconfig_3.txt
+++ b/pkg/model/tests/data/nodeupconfig_3.txt
@@ -12,12 +12,4 @@ Hooks:
 KeypairIDs: {}
 KubeletConfig:
   kubeconfigPath: /etc/kubernetes/igconfig.txt
-  nodeLabels:
-    kubernetes.io/role: node
-    label2: value2
-    labelname: labelvalue
-    node-role.kubernetes.io/node: ""
-  taints:
-  - key1=value1:NoSchedule
-  - key2=value2:NoExecute
 UpdatePolicy: automatic

--- a/pkg/model/tests/data/nodeupconfig_4.txt
+++ b/pkg/model/tests/data/nodeupconfig_4.txt
@@ -30,12 +30,4 @@ Hooks:
 KeypairIDs: {}
 KubeletConfig:
   kubeconfigPath: /etc/kubernetes/igconfig.txt
-  nodeLabels:
-    kubernetes.io/role: node
-    label2: value2
-    labelname: labelvalue
-    node-role.kubernetes.io/node: ""
-  taints:
-  - key1=value1:NoSchedule
-  - key2=value2:NoExecute
 UpdatePolicy: automatic

--- a/pkg/model/tests/data/nodeupconfig_5.txt
+++ b/pkg/model/tests/data/nodeupconfig_5.txt
@@ -30,12 +30,4 @@ Hooks:
 KeypairIDs: {}
 KubeletConfig:
   kubeconfigPath: /etc/kubernetes/igconfig.txt
-  nodeLabels:
-    kubernetes.io/role: node
-    label2: value2
-    labelname: labelvalue
-    node-role.kubernetes.io/node: ""
-  taints:
-  - key1=value1:NoSchedule
-  - key2=value2:NoExecute
 UpdatePolicy: automatic

--- a/pkg/testutils/cluster.go
+++ b/pkg/testutils/cluster.go
@@ -116,6 +116,7 @@ func BuildMinimalMasterInstanceGroup(subnet string) kops.InstanceGroup {
 	g.ObjectMeta.Name = "master-" + subnet
 	g.Spec.Role = kops.InstanceGroupRoleMaster
 	g.Spec.Subnets = []string{subnet}
+	g.Spec.Image = "ami-1234abcd"
 
 	return g
 }


### PR DESCRIPTION
There are three places where one can configure `kubeletConfig` in our API: `kubelet` and `masterKubelet` in the cluster config, and `kubelet` in the `instancegroup`. If you want to do any sort of testing or validation of the kubeletconfig you have to validate all three places now as the configs are not merged until one tries to build nodeup config.

This PR does the merge in `populateInstanceGroup` instead so that one can always test against the IGs kubelet config.

Also some minor cleanups along the way. The golden output changes that comes a part of this should be fine.