### PR TITLE
Release 1.23.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,13 @@ GITSHA := $(shell cd ${KOPS_ROOT}; git describe --always)
 # We lock the versions of our controllers also
 # We need to keep in sync with:
 #   upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.23.3
+DNS_CONTROLLER_TAG=1.23.4
 DNS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_DNS_CONTROLLER_TAG | awk '{print $$2}')
 #   upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/
-KOPS_CONTROLLER_TAG=1.23.3
+KOPS_CONTROLLER_TAG=1.23.4
 KOPS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KOPS_CONTROLLER_TAG | awk '{print $$2}')
 #   pkg/model/components/kubeapiserver/model.go
-KUBE_APISERVER_HEALTHCHECK_TAG=1.23.3
+KUBE_APISERVER_HEALTHCHECK_TAG=1.23.4
 KUBE_APISERVER_HEALTHCHECK_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KUBE_APISERVER_HEALTHCHECK_TAG | awk '{print $$2}')
 
 

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -79,7 +79,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -12,7 +12,7 @@ Contents: |
       - --client-key=/secrets/client.key
       command:
       - /kube-apiserver-healthcheck
-      image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+      image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 96d7e4980aa5bc31a2a29a4065db84fad7bbe456cdb427d2096738e8ebca1e22
+    manifestHash: fd1bc172a275b5adf9677339c76d27aa63c72bb51afaec11ffa2184df53916ab
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
+    manifestHash: a3f28e3bf077bb7a0cf93c7efb70205f238be6b5d0e044e5782db104d774debd
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: aabfd2646bac3d5f339b1bed641693414f38c8b5b08a7c536b9fbcc55643865a
+    manifestHash: 1c64d995c7eb054489e4f3fcb2c47040e0f92007f19e6b9246a331cc15fb7e57
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61c6927d5e7c71416e836fcd8ecf48b06fb36ea22770eba76d79b4a274768e26
+    manifestHash: 4aa3bf1e2bc23625dcd504e3eea014193395528d361987aeef3d876b08e024e8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ed282111072d319a3c0e77bb085d9750c87f738118ff37cb546f56503610f429
+    manifestHash: 91ac8752fa086b263c207561ac720dfc1c994b7f28dd4599408d99cdb9d47e17
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d58411252c4bb19ca4e1cc506889ac74b60e158018535e754dcfeec11f7047f0
+    manifestHash: f819447e1f93ae878a859eeb3f3b1e77b6a0856c32d5fd32a86c4a1091f3c758
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3707521b92032ae70f59e20a561620340c258b00af7c486ae5de68ae25edb81c
+    manifestHash: c487524365a89e03bb05f04e008e912017cfd29834c2b549da57f7315587d1a4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a6c32aec56f6122bffb7a02379748f74c2eab7c97ccfaec09e0bfb25a66a561b
+    manifestHash: 4571fb44acb8bdbfe854e24d2766114580c19fcfa2706120ddc49138a578ad2e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: f3f953803281ad4f0daf7bc116f934e55626ed70e468b191a5ec75be716351eb
+    manifestHash: f4009bf00f046392565662d57db1b3f13c17b6b3b50b132da1d784650a856631
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 28285bc979b7bba7cb27adc273d4e250eb7f33da23d7a5acc7e302db045eb8bf
+    manifestHash: 767d740964c4dddf63f408d31723a37b60b2858cea229593b3e32ed39c1d66d6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1f362698421c03f44cdf76c911eefaed05fc458c7d55cd227a886ebedef05eb4
+    manifestHash: f8fb36217905408176fd80c6d28fa750c31e0dcf3f60955e4b15a15a8dcdd717
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 41fc7158505e984094529b5267e5d9691641538190fb98db3d9a1efbe5ec30a2
+    manifestHash: 0a6bf79f7b1b4442a9286e3110395fc045026bf3fd2e4b8efac58f278d0f1e35
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c2d50c45f8d4fcae3a215f4837bb1741b175d5505b7eb501cdb25e2d0b8494ea
+    manifestHash: cedeac12e42270358e852f891de1453828aa39f8f471acbcda3e5950722f64f9
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
+    manifestHash: a3f28e3bf077bb7a0cf93c7efb70205f238be6b5d0e044e5782db104d774debd
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 83a3ad2437f61243a93be5722650208a7eb443b0165f7d68b0dc78dfd3a40981
+    manifestHash: f2bd60c331771428a577f2e761c304f7e79a7f3427075fadab94ec8d4c87e0a9
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
+    manifestHash: a3f28e3bf077bb7a0cf93c7efb70205f238be6b5d0e044e5782db104d774debd
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 09f9c45da7c7c520763828bd2ab61f919abe89f5132479261cb185056396403f
+    manifestHash: 3f8d42bed8bf3bc0e8b8848414dac7e6789f62d28fd602cb09d14401cbedf609
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 09177b6ce86654fc4d49740721900f37201d054038b86568c0b2116157a08926
+    manifestHash: 0b01142656407b80b34cc714e6365c1211a3e217cdde55c38affcdfbd8bf99d5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: ffb2e4e97efb5697cf6864179c64af87be9a9ec7c9960616e43e220a04a29d69
+    manifestHash: 0c426df0dc29beca9f63a0043006ec938cb827c13e64179359870ef379932f13
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 09177b6ce86654fc4d49740721900f37201d054038b86568c0b2116157a08926
+    manifestHash: 0b01142656407b80b34cc714e6365c1211a3e217cdde55c38affcdfbd8bf99d5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: ffb2e4e97efb5697cf6864179c64af87be9a9ec7c9960616e43e220a04a29d69
+    manifestHash: 0c426df0dc29beca9f63a0043006ec938cb827c13e64179359870ef379932f13
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 09177b6ce86654fc4d49740721900f37201d054038b86568c0b2116157a08926
+    manifestHash: 0b01142656407b80b34cc714e6365c1211a3e217cdde55c38affcdfbd8bf99d5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: ffb2e4e97efb5697cf6864179c64af87be9a9ec7c9960616e43e220a04a29d69
+    manifestHash: 0c426df0dc29beca9f63a0043006ec938cb827c13e64179359870ef379932f13
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 09177b6ce86654fc4d49740721900f37201d054038b86568c0b2116157a08926
+    manifestHash: 0b01142656407b80b34cc714e6365c1211a3e217cdde55c38affcdfbd8bf99d5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: ffb2e4e97efb5697cf6864179c64af87be9a9ec7c9960616e43e220a04a29d69
+    manifestHash: 0c426df0dc29beca9f63a0043006ec938cb827c13e64179359870ef379932f13
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_bucket_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 56af37086104cb56823990384fb059998f64d3d137721209493af3ea7a90ce31
+    manifestHash: 9903deb63ff01ed5aaaa97fbad52f2dd195e3bd859ec326214ec1c68e1daf586
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_bucket_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 497edf4b86b919dc2aff6d92e84cd5cda64bea6b72f5973f38b52c93625ad0ca
+    manifestHash: 09ac293da6d42c7898d543bf07838f180e54a3279c43bc582b27531c8e878d83
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_bucket_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fb6245e4d9a5d2f567358935242366b364b990161774e2c77adfbb49b7a67d1a
+    manifestHash: b1023840c2385d98f9eee591bb462541d8772ba3c91ed6e3b6ac693e285172e8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c2d50c45f8d4fcae3a215f4837bb1741b175d5505b7eb501cdb25e2d0b8494ea
+    manifestHash: cedeac12e42270358e852f891de1453828aa39f8f471acbcda3e5950722f64f9
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_bucket_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 14bc3252c02b612a73028b01e07509cc4b92f4a8624aded8f96241e83a093b62
+    manifestHash: 5fbf516e2dbe19a65d46d19054d30724e8bc45549fc10b9e9bc0eda59cfc08b5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c2d50c45f8d4fcae3a215f4837bb1741b175d5505b7eb501cdb25e2d0b8494ea
+    manifestHash: cedeac12e42270358e852f891de1453828aa39f8f471acbcda3e5950722f64f9
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_bucket_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c521c897d6471e0f27738571822e1845efcc5909bd7d721f9802452939ce4f61
+    manifestHash: e6a8f34a0042380aba98fa1e6be6484be405945a38b651c954983efba024fe3f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: c18a1c4a0bd377267a4a498169acc812b13d558ad622ff55717be825352b787e
+    manifestHash: 8edbcb3d5f721eeece24cf575e106de90e97660b8967fccf1dc5ddfe741b3166
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c521c897d6471e0f27738571822e1845efcc5909bd7d721f9802452939ce4f61
+    manifestHash: e6a8f34a0042380aba98fa1e6be6484be405945a38b651c954983efba024fe3f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 3a2c2807e13498f25537aafb4f4e2c9bdb6d2169b67fe6f8e107e60a7380c52e
+    manifestHash: eb3720beb17585ea60f4f1e9745fca0e7d2954d55553864025c961d2077bd8b3
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_bucket_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e95e045f0ad5842a8ac97341406ef59f888b9abfd7cac0a792ae76095193f1c7
+    manifestHash: 00176e387ca2ceb36c749e9bdb560cb325217f03c6bc549092678e7bf6bf7b43
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e95e045f0ad5842a8ac97341406ef59f888b9abfd7cac0a792ae76095193f1c7
+    manifestHash: 00176e387ca2ceb36c749e9bdb560cb325217f03c6bc549092678e7bf6bf7b43
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_bucket_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fe8f03fd9d917e73633f005b89d10480ea736158a8c3bec0828c8578015579f5
+    manifestHash: 08cc0178a32287c727b1b973183cf242e0db2a827e712f892048d1518ddf2a22
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_bucket_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3d6ba2d177ebf8f6e4130cc0e0f6f83750b9b7327e58d8b26536357b55c563a9
+    manifestHash: d9b38ca41ff39e073839e7c2f76db1415a6b13b73032f26ef417658cb74738a1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_bucket_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 91d6b5342c5973a4a16ecf69afbf175e7976a52e568103758b2003d859b167d4
+    manifestHash: f70500cbb03fafae00f8fac2a1a06bbd85fb27c402355b9a1a1842a2db872d35
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_bucket_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e8fd660e605442d88d0f699f1543b6c977480609b58b796daa0021109c845e64
+    manifestHash: 3512b7fe5b54818c4ed173e9d1b49d247e1075a2db336288496f2de9f815afdc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_bucket_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6e1ac660e669df1c014a944413a59e7aa817d6db013da114da70125cc4e1ddd7
+    manifestHash: 542a91e44bb99ae4a0d77211f8cbb2cf135f7842533e29f8cf821aaf08379132
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_bucket_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1e26419c433db91042505363d78c9287c95cade8381b0af578004c60e5943b7e
+    manifestHash: c19238646b55d13e9c9c7e365d29f484bce6764a049ed207670ff72f823e5b41
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c5e263fef0fdfbf6a01aa8fd1d21bd42b4c6a734e32cf0d65f24e74375f145c1
+    manifestHash: 124e035dbd0574302f0274dac8cf802b7a9a1817ed508c06f13c386aedf56db1
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_bucket_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1cf6f267a4dce799f396dd003f47c5cf2619e7ad373c605cd09cc857ddaae397
+    manifestHash: 85f0b3715b55f958819be43ee89ab3f0b46ea83d4013c773b3451008434bbd79
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_bucket_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 70cafb930f38211ff907ccecb48146e27d150d1d8920becbfeb19609a891ded9
+    manifestHash: 0d754fe389fd05e8cc6f7c00b6366a98953b2e502af58adff9e7af686ba637e3
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 490593652dc1cb24106911675b02f73e61b50e174fe94d20a18d27fa08dfc18d
+    manifestHash: 3575239e358ff373e6a854888b7663499550723a421809ea2448eb5488667e1a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_bucket_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1263b62be25505da4b1d6acac7a25c53f6755254dcb545a773fc08ef9ce2da84
+    manifestHash: 75c35bc3f7f0cb6cb09c40964527510eb6dd8d0dc7a7acf38164481f2742df5e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 622587b96c933d889f017fdea21f6667bc2020615e97db3fffcfb0b6cb41440f
+    manifestHash: b96c4141058261339ae5d5cb7aac8daed8c88fc5b8c4f77997d885d6afa6b697
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_bucket_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: faf836c052bbce50555a8b740438e7216e17d57f5ec2a31b18c63914ca412693
+    manifestHash: af5770d6ddf3973df725b87f9af301b10599be183add40da8053ff88a2129d81
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_bucket_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c74e70955cd8bff80ff3330899d1421c9fb120376fd7d5e91b452fda3be020ae
+    manifestHash: da21644e5d2df14e7e06c379e0dd13ab154b83512357b361896d08028327cbd8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_bucket_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ec3eaf2643ead4b0975a777b452c47a3f24358e4f713e3804fbc513559892427
+    manifestHash: 13f1493e7b86b1983e573f6458149665448914fd7de7eff23f1e4811abc4694d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_bucket_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
+    manifestHash: a3f28e3bf077bb7a0cf93c7efb70205f238be6b5d0e044e5782db104d774debd
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b47b3119e6ae46c943a052197cd56bf61542697499a41e6cbe0fbd5efd5c9059
+    manifestHash: a5c9fcf315e59caa0d82b7598c2b43f36bcf77996bfad87919ee9fa55882b1d5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_bucket_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: a707ee820f42106ccc331c872d49ee506b704a5d804c7ad42f38fe5cf463b5ff
+    manifestHash: 69ccb5855313a9a29468bac2ae898c622fddc0cc0b93f662b23234d2a77d5da6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_bucket_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2420e372ef1cb0d233aadcb4eb10fd54647173ddd2f34d294b26c27ec1616781
+    manifestHash: bc763bc21b9cb6a1371098567aa13d3e38a92a9f7326be72ecccd38f6a7e4d18
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_bucket_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_manifests-static-kube-apiserver-healthcheck_content
@@ -10,7 +10,7 @@ spec:
     - --client-key=/secrets/client.key
     command:
     - /kube-apiserver-healthcheck
