### PR TITLE
Revert back to using kubectl in channels

### DIFF
--- a/channels/pkg/channels/addon.go
+++ b/channels/pkg/channels/addon.go
@@ -41,6 +41,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type Applier interface {
+	Apply(ctx context.Context, data []byte) error
+}
+
 // Addon is a wrapper around a single version of an addon
 type Addon struct {
 	Name            string
@@ -153,7 +157,7 @@ func (a *Addon) GetManifestFullUrl() (*url.URL, error) {
 	return manifestURL, nil
 }
 
-func (a *Addon) EnsureUpdated(ctx context.Context, k8sClient kubernetes.Interface, cmClient certmanager.Interface, pruner *Pruner, applier *Applier, existingVersion *ChannelVersion) (*AddonUpdate, error) {
+func (a *Addon) EnsureUpdated(ctx context.Context, k8sClient kubernetes.Interface, cmClient certmanager.Interface, pruner *Pruner, applier Applier, existingVersion *ChannelVersion) (*AddonUpdate, error) {
 	required, err := a.GetRequiredUpdates(ctx, k8sClient, cmClient, existingVersion)
 	if err != nil {
 		return nil, err
@@ -179,7 +183,7 @@ func (a *Addon) EnsureUpdated(ctx context.Context, k8sClient kubernetes.Interfac
 	return required, merr
 }
 
-func (a *Addon) updateAddon(ctx context.Context, k8sClient kubernetes.Interface, pruner *Pruner, applier *Applier, required *AddonUpdate) error {
+func (a *Addon) updateAddon(ctx context.Context, k8sClient kubernetes.Interface, pruner *Pruner, applier Applier, required *AddonUpdate) error {
 	manifestURL, err := a.GetManifestFullUrl()
 	if err != nil {
 		return err

--- a/channels/pkg/channels/clientapplier.go
+++ b/channels/pkg/channels/clientapplier.go
@@ -33,13 +33,13 @@ import (
 	"k8s.io/kops/upup/pkg/fi"
 )
 
-type Applier struct {
+type ClientApplier struct {
 	Client     dynamic.Interface
 	RESTMapper *restmapper.DeferredDiscoveryRESTMapper
 }
 
 // Apply applies the manifest to the cluster.
-func (p *Applier) Apply(ctx context.Context, manifest []byte) error {
+func (p *ClientApplier) Apply(ctx context.Context, manifest []byte) error {
 	objects, err := kubemanifest.LoadObjectsFrom(manifest)
 	if err != nil {
 		return fmt.Errorf("failed to parse objects: %w", err)
@@ -70,7 +70,7 @@ func (p *Applier) Apply(ctx context.Context, manifest []byte) error {
 	return applyErrors
 }
 
-func (p *Applier) applyObjectsOfKind(ctx context.Context, gvk schema.GroupVersionKind, expectedObjects []*kubemanifest.Object) error {
+func (p *ClientApplier) applyObjectsOfKind(ctx context.Context, gvk schema.GroupVersionKind, expectedObjects []*kubemanifest.Object) error {
 	klog.V(2).Infof("applying objects of kind: %v", gvk)
 
 	restMapping, err := p.RESTMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
@@ -85,7 +85,7 @@ func (p *Applier) applyObjectsOfKind(ctx context.Context, gvk schema.GroupVersio
 	return nil
 }
 
-func (p *Applier) applyObjects(ctx context.Context, restMapping *meta.RESTMapping, expectedObjects []*kubemanifest.Object) error {
+func (p *ClientApplier) applyObjects(ctx context.Context, restMapping *meta.RESTMapping, expectedObjects []*kubemanifest.Object) error {
 	var merr error
 
 	for _, expectedObject := range expectedObjects {
@@ -96,7 +96,7 @@ func (p *Applier) applyObjects(ctx context.Context, restMapping *meta.RESTMappin
 	return merr
 }
 
-func (p *Applier) patchObject(ctx context.Context, restMapping *meta.RESTMapping, expectedObject *kubemanifest.Object) error {
+func (p *ClientApplier) patchObject(ctx context.Context, restMapping *meta.RESTMapping, expectedObject *kubemanifest.Object) error {
 	gvr := restMapping.Resource
 	name := expectedObject.GetName()
 	namespace := expectedObject.GetNamespace()

--- a/channels/pkg/channels/kubectlapplier.go
+++ b/channels/pkg/channels/kubectlapplier.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channels
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+type KubectlApplier struct{}
+
+// Apply calls kubectl apply to apply the manifest.
+// We will likely in future change this to create things directly (or more likely embed this logic into kubectl itself)
+func (*KubectlApplier) Apply(ctx context.Context, data []byte) error {
+	// We copy the manifest to a temp file because it is likely e.g. an s3 URL, which kubectl can't read
+	tmpDir, err := os.MkdirTemp("", "channel")
+	if err != nil {
+		return fmt.Errorf("error creating temp dir: %v", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			klog.Warningf("error deleting temp dir %q: %v", tmpDir, err)
+		}
+	}()
+
+	localManifestFile := path.Join(tmpDir, "manifest.yaml")
+	if err := os.WriteFile(localManifestFile, data, 0o600); err != nil {
+		return fmt.Errorf("error writing temp file: %v", err)
+	}
+	// First do an apply. This may fail when removing things from lists/arrays and required fields are not removed.
+	{
+		_, err := execKubectl(ctx, "apply", "-f", localManifestFile, "--server-side", "--force-conflicts", "--field-manager=kops")
+		if err != nil {
+			klog.Errorf("failed to apply the manifest: %v", err)
+		}
+
+	}
+
+	// Replace will force ownership on all fields to kops. But on some k8s versions, this will fail on e.g trying to set clusterIP to "".
+	{
+		_, err := execKubectl(ctx, "replace", "-f", localManifestFile, "--field-manager=kops")
+		if err != nil {
+			klog.Errorf("failed to replace manifest: %v", err)
+		}
+	}
+
+	// Do a final replace to ensure resources are correctly apply. This should always succeed if the addon is updated as expected.
+	{
+		_, err := execKubectl(ctx, "apply", "-f", localManifestFile, "--server-side", "--force-conflicts", "--field-manager=kops")
+		if err != nil {
+			return fmt.Errorf("failed to apply the manifest: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func execKubectl(ctx context.Context, args ...string) (string, error) {
+	kubectlPath := "kubectl" // Assume in PATH
+	cmd := exec.CommandContext(ctx, kubectlPath, args...)
+	env := os.Environ()
+	cmd.Env = env
+
+	human := strings.Join(cmd.Args, " ")
+	klog.V(2).Infof("Running command: %s", human)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Infof("error running %s", human)
+		klog.Info(string(output))
+		return string(output), fmt.Errorf("error running kubectl: %v", err)
+	}
+
+	return string(output), err
+}

--- a/channels/pkg/cmd/apply_channel.go
+++ b/channels/pkg/cmd/apply_channel.go
@@ -167,10 +167,13 @@ func applyMenu(ctx context.Context, menu *channels.AddonMenu, k8sClient kubernet
 		RESTMapper: restMapper,
 	}
 
-	applier := &channels.Applier{
-		Client:     dynamicClient,
-		RESTMapper: restMapper,
-	}
+	/*
+		applier := &channels.ClientApplier{
+			Client:     dynamicClient,
+			RESTMapper: restMapper,
+		}
+	*/
+	applier := &channels.KubectlApplier{}
 
 	var merr error
 


### PR DESCRIPTION
I think it will take a while to get the custom client production grade. Reverting to 1.24 behavior so that we get working tests and that this does not block any release.

Introduces an Applier interface and keeps the custom client based implementation.
