### PR TITLE
Release 1.24.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ GITSHA := $(shell cd ${KOPS_ROOT}; git describe --always)
 # We lock the versions of our controllers also
 # We need to keep in sync with:
 #   upup/models/cloudup/resources/addons/dns-controller/
-DNS_CONTROLLER_TAG=1.24.1
+DNS_CONTROLLER_TAG=1.24.2
 DNS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_DNS_CONTROLLER_TAG | awk '{print $$2}')
 #   upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/
-KOPS_CONTROLLER_TAG=1.24.1
+KOPS_CONTROLLER_TAG=1.24.2
 KOPS_CONTROLLER_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KOPS_CONTROLLER_TAG | awk '{print $$2}')
 #   pkg/model/components/kubeapiserver/model.go
-KUBE_APISERVER_HEALTHCHECK_TAG=1.24.1
+KUBE_APISERVER_HEALTHCHECK_TAG=1.24.2
 KUBE_APISERVER_HEALTHCHECK_PUSH_TAG=$(shell tools/get_workspace_status.sh | grep STABLE_KUBE_APISERVER_HEALTHCHECK_TAG | awk '{print $$2}')
 
 CGO_ENABLED=0

--- a/pkg/model/components/kubeapiserver/model.go
+++ b/pkg/model/components/kubeapiserver/model.go
@@ -79,7 +79,7 @@ kind: Pod
 spec:
   containers:
   - name: healthcheck
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         # The sidecar serves a healthcheck on the same port,

--- a/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
+++ b/pkg/model/components/kubeapiserver/tests/minimal/tasks.yaml
@@ -10,7 +10,7 @@ Contents: |
       - --ca-cert=/secrets/ca.crt
       - --client-cert=/secrets/client.crt
       - --client-key=/secrets/client.key
-      image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+      image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
       livenessProbe:
         httpGet:
           host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 217f25b3d2bad00e29f07b9025b1e4e0595d21fbc5c9a979f6322032c90c1c67
+    manifestHash: c9758568ae46441d539d510adf9840ff108c6605002ea22fb40dae02a3342f82
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 9887fce9353c01a3b797ab1b672caa6ebdca7c900281ceff11cf2bfccf078abb
+    manifestHash: 51ad8f149413904a92ab438e09616907eb1e795e805d5f50c3843b296cfe1b4a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -53,7 +53,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 69870b0fc5d9045b0e4dc2fb8df656063260173c8de4fab161888d4cd35c9b7e
+    manifestHash: 79861297a9a6b81e93f255c6852855bebc82896db9acffa696c938056fbbcf71
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_bastionuserdata.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 51bf4b6c6abc09573ce7dcaccf846556ff29634585228302e27e0fe669cce002
+    manifestHash: 02b6d9aed126a6dafcde4ebf91648a3e047fa125bbbfc90ec470d98097c4d47e
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_complex.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/complex/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0a621e60bb206ecb20db9bda5f986b1bb438a71ae40be54f7c3652343abf6948
+    manifestHash: 00d864139bc198471817cf3069eb4d629e7ecd57c541b2e77598eececef94012
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_compress.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/compress/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 081454b5cbdfd33776467d9ca18e06e871d8ca1aba4d1949bc260b1ccfb2b75c
+    manifestHash: 2a0cc564dbb0124196cba7418787275a7676de78e4b680af5a45c82ee50e098f
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_123.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/digit/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6dabb26fd8216a11d087a74c22a6671fd3797d9eea79c61550466b33a1d4190d
+    manifestHash: 3083b8f251d47988cc524f1959dfd1df75c62707464c35c25bf9976a8f4d443d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_existing-iam.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 85875b13607ced7b6d46d1151cefcebcd09fd2664d60b6e538989aa4b0486246
+    manifestHash: 2546da156fcfb25d3251c39fc5b4855af11280e2ec8c599ececbd90662c6d867
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_existingsg.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:

