### PR TITLE
Remove life cycle hooks when warmpool is disabled

### DIFF
--- a/cloudmock/aws/mockautoscaling/group.go
+++ b/cloudmock/aws/mockautoscaling/group.go
@@ -358,7 +358,8 @@ func (m *MockAutoscaling) PutLifecycleHook(input *autoscaling.PutLifecycleHookIn
 	if m.LifecycleHooks == nil {
 		m.LifecycleHooks = make(map[string]*autoscaling.LifecycleHook)
 	}
-	m.LifecycleHooks[*hook.AutoScalingGroupName] = hook
+	name := *input.AutoScalingGroupName + "::" + *input.LifecycleHookName
+	m.LifecycleHooks[name] = hook
 
 	return &autoscaling.PutLifecycleHookOutput{}, nil
 }
@@ -367,13 +368,14 @@ func (m *MockAutoscaling) DescribeLifecycleHooks(input *autoscaling.DescribeLife
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	name := *input.AutoScalingGroupName
 	response := &autoscaling.DescribeLifecycleHooksOutput{}
+	for _, lifecycleHookName := range input.LifecycleHookNames {
+		name := *input.AutoScalingGroupName + "::" + *lifecycleHookName
 
-	hook := m.LifecycleHooks[name]
-	if hook == nil {
-		return response, nil
+		hook := m.LifecycleHooks[name]
+		if hook != nil {
+			response.LifecycleHooks = append(response.LifecycleHooks, hook)
+		}
 	}
-	response.LifecycleHooks = []*autoscaling.LifecycleHook{hook}
 	return response, nil
 }

--- a/pkg/model/awsmodel/nodeterminationhandler.go
+++ b/pkg/model/awsmodel/nodeterminationhandler.go
@@ -112,6 +112,7 @@ func (b *NodeTerminationHandlerBuilder) configureASG(c *fi.ModelBuilderContext, 
 		DefaultResult:       aws.String("CONTINUE"),
 		HeartbeatTimeout:    aws.Int64(DefaultMessageRetentionPeriod),
 		LifecycleTransition: aws.String("autoscaling:EC2_INSTANCE_TERMINATING"),
+		Enabled:             aws.Bool(true),
 	}
 
 	c.AddTask(lifecyleTask)

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -225,3 +225,4 @@ spec:
     nodes: public
   warmPool:
     enableLifecycleHook: true
+    maxSize: 1

--- a/tests/integration/update_cluster/minimal-warmpool/in-v1alpha2.yaml
+++ b/tests/integration/update_cluster/minimal-warmpool/in-v1alpha2.yaml
@@ -43,6 +43,7 @@ spec:
     zone: us-test-1a
   warmPool:
     enableLifecycleHook: true
+    maxSize: 1
 
 ---
 

--- a/upup/pkg/fi/cloudup/awstasks/sqs.go
+++ b/upup/pkg/fi/cloudup/awstasks/sqs.go
@@ -116,7 +116,9 @@ func (q *SQS) Find(c *fi.Context) (*SQS, error) {
 		if reflect.DeepEqual(actualJson, expectedJson) {
 			klog.V(2).Infof("actual Policy was json-equal to expected; returning expected value")
 			actualPolicy = expectedPolicy
+			q.Policy = fi.NewStringResource(expectedPolicy)
 		}
+
 	}
 
 	actual := &SQS{


### PR DESCRIPTION
If one enables warm pool, then disables it, kops does not clean up life cycle hooks. This PR fixes that.