### PR TITLE
Write the user provided IG spec to state store instead of the full spec

### DIFF
--- a/pkg/apis/kops/validation/instancegroup_test.go
+++ b/pkg/apis/kops/validation/instancegroup_test.go
@@ -385,7 +385,7 @@ func TestIGUpdatePolicy(t *testing.T) {
 func TestValidInstanceGroup(t *testing.T) {
 	grid := []struct {
 		IG             *kops.InstanceGroup
-		ExpectedErrors int
+		ExpectedErrors []string
 		Description    string
 	}{
 		{
@@ -401,7 +401,7 @@ func TestValidInstanceGroup(t *testing.T) {
 					Image:   "my-image",
 				},
 			},
-			ExpectedErrors: 0,
+			ExpectedErrors: []string{},
 			Description:    "Valid master instance group failed to validate",
 		},
 		{
@@ -417,7 +417,7 @@ func TestValidInstanceGroup(t *testing.T) {
 					Image:   "my-image",
 				},
 			},
-			ExpectedErrors: 0,
+			ExpectedErrors: []string{},
 			Description:    "Valid API Server instance group failed to validate",
 		},
 		{
@@ -433,7 +433,7 @@ func TestValidInstanceGroup(t *testing.T) {
 					Image:   "my-image",
 				},
 			},
-			ExpectedErrors: 0,
+			ExpectedErrors: []string{},
 			Description:    "Valid node instance group failed to validate",
 		},
 		{
@@ -449,13 +449,28 @@ func TestValidInstanceGroup(t *testing.T) {
 					Image:   "my-image",
 				},
 			},
-			ExpectedErrors: 0,
+			ExpectedErrors: []string{},
 			Description:    "Valid bastion instance group failed to validate",
+		},
+		{
+			IG: &kops.InstanceGroup{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "eu-central-1a",
+				},
+				Spec: kops.InstanceGroupSpec{
+					Role:    kops.InstanceGroupRoleBastion,
+					Subnets: []string{"eu-central-1a"},
+					MaxSize: fi.Int32(1),
+					MinSize: fi.Int32(1),
+				},
+			},
+			ExpectedErrors: []string{"Forbidden::spec.image"},
+			Description:    "Valid instance group must have image set",
 		},
 	}
 	for _, g := range grid {
 		errList := ValidateInstanceGroup(g.IG, nil, true)
-		testErrors(t, g.Description, errList, []string{})
+		testErrors(t, g.Description, errList, g.ExpectedErrors)
 	}
 }
 

--- a/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/complex/expected-v1alpha2.yaml
@@ -65,11 +65,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -86,11 +83,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/different-amis/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/different-amis/expected-v1alpha2.yaml
@@ -77,11 +77,8 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: apiserver-us-test-1a
   role: APIServer
   subnets:
   - us-test-1a
@@ -101,11 +98,8 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: t2.micro
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test-1a
@@ -125,11 +119,8 @@ spec:
     httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -149,11 +140,8 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -66,12 +66,8 @@ metadata:
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-1
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: master-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -90,12 +86,8 @@ metadata:
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-2
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha/expected-v1alpha2.yaml
@@ -86,11 +86,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -107,11 +104,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -128,11 +122,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -149,11 +140,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a
@@ -170,11 +158,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1b
   role: Node
   subnets:
   - us-test-1b
@@ -191,11 +176,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1c
   role: Node
   subnets:
   - us-test-1c

--- a/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_encrypt/expected-v1alpha2.yaml
@@ -86,11 +86,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -107,11 +104,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b
   role: Master
   subnets:
   - us-test-1b
@@ -128,11 +122,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1c
   role: Master
   subnets:
   - us-test-1c
@@ -149,11 +140,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a
@@ -170,11 +158,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1b
   role: Node
   subnets:
   - us-test-1b
@@ -191,11 +176,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1c
   role: Node
   subnets:
   - us-test-1c

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -73,12 +73,8 @@ metadata:
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-1
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: master-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -97,12 +93,8 @@ metadata:
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-1
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: master-us-test1-b
   role: Master
   subnets:
   - us-test1
