### PR TITLE
Calico: Work around host port/conntrack problem

### DIFF
--- a/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.22.yaml.template
+++ b/upup/models/cloudup/resources/addons/networking.projectcalico.org/k8s-1.22.yaml.template
@@ -4705,6 +4705,12 @@ spec:
             # Controls the log level used by the BPF programs
             - name: FELIX_BPFLOGLEVEL
               value: "{{- or .Networking.Calico.BPFLogLevel "Off" }}"
+            # Temporary workaround for https://github.com/projectcalico/calico/issues/6522,
+            # allowing reply packets from containers using host ports to flow through DNAT reversal properly.
+            {{- if .Networking.Calico.BPFEnabled }}
+            - name: FELIX_BPFHostConntrackBypass
+              value: "false"
+            {{- end }}
             # Controls whether Felix inserts rules to the top of iptables chains, or appends to the bottom
             - name: FELIX_CHAININSERTMODE
               value: "{{- or .Networking.Calico.ChainInsertMode "insert" }}"


### PR DESCRIPTION
In Calico's released versions, per projectcalico/calico#6522, when using the eBPF data plane, containers using host ports cannot respond to connection attempts correctly. These container receive the packets from the client forwarded after DNAT, but when they reply, there is no conntrack entry for the would-be connection, so _netfilter_ drops the reply packets, preventing the connection from completing. The client never receives the reply packets. The conntrack entry is missing because Calico mistakenly attempts to optimize it away.

Work around the problem by disabling [the Calico Felix program's 
"BPFHostConntrackBypass" feature](https://projectcalico.docs.tigera.io/reference/felix/configuration#ebpf-dataplane-configuration). This is a temporary measure until the Calico maintainers can improve this feature to better handle host port traffic, preserving these conntrack entries as intended.

See [the related discussion in the "networking" channel](https://calicousers.slack.com/archives/CPEPF833L/p1661868642674109) of the "Calico Users" Slack workspace, in which @tomastigera suggested this fix.