### PR TITLE
Automated cherry pick of #14260: Bump verbosity level for some log statements

### DIFF
--- a/pkg/model/components/etcdmanager/model.go
+++ b/pkg/model/components/etcdmanager/model.go
@@ -483,7 +483,7 @@ func (b *EtcdManagerBuilder) buildPod(etcdCluster kops.EtcdClusterSpec, instance
 
 	if etcdCluster.Manager != nil && len(etcdCluster.Manager.Env) > 0 {
 		for _, envVar := range etcdCluster.Manager.Env {
-			klog.Warningf("overloading ENV var in manifest %s with %s=%s", bundle, envVar.Name, envVar.Value)
+			klog.V(2).Infof("overloading ENV var in manifest %s with %s=%s", bundle, envVar.Name, envVar.Value)
 			configOverwrite := v1.EnvVar{
 				Name:  envVar.Name,
 				Value: envVar.Value,

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -823,7 +823,6 @@ func (c *ApplyClusterCmd) upgradeSpecs(assetBuilder *assets.AssetBuilder) error 
 	}
 	c.Cluster = fullCluster
 
-	klog.Infof("Populating instance group from upgradeSpecs")
 	for i, g := range c.InstanceGroups {
 		fullGroup, err := PopulateInstanceGroupSpec(fullCluster, g, c.Cloud, c.channel)
 		if err != nil {

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -63,7 +63,7 @@ var awsDedicatedInstanceExceptions = map[string]bool{
 
 // PopulateInstanceGroupSpec sets default values in the InstanceGroup
 func PopulateInstanceGroupSpec(cluster *kops.Cluster, input *kops.InstanceGroup, cloud fi.Cloud, channel *kops.Channel) (*kops.InstanceGroup, error) {
-	klog.Infof("Populating instance group spec for %q", input.GetName())
+	klog.V(2).Infof("Populating instance group spec for %q", input.GetName())
 
 	var err error
 	err = validation.ValidateInstanceGroup(input, nil, false).ToAggregate()


### PR DESCRIPTION
Cherry pick of #14260 on release-1.25.

#14260: Bump verbosity level for some log statements

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```