### PR TITLE
Automated cherry pick of #14113: Add deployment-specific selectors to nth pdb

### DIFF
--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: b00959d209cb73161173970727425d39b8b88ce7c9fbfc60970c20dbe5ce9a97
+    manifestHash: 6ac10f1bcbec5c020a04ddb78b3c190752a8917ec32e7fe4eee486884e0a33bc
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -130,6 +130,7 @@ spec:
         app.kubernetes.io/name: aws-node-termination-handler
         k8s-app: aws-node-termination-handler
         kops.k8s.io/managed-by: kops
+        kops.k8s.io/nth-mode: sqs
         kubernetes.io/os: linux
     spec:
       affinity:
@@ -243,6 +244,7 @@ spec:
           matchLabels:
             app.kubernetes.io/instance: aws-node-termination-handler
             app.kubernetes.io/name: aws-node-termination-handler
+            kops.k8s.io/nth-mode: sqs
         maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
         whenUnsatisfiable: ScheduleAnyway
@@ -250,6 +252,7 @@ spec:
           matchLabels:
             app.kubernetes.io/instance: aws-node-termination-handler
             app.kubernetes.io/name: aws-node-termination-handler
+            kops.k8s.io/nth-mode: sqs
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: DoNotSchedule
@@ -274,3 +277,4 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: aws-node-termination-handler
       app.kubernetes.io/name: aws-node-termination-handler
+      kops.k8s.io/nth-mode: sqs

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -102,7 +102,7 @@ metadata:
     k8s-app: aws-node-termination-handler
     app.kubernetes.io/version: "{{ .Version }}"
 spec:
-  replicas: 1
+  replicas: {{ ControlPlaneControllerReplicas true }}
   selector:
     matchLabels:
       app.kubernetes.io/name: aws-node-termination-handler
@@ -115,6 +115,7 @@ spec:
         app.kubernetes.io/instance: aws-node-termination-handler
         k8s-app: aws-node-termination-handler
         kubernetes.io/os: linux
+        kops.k8s.io/nth-mode: sqs
     spec:
       nodeSelector: null
       {{ if not UseServiceAccountExternalPermissions }}
@@ -234,6 +235,7 @@ spec:
           matchLabels:
             app.kubernetes.io/name: aws-node-termination-handler
             app.kubernetes.io/instance: aws-node-termination-handler
+            kops.k8s.io/nth-mode: sqs
       - maxSkew: 1
         topologyKey: "kubernetes.io/hostname"
         whenUnsatisfiable: DoNotSchedule
@@ -241,7 +243,7 @@ spec:
           matchLabels:
             app.kubernetes.io/name: aws-node-termination-handler
             app.kubernetes.io/instance: aws-node-termination-handler
-
+            kops.k8s.io/nth-mode: sqs
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -256,6 +258,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: aws-node-termination-handler
       app.kubernetes.io/instance: aws-node-termination-handler
+      kops.k8s.io/nth-mode: sqs
   maxUnavailable: 1
 {{ else }}
 ---


### PR DESCRIPTION
Cherry pick of #14113 on release-1.24.

#14113: Add deployment-specific selectors to nth pdb

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```