### PR TITLE
Automated cherry pick of #14223: Remove warning for FindClusterStatus not implemented for

### DIFF
--- a/upup/pkg/fi/cloudup/hetzner/cloud.go
+++ b/upup/pkg/fi/cloudup/hetzner/cloud.go
@@ -422,10 +422,8 @@ func (c *hetznerCloudImplementation) FindVPCInfo(id string) (*fi.VPCInfo, error)
 	return nil, errors.New("hetzner cloud provider does not implement FindVPCInfo at this time")
 }
 
-// FindClusterStatus is not implemented
+// FindClusterStatus was used before etcd-manager to check the etcd cluster status and prevent unsupported changes.
 func (c *hetznerCloudImplementation) FindClusterStatus(cluster *kops.Cluster) (*kops.ClusterStatus, error) {
-	// TODO(hakman): Implement me
-	klog.Warning("hetzner cloud provider does not implement FindClusterStatus at this time")
 	return nil, nil
 }
 


### PR DESCRIPTION
Cherry pick of #14223 on release-1.25.

#14223: Remove warning for FindClusterStatus not implemented for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```