### PR TITLE
Allow self-managed aws-ebs-csi-driver

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -322,6 +322,22 @@ spec:
       enabled: true
 ```
 
+##### Self-managed aws-ebs-csi-driver
+
+{{ kops_feature_table(kops_added_default='1.25') }}
+
+The following configuration allows for a self-managed aws-ebs-csi-driver. Please note that if you’re using Amazon EBS volumes, you must install the Amazon EBS CSI driver. If the Amazon EBS CSI plugin is not installed, then volume operations will fail. 
+
+If IRSA is not enabled, the control plane will have the permissions to provision nodes, and the self-managed controllers should run on the control plane. If IRSA is enabled, kOps will create the respective AWS IAM Role, assign the policy, and establish a trust relationship allowing the ServiceAccount to assume the IAM Role. To configure Pods to assume the given IAM roles, enable the [Pod Identity Webhook](https://kops.sigs.k8s.io/addons/#pod-identity-webhook). Without this webhook, you need to modify your Pod specs yourself for your Pod to assume the defined roles.
+
+```yaml
+spec:
+  cloudConfig:
+    awsEBSCSIDriver:
+      enabled: true
+      managed: false
+```
+
 ## Custom addons
 
 The command `kops create cluster` does not support specifying addons to be added to the cluster when it is created. Instead they can be added after cluster creation using kubectl. Alternatively when creating a cluster from a yaml manifest, addons can be specified using `spec.addons`.

--- a/k8s/crds/kops.k8s.io_clusters.yaml
+++ b/k8s/crds/kops.k8s.io_clusters.yaml
@@ -322,6 +322,11 @@ spec:
                         description: 'Enabled enables the AWS EBS CSI driver Default:
                           false'
                         type: boolean
+                      managed:
+                        description: Managed controls if aws-ebs-csi-driver is manged
+                          and deployed by kOps. The deployment of aws-ebs-csi-driver
+                          is skipped if this is set to false.
+                        type: boolean
                       podAnnotations:
                         additionalProperties:
                           type: string

--- a/pkg/apis/kops/componentconfig.go
+++ b/pkg/apis/kops/componentconfig.go
@@ -883,6 +883,10 @@ type AWSEBSCSIDriver struct {
 	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
 
+	// Managed controls if aws-ebs-csi-driver is manged and deployed by kOps.
+	// The deployment of aws-ebs-csi-driver is skipped if this is set to false.
+	Managed *bool `json:"managed,omitempty"`
+
 	// Version is the container image tag used.
 	// Default: The latest stable release which is compatible with your Kubernetes version
 	Version *string `json:"version,omitempty"`

--- a/pkg/apis/kops/v1alpha2/componentconfig.go
+++ b/pkg/apis/kops/v1alpha2/componentconfig.go
@@ -909,6 +909,10 @@ type AWSEBSCSIDriver struct {
 	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
 
+	// Managed controls if aws-ebs-csi-driver is manged and deployed by kOps.
+	// The deployment of aws-ebs-csi-driver is skipped if this is set to false.
+	Managed *bool `json:"managed,omitempty"`
+
 	// Version is the container image tag used.
 	// Default: The latest stable release which is compatible with your Kubernetes version
 	Version *string `json:"version,omitempty"`

--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
@@ -1317,6 +1317,7 @@ func Convert_kops_AWSAuthenticationSpec_To_v1alpha2_AWSAuthenticationSpec(in *ko
 
 func autoConvert_v1alpha2_AWSEBSCSIDriver_To_kops_AWSEBSCSIDriver(in *AWSEBSCSIDriver, out *kops.AWSEBSCSIDriver, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Managed = in.Managed
 	out.Version = in.Version
 	out.VolumeAttachLimit = in.VolumeAttachLimit
 	out.PodAnnotations = in.PodAnnotations
@@ -1330,6 +1331,7 @@ func Convert_v1alpha2_AWSEBSCSIDriver_To_kops_AWSEBSCSIDriver(in *AWSEBSCSIDrive
 
 func autoConvert_kops_AWSEBSCSIDriver_To_v1alpha2_AWSEBSCSIDriver(in *kops.AWSEBSCSIDriver, out *AWSEBSCSIDriver, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Managed = in.Managed
 	out.Version = in.Version
 	out.VolumeAttachLimit = in.VolumeAttachLimit
 	out.PodAnnotations = in.PodAnnotations

--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
@@ -100,6 +100,11 @@ func (in *AWSEBSCSIDriver) DeepCopyInto(out *AWSEBSCSIDriver) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Managed != nil {
+		in, out := &in.Managed, &out.Managed
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Version != nil {
 		in, out := &in.Version, &out.Version
 		*out = new(string)

--- a/pkg/apis/kops/v1alpha3/componentconfig.go
+++ b/pkg/apis/kops/v1alpha3/componentconfig.go
@@ -880,6 +880,10 @@ type AWSEBSCSIDriver struct {
 	// Default: false
 	Enabled *bool `json:"enabled,omitempty"`
 
+	// Managed controls if aws-ebs-csi-driver is manged and deployed by kOps.
+	// The deployment of aws-ebs-csi-driver is skipped if this is set to false.
+	Managed *bool `json:"managed,omitempty"`
+
 	// Version is the container image tag used.
 	// Default: The latest stable release which is compatible with your Kubernetes version
 	Version *string `json:"version,omitempty"`

--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
@@ -1317,6 +1317,7 @@ func Convert_kops_AWSAuthenticationSpec_To_v1alpha3_AWSAuthenticationSpec(in *ko
 
 func autoConvert_v1alpha3_AWSEBSCSIDriver_To_kops_AWSEBSCSIDriver(in *AWSEBSCSIDriver, out *kops.AWSEBSCSIDriver, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Managed = in.Managed
 	out.Version = in.Version
 	out.VolumeAttachLimit = in.VolumeAttachLimit
 	out.PodAnnotations = in.PodAnnotations
@@ -1330,6 +1331,7 @@ func Convert_v1alpha3_AWSEBSCSIDriver_To_kops_AWSEBSCSIDriver(in *AWSEBSCSIDrive
 
 func autoConvert_kops_AWSEBSCSIDriver_To_v1alpha3_AWSEBSCSIDriver(in *kops.AWSEBSCSIDriver, out *AWSEBSCSIDriver, s conversion.Scope) error {
 	out.Enabled = in.Enabled
+	out.Managed = in.Managed
 	out.Version = in.Version
 	out.VolumeAttachLimit = in.VolumeAttachLimit
 	out.PodAnnotations = in.PodAnnotations

--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
@@ -101,6 +101,11 @@ func (in *AWSEBSCSIDriver) DeepCopyInto(out *AWSEBSCSIDriver) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Managed != nil {
+		in, out := &in.Managed, &out.Managed
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Version != nil {
 		in, out := &in.Version, &out.Version
 		*out = new(string)

--- a/pkg/apis/kops/zz_generated.deepcopy.go
+++ b/pkg/apis/kops/zz_generated.deepcopy.go
@@ -100,6 +100,11 @@ func (in *AWSEBSCSIDriver) DeepCopyInto(out *AWSEBSCSIDriver) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Managed != nil {
+		in, out := &in.Managed, &out.Managed
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Version != nil {
 		in, out := &in.Version, &out.Version
 		*out = new(string)

--- a/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
+++ b/upup/pkg/fi/cloudup/bootstrapchannelbuilder/bootstrapchannelbuilder.go
@@ -1102,7 +1102,9 @@ func (b *BootstrapChannelBuilder) buildAddons(c *fi.ModelBuilderContext) (*Addon
 				serviceAccountRoles = append(serviceAccountRoles, &awscloudcontrollermanager.ServiceAccount{})
 			}
 		}
-		if b.Cluster.Spec.CloudConfig != nil && b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver != nil && fi.BoolValue(b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled) {
+		if b.Cluster.Spec.CloudConfig != nil && b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver != nil &&
+			fi.BoolValue(b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver.Enabled) &&
+			(b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver.Managed == nil || fi.BoolValue(b.Cluster.Spec.CloudConfig.AWSEBSCSIDriver.Managed)) {
 			key := "aws-ebs-csi-driver.addons.k8s.io"
 
 			{


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- This PR allows provisioning of aws-ebs-csi-driver externally. kOps 1.24 with K8s 1.24 enables `external-cloud-controller-manager` which requires CSI. If you disable the CSI driver: 

```
cloudConfig:
    awsEBSCSIDriver:
      enabled: false