--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a643f5b7461d8dc510e2d634f79d90846b4b8b1a76e2444751234be335c5d49
+    manifestHash: 94650f7941474b6e22ed9b71cbda5398680b712a300cb3c1cc64ca293ba3f317
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_externallb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6fe1fbcd77ae9e77317e4fb6d23d415d91117c50b31b89d5adaada11243c17b3
+    manifestHash: 7c2c3d465ff6d827b5462fc00a891e90049727900c7928b217cb09fe0023cf00
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_externalpolicies.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8ea7e0e0a24ee67ab00d4a4d16e6f030bf5293ca8906c63ac8e9dcded2c0c2e8
+    manifestHash: 5045e4623a322c6899cc64bfbb190e3bf80912a121dffe9e298f013b94a686ce
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_ha.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1322bdbce7ebf6212ccea53269a8717f67bb768ad2596ca09283919de7aaf5c8
+    manifestHash: d952a05eabaee8128e68b1ff98aa82fa4be8c69cab1072b1123b1e26332adcf2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 21c76eee48a555eaa38368bffa71734d5153f59eb2c72293911671a24e388b8f
+    manifestHash: 19858861ba3bd5484da16214750388acffa2dc3383a5e1c5f6405b52323cb904
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_ha-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -61,7 +61,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/irsa119/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 9887fce9353c01a3b797ab1b672caa6ebdca7c900281ceff11cf2bfccf078abb
+    manifestHash: 51ad8f149413904a92ab438e09616907eb1e795e805d5f50c3843b296cfe1b4a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -53,7 +53,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 9887fce9353c01a3b797ab1b672caa6ebdca7c900281ceff11cf2bfccf078abb
+    manifestHash: 51ad8f149413904a92ab438e09616907eb1e795e805d5f50c3843b296cfe1b4a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -53,7 +53,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d6ccef4f68be3177bb83ebf257c35e3326b81c6325b82f030e7a19c9eaabac11
+    manifestHash: 843bed621fe0b1527f8dec5b60b9c57882ec7871596c5a3c57f7571a95757fc2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 9887fce9353c01a3b797ab1b672caa6ebdca7c900281ceff11cf2bfccf078abb
+    manifestHash: 51ad8f149413904a92ab438e09616907eb1e795e805d5f50c3843b296cfe1b4a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -53,7 +53,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d6ccef4f68be3177bb83ebf257c35e3326b81c6325b82f030e7a19c9eaabac11
+    manifestHash: 843bed621fe0b1527f8dec5b60b9c57882ec7871596c5a3c57f7571a95757fc2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 9887fce9353c01a3b797ab1b672caa6ebdca7c900281ceff11cf2bfccf078abb
+    manifestHash: 51ad8f149413904a92ab438e09616907eb1e795e805d5f50c3843b296cfe1b4a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -53,7 +53,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 593f1668ca98b5bfaade2923c1460c156b46b8288a04f8aa4a289abe033b7908
+    manifestHash: f62e223453bbb2dd0ca2f37073e2b16c6b1cc5c19c00c2bd9250a1f512032dc5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.23/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: fdea9b0e32c0aea8abc4b74cb0cefaa7c10d54cee30642ca089b474d6bc9493b
+    manifestHash: b1dc440bac6ef1c2ea0fdc68023629bec7a09e5cdc30862b40cdc5cd51a179bc
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-1.24/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c0fc7f2cdcb0a3dcba24ec5da6195efa63076f6d788a09fc56ee719eb02be6a4
+    manifestHash: 3f2c2ecbe3ba03b138fde1bc329c850c45513f6ef2c62d0b0f565dd3a5903820
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d3712fe7c23aba200406d65b3f445d7b9bde228ff078f95e296147db38b30486
+    manifestHash: 52bdf4c00f05da8c5ee93569d1ecf72109065e462a7d3e8a0e47e6d458a317f1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ef32079fd43e465efb247c85d5c2ce4a6492fdbe0d8f6a7abb9153f03fc2367d
+    manifestHash: 7fe576fd569db726b41af4a7f66b084c7ee2ca33ab094d06c4ca54c8062245c5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d3712fe7c23aba200406d65b3f445d7b9bde228ff078f95e296147db38b30486
+    manifestHash: 52bdf4c00f05da8c5ee93569d1ecf72109065e462a7d3e8a0e47e6d458a317f1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c0fc7f2cdcb0a3dcba24ec5da6195efa63076f6d788a09fc56ee719eb02be6a4
+    manifestHash: 3f2c2ecbe3ba03b138fde1bc329c850c45513f6ef2c62d0b0f565dd3a5903820
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d3712fe7c23aba200406d65b3f445d7b9bde228ff078f95e296147db38b30486
+    manifestHash: 52bdf4c00f05da8c5ee93569d1ecf72109065e462a7d3e8a0e47e6d458a317f1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6-private/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ef32079fd43e465efb247c85d5c2ce4a6492fdbe0d8f6a7abb9153f03fc2367d
+    manifestHash: 7fe576fd569db726b41af4a7f66b084c7ee2ca33ab094d06c4ca54c8062245c5
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d3712fe7c23aba200406d65b3f445d7b9bde228ff078f95e296147db38b30486
+    manifestHash: 52bdf4c00f05da8c5ee93569d1ecf72109065e462a7d3e8a0e47e6d458a317f1
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_minimal-ipv6.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: cd22265977d13a53236c599a6ef3b9f8656e19f9568723a8bd423c394be3bf7a
+    manifestHash: 77da3a01417add358329cf9b350881e53c9efcbe4cf5c340f34d20e8b502772a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_this.is.truly.a.really.really.long.cluster-name.minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8638ad3303262db65034837d555d7630adf2bb2b3c0a6295e4cc1b87367d2fe0
+    manifestHash: 60ebe7d99b7cd05917193b82f79615e75cb155bda1291cbe1738e53bfabe213a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_minimal-warmpool.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 12e2fbcdb901c72f3b1ff7e3b009b17b8b6d01b588d49ab97a767df6416de319
+    manifestHash: 2907e040105bda0a97f40efbd1a606a8b32cb55fa314dea14ba85dc0fdcc1607
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 21c76eee48a555eaa38368bffa71734d5153f59eb2c72293911671a24e388b8f
+    manifestHash: 19858861ba3bd5484da16214750388acffa2dc3383a5e1c5f6405b52323cb904
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_minimal-gce.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2d123f163f3f660b0dcc7976ba316b3b12a393448fa298852054c0e3d6090815
+    manifestHash: 4ac652bee25ebaf99560a092ea927f2941a307f1554ddefc2d3edf5f58cfe2d0
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 21c76eee48a555eaa38368bffa71734d5153f59eb2c72293911671a24e388b8f
+    manifestHash: 19858861ba3bd5484da16214750388acffa2dc3383a5e1c5f6405b52323cb904
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_minimal-gce-ilb.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -61,7 +61,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2389611b5f81941132fbc2abef05ee3f7a3e1ceeaa37cc0047b9086f61965e6c
+    manifestHash: 8d74576886e76cc0b208e06c2a5246fad309bb95f631bcdeb665fbcf2036cbb8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 21c76eee48a555eaa38368bffa71734d5153f59eb2c72293911671a24e388b8f
+    manifestHash: 19858861ba3bd5484da16214750388acffa2dc3383a5e1c5f6405b52323cb904
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 2389611b5f81941132fbc2abef05ee3f7a3e1ceeaa37cc0047b9086f61965e6c
+    manifestHash: 8d74576886e76cc0b208e06c2a5246fad309bb95f631bcdeb665fbcf2036cbb8
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 21c76eee48a555eaa38368bffa71734d5153f59eb2c72293911671a24e388b8f
+    manifestHash: 19858861ba3bd5484da16214750388acffa2dc3383a5e1c5f6405b52323cb904
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_minimal-gce-with-a-very-very-very-very-very-long-name.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 6a2879ea02fe1505b108c25ceeea3d9602bba9def25942baa29d92910c01b490
+    manifestHash: bdca3d55dfd33ee8b300f96ed005c22d93b441691dee8d1f53704d42c8110f5a
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 21c76eee48a555eaa38368bffa71734d5153f59eb2c72293911671a24e388b8f
+    manifestHash: 19858861ba3bd5484da16214750388acffa2dc3383a5e1c5f6405b52323cb904
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_minimal-gce-private.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -37,7 +37,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -61,7 +61,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 77208e10192ac0afe52e3941e932022460a3f6abb6adf0605daba4334d43f374
+    manifestHash: 4c5363e43907599170e655e6703ecb69751921546d2200e549050da1b4ec8ec7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 61d0de867adf8f73872ea361f0185f34eb37b79871667015c7b25019c1146db2
+    manifestHash: dca89234d4e9cd43ee24875450c4a2749c2f42bcc136293649e977c0b7927b5a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -53,7 +53,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 77208e10192ac0afe52e3941e932022460a3f6abb6adf0605daba4334d43f374
+    manifestHash: 4c5363e43907599170e655e6703ecb69751921546d2200e549050da1b4ec8ec7
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 253d48b32353e4a658f71f4d5a96b54c47840d859e9979fbca0c3e88d6950f18
+    manifestHash: 9bf77af4f2173762cfc9c9e5fe0dd2ec4a02c8ae1ce6def2c01965ebd9fc75ee
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -56,7 +56,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.k8s.local
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_minimal.k8s.local-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c460607f0aadece46c83ceca69920ac34bc6397c966ba8f99f6d1db6d9d7617c
+    manifestHash: 3d54e1cfdf61cf99bf5dd154b9104c6c7a2bd8b7466de1dd8973bfcdfe91137c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c460607f0aadece46c83ceca69920ac34bc6397c966ba8f99f6d1db6d9d7617c
+    manifestHash: 3d54e1cfdf61cf99bf5dd154b9104c6c7a2bd8b7466de1dd8973bfcdfe91137c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_mixedinstances.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 148e2bfbcaa5e43ad8b99ef659a212f5736baf4c772b40ab66e0a8aa43decf54
+    manifestHash: 08153ed498d6451f2e6a37e8e022fb5cece407a37d2aa4a201cf1590f24b8da4
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 0c72fd05b5ec0bd1bd6a9509241e9254351c8a1e3b72500d56a7c14e4abf16e1
+    manifestHash: bebc0b950df84b0aafdfc363f909d726239c8f0881d83e1104b2824ab1fc289b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_private-shared-ip.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: ad35589abb84442432a8df039c24a7aad181a4b4d8c1b88a72e7beb4ca781e52
+    manifestHash: 515ccd4a4dabb4e955ca0836b77cbff699301f4d691fa94f0b715b1ffc2c7683
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_private-shared-subnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: c5287257131c1d3005471364387fcf37b982d08b297f46071a6b1891a575bd21
+    manifestHash: f1d6930c213df42f75aa05285cf2f0413edce84d9c1e4910f499486c724ffe3d
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_privatecalico.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: aa182a55f52603ce6ac5b59b84a91e72b01a756dad06935b4d89d73f56dd871b
+    manifestHash: ff3353eecd4cb30b7afb7411b282756e8d1106e7f5b405977f3b881558822304
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecanal/data/aws_s3_object_privatecanal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5a744b06fde3b6627bce02e2d04b3dbbb76638ddeed0950ad7422a69f9436001
+    manifestHash: 3c303a22e54cfd8af196779d5d0e5b2a01fa8f9231cd7f588a2e5c7639e3f3ed
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 5a744b06fde3b6627bce02e2d04b3dbbb76638ddeed0950ad7422a69f9436001
+    manifestHash: 3c303a22e54cfd8af196779d5d0e5b2a01fa8f9231cd7f588a2e5c7639e3f3ed
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_privatecilium.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 79b4cac9a939b48518166778f1f328581e4df2a686346dc3f24e32e5d8b5d559
+    manifestHash: a78b6fe90b57ffc35838427a246eac1309ad4cc117de02a74ac0a99a006eb2de
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_privateciliumadvanced.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 8f6c29865c470ba5307d3c65162ccae32a3f5aee7dee8ef9d4b0e2487336568f
+    manifestHash: 30f729067c05f5b085be310eb00d8970ac435646deade6d34f8432b3fa230214
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 925f76b9195cae30c66f4c5cd36a78e70eb9fc42999beec115acbf5319b23743
+    manifestHash: efcf34663b7f32d400640a4623e8988e574d416446830d6f31b2e5ee8abdadc9
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_privatedns1.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: b5a056585428c4b60ac93d2ce0e31ac444cd91348c0da42b46913d0f33945947
+    manifestHash: caa107d7cce850c319c473c442a15c06d2d9a816c1b6aac40bfc1bb907b8ef8c
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 49c84f686252bc7b5a3468f3d69a97c0d9f0c332512692c7922b73dbf60e8feb
+    manifestHash: 507f4cf2845c63e134b7dd709c528c84dff52b3af381fa0ab1d017a1122fd47d
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_privatedns2.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 1e4ba1504a1cfd73d4b4ab7f5308fc5c5eb53780d3eb4c3356f635c24d0faa3f
+    manifestHash: e9f0085db3280af5889ccd00768f42a1ef5229b42c4c4865ac9e268b23cd4eb6
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_privateflannel.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e086b46e2a7fc3a91278c193201defa70c030e5ce5f93515fa2dcf78330ef987
+    manifestHash: b0176ba7d5abf46ef41d0f8ac11909859153d1edeeac202ada61eb4a0ccd4ebd
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_privatekopeio.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7903a86997042832628c0d5c39e73f85786227c731f51ce9a87101e290777e85
+    manifestHash: 5b5ddef1fb7fd900c2e62207759d18d87738af4f0d67df3ef929023bac0d24ee
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/privateweave/data/aws_s3_object_privateweave.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 9887fce9353c01a3b797ab1b672caa6ebdca7c900281ceff11cf2bfccf078abb
+    manifestHash: 51ad8f149413904a92ab438e09616907eb1e795e805d5f50c3843b296cfe1b4a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -53,7 +53,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 02e7fa88b2d781485740ff753a28014b81b3c379330b45ca45fd3998f1ecf815
+    manifestHash: 22a42238df40940a159363b99ce975f035e8dd717a8a12bb1beadbc186ec2a29
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_sharedsubnet.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: e18cff1fb1fe9c5cb9fa0d24cedf2b12a156a27e02519a7fa091ae64283bf774
+    manifestHash: 4745416ce87aa85b6ea1dc7b90d9651a006657878f806c0dce35ba75f7faed8b
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_sharedvpc.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: 7062759c6500979fee6203a981b6414e3cf0229162807dad5de3d82c3253b858
+    manifestHash: 341ed8943c592743fcaa4985aeeaf8be3dfad37996f97b6f6dc4025392253f44
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_unmanaged.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_manifests-static-kube-apiserver-healthcheck_content
@@ -8,7 +8,7 @@ spec:
     - --ca-cert=/secrets/ca.crt
     - --client-cert=/secrets/client.crt
     - --client-key=/secrets/client.key
