### PR TITLE
Automated cherry pick of #14134: Limit GCE network names to 63 chars

### DIFF
--- a/pkg/model/gcemodel/context.go
+++ b/pkg/model/gcemodel/context.go
@@ -34,7 +34,7 @@ type GCEModelContext struct {
 // LinkToNetwork returns the GCE Network object the cluster is located in
 func (c *GCEModelContext) LinkToNetwork() (*gcetasks.Network, error) {
 	if c.Cluster.Spec.NetworkID == "" {
-		return &gcetasks.Network{Name: s(c.SafeClusterName())}, nil
+		return &gcetasks.Network{Name: s(c.SafeTruncatedClusterName())}, nil
 	}
 	name, project, err := gce.ParseNameAndProjectFromNetworkID(c.Cluster.Spec.NetworkID)
 	if err != nil {
@@ -80,6 +80,11 @@ func (c *GCEModelContext) SafeSuffixedObjectName(name string) string {
 // SafeClusterName returns the cluster name escaped for use as a GCE resource name
 func (c *GCEModelContext) SafeClusterName() string {
 	return gce.SafeClusterName(c.Cluster.ObjectMeta.Name)
+}
+
+// SafeClusterName returns the cluster name escaped and truncated for use as a GCE resource name
+func (c *GCEModelContext) SafeTruncatedClusterName() string {
+	return gce.SafeTruncatedClusterName(c.Cluster.ObjectMeta.Name, 63)
 }
 
 // GCETagForRole returns the (network) tag for GCE instances in the given instance group role.

--- a/pkg/resources/gce/gce.go
+++ b/pkg/resources/gce/gce.go
@@ -1166,7 +1166,7 @@ func (d *clusterDiscoveryGCE) listNetworks() ([]*resources.Resource, error) {
 	}
 
 	for _, o := range networks.Items {
-		if o.Name != gce.SafeClusterName(d.clusterName) {
+		if o.Name != gce.SafeTruncatedClusterName(d.clusterName, 63) {
 			klog.V(8).Infof("skipping network with name %q", o.Name)
 			continue
 		}

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/kubernetes.tf
@@ -233,7 +233,7 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-with-a-very-ver
   }
   disabled    = false
   name        = "master-to-master-minimal-gce-with-a-very-very-very-very--96dqvi"
-  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_tags = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
   target_tags = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -259,7 +259,7 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-with-a-very-very-
   }
   disabled    = false
   name        = "master-to-node-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
-  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_tags = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
   target_tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -275,7 +275,7 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
   }
   disabled    = false
   name        = "node-to-master-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
-  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
   target_tags = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -301,7 +301,7 @@ resource "google_compute_firewall" "node-to-node-minimal-gce-with-a-very-very-ve
   }
   disabled    = false
   name        = "node-to-node-minimal-gce-with-a-very-very-very-very-very-96dqvi"
-  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
   target_tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -317,7 +317,7 @@ resource "google_compute_firewall" "nodeport-external-to-node-ipv6-minimal-gce-w
   }
   disabled      = true
   name          = "nodeport-external-to-node-ipv6-minimal-gce-with-a-very-v-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["::/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -333,7 +333,7 @@ resource "google_compute_firewall" "nodeport-external-to-node-minimal-gce-with-a
   }
   disabled      = true
   name          = "nodeport-external-to-node-minimal-gce-with-a-very-very-v-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -345,7 +345,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-with
   }
   disabled      = true
   name          = "ssh-external-to-master-ipv6-minimal-gce-with-a-very-very-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["::/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -357,7 +357,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-with-a-ve
   }
   disabled      = false
   name          = "ssh-external-to-master-minimal-gce-with-a-very-very-very-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -369,7 +369,7 @@ resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-with-a
   }
   disabled      = true
   name          = "ssh-external-to-node-ipv6-minimal-gce-with-a-very-very-v-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["::/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -381,7 +381,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-with-a-very
   }
   disabled      = false
   name          = "ssh-external-to-node-minimal-gce-with-a-very-very-very-v-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -391,7 +391,7 @@ resource "google_compute_forwarding_rule" "us-test-1-minimal-gce-with-a-very-ver
   ip_protocol           = "TCP"
   load_balancing_scheme = "INTERNAL"
   name                  = "us-test-1-minimal-gce-with-a-very-very-very-very-very-lo-96dqvi"
-  network               = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network               = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   ports                 = ["443"]
   subnetwork            = "us-test-1"
 }
@@ -452,7 +452,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-with-
   }
   name_prefix = "master-us-test1-a-minimal-ivl9ll-"
   network_interface {
-    network    = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+    network    = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
     subnetwork = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
   }
   scheduling {
@@ -496,7 +496,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
   }
   name_prefix = "nodes-minimal-gce-with-a--k0ql96-"
   network_interface {
-    network    = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+    network    = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
     subnetwork = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
   }
   scheduling {
@@ -511,14 +511,14 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
   tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
 
-resource "google_compute_network" "minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
+resource "google_compute_network" "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi" {
   auto_create_subnetworks = false
-  name                    = "minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
+  name                    = "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi"
 }
 
 resource "google_compute_router" "nat-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {
   name    = "nat-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi"
-  network = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
 }
 
 resource "google_compute_router_nat" "nat-minimal-gce-with-a-very-very-very-very-very-long-nam-96dqvi" {
@@ -536,7 +536,7 @@ resource "google_compute_router_nat" "nat-minimal-gce-with-a-very-very-very-very
 resource "google_compute_subnetwork" "us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi" {
   ip_cidr_range = "10.0.16.0/20"
   name          = "us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   region        = "us-test1"
 }
 

--- a/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/kubernetes.tf
@@ -209,7 +209,7 @@ resource "google_compute_firewall" "kubernetes-master-https-ipv6-minimal-gce-wit
   }
   disabled      = true
   name          = "kubernetes-master-https-ipv6-minimal-gce-with-a-very-ver-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["::/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -221,7 +221,7 @@ resource "google_compute_firewall" "kubernetes-master-https-minimal-gce-with-a-v
   }
   disabled      = false
   name          = "kubernetes-master-https-minimal-gce-with-a-very-very-ver-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -247,7 +247,7 @@ resource "google_compute_firewall" "master-to-master-minimal-gce-with-a-very-ver
   }
   disabled    = false
   name        = "master-to-master-minimal-gce-with-a-very-very-very-very--96dqvi"
