### PR TITLE
Automated cherry pick of #14244: aws-node-termination-handler: Add option to fetch node name

### DIFF
--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.11
     manifest: node-termination-handler.aws/k8s-1.11.yaml
-    manifestHash: a383a07194c3bc355de31f8ae0bea06f756bd586dd2ca55d50b5e03621217a3c
+    manifestHash: ddaf453a66065e31f1f97806b44e7b11bfcfe1835519bc43a7bf29731f31273f
     name: node-termination-handler.aws
     prune:
       kinds:

--- a/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
+++ b/tests/integration/update_cluster/nth_sqs_resources/data/aws_s3_object_nthsqsresources.longclustername.example.com-addons-node-termination-handler.aws-k8s-1.11_content
@@ -177,6 +177,8 @@ spec:
           value: aws-node-termination-handler/managed
         - name: ASSUME_ASG_TAG_PROPAGATION
           value: "false"
+        - name: USE_PROVIDER_ID
+          value: "true"
         - name: DRY_RUN
           value: "false"
         - name: CORDON_ONLY

--- a/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
+++ b/upup/models/cloudup/resources/addons/node-termination-handler.aws/k8s-1.11.yaml.template
@@ -177,6 +177,8 @@ spec:
           value: "{{ .ManagedASGTag }}"
         - name: ASSUME_ASG_TAG_PROPAGATION
           value: "false"
+        - name: USE_PROVIDER_ID
+          value: "true"
         - name: DRY_RUN
           value: "false"
         - name: CORDON_ONLY


### PR DESCRIPTION
Cherry pick of #14244 on release-1.25.

#14244: aws-node-termination-handler: Add option to fetch node name

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```