-    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.1
+    image: registry.k8s.io/kops/kube-apiserver-healthcheck:1.24.2
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: d10aa065de456d393b5c5ca56d669075c7619b6299b1193ed08b564059caf890
+    manifestHash: f8c298fbdb3f959300594f57e2db373c0c07fc3003fc7c8a259e6ee8d31eb522
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-dns-controller.addons.k8s.io-k8s-1.12_content
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -50,7 +50,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
+++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_minimal.example.com-addons-kops-controller.addons.k8s.io-k8s-1.16_content
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
+++ b/upup/models/cloudup/resources/addons/dns-controller.addons.k8s.io/k8s-1.12.yaml.template
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
 spec:
   replicas: 1
   strategy:
@@ -19,7 +19,7 @@ spec:
       labels:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
-        version: v1.24.1
+        version: v1.24.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -49,7 +49,7 @@ spec:
       nodeSelector: null
       containers:
       - name: dns-controller
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         args:
 {{ range $arg := DnsControllerArgv }}
         - "{{ $arg }}"

--- a/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
+++ b/upup/models/cloudup/resources/addons/kops-controller.addons.k8s.io/k8s-1.16.yaml.template
@@ -19,7 +19,7 @@ metadata:
   labels:
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
 spec:
   selector:
     matchLabels:
