### PR TITLE
Revert "Remove passing cluster name as positional argument"

### DIFF
--- a/cmd/kops/create_cluster.go
+++ b/cmd/kops/create_cluster.go
@@ -180,7 +180,7 @@ func NewCmdCreateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	encryptEtcdStorage := false
 
 	cmd := &cobra.Command{
-		Use:               "cluster",
+		Use:               "cluster [CLUSTER]",
 		Short:             createClusterShort,
 		Long:              createClusterLong,
 		Example:           createClusterExample,

--- a/cmd/kops/create_secret_ciliumpassword.go
+++ b/cmd/kops/create_secret_ciliumpassword.go
@@ -64,7 +64,7 @@ func NewCmdCreateSecretCiliumPassword(f *util.Factory, out io.Writer) *cobra.Com
 	options := &CreateSecretCiliumPasswordOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "ciliumpassword -f FILENAME",
+		Use:               "ciliumpassword [CLUSTER] -f FILENAME",
 		Short:             createSecretCiliumPasswordShort,
 		Long:              createSecretCiliumPasswordLong,
 		Example:           createSecretCiliumPasswordExample,

--- a/cmd/kops/create_secret_dockerconfig.go
+++ b/cmd/kops/create_secret_dockerconfig.go
@@ -69,7 +69,7 @@ func NewCmdCreateSecretDockerConfig(f *util.Factory, out io.Writer) *cobra.Comma
 	options := &CreateSecretDockerConfigOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "dockerconfig -f FILENAME",
+		Use:               "dockerconfig [CLUSTER] -f FILENAME",
 		Short:             createSecretDockerConfigShort,
 		Long:              createSecretDockerConfigLong,
 		Example:           createSecretDockerConfigExample,

--- a/cmd/kops/create_secret_encryptionconfig.go
+++ b/cmd/kops/create_secret_encryptionconfig.go
@@ -63,7 +63,7 @@ func NewCmdCreateSecretEncryptionConfig(f *util.Factory, out io.Writer) *cobra.C
 	options := &CreateSecretEncryptionConfigOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "encryptionconfig -f FILENAME",
+		Use:               "encryptionconfig [CLUSTER] -f FILENAME",
 		Short:             createSecretEncryptionConfigShort,
 		Long:              createSecretEncryptionConfigLong,
 		Example:           createSecretEncryptionConfigExample,

--- a/cmd/kops/create_secret_weavepassword.go
+++ b/cmd/kops/create_secret_weavepassword.go
@@ -71,7 +71,7 @@ func NewCmdCreateSecretWeavePassword(f *util.Factory, out io.Writer) *cobra.Comm
 	options := &CreateSecretWeavePasswordOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "weavepassword",
+		Use:               "weavepassword [CLUSTER]",
 		Short:             createSecretWeavePasswordShort,
 		Long:              createSecretWeavePasswordLong,
 		Example:           createSecretWeavePasswordExample,

--- a/cmd/kops/create_sshpublickey.go
+++ b/cmd/kops/create_sshpublickey.go
@@ -52,7 +52,7 @@ func NewCmdCreateSSHPublicKey(f *util.Factory, out io.Writer) *cobra.Command {
 	options := &CreateSSHPublicKeyOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "sshpublickey",
+		Use:               "sshpublickey [CLUSTER]",
 		Short:             createSSHPublicKeyShort,
 		Long:              createSSHPublicKeyLong,
 		Example:           createSSHPublicKeyExample,

--- a/cmd/kops/delete_cluster.go
+++ b/cmd/kops/delete_cluster.go
@@ -66,7 +66,7 @@ func NewCmdDeleteCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	options := &DeleteClusterOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "cluster",
+		Use:               "cluster [CLUSTER]",
 		Short:             deleteClusterShort,
 		Long:              deleteClusterLong,
 		Example:           deleteClusterExample,

--- a/cmd/kops/delete_sshpublickey.go
+++ b/cmd/kops/delete_sshpublickey.go
@@ -46,7 +46,7 @@ func NewCmdDeleteSSHPublicKey(f *util.Factory, out io.Writer) *cobra.Command {
 	options := &DeleteSSHPublicKeyOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "sshpublickey",
+		Use:               "sshpublickey [CLUSTER]",
 		Short:             deleteSSHPublicKeyShort,
 		Example:           deleteSSHPublicKeyExample,
 		Args:              rootCommand.clusterNameArgs(&options.ClusterName),

--- a/cmd/kops/edit_cluster.go
+++ b/cmd/kops/edit_cluster.go
@@ -74,7 +74,7 @@ func NewCmdEditCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	options := &EditClusterOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "cluster",
+		Use:               "cluster [CLUSTER]",
 		Short:             i18n.T("Edit cluster."),
 		Long:              editClusterLong,
 		Example:           editClusterExample,

--- a/cmd/kops/get_assets.go
+++ b/cmd/kops/get_assets.go
@@ -84,7 +84,7 @@ func NewCmdGetAssets(f *util.Factory, out io.Writer, getOptions *GetOptions) *co
 	}
 
 	cmd := &cobra.Command{
-		Use:               "assets",
+		Use:               "assets [CLUSTER]",
 		Short:             getAssetsShort,
 		Long:              getAssetsLong,
 		Example:           getAssetsExample,

--- a/cmd/kops/get_instances.go
+++ b/cmd/kops/get_instances.go
@@ -67,7 +67,7 @@ type renderableCloudInstance struct {
 
 func NewCmdGetInstances(f *util.Factory, out io.Writer, options *GetOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "instances",
+		Use:               "instances [CLUSTER]",
 		Short:             getInstancesShort,
 		Example:           getInstancesExample,
 		Args:              rootCommand.clusterNameArgs(&options.ClusterName),

--- a/cmd/kops/get_sshpublickeys.go
+++ b/cmd/kops/get_sshpublickeys.go
@@ -50,7 +50,7 @@ func NewCmdGetSSHPublicKeys(f *util.Factory, out io.Writer, getOptions *GetOptio
 		GetOptions: getOptions,
 	}
 	cmd := &cobra.Command{
-		Use:               "sshpublickeys",
+		Use:               "sshpublickeys [CLUSTER]",
 		Aliases:           []string{"sshpublickey", "ssh"},
 		Short:             getSSHPublicKeysShort,
 		Example:           getSSHPublicKeysExample,

--- a/cmd/kops/rolling-update_cluster.go
+++ b/cmd/kops/rolling-update_cluster.go
@@ -166,7 +166,7 @@ func NewCmdRollingUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	options.InitDefaults()
 
 	cmd := &cobra.Command{
-		Use:               "cluster",
+		Use:               "cluster [CLUSTER]",
 		Short:             rollingupdateShort,
 		Long:              rollingupdateLong,
 		Example:           rollingupdateExample,

--- a/cmd/kops/root.go
+++ b/cmd/kops/root.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/kops/pkg/client/simple"
 	"k8s.io/kops/pkg/commands"
 	"k8s.io/kops/pkg/commands/commandutils"
-	"k8s.io/kops/pkg/featureflag"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -268,13 +267,10 @@ func (c *RootCmd) clusterNameArgsAllowNoCluster(clusterName *string) func(cmd *c
 func (c *RootCmd) ProcessArgs(args []string) error {
 	if len(args) > 0 {
 		fmt.Fprintf(os.Stderr, "\n")
-		fmt.Fprintf(os.Stderr, "\nClusterName as positional argument is deprecated and will be removed\n")
-		fmt.Fprintf(os.Stderr, "Use `KOPS_FEATURE_FLAGS=PositionalClusterArg` to revert to the old behavior.")
+		fmt.Fprintf(os.Stderr, "\nClusterName as positional argument is deprecated and will be removed in a future version\n")
 		fmt.Fprintf(os.Stderr, "\n")
 	}
-	if !featureflag.PositionalClusterArg.Enabled() {
-		return nil
-	}
+
 	if len(args) == 0 {
 		return nil
 	}

--- a/cmd/kops/toolbox_dump.go
+++ b/cmd/kops/toolbox_dump.go
@@ -75,7 +75,7 @@ func NewCmdToolboxDump(f commandutils.Factory, out io.Writer) *cobra.Command {
 	options.InitDefaults()
 
 	cmd := &cobra.Command{
-		Use:               "dump",
+		Use:               "dump [CLUSTER]",
 		Short:             toolboxDumpShort,
 		Long:              toolboxDumpLong,
 		Example:           toolboxDumpExample,

--- a/cmd/kops/toolbox_template.go
+++ b/cmd/kops/toolbox_template.go
@@ -79,7 +79,7 @@ func NewCmdToolboxTemplate(f commandutils.Factory, out io.Writer) *cobra.Command
 	}
 
 	cmd := &cobra.Command{
-		Use:               "template",
+		Use:               "template [CLUSTER]",
 		Short:             toolboxTemplatingShort,
 		Long:              toolboxTemplatingLong,
 		Example:           toolboxTemplatingExample,

--- a/cmd/kops/update_cluster.go
+++ b/cmd/kops/update_cluster.go
@@ -101,7 +101,7 @@ func NewCmdUpdateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	options.InitDefaults()
 
 	cmd := &cobra.Command{
-		Use:               "cluster",
+		Use:               "cluster [CLUSTER]",
 		Short:             updateClusterShort,
 		Long:              updateClusterLong,
 		Example:           updateClusterExample,

--- a/cmd/kops/upgrade_cluster.go
+++ b/cmd/kops/upgrade_cluster.go
@@ -66,7 +66,7 @@ func NewCmdUpgradeCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	options := &UpgradeClusterOptions{}
 
 	cmd := &cobra.Command{
-		Use:               "cluster",
+		Use:               "cluster [CLUSTER]",
 		Short:             upgradeClusterShort,
 		Long:              upgradeClusterLong,
 		Example:           upgradeClusterExample,

--- a/cmd/kops/validate_cluster.go
+++ b/cmd/kops/validate_cluster.go
@@ -78,7 +78,7 @@ func NewCmdValidateCluster(f *util.Factory, out io.Writer) *cobra.Command {
 	options.InitDefaults()
 
 	cmd := &cobra.Command{
-		Use:               "cluster",
+		Use:               "cluster [CLUSTER]",
 		Short:             validateClusterShort,
 		Long:              validateClusterLong,
 		Example:           validateClusterExample,

--- a/docs/cli/kops_create_cluster.md
+++ b/docs/cli/kops_create_cluster.md
@@ -12,7 +12,7 @@ Create a Kubernetes cluster using command line flags. This command creates cloud
  These operations are done in parallel and rely on eventual consistency.
 
 ```
-kops create cluster [flags]
+kops create cluster [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_create_secret_ciliumpassword.md
+++ b/docs/cli/kops_create_secret_ciliumpassword.md
@@ -10,7 +10,7 @@ Create a Cilium IPsec configuration.
 Create a new Cilium IPsec configuration and store it in the state store. This is used by Cilium to encrypt communication between pods/nodes.
 
 ```
-kops create secret ciliumpassword -f FILENAME [flags]
+kops create secret ciliumpassword [CLUSTER] -f FILENAME [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_create_secret_dockerconfig.md
+++ b/docs/cli/kops_create_secret_dockerconfig.md
@@ -14,7 +14,7 @@ Create a new Docker config and store it in the state store. Used to configure Do
  This will also work when using containerd as the container runtime.
 
 ```
-kops create secret dockerconfig -f FILENAME [flags]
+kops create secret dockerconfig [CLUSTER] -f FILENAME [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_create_secret_encryptionconfig.md
+++ b/docs/cli/kops_create_secret_encryptionconfig.md
@@ -10,7 +10,7 @@ Create an encryption config.
 Create a new encryption config and store it in the state store. Used to configure encryption-at-rest by the kube-apiserver process.
 
 ```
-kops create secret encryptionconfig -f FILENAME [flags]
+kops create secret encryptionconfig [CLUSTER] -f FILENAME [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_create_secret_weavepassword.md
+++ b/docs/cli/kops_create_secret_weavepassword.md
@@ -14,7 +14,7 @@ Create a new weave encryption secret and store it in the state store. Used by We
  WARNING: cannot be enabled or changed on a running cluster without downtime.
 
 ```
-kops create secret weavepassword [flags]
+kops create secret weavepassword [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_create_sshpublickey.md
+++ b/docs/cli/kops_create_sshpublickey.md
@@ -10,7 +10,7 @@ Create an SSH public key.
 Create a new SSH public key, and store the key in the state store.  The key is not updated by this command.
 
 ```
-kops create sshpublickey [flags]
+kops create sshpublickey [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_delete_cluster.md
+++ b/docs/cli/kops_delete_cluster.md
@@ -10,7 +10,7 @@ Delete a cluster.
 Deletes a Kubernetes cluster and all associated resources.  Resources include instancegroups, secrets, and the state store.  There is no "UNDO" for this command.
 
 ```
-kops delete cluster [flags]
+kops delete cluster [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_delete_sshpublickey.md
+++ b/docs/cli/kops_delete_sshpublickey.md
@@ -6,7 +6,7 @@
 Delete an SSH public key.
 
 ```
-kops delete sshpublickey [flags]
+kops delete sshpublickey [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_edit_cluster.md
+++ b/docs/cli/kops_edit_cluster.md
@@ -17,7 +17,7 @@ This command changes the desired cluster configuration in the registry.
 kops edit does not update the cloud resources; to apply the changes use `kops update cluster`.
 
 ```
-kops edit cluster [flags]
+kops edit cluster [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_get_assets.md
+++ b/docs/cli/kops_get_assets.md
@@ -14,7 +14,7 @@ When invoked with the `--copy` flag, will copy each asset from the
 canonical to the download location.
 
 ```
-kops get assets [flags]
+kops get assets [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_get_instances.md
+++ b/docs/cli/kops_get_instances.md
@@ -6,7 +6,7 @@
 Display cluster instances.
 
 ```
-kops get instances [flags]
+kops get instances [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_get_sshpublickeys.md
+++ b/docs/cli/kops_get_sshpublickeys.md
@@ -6,7 +6,7 @@
 Get one or many secrets.
 
 ```
-kops get sshpublickeys [flags]
+kops get sshpublickeys [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_rolling-update_cluster.md
+++ b/docs/cli/kops_rolling-update_cluster.md
@@ -22,7 +22,7 @@ Note: terraform users will need to run all of the following commands from the sa
 `terraform apply` prior to running `kops rolling-update cluster`.
 
 ```
-kops rolling-update cluster [flags]
+kops rolling-update cluster [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_toolbox_dump.md
+++ b/docs/cli/kops_toolbox_dump.md
@@ -10,7 +10,7 @@ Dump cluster information
 Displays cluster information.  Includes information about cloud and Kubernetes resources.
 
 ```
-kops toolbox dump [flags]
+kops toolbox dump [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_toolbox_template.md
+++ b/docs/cli/kops_toolbox_template.md
@@ -10,7 +10,7 @@ Generate cluster.yaml from template
 Generate cluster.yaml from values input yaml file and apply template.
 
 ```
-kops toolbox template [flags]
+kops toolbox template [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_update_cluster.md
+++ b/docs/cli/kops_update_cluster.md
@@ -12,7 +12,7 @@ Create or update cloud or cluster resources to match the current cluster and ins
  If, such as during a Kubernetes upgrade, nodes need updating, a rolling-update may be subsequently required.
 
 ```
-kops update cluster [flags]
+kops update cluster [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_upgrade_cluster.md
+++ b/docs/cli/kops_upgrade_cluster.md
@@ -12,7 +12,7 @@ production ready Kubernetes version. After this command is run, use `kops update
 to finish a cluster upgrade.
 
 ```
-kops upgrade cluster [flags]
+kops upgrade cluster [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/cli/kops_validate_cluster.md
+++ b/docs/cli/kops_validate_cluster.md
@@ -15,7 +15,7 @@ This commands validates the following components:
   4.  All pods with a critical priority are running and have "Ready" status.
 
 ```
-kops validate cluster [flags]
+kops validate cluster [CLUSTER] [flags]
 ```
 
 ### Examples

--- a/docs/releases/1.25-NOTES.md
+++ b/docs/releases/1.25-NOTES.md
@@ -20,12 +20,6 @@ This changes the default behavior where the CSI snaphotter container was always 
 
 So in case of manually deployed CRDs to make the snapshotter work it is now necessary to [enable the snapshot controller](https://kops.sigs.k8s.io/addons/#snapshot-controller).
 
-## kOps CLI no longer accepts cluster name as positional argument
-
-Prior to kOps 1.25, one could pass cluser name as a CLI argument to most functions. E.g `kOps get <clustername>`. As of kOps 1.25, kOps commands only accepts the cluster name through the `--name` flag or the `KOPS_CLUSTER_NAME` environment variable. The one exception to this change is the `kops get cluster` command, which still accepts one or more cluster names as positional arguments.
-
-This change is behind a feature flag. For now, one can revert to the old behavior by setting `KOPS_FEATURE_FLAGS=PositionalClusterArg`.
-
 ## Other breaking changes
 
 * Support for Kubernetes version 1.19 has been removed.

--- a/pkg/featureflag/featureflag.go
+++ b/pkg/featureflag/featureflag.go
@@ -92,8 +92,6 @@ var (
 	ImageDigest = new("ImageDigest", Bool(true))
 	// Hetzner toggles the Hetzner Cloud support.
 	Hetzner = new("Hetzner", Bool(false))
-	// PositionalClusterArg enables passing cluster name as positional argument to various kOps commands
-	PositionalClusterArg = new("PositionalClusterArg", Bool(false))
 )
 
 // FeatureFlag defines a feature flag


### PR DESCRIPTION
This reverts commit 824eb9cabb04ca81990dd96330e3d85e7d76650b / #14076.

The current deprecation pace is too fast, so we'll start off with only a warning.