### PR TITLE
Automated cherry pick of #14137: Always disable rp_filter when using cilium

### DIFF
--- a/nodeup/pkg/model/sysctls.go
+++ b/nodeup/pkg/model/sysctls.go
@@ -176,6 +176,14 @@ func (b *SysctlBuilder) Build(c *fi.ModelBuilderContext) error {
 			"")
 	}
 
+	if b.Cluster.Spec.Networking.Cilium != nil {
+		sysctls = append(sysctls,
+			"# Depending on systemd version, cloud and distro, rp_filters may be enabled.",
+			"# Cilium requires this to be disabled. See https://github.com/cilium/cilium/issues/10645",
+			"net.ipv4.conf.all.rp_filter=0",
+			"")
+	}
+
 	if params := b.NodeupConfig.SysctlParameters; len(params) > 0 {
 		sysctls = append(sysctls,
 			"# Custom sysctl parameters from instance group spec",

--- a/pkg/model/components/cilium.go
+++ b/pkg/model/components/cilium.go
@@ -40,7 +40,7 @@ func (b *CiliumOptionsBuilder) BuildOptions(o interface{}) error {
 	}
 
 	if c.Version == "" {
-		c.Version = "v1.11.6"
+		c.Version = "v1.11.8"
 	}
 
 	if c.EnableEndpointHealthChecking == nil {

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
@@ -223,7 +223,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.11.6
+      version: v1.11.8
   nonMasqueradeCIDR: ::/0
   secretStore: memfs://clusters.example.com/minimal-ipv6.example.com/secrets
   serviceClusterIPRange: fd00:5e4f:ce::/108

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 99b8da549d0a419996ad845a414086285af3d17de813c5668f31bccea3c0ff2b
+    manifestHash: 885eef8af3ca9960806352dc7d904fec987750df68325dc6f55bfc157248e352
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -366,7 +366,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.6
+        image: quay.io/cilium/cilium:v1.11.8
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -462,7 +462,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.6
+        image: quay.io/cilium/cilium:v1.11.8
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -598,7 +598,7 @@ spec:
           value: api.internal.minimal-ipv6.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.6
+        image: quay.io/cilium/operator:v1.11.8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
@@ -166,7 +166,7 @@ CloudProvider: aws
 ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
 InstanceGroupName: nodes
 InstanceGroupRole: Node
-NodeupConfigHash: /VQjQFfNW9a3TOgtOAikUAJFycuJKNZEGwx8X8H6bhg=
+NodeupConfigHash: EOCTeNdcxDgQ0oeSjIsxaSH+KYj0bCVcAXqffSNWDr8=
 
 __EOF_KUBE_ENV
 

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
@@ -206,7 +206,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.11.6
+      version: v1.11.8
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/minimal-warmpool.example.com/secrets

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 1b13dfbe5888a602daac1e46d8f41547c9c5aaa4b48cbbccc4a04a4c2aa59795
+    manifestHash: 6e64c69e829725c3a7392cdced0ea1517047848fa966a4a30cb0bc71ba1ace34
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -366,7 +366,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.6
+        image: quay.io/cilium/cilium:v1.11.8
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -462,7 +462,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.6
+        image: quay.io/cilium/cilium:v1.11.8
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -598,7 +598,7 @@ spec:
           value: api.internal.minimal-warmpool.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.6
+        image: quay.io/cilium/operator:v1.11.8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_nodeupconfig-nodes_content
@@ -67,8 +67,8 @@ containerdConfig:
   logLevel: info
   version: 1.4.13
 warmPoolImages:
-- quay.io/cilium/cilium:v1.11.6
-- quay.io/cilium/operator:v1.11.6
+- quay.io/cilium/cilium:v1.11.8
+- quay.io/cilium/operator:v1.11.8
 - registry.k8s.io/kube-proxy:v1.21.0
 - registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0
 - registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
@@ -192,7 +192,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: vxlan
-      version: v1.11.6
+      version: v1.11.8
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/privatecilium.example.com/secrets

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: 198c6022ba7a63e596a1734db37c3f60742f4d695a51d3dd309ec8e4c3639523
+    manifestHash: 0a48484bccbca31684a69e404f2a0cf6c261b28821af87391b4f401a381efb4a
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -366,7 +366,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.6
+        image: quay.io/cilium/cilium:v1.11.8
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -462,7 +462,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.6
+        image: quay.io/cilium/cilium:v1.11.8
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -598,7 +598,7 @@ spec:
           value: api.internal.privatecilium.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.6
+        image: quay.io/cilium/operator:v1.11.8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
@@ -202,7 +202,7 @@ spec:
       sidecarIstioProxyImage: cilium/istio_proxy
       toFqdnsDnsRejectResponseCode: refused
       tunnel: disabled
-      version: v1.11.6
+      version: v1.11.8
   nonMasqueradeCIDR: 100.64.0.0/10
   podCIDR: 100.96.0.0/11
   secretStore: memfs://clusters.example.com/privateciliumadvanced.example.com/secrets

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: ca97616234027899e1780d84efe12db5132018a486c983fbdd4531256d413923
+    manifestHash: 7599559ab676fd5770f5fc352c0e8826c25487fc6d30e4747766eae256494fb8
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-networking.cilium.io-k8s-1.16_content
@@ -380,7 +380,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/cilium:v1.11.6
+        image: quay.io/cilium/cilium:v1.11.8
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:
@@ -482,7 +482,7 @@ spec:
               key: clean-cilium-bpf-state
               name: cilium-config
               optional: true
-        image: quay.io/cilium/cilium:v1.11.6
+        image: quay.io/cilium/cilium:v1.11.8
         imagePullPolicy: IfNotPresent
         name: clean-cilium-state
         resources:
@@ -629,7 +629,7 @@ spec:
           value: api.internal.privateciliumadvanced.example.com
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
-        image: quay.io/cilium/operator:v1.11.6
+        image: quay.io/cilium/operator:v1.11.8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: c36bf98b69107c123dffc67ad70a023401b5fa4cc7d384a184e6a46b8637ada4
+    manifestHash: 0e32186e63e0a1df3398bacd6c6ee5827e6738cb5b20558331b8f9c4e0859d68
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -55,7 +55,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: c36bf98b69107c123dffc67ad70a023401b5fa4cc7d384a184e6a46b8637ada4
+    manifestHash: 0e32186e63e0a1df3398bacd6c6ee5827e6738cb5b20558331b8f9c4e0859d68
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -62,7 +62,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.16
     manifest: networking.cilium.io/k8s-1.16-v1.11.yaml
-    manifestHash: c36bf98b69107c123dffc67ad70a023401b5fa4cc7d384a184e6a46b8637ada4
+    manifestHash: 0e32186e63e0a1df3398bacd6c6ee5827e6738cb5b20558331b8f9c4e0859d68
     name: networking.cilium.io
     needsRollingUpdate: all
     selector:


### PR DESCRIPTION
Cherry pick of #14137 on release-1.24.

#14137: Always disable rp_filter when using cilium

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```