@@ -31,7 +31,7 @@ spec:
       labels:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
-        version: v1.24.1
+        version: v1.24.2
 {{ if UseKopsControllerForNodeBootstrap }}
       annotations:
         dns.alpha.kubernetes.io/internal: kops-controller.internal.{{ ClusterName }}
@@ -67,7 +67,7 @@ spec:
       serviceAccount: kops-controller
       containers:
       - name: kops-controller
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         volumeMounts:
 {{ if .UseHostCertificates }}
         - mountPath: /etc/ssl/certs

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc-containerd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/amazonvpc/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awscloudcontroller/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/crd/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/awsiamauthenticator/mappings/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/cilium/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/coredns/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/insecure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/metrics-server/secure-1.19/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/dns-controller.addons.k8s.io-k8s-1.12.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: dns-controller.addons.k8s.io
     k8s-app: dns-controller
-    version: v1.24.1
+    version: v1.24.2
   name: dns-controller
   namespace: kube-system
 spec:
@@ -26,7 +26,7 @@ spec:
         k8s-addon: dns-controller.addons.k8s.io
         k8s-app: dns-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -53,7 +53,7 @@ spec:
           value: arn:aws-test:iam::123456789012:role/dns-controller.kube-system.sa.minimal.example.com
         - name: AWS_WEB_IDENTITY_TOKEN_FILE
           value: /var/run/secrets/amazonaws.com/token