```
you will encounter the following error: 

```
Error: completed cluster failed validation: spec.externalCloudControllerManager: Forbidden: AWS external CCM cannot be used without enabling spec.cloudConfig.AWSEBSCSIDriver.
```

**What testing is done?** 
- Old behavior:
```
$ ./kops update cluster --name old-behavior.k8s.local | grep ebs-csi-driver
I0822 17:02:48.070331  455254 apply_cluster.go:822] Populating instance group from upgradeSpecs
I0822 17:02:48.070369  455254 populate_instancegroup_spec.go:65] Populating instance group spec for "master-us-east-1a"
I0822 17:02:48.070567  455254 populate_instancegroup_spec.go:65] Populating instance group spec for "nodes-us-east-1a"
I0822 17:02:49.686892  455254 apply_cluster.go:485] Gossip DNS: skipping DNS validation
I0822 17:02:55.026020  455254 executor.go:111] Tasks: 0 done / 98 total; 44 can run
W0822 17:02:55.317923  455254 vfs_castore.go:379] CA private key was not found
I0822 17:02:55.375552  455254 executor.go:111] Tasks: 44 done / 98 total; 18 can run
I0822 17:02:55.576459  455254 executor.go:111] Tasks: 62 done / 98 total; 26 can run
I0822 17:02:55.844811  455254 executor.go:111] Tasks: 88 done / 98 total; 2 can run
I0822 17:02:55.947808  455254 executor.go:111] Tasks: 90 done / 98 total; 4 can run
I0822 17:02:56.262856  455254 executor.go:111] Tasks: 94 done / 98 total; 2 can run
I0822 17:02:56.527165  455254 executor.go:111] Tasks: 96 done / 98 total; 2 can run
I0822 17:02:56.679547  455254 executor.go:111] Tasks: 98 done / 98 total; 0 can run
  ManagedFile/old-behavior.k8s.local-addons-aws-ebs-csi-driver.addons.k8s.io-k8s-1.17
  	Location            	addons/aws-ebs-csi-driver.addons.k8s.io/k8s-1.17.yaml
