### PR TITLE
Update recommended kOps versions in alpha and stable

### DIFF
--- a/channels/alpha
+++ b/channels/alpha
@@ -134,31 +134,31 @@ spec:
     requiredVersion: 1.11.10
   kopsVersions:
   - range: ">=1.24.0-alpha.1"
-    recommendedVersion: "1.24.0"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.24.0
     kubernetesVersion: 1.24.4
   - range: ">=1.23.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.23.0
     kubernetesVersion: 1.23.10
   - range: ">=1.22.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.22.0
     kubernetesVersion: 1.22.13
   - range: ">=1.21.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.21.0
     kubernetesVersion: 1.21.14
   - range: ">=1.20.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.20.0
     kubernetesVersion: 1.20.15
   - range: ">=1.19.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.19.0
     kubernetesVersion: 1.19.16
   - range: ">=1.18.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.18.0
     kubernetesVersion: 1.18.20
   - range: ">=1.17.0-alpha.1"

--- a/channels/alpha
+++ b/channels/alpha
@@ -158,7 +158,7 @@ spec:
     #requiredVersion: 1.19.0
     kubernetesVersion: 1.19.16
   - range: ">=1.18.0-alpha.1"
-    recommendedVersion: "1.24.2"
+    recommendedVersion: "1.23.4"
     #requiredVersion: 1.18.0
     kubernetesVersion: 1.18.20
   - range: ">=1.17.0-alpha.1"

--- a/channels/stable
+++ b/channels/stable
@@ -134,31 +134,31 @@ spec:
     requiredVersion: 1.11.10
   kopsVersions:
   - range: ">=1.24.0-alpha.1"
-    recommendedVersion: "1.24.0"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.24.0
     kubernetesVersion: 1.24.4
   - range: ">=1.23.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.23.0
     kubernetesVersion: 1.23.10
   - range: ">=1.22.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.22.0
     kubernetesVersion: 1.22.13
   - range: ">=1.21.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.21.0
     kubernetesVersion: 1.21.14
   - range: ">=1.20.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.20.0
     kubernetesVersion: 1.20.15
   - range: ">=1.19.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.19.0
     kubernetesVersion: 1.19.16
   - range: ">=1.18.0-alpha.1"
-    recommendedVersion: "1.23.2"
+    recommendedVersion: "1.24.2"
     #requiredVersion: 1.18.0
     kubernetesVersion: 1.18.20
   - range: ">=1.17.0-alpha.1"

--- a/channels/stable
+++ b/channels/stable
@@ -158,7 +158,7 @@ spec:
     #requiredVersion: 1.19.0
     kubernetesVersion: 1.19.16
   - range: ">=1.18.0-alpha.1"
-    recommendedVersion: "1.24.2"
+    recommendedVersion: "1.23.4"
     #requiredVersion: 1.18.0
     kubernetesVersion: 1.18.20
   - range: ">=1.17.0-alpha.1"


### PR DESCRIPTION
Currently pointing to `1.24.0` for `1.24+` and to `1.23.2` for all previous versions.
Bumping the recommended to the latest and greatest kOps 1.24.2 in both channels.