-        image: registry.k8s.io/kops/dns-controller:1.24.1
+        image: registry.k8s.io/kops/dns-controller:1.24.2
         name: dns-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/service-account-iam/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: 9887fce9353c01a3b797ab1b672caa6ebdca7c900281ceff11cf2bfccf078abb
+    manifestHash: 51ad8f149413904a92ab438e09616907eb1e795e805d5f50c3843b296cfe1b4a
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/kops-controller.addons.k8s.io-k8s-1.16.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kops
     k8s-addon: kops-controller.addons.k8s.io
     k8s-app: kops-controller
-    version: v1.24.1
+    version: v1.24.2
   name: kops-controller
   namespace: kube-system
 spec:
@@ -39,7 +39,7 @@ spec:
         k8s-addon: kops-controller.addons.k8s.io
         k8s-app: kops-controller
         kops.k8s.io/managed-by: kops
-        version: v1.24.1
+        version: v1.24.2
     spec:
       affinity:
         nodeAffinity:
@@ -63,7 +63,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
-        image: registry.k8s.io/kops/kops-controller:1.24.1
+        image: registry.k8s.io/kops/kops-controller:1.24.2
         name: kops-controller
         resources:
           requests:

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/simple/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
+++ b/upup/pkg/fi/cloudup/tests/bootstrapchannelbuilder/weave/manifest.yaml
@@ -6,7 +6,7 @@ spec:
   addons:
   - id: k8s-1.16
     manifest: kops-controller.addons.k8s.io/k8s-1.16.yaml