@@ -121,12 +113,8 @@ metadata:
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-1
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: master-us-test1-c
   role: Master
   subnets:
   - us-test1
@@ -145,12 +133,8 @@ metadata:
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-2
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1
@@ -169,12 +153,8 @@ metadata:
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-2
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-us-test1-b
   role: Node
   subnets:
   - us-test1
@@ -193,12 +173,8 @@ metadata:
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-2
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-us-test1-c
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zone/expected-v1alpha2.yaml
@@ -78,11 +78,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a-1
   role: Master
   subnets:
   - us-test-1a
@@ -99,11 +96,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a-2
   role: Master
   subnets:
   - us-test-1a
@@ -120,11 +114,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a-3
   role: Master
   subnets:
   - us-test-1a
@@ -141,11 +132,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_shared_zones/expected-v1alpha2.yaml
@@ -94,11 +94,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a-1
   role: Master
   subnets:
   - us-test-1a
@@ -115,11 +112,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a-2
   role: Master
   subnets:
   - us-test-1a
@@ -136,11 +130,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a-3
   role: Master
   subnets:
   - us-test-1a
@@ -157,11 +148,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b-1
   role: Master
   subnets:
   - us-test-1b
@@ -178,11 +166,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1b-2
   role: Master
   subnets:
   - us-test-1b
@@ -199,11 +184,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a
@@ -220,11 +202,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1b
   role: Node
   subnets:
   - us-test-1b

--- a/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ingwspecified/expected-v1alpha2.yaml
@@ -75,11 +75,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.micro
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test-1a
@@ -96,11 +93,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -117,11 +111,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ipv6/expected-v1alpha2.yaml
@@ -71,11 +71,8 @@ spec:
     httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -95,11 +92,8 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/karpenter/expected-v1alpha2.yaml
@@ -83,11 +83,8 @@ spec:
     httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -107,10 +104,6 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   manager: Karpenter
-  maxSize: 2
-  minSize: 2
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.20/expected-v1alpha2.yaml
@@ -66,11 +66,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -87,11 +84,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.21/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.21/expected-v1alpha2.yaml
@@ -66,11 +66,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -87,11 +84,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.22/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.22/expected-v1alpha2.yaml
@@ -69,11 +69,8 @@ spec:
     httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -93,11 +90,8 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.23/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.23/expected-v1alpha2.yaml
@@ -69,11 +69,8 @@ spec:
     httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -93,11 +90,8 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.24/expected-v1alpha2.yaml
@@ -69,11 +69,8 @@ spec:
     httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -93,11 +90,8 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.25/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.25/expected-v1alpha2.yaml
@@ -69,11 +69,8 @@ spec:
     httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -93,11 +90,8 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/minimal-1.26/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/minimal-1.26/expected-v1alpha2.yaml
@@ -69,11 +69,8 @@ spec:
     httpPutResponseHopLimit: 3
     httpTokens: required
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -93,11 +90,8 @@ spec:
     httpPutResponseHopLimit: 1
     httpTokens: required
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ngwspecified/expected-v1alpha2.yaml
@@ -75,11 +75,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.micro
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test-1a
@@ -96,11 +93,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -117,11 +111,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/overrides/expected-v1alpha2.yaml
@@ -69,11 +69,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -90,11 +87,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/private/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private/expected-v1alpha2.yaml
@@ -78,11 +78,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.micro
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test-1a
@@ -102,11 +99,8 @@ spec:
   - sg-exampleid4
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -126,11 +120,8 @@ spec:
   - sg-exampleid2
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -73,12 +73,8 @@ metadata:
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: f1-micro
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: bastions
   role: Bastion
   subnets:
   - us-test1
@@ -100,12 +96,8 @@ spec:
   - sg-exampleid4
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-1
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: master-us-test1-a
   role: Master
   subnets:
   - us-test1