```

- New behavior: 
```
$ ./kops update cluster --name new-behavior.k8s.local | grep ebs-csi-driver
I0822 17:02:09.223997  454050 apply_cluster.go:822] Populating instance group from upgradeSpecs
I0822 17:02:09.224027  454050 populate_instancegroup_spec.go:65] Populating instance group spec for "master-us-east-1a"
I0822 17:02:09.224269  454050 populate_instancegroup_spec.go:65] Populating instance group spec for "nodes-us-east-1a"
I0822 17:02:10.842019  454050 apply_cluster.go:485] Gossip DNS: skipping DNS validation
I0822 17:02:13.979847  454050 executor.go:111] Tasks: 0 done / 97 total; 43 can run
W0822 17:02:14.349111  454050 vfs_castore.go:379] CA private key was not found
I0822 17:02:14.410168  454050 executor.go:111] Tasks: 43 done / 97 total; 18 can run
I0822 17:02:14.656567  454050 executor.go:111] Tasks: 61 done / 97 total; 26 can run
I0822 17:02:15.125537  454050 executor.go:111] Tasks: 87 done / 97 total; 2 can run
I0822 17:02:15.230007  454050 executor.go:111] Tasks: 89 done / 97 total; 4 can run
I0822 17:02:15.582829  454050 executor.go:111] Tasks: 93 done / 97 total; 2 can run
I0822 17:02:15.882818  454050 executor.go:111] Tasks: 95 done / 97 total; 2 can run
I0822 17:02:15.998724  454050 executor.go:111] Tasks: 97 done / 97 total; 0 can run
```

```
$ ./kops get cluster new-behavior.k8s.local -o yaml > new.yaml

$ ./kops get cluster old-behavior.k8s.local -o yaml > old.yaml

$ diff old.yaml new.yaml
13a15,18
>   cloudConfig:
>     awsEBSCSIDriver:
>       enabled: true
>       managed: false
```

Signed-off-by: Eddie Torres <torredil@amazon.com>