-    manifestHash: db994a90b869613f2fe69ed196a3f88b9fb256c4a8177bb4254e1fdf4faab5a3
+    manifestHash: c8f1dd43151d72363a4dd72767288b7af8e2913232b1e701d5800521a1bc5ab2
     name: kops-controller.addons.k8s.io
     needsRollingUpdate: control-plane
     selector:
@@ -34,7 +34,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.12
     manifest: dns-controller.addons.k8s.io/k8s-1.12.yaml
-    manifestHash: d5c02aad5ffe8c96a5cc57dc867864b46e37459ad9d5dbf2c1536c322ca072d9
+    manifestHash: 5495f02f6e46206aad2c9d4aae7fded895dbe54f18f37cc74f150c2446b4bc7c
     name: dns-controller.addons.k8s.io
     selector:
       k8s-addon: dns-controller.addons.k8s.io

--- a/upup/pkg/fi/cloudup/urls_test.go
+++ b/upup/pkg/fi/cloudup/urls_test.go
@@ -36,29 +36,29 @@ func Test_BuildMirroredAsset(t *testing.T) {
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-amd64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.24.1/images/protokube-linux-amd64",
-				"https://github.com/kubernetes/kops/releases/download/v1.24.1/images-protokube-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.24.2/images/protokube-linux-amd64",
+				"https://github.com/kubernetes/kops/releases/download/v1.24.2/images-protokube-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/images/protokube-linux-arm64",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.24.1/images/protokube-linux-arm64",
-				"https://github.com/kubernetes/kops/releases/download/v1.24.1/images-protokube-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.24.2/images/protokube-linux-arm64",
+				"https://github.com/kubernetes/kops/releases/download/v1.24.2/images-protokube-linux-arm64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/amd64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.24.1/linux/amd64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.24.1/nodeup-linux-amd64",
+				"https://artifacts.k8s.io/binaries/kops/1.24.2/linux/amd64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.24.2/nodeup-linux-amd64",
 			},
 		},
 		{
 			url: "https://artifacts.k8s.io/binaries/kops/%s/linux/arm64/nodeup",
 			expected: []string{
-				"https://artifacts.k8s.io/binaries/kops/1.24.1/linux/arm64/nodeup",
-				"https://github.com/kubernetes/kops/releases/download/v1.24.1/nodeup-linux-arm64",
+				"https://artifacts.k8s.io/binaries/kops/1.24.2/linux/arm64/nodeup",
+				"https://github.com/kubernetes/kops/releases/download/v1.24.2/nodeup-linux-arm64",
 			},
 		},
 	}