-    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.3
+    image: k8s.gcr.io/kops/kube-apiserver-healthcheck:1.23.4
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 3adf15dd18bf4035dd5d8a7d08d9452c7891547bb4f4645559c784efb8efafdc
+    manifestHash: f2e83c99628d3e33eb741dcdf909a096d27303ab005fcf6de77c4bc5e4b917bd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_bucket_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
 spec:
   replicas: 1
   strategy:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.23.3
+        version: v1.23.4
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -38,7 +38,7 @@ spec:
       serviceAccount: dns-controller
       containers:
       - name: dns-controller
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         command:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
 spec:
   selector:
     matchLabels:
@@ -31,7 +31,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.23.3
+        version: v1.23.4
 {{ if UseKopsControllerForNodeBootstrap }}
       annotations:
         dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
@@ -53,7 +53,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ea11d747b0efe5c1e7cf795e0c525006a4268d7d77ff037f4319a1a91d8d1622
+    manifestHash: b3adcd8cb7d4f9912e57910c880dd3c6a4c7479a3cdc4eb3a22a8a2f9212a8c0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ea11d747b0efe5c1e7cf795e0c525006a4268d7d77ff037f4319a1a91d8d1622
+    manifestHash: b3adcd8cb7d4f9912e57910c880dd3c6a4c7479a3cdc4eb3a22a8a2f9212a8c0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.18/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ea11d747b0efe5c1e7cf795e0c525006a4268d7d77ff037f4319a1a91d8d1622
+    manifestHash: b3adcd8cb7d4f9912e57910c880dd3c6a4c7479a3cdc4eb3a22a8a2f9212a8c0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -47,7 +47,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.23.3
+    version: v1.23.4
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -44,7 +44,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: k8s.gcr.io/kops/dns-controller:1.23.3
+        image: k8s.gcr.io/kops/dns-controller:1.23.4
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: e9e8cbde35a5d5eb477744616e8070aa97b826dac91c4161cc880ebbbb1e057b
+    manifestHash: a3f28e3bf077bb7a0cf93c7efb70205f238be6b5d0e044e5782db104d774debd
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.23.3
+    version: v1.23.4
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.23.3
+        version: v1.23.4
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: k8s.gcr.io/kops/kops-controller:1.23.3
+        image: k8s.gcr.io/kops/kops-controller:1.23.4
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 61f9e41e7d97be490e7c0d9c0f2d3540ff1eca4ee601ed404e86263b3e9d2623
+    manifestHash: 0da9981267b690e2ccc320dfa99da59e78747d236347012f2e75603459744e75
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -40,7 +40,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 36a2d81e5b645ce3e83ddd3e5a0ec0b9845c517d7cf902ede6b92985b596660f
+    manifestHash: ab02a45370dad2141a4852021f498446df3d5e6ac33453f0427d0d8f0609c1d0
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/urls_test.go
+++ b/upup/pkg/fi/cloudup/urls_test.go
@@ -36,29 +36,29 @@ func Test_BuildMirroredAsset(t *testing.T) {
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-amd64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.3/images/protokube-linux-amd64",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.3/images-protokube-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.4/images/protokube-linux-amd64",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.4/images-protokube-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-arm64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.3/images/protokube-linux-arm64",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.3/images-protokube-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.4/images/protokube-linux-arm64",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.4/images-protokube-linux-arm64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/amd64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.3/linux/amd64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.3/nodeup-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.4/linux/amd64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.4/nodeup-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/arm64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.23.3/linux/arm64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.23.3/nodeup-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.23.4/linux/arm64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.23.4/nodeup-linux-arm64",
 			},
 		},
 	}

