### PR TITLE
Fix the non-ci markers

### DIFF
--- a/tests/e2e/scenarios/upgrade-ab/run-test.sh
+++ b/tests/e2e/scenarios/upgrade-ab/run-test.sh
@@ -29,12 +29,14 @@ if [[ "$K8S_VERSION_A" == "latest" ]]; then
 fi
 if [[ "$K8S_VERSION_B" == "latest" ]]; then
   K8S_VERSION_B=$(curl https://storage.googleapis.com/kubernetes-release/release/latest.txt)
+  TEST_PACKAGE_MARKER="latest.txt"
 fi
 if [[ "$K8S_VERSION_A" == "stable" ]]; then
   K8S_VERSION_A=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 fi
 if [[ "$K8S_VERSION_B" == "stable" ]]; then
   K8S_VERSION_B=$(curl https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+  TEST_PACKAGE_MARKER="stable.txt"
 fi
 if [[ "$K8S_VERSION_A" == "ci" ]]; then
   K8S_VERSION_A=https://storage.googleapis.com/k8s-release-dev/ci/$(curl https://storage.googleapis.com/k8s-release-dev/ci/latest.txt)
@@ -137,8 +139,12 @@ test_package_args="--parallel 25"
 
 if [[ -n ${TEST_PACKAGE_MARKER-} ]]; then
   test_package_args+=" --test-package-marker=${TEST_PACKAGE_MARKER}"
-  test_package_args+=" --test-package-dir=${TEST_PACKAGE_DIR-}"
-  test_package_args+=" --test-package-bucket=${TEST_PACKAGE_BUCKET-}"
+  if [[ -n ${TEST_PACKAGE_DIR-} ]]; then
+    test_package_args+=" --test-package-dir=${TEST_PACKAGE_DIR-}"
+  fi
+  if [[ -n ${TEST_PACKAGE_BUCKET-} ]]; then
+    test_package_args+=" --test-package-bucket=${TEST_PACKAGE_BUCKET-}"
+  fi
 else
   test_package_args+=" --test-package-version=${TEST_PACKAGE_VERSION}"
 fi


### PR DESCRIPTION
/cc @hakman @rifelpet 

This should hopefully take case of the klatest upgrades, which are the last of the e2e unexpectedly failing.