### PR TITLE
GCE: change default control-plane instance type to e2-medium

### DIFF
--- a/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/gce_byo_sa/expected-v1alpha2.yaml
@@ -65,7 +65,7 @@ metadata:
   name: master-us-test1-a
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
-  machineType: n1-standard-1
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Master

--- a/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/ha_gce/expected-v1alpha2.yaml
@@ -72,7 +72,7 @@ metadata:
   name: master-us-test1-a
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
-  machineType: n1-standard-1
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Master
@@ -92,7 +92,7 @@ metadata:
   name: master-us-test1-b
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
-  machineType: n1-standard-1
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Master
@@ -112,7 +112,7 @@ metadata:
   name: master-us-test1-c
 spec:
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
-  machineType: n1-standard-1
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Master

--- a/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
+++ b/tests/integration/create_cluster/private_gce/expected-v1alpha2.yaml
@@ -95,7 +95,7 @@ spec:
   - sg-exampleid3
   - sg-exampleid4
   image: ubuntu-os-cloud/ubuntu-2004-focal-v20220118
-  machineType: n1-standard-1
+  machineType: e2-medium
   maxSize: 1
   minSize: 1
   role: Master

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -43,7 +43,7 @@ const (
 	defaultBastionMachineTypeAzure   = "Standard_B2ms"
 	defaultBastionMachineTypeHetzner = "cx11"
 
-	defaultMasterMachineTypeGCE     = "n1-standard-1"
+	defaultMasterMachineTypeGCE     = "e2-medium"
 	defaultMasterMachineTypeDO      = "s-2vcpu-4gb"
 	defaultMasterMachineTypeAzure   = "Standard_B2ms"
 	defaultMasterMachineTypeHetzner = "cx21"


### PR DESCRIPTION
This better matches the AWS machine, which is also a burstable 2 core
machine.  Without this pods sometimes fail to schedule on single core
machines.