@@ -127,12 +119,8 @@ spec:
   - sg-exampleid2
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
   machineType: n1-standard-2
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-us-test1-a
   role: Node
   subnets:
   - us-test1

--- a/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_shared_subnets/expected-v1alpha2.yaml
@@ -75,11 +75,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -96,11 +93,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets/expected-v1alpha2.yaml
@@ -68,11 +68,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -89,11 +86,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_subnets_vpc_lookup/expected-v1alpha2.yaml
@@ -68,11 +68,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -89,11 +86,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/shared_vpc/expected-v1alpha2.yaml
@@ -67,11 +67,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: m3.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: master-us-test-1a
   role: Master
   subnets:
   - us-test-1a
@@ -88,11 +85,8 @@ metadata:
 spec:
   image: 099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220615
   machineType: t2.medium
-  manager: CloudGroup
   maxSize: 1
   minSize: 1
-  nodeLabels:
-    kops.k8s.io/instancegroup: nodes-us-test-1a
   role: Node
   subnets:
   - us-test-1a

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -819,6 +819,7 @@ func (c *ApplyClusterCmd) upgradeSpecs(assetBuilder *assets.AssetBuilder) error 
 	}
 	c.Cluster = fullCluster
 
+	klog.Infof("Populating instance group from upgradeSpecs")
 	for i, g := range c.InstanceGroups {
 		fullGroup, err := PopulateInstanceGroupSpec(fullCluster, g, c.Cloud, c.channel)
 		if err != nil {

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -20,18 +20,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/blang/semver/v4"
 	"k8s.io/klog/v2"
 
 	"k8s.io/kops/pkg/apis/kops"
-	"k8s.io/kops/pkg/apis/kops/util"
 	"k8s.io/kops/pkg/apis/kops/validation"
-	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
-	"k8s.io/kops/util/pkg/architectures"
 	"k8s.io/kops/util/pkg/reflectutils"
 )
 
@@ -67,116 +62,16 @@ var awsDedicatedInstanceExceptions = map[string]bool{
 // PopulateInstanceGroupSpec sets default values in the InstanceGroup
 // The InstanceGroup is simpler than the cluster spec, so we just populate in place (like the rest of k8s)
 func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup, cloud fi.Cloud, channel *kops.Channel) (*kops.InstanceGroup, error) {
+	klog.Infof("Populating instance group spec for %q", input.GetName())
+
 	var err error
 	err = validation.ValidateInstanceGroup(input, nil, false).ToAggregate()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed validating input specs: %w", err)
 	}
 
 	ig := &kops.InstanceGroup{}
 	reflectutils.JSONMergeStruct(ig, input)
-
-	// TODO: Clean up
-	if ig.IsMaster() {
-		if ig.Spec.MachineType == "" {
-			ig.Spec.MachineType, err = defaultMachineType(cloud, cluster, ig)
-			if err != nil {
-				return nil, fmt.Errorf("error assigning default machine type for masters: %v", err)
-			}
-
-		}
-		if ig.Spec.MinSize == nil {
-			ig.Spec.MinSize = fi.Int32(1)
-		}
-		if ig.Spec.MaxSize == nil {
-			ig.Spec.MaxSize = fi.Int32(1)
-		}
-	} else if ig.Spec.Role == kops.InstanceGroupRoleBastion {
-		if ig.Spec.MachineType == "" {
-			ig.Spec.MachineType, err = defaultMachineType(cloud, cluster, ig)
-			if err != nil {
-				return nil, fmt.Errorf("error assigning default machine type for bastions: %v", err)
-			}
-		}
-		if ig.Spec.MinSize == nil {
-			ig.Spec.MinSize = fi.Int32(1)
-		}
-		if ig.Spec.MaxSize == nil {
-			ig.Spec.MaxSize = fi.Int32(1)
-		}
-	} else {
-		if ig.IsAPIServerOnly() && !featureflag.APIServerNodes.Enabled() {
-			return nil, fmt.Errorf("apiserver nodes requires the APIServerNodes feature flag to be enabled")
-		}
-		if ig.Spec.MachineType == "" {
-			ig.Spec.MachineType, err = defaultMachineType(cloud, cluster, ig)
-			if err != nil {
-				return nil, fmt.Errorf("error assigning default machine type for nodes: %v", err)
-			}
-		}
-		if ig.Spec.MinSize == nil {
-			ig.Spec.MinSize = fi.Int32(2)
-		}
-		if ig.Spec.MaxSize == nil {
-			ig.Spec.MaxSize = fi.Int32(2)
-		}
-	}
-
-	if ig.Spec.Image == "" {
-		architecture, err := MachineArchitecture(cloud, ig.Spec.MachineType)
-		if err != nil {
-			return nil, fmt.Errorf("unable to determine machine architecture for InstanceGroup %q: %v", ig.ObjectMeta.Name, err)
-		}
-		ig.Spec.Image = defaultImage(cluster, channel, architecture)
-		if ig.Spec.Image == "" {
-			return nil, fmt.Errorf("unable to determine default image for InstanceGroup %s", ig.ObjectMeta.Name)
-		}
-	}
-
-	if ig.Spec.Tenancy != "" && ig.Spec.Tenancy != "default" {
-		switch cluster.Spec.GetCloudProvider() {
-		case kops.CloudProviderAWS:
-			if _, ok := awsDedicatedInstanceExceptions[ig.Spec.MachineType]; ok {
-				return nil, fmt.Errorf("invalid dedicated instance type: %s", ig.Spec.MachineType)
-			}
-		default:
-			klog.Warning("Trying to set tenancy on non-AWS environment")
-		}
-	}
-
-	if ig.IsMaster() {
-		if len(ig.Spec.Subnets) == 0 {
-			return nil, fmt.Errorf("master InstanceGroup %s did not specify any Subnets", ig.ObjectMeta.Name)
-		}
-	} else if ig.IsAPIServerOnly() && cluster.Spec.IsIPv6Only() {
-		if len(ig.Spec.Subnets) == 0 {
-			for _, subnet := range cluster.Spec.Subnets {
-				if subnet.Type != kops.SubnetTypePrivate && subnet.Type != kops.SubnetTypeUtility {
-					ig.Spec.Subnets = append(ig.Spec.Subnets, subnet.Name)
-				}
-			}
-		}
-	} else {
-		if len(ig.Spec.Subnets) == 0 {
-			for _, subnet := range cluster.Spec.Subnets {
-				if subnet.Type != kops.SubnetTypeDualStack && subnet.Type != kops.SubnetTypeUtility {
-					ig.Spec.Subnets = append(ig.Spec.Subnets, subnet.Name)
-				}
-			}
-		}
-
-		if len(ig.Spec.Subnets) == 0 {
-			for _, subnet := range cluster.Spec.Subnets {
-				if subnet.Type != kops.SubnetTypeUtility {
-					ig.Spec.Subnets = append(ig.Spec.Subnets, subnet.Name)
-				}
-			}
-		}
-	}
-
-	if len(ig.Spec.Subnets) == 0 {
-		return nil, fmt.Errorf("unable to infer any Subnets for InstanceGroup %s ", ig.ObjectMeta.Name)
-	}
 
 	hasGPU := false
 	clusterNvidia := false
@@ -295,64 +190,4 @@ func defaultMachineType(cloud fi.Cloud, cluster *kops.Cluster, ig *kops.Instance
 
 	klog.V(2).Infof("Cannot set default MachineType for CloudProvider=%q, Role=%q", cluster.Spec.GetCloudProvider(), ig.Spec.Role)
 	return "", nil
-}
-
-// defaultImage returns the default Image, based on the cloudprovider
-func defaultImage(cluster *kops.Cluster, channel *kops.Channel, architecture architectures.Architecture) string {
-	if channel != nil {
-		var kubernetesVersion *semver.Version
-		if cluster.Spec.KubernetesVersion != "" {
-			var err error
-			kubernetesVersion, err = util.ParseKubernetesVersion(cluster.Spec.KubernetesVersion)
-			if err != nil {
-				klog.Warningf("cannot parse KubernetesVersion %q in cluster", cluster.Spec.KubernetesVersion)
-			}
-		}
-		if kubernetesVersion != nil {
-			image := channel.FindImage(cluster.Spec.GetCloudProvider(), *kubernetesVersion, architecture)
-			if image != nil {
-				return image.Name
-			}
-		}
-	}
-
-	switch cluster.Spec.GetCloudProvider() {
-	case kops.CloudProviderDO:
-		return defaultDONodeImage
-	}
-	klog.Infof("Cannot set default Image for CloudProvider=%q", cluster.Spec.GetCloudProvider())
-	return ""
-}
-
-func MachineArchitecture(cloud fi.Cloud, machineType string) (architectures.Architecture, error) {
-	if machineType == "" {
-		return architectures.ArchitectureAmd64, nil
-	}
-
-	switch cloud.ProviderID() {
-	case kops.CloudProviderAWS:
-		info, err := cloud.(awsup.AWSCloud).DescribeInstanceType(machineType)
-		if err != nil {
-			return "", fmt.Errorf("error finding instance info for instance type %q: %v", machineType, err)
-		}
-		if info.ProcessorInfo == nil || len(info.ProcessorInfo.SupportedArchitectures) == 0 {
-			return "", fmt.Errorf("error finding architecture info for instance type %q", machineType)
-		}
-		var unsupported []string
-		for _, arch := range info.ProcessorInfo.SupportedArchitectures {
-			// Return the first found supported architecture, in order of popularity
-			switch fi.StringValue(arch) {
-			case ec2.ArchitectureTypeX8664:
-				return architectures.ArchitectureAmd64, nil
-			case ec2.ArchitectureTypeArm64:
-				return architectures.ArchitectureArm64, nil
-			default:
-				unsupported = append(unsupported, fi.StringValue(arch))
-			}
-		}
-		return "", fmt.Errorf("unsupported architecture for instance type %q: %v", machineType, unsupported)
-	default:
-		// No other clouds are known to support any other architectures at this time
-		return architectures.ArchitectureAmd64, nil
-	}
 }

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec_test.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec_test.go
@@ -70,16 +70,6 @@ func TestPopulateInstanceGroup_Role_Required(t *testing.T) {
 	expectErrorFromPopulateInstanceGroup(t, cluster, g, channel, "spec.role")
 }
 
-func TestPopulateInstanceGroup_Image_Required(t *testing.T) {
-	_, cluster := buildMinimalCluster()
-	g := buildMinimalNodeInstanceGroup()
-	g.Spec.Image = ""
-
-	channel := &kopsapi.Channel{}
-
-	expectErrorFromPopulateInstanceGroup(t, cluster, g, channel, "unable to determine default image for InstanceGroup nodes")
-}
-
 func TestPopulateInstanceGroup_AddTaintsCollision(t *testing.T) {
 	_, cluster := buildMinimalCluster()
 	input := buildMinimalNodeInstanceGroup()


### PR DESCRIPTION
With clusters, we write the input spec to the cluster store. The full spec is also uploaded, which is eventually used by nodeup.

With IGs, however, we write the full spec (after expanding and setting all defaults) to the cluster store. Further defaults are then done in places less appropriate such as during nodeup or during the building of nodeup config. The reason for this is probably that nodeup used the IG spec earlier, while now this isn't needed since nodeup only uses the nodeup config.

This PR writes the input spec to the cluster store, but it does validate the expanded cluster spec (_before_ the not so appropriate expansion though!). This will allow us to move more expansions to populateInstanceGroupSpec without mutating the user input before storing it.

Some of the setup logic done in populateInstanceGroupSpec such as setting image and machine type has been moved to new_cluster.

Some of the mutation has been skipped as well (some node labels and the provider type), which is the cause of the create cluster golden output diffs. There should be no diffs to update cluster or nodeup configs though.