### PR TITLE
Disable some flags in kube-controller-manager and kube-scheduler when logging-format is not text

### DIFF
--- a/nodeup/pkg/model/kube_scheduler.go
+++ b/nodeup/pkg/model/kube_scheduler.go
@@ -272,11 +272,17 @@ func (b *KubeSchedulerBuilder) buildPod(kubeScheduler *kops.KubeSchedulerConfig)
 		container.Args = append(container.Args, sortedStrings(flags)...)
 	} else {
 		container.Command = []string{"/usr/local/bin/kube-scheduler"}
-		container.Args = append(
-			sortedStrings(flags),
-			"--logtostderr=false", // https://github.com/kubernetes/klog/issues/60
-			"--alsologtostderr",
-			"--log-file=/var/log/kube-scheduler.log")
+		if kubeScheduler.LogFormat != "" && kubeScheduler.LogFormat != "text" {
+			// When logging-format is not text, some flags are not accepted.
+			// https://github.com/kubernetes/kops/issues/14100
+			container.Args = sortedStrings(flags)
+		} else {
+			container.Args = append(
+				sortedStrings(flags),
+				"--logtostderr=false", // https://github.com/kubernetes/klog/issues/60
+				"--alsologtostderr",
+				"--log-file=/var/log/kube-scheduler.log")
+		}
 	}
 
 	if kubeScheduler.MaxPersistentVolumes != nil {


### PR DESCRIPTION
Fixes #14100 

`kube-controller-manager` and `kube-scheduler` version of https://github.com/kubernetes/kops/pull/13264 .

Disable these flags because these are not accepted when logging-format is `json`.
* --logtostderr
* --alsologtostderr
* --log-file

https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/

And I confirmed kube-proxy, but there is no option regarding logging-format in [kube-proxy](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/). Of course, kops does not have such an option.
https://github.com/kubernetes/kops/blob/6f4bb0e4daf52084407491fb875f8621c1927eca/pkg/apis/kops/componentconfig.go#L238-L278