### PR TITLE
Automated cherry pick of #14254: Fix CAS cordon flag

### DIFF
--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 729dcadedb99acbf9a9b72bdb73bbc18525352865e12c7e3c2eb67cf83544dbb
+    manifestHash: 3aa20855e262fa4427110cb8c02c2062db67878695d8861589b2cbc6d8572d76
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -330,7 +330,7 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
-        - --cordon-node-before-terminating="true"
+        - --cordon-node-before-terminating=true
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: e14369e0688f93dc6578f464f8da46a9b0001410e5510713513b4aa06a0cdbce
+    manifestHash: 66b68a0e4e3b5982dac1b3b279c319750b164413d9287abd0118cc421a74dcd5
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa23/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -330,7 +330,7 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
-        - --cordon-node-before-terminating="true"
+        - --cordon-node-before-terminating=true
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: faa9596e64df6bbf071647f3a74acb0230cccb801a330bccb67821251eb73140
+    manifestHash: 6afa3736e0b25db06f8644fa2c2dbad6704ced7056d48aa9d53e7e16e48de4bf
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa24/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -330,7 +330,7 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
-        - --cordon-node-before-terminating="true"
+        - --cordon-node-before-terminating=true
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -48,7 +48,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 995129efbafc17f912c327c8fcce41ab5389b7b9e487ca936d0d47fcc51dc789
+    manifestHash: 66644bc20f035c6c73f870100b8f083f266e851a80f76d8cc74240a7d852db4b
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa25/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -330,7 +330,7 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
-        - --cordon-node-before-terminating="true"
+        - --cordon-node-before-terminating=true
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 995129efbafc17f912c327c8fcce41ab5389b7b9e487ca936d0d47fcc51dc789
+    manifestHash: 66644bc20f035c6c73f870100b8f083f266e851a80f76d8cc74240a7d852db4b
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm-irsa26/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -330,7 +330,7 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
-        - --cordon-node-before-terminating="true"
+        - --cordon-node-before-terminating=true
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: cd6497b9d972c3a828e8a2057ed7f907729674192b10377f8378d413f80126fe
+    manifestHash: 91ec876d9fef5d9dfd5ca7c9aca880da90d798c3894fb1699a610b7ff231b527
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -333,7 +333,7 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
-        - --cordon-node-before-terminating="true"
+        - --cordon-node-before-terminating=true
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-bootstrap_content
@@ -41,7 +41,7 @@ spec:
     version: 9.99.0
   - id: k8s-1.15
     manifest: cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml
-    manifestHash: 6393b5636a0aa88b21e94c52a6209a03a6257be6e6344ab1c5887d5d9f2634c5
+    manifestHash: 8908b36fc06477773fea4bf325ddd03215749ecb7906a62f5b911c449c0910cb
     name: cluster-autoscaler.addons.k8s.io
     selector:
       k8s-addon: cluster-autoscaler.addons.k8s.io

--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
+++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_minimal.example.com-addons-cluster-autoscaler.addons.k8s.io-k8s-1.15_content
@@ -334,7 +334,7 @@ spec:
         - --scale-down-delay-after-add=10m0s
         - --new-pod-scale-up-delay=0s
         - --max-node-provision-time=15m0s
-        - --cordon-node-before-terminating="true"
+        - --cordon-node-before-terminating=true
         - --logtostderr=true
         - --stderrthreshold=info
         - --v=4

--- a/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
+++ b/upup/models/cloudup/resources/addons/cluster-autoscaler.addons.k8s.io/k8s-1.15.yaml.template
@@ -331,7 +331,7 @@ spec:
             - --max-node-provision-time={{ .MaxNodeProvisionTime }}
             # This flag does not exist before CAS 1.21
             {{ if IsKubernetesGTE "1.21" }}
-            - --cordon-node-before-terminating="{{ WithDefaultBool .CordonNodeBeforeTerminating true }}"
+            - --cordon-node-before-terminating={{ WithDefaultBool .CordonNodeBeforeTerminating true }}
             {{ end }}
             - --logtostderr=true
             - --stderrthreshold=info


### PR DESCRIPTION
Cherry pick of #14254 on release-1.25.

#14254: Fix CAS cordon flag

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```