### PR TITLE
Accommodate S3 VFS paths designating bucket owner

### DIFF
--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -299,7 +299,13 @@ func (c *VFSContext) buildS3Path(p string) (*S3Path, error) {
 		return nil, fmt.Errorf("invalid s3 path: %q", p)
 	}
 
-	s3path := newS3Path(c.s3Context, u.Scheme, bucket, u.Path, true)
+	var expectedBucketOwner string
+	const ownerParam = "x-amz-expected-bucket-owner"
+	if values := u.Query(); values.Has(ownerParam) {
+		expectedBucketOwner = values.Get(ownerParam)
+	}
+
+	s3path := newS3Path(c.s3Context, u.Scheme, bucket, u.Path, true, expectedBucketOwner)
 	return s3path, nil
 }
 
@@ -317,7 +323,7 @@ func (c *VFSContext) buildDOPath(p string) (*S3Path, error) {
 		return nil, fmt.Errorf("invalid spaces path: %q", p)
 	}
 
-	s3path := newS3Path(c.s3Context, u.Scheme, bucket, u.Path, false)
+	s3path := newS3Path(c.s3Context, u.Scheme, bucket, u.Path, false, "")
 	return s3path, nil
 }
 

--- a/util/pkg/vfs/s3context.go
+++ b/util/pkg/vfs/s3context.go
@@ -130,7 +130,7 @@ func getCustomS3Config(endpoint string, region string) (*aws.Config, error) {
 	return s3Config, nil
 }
 
-func (s *S3Context) getDetailsForBucket(bucket string) (*S3BucketDetails, error) {
+func (s *S3Context) getDetailsForBucket(bucket string, expectedBucketOwner string) (*S3BucketDetails, error) {
 	s.mutex.Lock()
 	bucketDetails := s.bucketDetails[bucket]
 	s.mutex.Unlock()
@@ -181,6 +181,9 @@ func (s *S3Context) getDetailsForBucket(bucket string) (*S3BucketDetails, error)
 
 	request := &s3.GetBucketLocationInput{
 		Bucket: &bucket,
+	}
+	if expectedBucketOwner != "" {
+		request.ExpectedBucketOwner = &expectedBucketOwner
 	}
 	var response *s3.GetBucketLocationOutput
 


### PR DESCRIPTION
In VFS paths using the "s3" scheme designating paths within S3 buckets, accept the "x-amz-expected-bucket-owner" query parameter nominating [an AWS account ID that we expect will own the S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-owner-condition.html). When this query parameter is present in a parsed VFS path, include its value in AWS Go SDK calls that accept an "ExpectedBucketOwner" parameter. (If there are multiple occurrences of this parameter in the query string, use the first occurrence's value.) If the target S3 bucket turns out to be owned by an AWS account with a different ID, these API calls will fail.

Propagate this expected owning account ID when constructing new VFS paths from a path with such an ID already bound.