--- a/version.go
+++ b/version.go
@@ -21,8 +21,8 @@ var Version = KOPS_RELEASE_VERSION
 
 // These constants are parsed by build tooling - be careful about changing the formats
 const (
-	KOPS_RELEASE_VERSION = "1.23.3"
-	KOPS_CI_VERSION      = "1.23.4"
+	KOPS_RELEASE_VERSION = "1.23.4"
+	KOPS_CI_VERSION      = "1.23.5"
 )
 
 // GitVersion should be replaced by the makefile


### PR DESCRIPTION
- Make service topology for cilium configurable
- Remove support for Weave as of k8s 1.23
- Update Go to v1.17.5
- Update controller-runtime to v0.11.0
- Update containerd to v1.6.0-beta.4
- Run hack/update-expected.sh
- Ignore images hosted in private ECR repositories as containerd cannot actually pull these
- Prevent creation of unsupported etcd clusters
- Update k8s dependencies to v1.23.1
- Remove TerraformJSON feature flag and functionality
- Remove unused json field tags from terraform structs
- Remove remaining references to TerraformJSON feature flag
- Add managed-by label to static kube-proxy pods
- Kube components log to stdout
- Fix OpenStack SecurityGroupRule/LB with IPv6 CIDR
- external CCM for GCE
- generated: ./hack/update-bazel.sh
- update deps
- Migrate to GCE CCM in k8s 1.24
- Bump Cluster Autoscaler and update manifest
- Remove the v1alpha3 API version
- force update dependencies
- Add action for automatically tagging releases
- Remove temporary restrictions on automatically tagging releases
- Bump external-snapshotted to v5.0.0
- Support price and priority cluster-autoscaler expanders.
- Fix CRDs, clarify docs, and add cloud provider check for price expander.
- Warn that the price expander is only supported on GCE in the docs.
- Less crashing when validating.
- Fix StringValue nit
- Keep docs DRY.
- fix ipv4+ipv6 sec groups/listeners in OpenStack
- make gazelle
- Update containerd to v1.6.0-beta.5
- Run hack/update-expected.sh
- Update containerd to v1.6.0-rc.0
- Run hack/update-expected.sh
- Don't try to add node name to instances without node object
- Do not create an IAM role for dns-controller on gossip clusters
- Add DescribeRegions to nodeup privs
- Create helper function for ec2 create/tag-on-create IAM permissions
- Remove tag condition on listeners
- Update to aws-sdk-go to v1.42.37
- use 1.23.1 ccm for openstack
- expose external ccm metrics for OpenStack
- OpenStack - Add loadbalancer pool monitor to API LB
- Bump CCM images
- No need to set kubelet in tests
- Don't set legacy IAM by default
- Update pause image to v3.6
- Run hack/update-expected.sh
- Bump etcd-manager to v3.0.20220128
- JWKS / IRSA: Expose public ACLs to terraform
- add drain-timeout flag to rolling-update cluster
- Use etcd-manager pre-release until final release has been cut
- Update Calico to v3.21.2
- Update Canal to v3.21.2
- Run hack/update-expected.sh
- Update Calico to v3.21.4
- Update Canal to v3.21.4
- Run hack/update-expected.sh
- Fix etcd-manager for ipv6
- Update containerd to v1.6.0-rc.2
- Run hack/update-expected.sh
- Fix CSI migration feature gates
- Remove snapshot controller dependency on ebs csi driver
- always enable Leader Election
- always enable Leader Election
- generated: ./hack/update-expected.sh
- use pkg/flagbuilder to build argv
- update test ordering and tests for leader election.
- generated: ./hack/update-bazel.sh
- generated: ./hack/update-expected.sh
- Update containerd to v1.6.0-rc.3
- Run hack/update-expected.sh
- always enable Leader Election
- Minor fix for json response to keep it consistent for single or multiple clusters
- Fix irsa for k8s < 1.20
- Add test for irsa on k8s 1.19
- Refactor serviceaccountissuerdiscovery validation
- Add support for graceful node shutdown
- hack update-expected
- Install runc from opencontainers/runc
- Run hack/update-expected.sh
- Do not enable graceful shutdown if k8s version < 1.21
- Fix nilpointer when graceful shutdown is not configured
- update expected
- Install contained from the release package
- Run hack/update-expected.sh
- Bump aws-cni to 1.10.2
- Align manifest with master of aws-cni repo
- Apply suggestions
- Run hack/update-expected.sh
- Allow PrefixList for sshAccess and kubernetesApiAccess
- Update containerd to v1.6.0
- Run hack/update-expected.sh
- Update LBC to 2.4.0
- Disable some flags in kube-apiserver when logging-format is not text
- Enable RBN with AWS CCM 1.22.0-alpha.1
- Improve HA for various addons
- LBC has to run on the control plane, so set replicas accordingly
- Validate taints in IG spec
- Prevent populate ig from adding nvidia taint if it has already been set
- Fix backporting issues
- Do not create a cert-manager namespace
- Add missing permissions to aws lbc for irsa
- Initial changes for vpc
- Release 1.23.0-beta.2
- Update to etcd-manager v3.0.20220203
- Update expected test output for etcd-manager bump
- use own function to define CSI image version
- Add support to install EKS Pod Identity Webhook
- Add managed-by label to addon pods
- Use cert-manager and pod-identity-webhook in integration test of irsa
- Update addons document for Pod Identity Webhook
- Add PodDisruptionBudget and topologySpreadConstraints for eks-pod-identity-webhook
- Minor cleanup of the Deployment
- Update expected test data
- check if UsePolicyConfigMap flag is true
- use suggested changes
- add support for ed25519 keys
- Bump AWS SDK to v1.43.11
- Update containerd to v1.6.1
- Run hack/update-expected.sh
- Use proper image and add health check
- Release 1.23.0 (#13339)
- Add missing permissions to aws lbc for IP targeting
- Allow taints with unique key,value,effect
- Add protocol explicitly to services
- Add integration test for really long cluster names
- If kubetest2 fails cluster validation, we run down before exiting
- Truncate the standard role names
- update k8s dependencies
- Correctly detect GovCloud regions
- Update golangci-lint to v1.45.0
- Do not return a '-1' exit if no keys found and json/yaml output
- Require tag on create for external AWS CCM
- Add a k8s 1.23 version of the ccm test
- Push partition into the policy struct
- Add CreateSecurityGroup permission for vpcs
- Update containerd to v1.6.2
- Run hack/update-expected.sh
- Add back hash for containerd v1.6.1
- Enable etcd corruption check as mitigatio of 3.5 corruption issue
- Pick the right OS server group when creating cloud groups
- Only delete node object on GCE
- Remove checks that doesn't work when we do not delete the node object
- bump aws cni to version 1.10.3
- output of hack/update-expected.sh
- Update Calico to v3.21.5
- Update Canal to v3.21.5
- Run hack/update-expected.sh
- Update to etcd-manager 3.0.20220417
- Revert "Enable etcd corruption check as mitigatio of 3.5 corruption issue"
- Use etcd 3.5.3 instead of 3.5.1
- Update test data for etcd 3.5.3
- Bump CCM 1.22 and 1.23 images to stable versions
- Revert to using 1.23.0-alpha.0 for AWS CCM
- Run hack/update-expected.sh
- Update aws-sdk-go to v1.43.41
- add cluster autoscaler pod annotations
- add apimachinery generations
- change template yaml
- Release 1.23.1 (#13527)
- Allow cluster autoscaler to get EC2 instance types
- Use a pointer type in type assertion
- Update Go to v1.17.9
- Add back support for Ubuntu 18.04
- Add support for Rocky Linux 8
- Update Canal's Flannel to v0.15.1
- Include sysctls in toolbox dump
- Fix OIDC Provider cleanup
- Re-add net.bridge settings for flannel
- Update containerd to v1.6.3
- Run hack/update-expected.sh
- Revert "Update containerd to v1.6.3"
- Revert "Run hack/update-expected.sh"
- Fix unexpected type for object metadata when using gossip DNS
- Update containerd to v1.6.4
- Run hack/update-expected.sh
- Update etcd-manager to v3.0.20220503
- Run hack/update-expected.sh
- Add hashes for containerd and Docker in order to fix CVE-2022-23648
- Avoid resolv.conf file loopback for Flatcar distro
- Release 1.23.2 (#13630)
- Increase timeout for pushing binaries to staging
- Update runc to v1.1.2
- Run hack/update-expected.sh
- Add a nameservers parameter for cert-manager
- Remove unused DNS logic from Protokube
- Run hack/update-bazel.sh
- Fix Protokube gossip flag
- Add hashes for latest Docker versions
- Update Docker to v20.10.17
- Run hack/update-expected.sh
- Add hashes for latest containerd versions
- Update containerd to v1.6.6
- Run hack/update-expected.sh
- Update containerd fallback to v1.4.13
- Fix codegen targets and whitespace errors in Makefile
- Add support for setting mode field on file assets
- Update documentation for fileAssets and fix whitespace error
- Fix API group being incorrect for ingresses
- Update after running hack/update-expected.sh
- Update runc to v1.1.3
- Run hack/update-expected.sh
- Update AWS CCM images for k8s 1.20-1.22
- Run hack/update-expected.sh
- Avoid spurious changes with ed25519 keys
- Update etcd-manager to v3.0.20220617
- Run hack/update-expected.sh
- Mount /etc/hosts from host for CoreDNS
- Run hack/update-expected.sh
- Update etcd-manager to v3.0.20220717
- Run hack/update-expected.sh
- Update Go to v1.17.12
- Switch to latest MacOS version for CI
- Revert to using instance private DNS name to lookup hostname
- Run hack/update-bazel.sh
- Check keyset existence before attempting to distrust
- Fix SIGSEGV when deleting a Hetzner instance
- Release 1.23.3 (#14051)
- aws-ebs-csi-driver: remove preStop hook
- fixup! aws-ebs-csi-driver: remove preStop hook
- cilium: fix wrong pod annotations templating
- cilium: add integration test for pod annotations
- Disable some flags in kube-controller-manager and kube-scheduler when logging-format is not text
- Update runc to v1.1.4
- Run hack/update-expected.sh
- Release 1.23.4