--- a/version.go
+++ b/version.go
@@ -21,8 +21,8 @@ var Version = KOPS_RELEASE_VERSION
 
 // These constants are parsed by build tooling - be careful about changing the formats
 const (
-	KOPS_RELEASE_VERSION = "1.24.1"
-	KOPS_CI_VERSION      = "1.24.2"
+	KOPS_RELEASE_VERSION = "1.24.2"
+	KOPS_CI_VERSION      = "1.24.3"
 )
 
 // GitVersion should be replaced by the makefile


### PR DESCRIPTION
- Add hashes for latest Docker versions
- Update Docker to v20.10.17
- Run hack/update-expected.sh
- Add hashes for latest containerd versions
- Update containerd to v1.6.6
- Run hack/update-expected.sh
- Update containerd fallback to v1.4.13
- Channels to have exit status 1 on apply failure
- Fix codegen targets and whitespace errors in Makefile
- Add support for setting mode field on file assets
- Update documentation for fileAssets and fix whitespace error
- Revert "Use kubectl replace instead of apply when updating addons"
- Fix API group being incorrect for ingresses
- Update after running hack/update-expected.sh
- Update runc to v1.1.3
- Run hack/update-expected.sh
- Update AWS CCM images for k8s 1.20-1.22
- Run hack/update-expected.sh
- Fix namespace for cert manager webhook config
- Avoid spurious changes with ed25519 keys
- Add back the metrics-server 443 port with a new name
- Fix broken node selector for node termination handler
- Release 1.24.0-beta.2 (#13788)
- replace flexdriver with busybox
- update expected
- Update etcd-manager to v3.0.20220617
- Run hack/update-expected.sh
- Fix tests
- Do not run CAS on spot instances
- Fix GCE resource tracking
- Limit GCE ASG labels to 63 chars
- Run hack/update-expected.sh
- Adding GuestAccelerators to InstanceTemplate
- Limit GCE tag for role to 63 chars
- Replace manifests after apply
- Fix upgrade-ab skip e2e test
- Don't try to manage the kube-system namespace
- Run hack/update-expected.sh
- Remove unneeded kube-proxy service account
- Move kube-dns service account to kube-dns addon
- Completely remove core addons
- Run hack/update-expected.sh
- Disable removal or CCM leader migration
- Release 1.24.0-beta.3
- Clean-up firewall rules that contain targets with the cluster name hash
- Add integration test for GCE cluster with very long cluster name
- Log errors from detachInstance
- gce: Move out of beta, drop feature flag
- Run make gen-cli-docs
- gce: set ProvisioningModel on InstanceTemplate
- Fix cleanup of firewall rules that contain the cluster name hash
- Apply PKI even if addon fails
- Update dependencies
- Refactor ClusterPrefixedName and ClusterSuffixedName to not return error
- Mount /etc/hosts from host for CoreDNS
- Run hack/update-expected.sh
- Limit GCE names to 63 chars for various resources
- Make IRSA webhook configure apps to use regional STS and set the default region on them
- Make it possible to enable the shield addon for LBC
- Increase length of cluster name for GCE long cluster name integration test
- Add integration test for GCE cluster with internal LB and very long cluster name
- Run hack/update-expected.sh
- Limit GCE router name to 63 chars
- Run hack/update-expected.sh
- Remove the v1alpha3 API version
- Update Cilium to 1.11.6
- Fix unsetting ASG max price
- Revert "Add back the metrics-server 443 port with a new name"
- aws: introduce maximum instance lifetime in cluster
- Fix doc of NewOpenStackCloudProvider
- Add config drive as a source for OpenStack instance metadata
- Be more specific when filtering OS instance ports
- Use csi-snapshotter for OS only when the controller is enabled
- Bump EBS CSI driver to 1.8.0
- Run hack/update-expected.sh
- Release 1.24.0 (#13957)
- Use Calico v3.23 for Kubernetes 1.22+
- Run hack/update-expected.sh
- Use control-plane node role for AWS IAM Authenticator
- Enable AWS IAM Authenticator in complex integration test
- Upgrade complex integration test case to k8s 1.24
- Skip deregistering the instance during rolling update for Spotinst
- Upgrade aws-iam-authenticator to v0.5.9
- Add option to set etcd-manager backup interval
- Use only IPv4 for Hetzner servers
- Add option to set number of replicas for pod-identity-webhook
- Update etcd-manager to v3.0.20220717
- Run hack/update-expected.sh
- Update Go to v1.18.4
- Remove replaces from go.mod
- Update k8s.io/client-go to match k8s.io/api
- Run "make gomod"
- Upgrade DO CSI driver to 4.2.0
- Update Calico to v3.23.2
- Update Calico to v3.23.3
- Update Canal to v3.23.3
- Run hack/update-expected.sh
- Switch to latest MacOS version for CI
- Update dependencies
- Revert to using instance private DNS name to lookup hostname
- Add server group management for Hetzner
- Update etcd-manager to v3.0.20220727
- Run hack/update-expected.sh
- Check keyset existence before attempting to distrust
- Fix SIGSEGV when deleting a Hetzner instance
- Remove namespaces from cluster-scoped resources in CNI manifests
- ./hack/update-expected.sh
- Enable rolling updates for Hetzner
- Wait for load balancer to be ready for Hetzner
- Add multiple SSH keys support for Hetzner
- Use cabundle for etcd CA files
- Release 1.24.1 (#14071)
- Allow configuring OpenStack CCM networking options
- aws-ebs-csi-driver: remove preStop hook
- fixup! aws-ebs-csi-driver: remove preStop hook
- Add option to configure runc version for containerd
- Run hack/update-expected.sh
- Bump nvidia device plugin to 0.12.0
- Add hashes for containerd v1.6.7
- Update containerd to v1.6.8
- Run hack/update-expected.sh
- Disable some flags in kube-controller-manager and kube-scheduler when logging-format is not text
- Add deployment-specific selectors to nth pdb
- Bump the CCM images
- Limit GCE network names to 63 chars
- Run hack/update-expected.sh
- Update runc to v1.1.4
- Run hack/update-expected.sh
- OIDC: Tolerate extra service-account key set items
- Always disable rp_filter when using cilium
- Bump cilium to 1.11.8
- Bump cert-manager to 1.8.2
- Release 1.24.2
