### PR TITLE
Automated cherry pick of #13914: Ignore the _rundir that kubetest2 now creates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ _output
 
 # Used by E2E testing
 _artifacts
+_rundir


### PR DESCRIPTION
Cherry pick of #13914 on release-1.24.

#13914: Ignore the _rundir that kubetest2 now creates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```