### PR TITLE
OIDC: Tolerate extra service-account key set items

### DIFF
--- a/pkg/model/issuerdiscovery.go
+++ b/pkg/model/issuerdiscovery.go
@@ -130,6 +130,9 @@ func (o *OIDCKeys) Open() (io.Reader, error) {
 		if item.DistrustTimestamp != nil {
 			continue
 		}
+		if item.Certificate == nil || item.Certificate.Subject.CommonName != "service-account" {
+			continue
+		}
 
 		publicKey := item.Certificate.PublicKey
 		publicKeyDERBytes, err := x509.MarshalPKIXPublicKey(publicKey)


### PR DESCRIPTION
When reading the _kOps_ "service-account" key set in preparation for publishing the OIDC JWKS file (such as to S3 alongside the discovery document), in some cases the set contains items that either lack an X.509 certificate or contain such a certificate issued for a subject with common name other than "service-account." Ignore these extra key set items and instead only project JWKS keys for those with an X.509
certificate with the expected subject common name.

Refs: #14174