### PR TITLE
Plug the IAM role leak

### DIFF
--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -1998,9 +1998,6 @@ func ListIAMRoles(cloud fi.Cloud, clusterName string) ([]*resources.Resource, er
 		err := c.IAM().ListRolesPages(request, func(p *iam.ListRolesOutput, lastPage bool) bool {
 			for _, r := range p.Roles {
 				name := aws.StringValue(r.RoleName)
-				if !strings.HasSuffix(name, "."+clusterName) {
-					continue
-				}
 
 				getRequest := &iam.GetRoleInput{RoleName: r.RoleName}
 				roleOutput, err := c.IAM().GetRole(getRequest)

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -2084,9 +2084,6 @@ func ListIAMInstanceProfiles(cloud fi.Cloud, clusterName string) ([]*resources.R
 	err := c.IAM().ListInstanceProfilesPages(request, func(p *iam.ListInstanceProfilesOutput, lastPage bool) bool {
 		for _, p := range p.InstanceProfiles {
 			name := aws.StringValue(p.InstanceProfileName)
-			if !strings.HasSuffix(name, "."+clusterName) {
-				continue
-			}
 
 			getRequest := &iam.GetInstanceProfileInput{InstanceProfileName: p.InstanceProfileName}
 			profileOutput, err := c.IAM().GetInstanceProfile(getRequest)

--- a/pkg/resources/aws/aws.go
+++ b/pkg/resources/aws/aws.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -2002,8 +2003,14 @@ func ListIAMRoles(cloud fi.Cloud, clusterName string) ([]*resources.Resource, er
 				getRequest := &iam.GetRoleInput{RoleName: r.RoleName}
 				roleOutput, err := c.IAM().GetRole(getRequest)
 				if err != nil {
-					getRoleErr = fmt.Errorf("calling IAM GetRole on %s: %w", name, err)
-					return false
+					if awserror, ok := err.(awserr.RequestFailure); ok && awserror.StatusCode() == 403 {
+						klog.Warningf("failed to determine ownership of %q: %v", *r.RoleName, awserror)
+
+						return true
+					} else {
+						getRoleErr = fmt.Errorf("calling IAM GetRole on %s: %w", name, err)
+						return false
+					}
 				}
 				for _, tag := range roleOutput.Role.Tags {
 					if fi.StringValue(tag.Key) == ownershipTag && fi.StringValue(tag.Value) == "owned" {


### PR DESCRIPTION
Looks like we were indeed leaking IAM roles. The code has assumed that all roles are prefixed with the cluster name, which is true for the instance profile roles, but rarely true for the SA roles. The SA roles have almost always truncated names.