-  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_tags = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
   target_tags = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -273,7 +273,7 @@ resource "google_compute_firewall" "master-to-node-minimal-gce-with-a-very-very-
   }
   disabled    = false
   name        = "master-to-node-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
-  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_tags = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
   target_tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -289,7 +289,7 @@ resource "google_compute_firewall" "node-to-master-minimal-gce-with-a-very-very-
   }
   disabled    = false
   name        = "node-to-master-minimal-gce-with-a-very-very-very-very-ve-96dqvi"
-  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
   target_tags = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -315,7 +315,7 @@ resource "google_compute_firewall" "node-to-node-minimal-gce-with-a-very-very-ve
   }
   disabled    = false
   name        = "node-to-node-minimal-gce-with-a-very-very-very-very-very-96dqvi"
-  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network     = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
   target_tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -331,7 +331,7 @@ resource "google_compute_firewall" "nodeport-external-to-node-ipv6-minimal-gce-w
   }
   disabled      = true
   name          = "nodeport-external-to-node-ipv6-minimal-gce-with-a-very-v-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["::/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -347,7 +347,7 @@ resource "google_compute_firewall" "nodeport-external-to-node-minimal-gce-with-a
   }
   disabled      = true
   name          = "nodeport-external-to-node-minimal-gce-with-a-very-very-v-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -359,7 +359,7 @@ resource "google_compute_firewall" "ssh-external-to-master-ipv6-minimal-gce-with
   }
   disabled      = true
   name          = "ssh-external-to-master-ipv6-minimal-gce-with-a-very-very-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["::/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -371,7 +371,7 @@ resource "google_compute_firewall" "ssh-external-to-master-minimal-gce-with-a-ve
   }
   disabled      = false
   name          = "ssh-external-to-master-minimal-gce-with-a-very-very-very-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-ver-96dqvi-k8s-io-role-master"]
 }
@@ -383,7 +383,7 @@ resource "google_compute_firewall" "ssh-external-to-node-ipv6-minimal-gce-with-a
   }
   disabled      = true
   name          = "ssh-external-to-node-ipv6-minimal-gce-with-a-very-very-v-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["::/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -395,7 +395,7 @@ resource "google_compute_firewall" "ssh-external-to-node-minimal-gce-with-a-very
   }
   disabled      = false
   name          = "ssh-external-to-node-minimal-gce-with-a-very-very-very-v-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
@@ -451,7 +451,7 @@ resource "google_compute_instance_template" "master-us-test1-a-minimal-gce-with-
   network_interface {
     access_config {
     }
-    network    = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+    network    = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
     subnetwork = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
   }
   scheduling {
@@ -497,7 +497,7 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
   network_interface {
     access_config {
     }
-    network    = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+    network    = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
     subnetwork = google_compute_subnetwork.us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi.name
   }
   scheduling {
@@ -512,15 +512,15 @@ resource "google_compute_instance_template" "nodes-minimal-gce-with-a-very-very-
   tags = ["minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node"]
 }
 
-resource "google_compute_network" "minimal-gce-with-a-very-very-very-very-very-long-name-example-com" {
+resource "google_compute_network" "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi" {
   auto_create_subnetworks = false
-  name                    = "minimal-gce-with-a-very-very-very-very-very-long-name-example-com"
+  name                    = "minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi"
 }
 
 resource "google_compute_subnetwork" "us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi" {
   ip_cidr_range = "10.0.16.0/20"
   name          = "us-test1-minimal-gce-with-a-very-very-very-very-very-lon-96dqvi"
-  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-example-com.name
+  network       = google_compute_network.minimal-gce-with-a-very-very-very-very-very-long-name-ex-96dqvi.name
   region        = "us-test1"
 }
 

--- a/upup/pkg/fi/cloudup/gce/utils.go
+++ b/upup/pkg/fi/cloudup/gce/utils.go
@@ -92,12 +92,27 @@ func ClusterSuffixedName(objectName string, clusterName string, maxLength int) s
 	return prefix + suffix
 }
 
-// SafeClusterName returns a cluster-suffixed name
+// SafeClusterName returns a safe cluster name
 // deprecated: prefer ClusterSuffixedName
 func SafeClusterName(clusterName string) string {
 	// GCE does not support . in tags / names
 	safeClusterName := strings.Replace(clusterName, ".", "-", -1)
 	return safeClusterName
+}
+
+// SafeTruncatedClusterName returns a safe and truncated cluster name
+func SafeTruncatedClusterName(clusterName string, maxLength int) string {
+	// GCE does not support . in tags / names
+	safeClusterName := strings.Replace(clusterName, ".", "-", -1)
+
+	opt := truncate.TruncateStringOptions{
+		MaxLength:     maxLength,
+		AlwaysAddHash: false,
+		HashLength:    6,
+	}
+	truncatedClusterName := truncate.TruncateString(safeClusterName, opt)
+
+	return truncatedClusterName
 }
 
 // SafeObjectName returns the object name and cluster name escaped for GCE


### PR DESCRIPTION
Cherry pick of #14134 on release-1.24.

#14134: Limit GCE network names to 63 chars

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```