### PR TITLE
Bump snapshot-controller to 6.0.1

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -134,7 +134,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: b90c4e2d827b79e747410bce1a45262ab46ee070e3a7c035879b14a1735fcb6c
+    manifestHash: afddd701326e01eeb49e71ac389d8f31925bdd618f1767bcf112104338f0264f
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1089,14 +1089,6 @@ rules:
   - watch
   - update
 - apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - events
@@ -1119,11 +1111,9 @@ rules:
   resources:
   - volumesnapshotcontents
   verbs:
-  - create
   - get
   - list
   - watch
-  - update
   - delete
   - patch
 - apiGroups:
@@ -1224,10 +1214,10 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -1271,7 +1261,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -141,7 +141,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: b90c4e2d827b79e747410bce1a45262ab46ee070e3a7c035879b14a1735fcb6c
+    manifestHash: afddd701326e01eeb49e71ac389d8f31925bdd618f1767bcf112104338f0264f
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1089,14 +1089,6 @@ rules:
   - watch
   - update
 - apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - events
@@ -1119,11 +1111,9 @@ rules:
   resources:
   - volumesnapshotcontents
   verbs:
-  - create
   - get
   - list
   - watch
-  - update
   - delete
   - patch
 - apiGroups:
@@ -1224,10 +1214,10 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -1271,7 +1261,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -141,7 +141,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: b90c4e2d827b79e747410bce1a45262ab46ee070e3a7c035879b14a1735fcb6c
+    manifestHash: afddd701326e01eeb49e71ac389d8f31925bdd618f1767bcf112104338f0264f
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1089,14 +1089,6 @@ rules:
   - watch
   - update
 - apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - events
@@ -1119,11 +1111,9 @@ rules:
   resources:
   - volumesnapshotcontents
   verbs:
-  - create
   - get
   - list
   - watch
-  - update
   - delete
   - patch
 - apiGroups:
@@ -1224,10 +1214,10 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -1271,7 +1261,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -141,7 +141,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: b90c4e2d827b79e747410bce1a45262ab46ee070e3a7c035879b14a1735fcb6c
+    manifestHash: afddd701326e01eeb49e71ac389d8f31925bdd618f1767bcf112104338f0264f
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1089,14 +1089,6 @@ rules:
   - watch
   - update
 - apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - events
@@ -1119,11 +1111,9 @@ rules:
   resources:
   - volumesnapshotcontents
   verbs:
-  - create
   - get
   - list
   - watch
-  - update
   - delete
   - patch
 - apiGroups:
@@ -1224,10 +1214,10 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -1271,7 +1261,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -134,7 +134,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: b90c4e2d827b79e747410bce1a45262ab46ee070e3a7c035879b14a1735fcb6c
+    manifestHash: afddd701326e01eeb49e71ac389d8f31925bdd618f1767bcf112104338f0264f
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1089,14 +1089,6 @@ rules:
   - watch
   - update
 - apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - events
@@ -1119,11 +1111,9 @@ rules:
   resources:
   - volumesnapshotcontents
   verbs:
-  - create
   - get
   - list
   - watch
-  - update
   - delete
   - patch
 - apiGroups:
@@ -1224,10 +1214,10 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -1271,7 +1261,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -134,7 +134,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: b90c4e2d827b79e747410bce1a45262ab46ee070e3a7c035879b14a1735fcb6c
+    manifestHash: afddd701326e01eeb49e71ac389d8f31925bdd618f1767bcf112104338f0264f
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1089,14 +1089,6 @@ rules:
   - watch
   - update
 - apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - events
@@ -1119,11 +1111,9 @@ rules:
   resources:
   - volumesnapshotcontents
   verbs:
-  - create
   - get
   - list
   - watch
-  - update
   - delete
   - patch
 - apiGroups:
@@ -1224,10 +1214,10 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -1271,7 +1261,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -127,7 +127,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.20
     manifest: snapshot-controller.addons.k8s.io/k8s-1.20.yaml
-    manifestHash: b90c4e2d827b79e747410bce1a45262ab46ee070e3a7c035879b14a1735fcb6c
+    manifestHash: afddd701326e01eeb49e71ac389d8f31925bdd618f1767bcf112104338f0264f
     name: snapshot-controller.addons.k8s.io
     needsPKI: true
     selector:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-snapshot-controller.addons.k8s.io-k8s-1.20_content
@@ -1089,14 +1089,6 @@ rules:
   - watch
   - update
 - apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - events
@@ -1119,11 +1111,9 @@ rules:
   resources:
   - volumesnapshotcontents
   verbs:
-  - create
   - get
   - list
   - watch
-  - update
   - delete
   - patch
 - apiGroups:
@@ -1224,10 +1214,10 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -1271,7 +1261,7 @@ spec:
       - args:
         - --tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt
         - --tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key
-        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-validation
         ports:

--- a/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
+++ b/upup/models/cloudup/resources/addons/snapshot-controller.addons.k8s.io/k8s-1.20.yaml.template
@@ -1052,14 +1052,6 @@ rules:
   - watch
   - update
 - apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - events
@@ -1082,11 +1074,9 @@ rules:
   resources:
   - volumesnapshotcontents
   verbs:
-  - create
   - get
   - list
   - watch
-  - update
   - delete
   - patch
 - apiGroups:
@@ -1164,7 +1154,7 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: gcr.io/k8s-staging-sig-storage/snapshot-controller:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-controller:v6.0.1
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
       topologySpreadConstraints:
@@ -1180,7 +1170,7 @@ spec:
         labelSelector:
           matchLabels:
             app: snapshot-controller
-      serviceAccount: snapshot-controller
+      serviceAccountName: snapshot-controller
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1201,7 +1191,7 @@ spec:
     spec:
       containers:
       - name: snapshot-validation
-        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.0
+        image: registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1
         imagePullPolicy: IfNotPresent
         args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/tls.crt', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/tls.key']
         ports:


### PR DESCRIPTION
Upstream has very inconsistent example deployments, and are not even using the latest images there. But I verified this to be working using the k8s e2e suite with snapshotting enabled.