### PR TITLE
Automated cherry pick of #14175: OIDC: Tolerate extra service-account key set items

### DIFF
--- a/pkg/model/issuerdiscovery.go
+++ b/pkg/model/issuerdiscovery.go
@@ -130,6 +130,9 @@ func (o *OIDCKeys) Open() (io.Reader, error) {
 		if item.DistrustTimestamp != nil {
 			continue
 		}
+		if item.Certificate == nil || item.Certificate.Subject.CommonName != "service-account" {
+			continue
+		}
 
 		publicKey := item.Certificate.PublicKey
 		publicKeyDERBytes, err := x509.MarshalPKIXPublicKey(publicKey)


### PR DESCRIPTION
Cherry pick of #14175 on release-1.24.

#14175: OIDC: Tolerate extra service-account key set items

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```