### PR TITLE
aws-node-termination-handler to match node using providerID instead of AWS DNS name

### DIFF
--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: a383a07194c3bc355de31f8ae0bea06f756bd586dd2ca55d50b5e03621217a3c
+    manifestHash: ddaf453a66065e31f1f97806b44e7b11bfcfe1835519bc43a7bf29731f31273f
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -177,6 +177,8 @@ spec:
           value: aws-node-termination-handler/managed
         - name: ASSUME_ASG_TAG_PROPAGATION
           value: "false"
+        - name: USE_PROVIDER_ID
+          value: "true"
         - name: DRY_RUN
           value: "false"
         - name: CORDON_ONLY

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -177,6 +177,8 @@ spec:
           value: "{{ .ManagedASGTag }}"
         - name: ASSUME_ASG_TAG_PROPAGATION
           value: "false"
+        - name: USE_PROVIDER_ID
+          value: "true"
         - name: DRY_RUN
           value: "false"
         - name: CORDON_ONLY


### PR DESCRIPTION
on `aws-node-termination-handler`, fetch node name through Kubernetes node `.spec.providerID` since Kops use InstanceID as node name.

Ref:
 - https://github.com/aws/aws-node-termination-handler/commit/701db81ccfb58d94c2b6df2b1bd273a442a4d05e